### PR TITLE
feat(arm64): make Linux aarch64 build + CI-test on every fg-main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, fg-main]
   pull_request:
 
 jobs:
@@ -17,6 +17,9 @@ jobs:
           - os: ubuntu-latest
             arch_flag: "avx2"
             name: "Linux x86_64 AVX2"
+          - os: ubuntu-24.04-arm
+            arch_flag: ""
+            name: "Linux ARM64"
           - os: macos-latest
             arch_flag: ""
             name: "macOS ARM64"

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,11 @@ endif
 # Detect architecture
 UNAME_M := $(shell uname -m)
 UNAME_S := $(shell uname -s)
+# Treat macOS ("arm64") and Linux ("aarch64") as the same ARM build target.
+IS_ARM := $(filter $(UNAME_M),arm64 aarch64)
 
 # ARM/Apple Silicon support
-ifeq ($(UNAME_M),arm64)
+ifneq ($(IS_ARM),)
     ARCH_FLAGS = -DAPPLE_SILICON=1
     # sse2neon flags - define SSE feature macros for translation
     SSE2NEON_FLAGS = -D__SSE__=1 -D__SSE2__=1 -D__SSE3__=1 -D__SSSE3__=1 -D__SSE4_1__=1 -D__SSE4_2__=1
@@ -74,7 +76,7 @@ BWA_LIB=    libbwa.a
 SAFE_STR_LIB=    ext/safestringlib/libsafestring.a
 
 # Architecture-specific builds (x86 only, ARM uses default from above)
-ifneq ($(UNAME_M),arm64)
+ifeq ($(IS_ARM),)
 ifeq ($(arch),sse41)
 	ifeq ($(CXX), icpc)
 		ARCH_FLAGS=-msse4.1
@@ -116,7 +118,7 @@ endif
 endif
 
 # ARM64/Apple Silicon single-binary build
-ifeq ($(UNAME_M),arm64)
+ifneq ($(IS_ARM),)
 ifeq ($(arch),arm64)
     ARCH_FLAGS = -DAPPLE_SILICON=1
 else ifeq ($(arch),)
@@ -135,7 +137,7 @@ CXXFLAGS+=	-g -O3 -fpermissive $(ARCH_FLAGS) #-Wall ##-xSSE2
 all:$(EXE)
 
 multi:
-ifeq ($(UNAME_M),arm64)
+ifneq ($(IS_ARM),)
 	@echo "ARM64 detected - building single arm64 binary instead of multi"
 	$(MAKE) arm64
 else

--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -852,10 +852,13 @@ int kswv::kswv_neon_16(int16_t seq1SoA[],
 
             /* Core computation */
             int16x8_t xor_val = veorq_s16(s1, s2);
-            /* Use table lookup with limited index range */
-            int16x8_t sbt = vqtbl1q_s8(vreinterpretq_s8_s16(perm_vec),
-                                        vreinterpretq_u8_s16(xor_val));
-            sbt = vreinterpretq_s16_s8(sbt);
+            /* Table lookup with limited index range. vqtbl1q_s8 returns
+             * int8x16_t; reinterpret to int16x8_t so downstream arithmetic
+             * on `sbt` (vaddq_s16, etc.) types correctly. Apple's clang
+             * accepts the implicit conversion; gcc aarch64 does not. */
+            int16x8_t sbt = vreinterpretq_s16_s8(
+                vqtbl1q_s8(vreinterpretq_s8_s16(perm_vec),
+                           vreinterpretq_u8_s16(xor_val)));
 
             /* Check for boundary */
             int16x8_t or_val = vorrq_s16(s1, s2);


### PR DESCRIPTION
## Summary

Make the fork actually build on Linux ARM64 and exercise it in CI.

### Makefile

Prior to this change the Apple-Silicon work in \`ae73227\` only fired on macOS: the Makefile's \`ifeq (\$(UNAME_M),arm64)\` check matches only macOS's \`uname -m\` output. Linux ARM64 reports \`aarch64\` and fell through to the x86 \`multi\` target, producing this on every aarch64 host:

\`\`\`
g++: error: unrecognized command-line option '-msse'
\`\`\`

Fix the detection to cover both names via a single \`IS_ARM\` variable (\`\$(filter \$(UNAME_M),arm64 aarch64)\`), then swap the four \`UNAME_M==arm64\` checks to use it:

- NEON / sse2neon flag block (was gated on macOS only)
- x86 arch-specific block (was running on aarch64 by mistake)
- ARM64 single-binary build block
- \`multi\` target ARM64 short-circuit

### CI

- Trigger the workflow on pushes to \`fg-main\` (our integration branch), not just \`master\`.
- Add a \`ubuntu-24.04-arm\` matrix entry so the aarch64 path runs on every PR.

## Test plan

- [ ] All four matrix entries (x86 SSE4.1, x86 AVX2, Linux ARM64, macOS ARM64) pass on this PR.
- [x] macOS ARM64 still builds locally (no functional change on that path; just swapped the gating variable).
- [ ] Linux ARM64 now produces a single-binary NEON build.