### PR TITLE
chore: configure CodeRabbit to review PRs against fg-main

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Review PRs targeting our fg-main integration branch in addition to the
+# repository's default branch (master). The default branch is always
+# reviewed; this list adds extra base branches.
+language: "en"
+reviews:
+  auto_review:
+    base_branches:
+      - "fg-main"


### PR DESCRIPTION
## Summary

Adds a minimal \`.coderabbit.yaml\` with \`reviews.base_branches: [fg-main]\` so the bot runs on PRs targeting our integration branch. The repository's default branch (master) is always reviewed automatically; this adds \`fg-main\` to the list.

Split out of #1 so it can merge first — once active, CodeRabbit will review #1 itself.

## Test plan

- [ ] Merge this PR.
- [ ] Verify CodeRabbit runs on the next PR opened against \`fg-main\` (e.g., #1 after a rebase).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added review configuration to enable automated reviews for an expanded set of integration branches, ensuring pull requests against those branches are included in review workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->