### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Summary

Pin every GitHub Action reference in the workflows to a full-length commit SHA, with the semver tag preserved as a trailing comment.

Currently only \`actions/checkout\` is used in the repo; this PR pins it to the commit that \`v4\` resolves to today (\`v4.3.1\`):

\`\`\`diff
- uses: actions/checkout@v4
+ uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
\`\`\`

## Why

Floating tags like \`@v4\` can be force-moved to any commit. Pinning to a full SHA means CI behavior is reproducible and protected against silent upstream changes (including malicious ones). This matches standard security guidance (e.g. [GitHub docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [StepSecurity](https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security)).

Future PRs that add or update actions should follow the same \`uses: owner/action@<full-sha> # <semver>\` convention. Renovate / Dependabot can be configured to keep pins fresh.

## Test plan

- [ ] CI matrix (x86 SSE4.1, x86 AVX2, macOS ARM64, and once #1 lands, Linux ARM64) runs green on this PR.