### PR TITLE
fix(hdr): align bwamem.h declarations with bwamem.cpp definitions

### DIFF
--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -265,8 +265,15 @@ int mem_kernel1_core(FMI_search *fmi, const mem_opt_t *opt,
                      bseq1_t *seq_,
                      int nseq,
                      mem_chain_v *chain_ar,
+                     mem_seed_t *seedBuf,
+                     int64_t seedBufSize,
                      mem_cache *mmc,
                      int tid);
+
+int mem_kernel2_core(FMI_search *fmi, const mem_opt_t *opt,
+                     bseq1_t *seq_, mem_alnreg_v *regs, int nseq,
+                     mem_chain_v *chain_ar, mem_cache *mmc,
+                     uint8_t *ref_string, int tid);
 
 void* _mm_realloc(void *ptr, int64_t csize, int64_t nsize, int16_t dsize);
 


### PR DESCRIPTION
## Summary

\`bwamem.h\` had a **stale 7-parameter declaration** of \`mem_kernel1_core\`, while the actual definition in \`bwamem.cpp\` takes **9 parameters** (adds \`mem_seed_t *seedBuf\` and \`int64_t seedBufSize\`). \`mem_kernel2_core\` wasn't declared in the header at all.

Consumers that include only \`bwamem.h\` (e.g. FFI shims for language bindings) currently have to carry local forward declarations for both functions. This brings the header in sync with the real signatures so \`#include \"bwamem.h\"\` alone is sufficient.

No behavior change.

## Test plan

- [x] Build on macOS arm64 is clean.
- [ ] CI matrix green (Linux x86_64 SSE4.1/AVX2, Linux ARM64, macOS ARM64).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced core processing function interfaces with updated signatures and new processing capabilities for improved sequence analysis workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->