### PR TITLE
feat(hdr): export mem_infer_dir for external consumers

### DIFF
--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -287,6 +287,13 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
                          mem_alnreg_v *ma, mem_cache *mmc, int pcnt, int32_t gcnt,
                          int32_t &maxRefLen, int32_t &maxQerLen, int32_t tid);
 
+/* Given two alignment begin positions (rb) on the 2-bit-packed concat-with-
+ * reverse-complement index, infer the pair orientation (0=FF, 1=FR, 2=RF,
+ * 3=RR) and the distance between 5' ends. Exposed so that external consumers
+ * can share the same proper-pair classification used by mem_sam_pe's
+ * no_pairing fallback. */
+int mem_infer_dir(int64_t l_pac, int64_t b1, int64_t b2, int64_t *dist);
+
 int mem_sam_pe_batch(const mem_opt_t *opt, mem_cache *mmc,
                      int64_t &pcnt, int64_t &pcnt8, kswr_t *aln,
                      int32_t, int32_t, int tid);

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -55,7 +55,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 
 extern uint64_t tprof[LIM_R][LIM_C];
 
-static inline int mem_infer_dir(int64_t l_pac, int64_t b1, int64_t b2, int64_t *dist)
+int mem_infer_dir(int64_t l_pac, int64_t b1, int64_t b2, int64_t *dist)
 {
     int64_t p2;
     int r1 = (b1 >= l_pac), r2 = (b2 >= l_pac);


### PR DESCRIPTION
## Summary

\`mem_sam_pe\`'s \`no_pairing\` fallback uses a small helper, \`mem_infer_dir\`, to classify a read pair's orientation (0=FF, 1=FR, 2=RF, 3=RR) and 5'-to-5' distance from two alignment \`rb\` values. The helper was \`static inline\` in \`bwamem_pair.cpp\` and unreachable from outside the TU.

External consumers (FFI shims, language bindings) that want to replicate the proper-pair decision without re-deriving the bit logic around the 2-bit-packed index layout currently have to copy-paste the 8-line body. This PR drops the \`static inline\`, adds a declaration in \`bwamem.h\`, and keeps the definition unchanged. No behavior change for in-tree callers.

## Test plan

- [x] Build clean on macOS arm64.
- [x] \`nm libbwa.a\` confirms the symbol is now global (\`T __Z13mem_infer_dirxxxPx\`) instead of local.
- [ ] CI matrix green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed `mem_infer_dir` function as a public API for pair-end read alignment operations, enabling external tools to compute proper-pair orientation and distance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->