### PR TITLE
chore: move profiling globals out of main.cpp into profiling.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,8 @@ Contacts: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@
 
 
 // ----------------------------------
-uint64_t proc_freq, tprof[LIM_R][LIM_C], prof[LIM_R];
+// Profiling globals are now defined in profiling.cpp so they live in
+// libbwa.a and are visible to library consumers that don't link main.o.
 // ----------------------------------
 
 int usage()

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -33,6 +33,13 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include <assert.h>
 #include "profiling.h"
 
+// Profiling globals. Defined here rather than in main.cpp so they are part of
+// libbwa.a and visible to consumers that link the library without pulling in
+// main.o (e.g. language bindings).
+uint64_t proc_freq = 0;
+uint64_t tprof[LIM_R][LIM_C] = {{0}};
+uint64_t prof[LIM_R] = {0};
+
 int find_opt(uint64_t *a, int len, uint64_t *max, uint64_t *min, double *avg)
 {
     *max = 0;

--- a/src/profiling.h
+++ b/src/profiling.h
@@ -30,6 +30,10 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #ifndef _PROFILE_HPP
 #define _PROFILE_HPP
 
+#include <stdint.h>
+#include "macro.h"
+
 int display_stats(int );
 extern uint64_t proc_freq, tprof[LIM_R][LIM_C];
+extern uint64_t prof[LIM_R];
 #endif


### PR DESCRIPTION
## Summary

The profiling counters `proc_freq`, `tprof[LIM_R][LIM_C]`, and `prof[LIM_R]` are defined in `main.cpp`. That means they only ship with the `bwa-mem2` executable — not with `libbwa.a`. Consumers that link `libbwa.a` without also linking `main.o` (e.g. language bindings that call the alignment kernels directly) hit undefined references for these symbols.

This moves the definitions into `profiling.cpp`, where they live next to the profiling functions that actually use them, and adds the missing `extern` for `prof` to `profiling.h`. No behavior change for the `bwa-mem2` binary itself.

- `src/main.cpp` — remove the global definitions (replaced by a comment noting where they moved).
- `src/profiling.cpp` — add definitions (zero-initialized).
- `src/profiling.h` — add `extern uint64_t prof[LIM_R];`.

`src/profiling.o` is already part of `OBJS` in the `Makefile`, so no build-system change is needed.

## Test plan

- [x] `make arm64` succeeds on macOS / Apple Silicon (verified locally)
- [x] Resulting `bwa-mem2 version` still prints `2.2.1`
- [ ] CI: Linux x86_64 multi-arch build succeeds
- [ ] CI: Linux aarch64 build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized profiling state into the shared library, improving modularity and ensuring profiling data is provided consistently from the library rather than the main executable. This simplifies build/link behavior and makes profiling functionality more uniformly available to consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->