### PR TITLE
ci: pin dwgsim seed (-z 42) to stop bwa-vs-bwa-mem2 parity test flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,14 @@ jobs:
 
       - name: Simulate reads with dwgsim
         run: |
+          # Pin -z so the simulated reads are reproducible across CI runs.
+          # Without this, each job gets a different time-seeded batch and a
+          # stray read spanning the phiX174 circular origin can produce a
+          # byte-level diff vs bwa, flaking the comparison step. See issue
+          # #11 for plans to replace this test with a curated dataset
+          # (via holodeck) and drop dwgsim entirely.
           /tmp/dwgsim-src/dwgsim \
+            -z 42 \
             -N 500 -1 150 -2 150 \
             -r 0.001 -S 2 \
             /tmp/ci-test/phix174.fa \


### PR DESCRIPTION
## Summary

The \`Compare bwa and bwa-mem2 output\` step requires **byte-identical** SAM from the two aligners, but \`dwgsim\` is currently invoked without \`-z\`, so every CI run simulates a different batch of reads. Roughly one job in four picks up a read spanning the phiX174 circular origin that \`bwa\` and \`bwa-mem2\` place differently (pos=1 vs pos=2, with internally-inconsistent \`NM:i:107\` + \`AS:i:150\` on the bwa-mem2 side), which flakes the diff step on whichever matrix job happened to draw that read.

Evidence:

- PR #5 (header-only diff, no runtime change) failed only on Linux ARM64.
- PR #9 (unrelated refactor) failed only on Linux x86_64 AVX2.
- The branch that introduced this CI (\`ci/trigger-fg-main-and-linux-aarch64\`) failed 4x consecutively before passing once.

Pinning \`-z 42\` makes the simulated reads reproducible, which makes the parity step deterministic on every job.

The underlying tool-level disagreement on wrap-around reads is pre-existing and orthogonal to this PR — tracked separately in #11, where we'll replace phiX174 + dwgsim with a curated dataset via holodeck.

## Test plan

- [x] Pin seed, push; PR CI runs should pass on all four matrix jobs with this change
- [ ] Once merged, re-run PR #5 and PR #9 CI — both should go green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made CI simulation deterministic so generated reads and downstream test inputs are consistent across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
