### PR TITLE
feat: --bam[=LEVEL] output flag for direct BAM emission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,11 @@ jobs:
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev bwa
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev bwa autoconf automake
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install bwa
+        run: brew install bwa autoconf automake
 
       - name: Build bwa-mem2
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ext/sse2neon"]
 	path = ext/sse2neon
 	url = https://github.com/DLTcollab/sse2neon.git
+[submodule "ext/htslib"]
+	path = ext/htslib
+	url = https://github.com/samtools/htslib.git

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,15 @@ endif
 
 MEM_FLAGS=	-DSAIS=1
 CPPFLAGS+=	-DENABLE_PREFETCH -DV17=1 -DMATE_SORT=0 $(MEM_FLAGS)
-INCLUDES+=   -Isrc -Iext/safestringlib/include
-LIBS=		-lpthread -lm -lz -L. -lbwa -Lext/safestringlib -lsafestring $(STATIC_GCC) $(LIBS_EXTRA)
+INCLUDES+=   -Isrc -Iext/safestringlib/include -Iext/htslib
+LIBS=		-lpthread -lm -lz -L. -lbwa -Lext/safestringlib -lsafestring -Lext/htslib -lhts $(STATIC_GCC) $(LIBS_EXTRA)
 OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/memcpy_bwamem.o src/kthread.o \
 			src/kstring.o src/ksw.o src/bntseq.o src/bwamem.o src/profiling.o src/bandedSWA.o \
 			src/FMI_search.o src/read_index_ele.o src/bwamem_pair.o src/kswv.o src/bwa.o \
-			src/bwamem_extra.o src/kopen.o
+			src/bwamem_extra.o src/kopen.o src/bam_writer.o
 BWA_LIB=    libbwa.a
 SAFE_STR_LIB=    ext/safestringlib/libsafestring.a
+HTS_LIB=    ext/htslib/libhts.a
 
 # Architecture-specific builds (x86 only, ARM uses default from above)
 ifeq ($(IS_ARM),)
@@ -161,7 +162,7 @@ arm64:
 	ln -sf bwa-mem2.arm64 bwa-mem2
 
 
-$(EXE):$(BWA_LIB) $(SAFE_STR_LIB) src/main.o
+$(EXE):$(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) src/main.o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) src/main.o $(BWA_LIB) $(LIBS) -o $@
 
 $(BWA_LIB):$(OBJS)
@@ -177,9 +178,20 @@ endif
 $(SAFE_STR_LIB):
 	cd ext/safestringlib/ && $(MAKE) clean && $(MAKE) CC=$(CC) CFLAGS="-Iinclude -Isafeclib $(SAFE_EXTRA_CFLAGS) -fstack-protector-strong -fPIE -fPIC -O2" directories libsafestring.a
 
+# htslib: minimal configure (no lzma/bz2/curl/S3/GCS/plugins), zlib only.
+# Guard on config.mk (only created by ./configure) rather than Makefile, which
+# is checked into the htslib tree and would make the guard a no-op.
+$(HTS_LIB):
+	cd ext/htslib && \
+	    ([ -f config.mk ] || (autoreconf -i && \
+	        ./configure --disable-lzma --disable-libcurl --disable-gcs \
+	                    --disable-s3 --disable-plugins --disable-bz2)) && \
+	    $(MAKE) libhts.a
+
 clean:
 	rm -fr src/*.o $(BWA_LIB) $(EXE) bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
 	cd ext/safestringlib/ && $(MAKE) clean
+	-[ -f ext/htslib/config.mk ] && cd ext/htslib && $(MAKE) distclean
 
 # Profile-Guided Optimization (PGO) targets for Apple Silicon
 # Usage: make pgo-generate && <run training workload> && make pgo-use
@@ -243,3 +255,4 @@ src/read_index_ele.o: src/read_index_ele.h src/utils.h src/bntseq.h
 src/read_index_ele.o: src/macro.h
 src/utils.o: src/utils.h src/ksort.h src/kseq.h
 src/memcpy_bwamem.o: src/memcpy_bwamem.h
+src/bam_writer.o: src/bam_writer.h src/bwamem.h src/bwa.h src/bntseq.h

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -1,0 +1,388 @@
+/* SPDX-License-Identifier: MIT */
+
+/* htslib headers before any bwa-mem2 header that pulls in kstring.h
+ * (they share the KSTRING_H include guard). */
+#include "htslib/sam.h"
+#include "htslib/kstring.h"
+
+#include "bam_writer.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+struct bam_writer_s {
+    htsFile   *fp;
+    sam_hdr_t *hdr;
+};
+
+extern char bwa_rg_id[256];
+
+extern "C" {
+struct bam1_t *bam_writer_alloc(void)             { return bam_init1(); }
+void           bam_writer_free(struct bam1_t *b)  { if (b) bam_destroy1(b); }
+}
+
+bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
+                              const char *hdr_line, const char *bwa_pg,
+                              int compression_level)
+{
+    if (path == NULL || bns == NULL) return NULL;
+
+    sam_hdr_t *hdr = sam_hdr_init();
+    if (hdr == NULL) return NULL;
+    if (sam_hdr_add_line(hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL) < 0) goto fail;
+    for (int i = 0; i < bns->n_seqs; ++i) {
+        char len_buf[32];
+        snprintf(len_buf, sizeof(len_buf), "%lld", (long long)bns->anns[i].len);
+        if (sam_hdr_add_line(hdr, "SQ", "SN", bns->anns[i].name, "LN", len_buf, NULL) < 0)
+            goto fail;
+    }
+    if (hdr_line != NULL && hdr_line[0] != '\0' && sam_hdr_add_lines(hdr, hdr_line, 0) < 0)
+        goto fail;
+    if (bwa_pg != NULL && bwa_pg[0] != '\0' && sam_hdr_add_lines(hdr, bwa_pg, 0) < 0)
+        goto fail;
+
+    {
+        if (compression_level < 0) compression_level = 0;
+        if (compression_level > 9) compression_level = 9;
+        char mode[8];
+        snprintf(mode, sizeof(mode), "wb%d", compression_level);
+        htsFile *fp = hts_open(path, mode);
+        if (fp == NULL) goto fail;
+        if (sam_hdr_write(fp, hdr) < 0) { hts_close(fp); goto fail; }
+        bam_writer_t *w = (bam_writer_t *)calloc(1, sizeof(*w));
+        if (w == NULL) { hts_close(fp); goto fail; }
+        w->fp = fp; w->hdr = hdr;
+        return w;
+    }
+fail:
+    sam_hdr_destroy(hdr);
+    return NULL;
+}
+
+int bam_writer_write(bam_writer_t *w, struct bam1_t *b)
+{
+    if (w == NULL || b == NULL) return -1;
+    return sam_write1(w->fp, w->hdr, b);
+}
+
+int bam_writer_close(bam_writer_t *w)
+{
+    if (w == NULL) return 0;
+    int rc = 0;
+    if (w->hdr) { sam_hdr_destroy(w->hdr); w->hdr = NULL; }
+    if (w->fp)  { if (hts_close(w->fp) < 0) rc = -1; w->fp = NULL; }
+    free(w);
+    return rc;
+}
+
+/* ------------------------------------------------------------------- */
+/* mem_aln_t -> bam1_t                                                  */
+/* ------------------------------------------------------------------- */
+
+/* bwa-mem2 CIGAR op encoding is 0=M,1=I,2=D,3=S,4=H. BAM's is
+ * 0=M,1=I,2=D,3=N,4=S,5=H. Remap on emit. */
+static const uint32_t BAM_OP_FROM_MEM[5] = { 0, 1, 2, 4, 5 };
+
+/* Append SAM-text aux fields ("TAG:TYPE:VALUE" tokens, TAB-separated) onto
+ * `b` as packed BAM aux. Mirrors the literal s->comment append that
+ * mem_aln2sam does on the SAM path so --bam preserves -C output. Only TAB
+ * is treated as a separator (matching SAM's grammar); spaces are kept
+ * inside Z values, which is exactly how the SAM path treats them when the
+ * FASTQ comment is appended verbatim. Only the common scalar types
+ * (A/i/f/Z/H) are handled; B (typed array) is skipped because parsing it
+ * is non-trivial and FASTQ comments effectively never use it. Malformed
+ * tokens are skipped silently. */
+static void append_sam_aux_tokens(struct bam1_t *b, const char *s)
+{
+    if (s == NULL) return;
+    while (*s) {
+        while (*s == '\t') ++s;
+        if (!*s) break;
+        const char *tok = s;
+        while (*s && *s != '\t') ++s;
+        size_t tok_len = (size_t)(s - tok);
+        /* Need at least "XX:T:" (5 chars) and a non-empty value. */
+        if (tok_len < 6 || tok[2] != ':' || tok[4] != ':') continue;
+        char tag[2] = { tok[0], tok[1] };
+        char type   = tok[3];
+        const char *val  = tok + 5;
+        size_t      vlen = tok_len - 5;
+        switch (type) {
+            case 'A':
+                if (vlen >= 1) {
+                    char c = val[0];
+                    bam_aux_append(b, tag, 'A', 1, (const uint8_t *)&c);
+                }
+                break;
+            case 'i': {
+                char *end = NULL;
+                int64_t iv = (int64_t)strtoll(val, &end, 10);
+                if (end != val) {
+                    int32_t i32 = (int32_t)iv;
+                    bam_aux_append(b, tag, 'i', sizeof(i32),
+                                   (const uint8_t *)&i32);
+                }
+                break;
+            }
+            case 'f': {
+                char *end = NULL;
+                float fv = strtof(val, &end);
+                if (end != val) {
+                    bam_aux_append(b, tag, 'f', sizeof(fv),
+                                   (const uint8_t *)&fv);
+                }
+                break;
+            }
+            case 'Z':
+            case 'H': {
+                char *buf = (char *)malloc(vlen + 1);
+                if (buf == NULL) break;
+                memcpy(buf, val, vlen);
+                buf[vlen] = '\0';
+                bam_aux_append(b, tag, type, (int)vlen + 1,
+                               (const uint8_t *)buf);
+                free(buf);
+                break;
+            }
+            default:
+                /* B-type and unknown — leave unconverted rather than emit a
+                 * wrong-typed tag. */
+                break;
+        }
+    }
+}
+
+/* Reference-consumed length summed across a bwa-mem2-encoded CIGAR. Only
+ * M (0) and D (2) consume ref; S/H are soft/hard clips. Matches get_rlen()
+ * in bwamem.cpp. */
+static int64_t cigar_ref_len_mem(const uint32_t *cigar, int n)
+{
+    int64_t l = 0;
+    for (int i = 0; i < n; ++i) {
+        int op = cigar[i] & 0xf;
+        if (op == 0 || op == 2) l += cigar[i] >> 4;
+    }
+    return l;
+}
+
+int mem_aln_to_bam(struct bam1_t *b,
+                   const mem_opt_t *opt, const bntseq_t *bns,
+                   const bseq1_t *s, int n_alns,
+                   const mem_aln_t *list, int which,
+                   const mem_aln_t *m_)
+{
+    if (b == NULL || opt == NULL || s == NULL || list == NULL) return -1;
+
+    mem_aln_t p = list[which];
+    mem_aln_t m;
+    const mem_aln_t *mp = NULL;
+    if (m_ != NULL) { m = *m_; mp = &m; }
+
+    p.flag |= mp ? 0x1 : 0;
+    p.flag |= p.rid < 0 ? 0x4 : 0;
+    p.flag |= mp && mp->rid < 0 ? 0x8 : 0;
+    if (p.rid < 0 && mp && mp->rid >= 0) {
+        p.rid = mp->rid; p.pos = mp->pos; p.is_rev = mp->is_rev; p.n_cigar = 0;
+    }
+    if (mp && mp->rid < 0 && p.rid >= 0) {
+        m.rid = p.rid; m.pos = p.pos; m.is_rev = p.is_rev; m.n_cigar = 0;
+    }
+    p.flag |= p.is_rev ? 0x10 : 0;
+    p.flag |= mp && mp->is_rev ? 0x20 : 0;
+
+    uint16_t flag16 = (uint16_t)((p.flag & 0xffff) | (p.flag & 0x10000 ? 0x100 : 0));
+
+    /* Remap primary CIGAR: bwa-mem2 ops -> BAM ops, + soft->hard for supp */
+    uint32_t *bam_cigar = NULL;
+    size_t    bam_n_cigar = 0;
+    if (p.n_cigar > 0) {
+        bam_cigar = (uint32_t *)malloc((size_t)p.n_cigar * sizeof(uint32_t));
+        if (bam_cigar == NULL) return -1;
+        for (int i = 0; i < p.n_cigar; ++i) {
+            int op  = p.cigar[i] & 0xf;
+            int len = p.cigar[i] >> 4;
+            if (!(opt->flag & MEM_F_SOFTCLIP) && !p.is_alt && (op == 3 || op == 4))
+                op = which ? 4 : 3;
+            uint32_t bam_op = (op >= 0 && op < 5) ? BAM_OP_FROM_MEM[op] : 0;
+            bam_cigar[i] = ((uint32_t)len << 4) | bam_op;
+        }
+        bam_n_cigar = (size_t)p.n_cigar;
+    }
+
+    hts_pos_t tlen = 0;
+    if (mp && mp->rid >= 0 && p.rid == mp->rid && p.n_cigar > 0 && m.n_cigar > 0) {
+        /* TLEN uses ref-consumed lengths. bwa-mem2 and BAM both encode
+         * M=0, D=2, so we can count directly on the pre-remap CIGARs. */
+        int64_t p_rlen = cigar_ref_len_mem(p.cigar, p.n_cigar);
+        int64_t m_rlen = cigar_ref_len_mem(m.cigar, m.n_cigar);
+        int64_t p0 = p.pos + (p.is_rev ? p_rlen - 1 : 0);
+        int64_t p1 = m.pos + (m.is_rev ? m_rlen - 1 : 0);
+        tlen = -(p0 - p1 + (p0 > p1 ? 1 : p0 < p1 ? -1 : 0));
+    }
+
+    /* SEQ/QUAL range with supp soft-clip trim */
+    int qb = 0, qe = s->l_seq;
+    if (p.n_cigar && which && !(opt->flag & MEM_F_SOFTCLIP) && !p.is_alt) {
+        int c0 = p.cigar[0] & 0xf;
+        int cN = p.cigar[p.n_cigar-1] & 0xf;
+        if (!p.is_rev) {
+            if (c0 == 3 || c0 == 4) qb += p.cigar[0] >> 4;
+            if (cN == 3 || cN == 4) qe -= p.cigar[p.n_cigar-1] >> 4;
+        } else {
+            if (c0 == 3 || c0 == 4) qe -= p.cigar[0] >> 4;
+            if (cN == 3 || cN == 4) qb += p.cigar[p.n_cigar-1] >> 4;
+        }
+    }
+
+    int emit_seq = !(p.flag & 0x100);
+    size_t l_emit = 0;
+    char *seq_text = NULL;
+    char *qual_bin = NULL;
+    if (emit_seq && qe > qb) {
+        l_emit = (size_t)(qe - qb);
+        seq_text = (char *)malloc(l_emit + 1);
+        if (seq_text == NULL) { free(bam_cigar); return -1; }
+        if (!p.is_rev) {
+            for (size_t i = 0; i < l_emit; ++i) seq_text[i] = "ACGTN"[(int)s->seq[qb + (int)i]];
+        } else {
+            for (size_t i = 0; i < l_emit; ++i) seq_text[i] = "TGCAN"[(int)s->seq[qe - 1 - (int)i]];
+        }
+        seq_text[l_emit] = '\0';
+        if (s->qual) {
+            qual_bin = (char *)malloc(l_emit);
+            if (qual_bin == NULL) { free(seq_text); free(bam_cigar); return -1; }
+            if (!p.is_rev) {
+                for (size_t i = 0; i < l_emit; ++i) qual_bin[i] = (char)((unsigned char)s->qual[qb + (int)i] - 33);
+            } else {
+                for (size_t i = 0; i < l_emit; ++i) qual_bin[i] = (char)((unsigned char)s->qual[qe - 1 - (int)i] - 33);
+            }
+        }
+    }
+
+    int ret = bam_set1(b,
+                       strlen(s->name), s->name,
+                       flag16, p.rid, (hts_pos_t)p.pos, p.mapq,
+                       bam_n_cigar, bam_cigar,
+                       mp ? mp->rid : -1, mp ? (hts_pos_t)mp->pos : -1, tlen,
+                       l_emit, seq_text, qual_bin,
+                       /* l_aux */ 0);
+    free(bam_cigar); free(seq_text); free(qual_bin);
+    if (ret < 0) return -1;
+
+    if (p.n_cigar > 0) {
+        int32_t nm = (int32_t)p.NM;
+        bam_aux_append(b, "NM", 'i', sizeof(nm), (const uint8_t *)&nm);
+        const char *md = (const char *)(p.cigar + p.n_cigar);
+        bam_aux_append(b, "MD", 'Z', (int)strlen(md) + 1, (const uint8_t *)md);
+    }
+    if (mp && mp->n_cigar > 0) {
+        /* Dynamic buffer: CIGARs with >~800 ops would silently truncate a
+         * fixed stack buffer. kstring_t grows as needed. */
+        kstring_t mc = {0, 0, NULL};
+        for (int i = 0; i < mp->n_cigar; ++i) {
+            int op = mp->cigar[i] & 0xf;
+            int len = mp->cigar[i] >> 4;
+            if (!(opt->flag & MEM_F_SOFTCLIP) && !mp->is_alt && (op == 3 || op == 4))
+                op = which ? 4 : 3;
+            ksprintf(&mc, "%d%c", len, "MIDSH"[op]);
+        }
+        if (mc.l > 0)
+            bam_aux_append(b, "MC", 'Z', (int)mc.l + 1, (const uint8_t *)mc.s);
+        free(mc.s);
+    }
+    if (p.score >= 0) {
+        int32_t as = (int32_t)p.score;
+        bam_aux_append(b, "AS", 'i', sizeof(as), (const uint8_t *)&as);
+    }
+    if (p.sub >= 0) {
+        int32_t xs = (int32_t)p.sub;
+        bam_aux_append(b, "XS", 'i', sizeof(xs), (const uint8_t *)&xs);
+    }
+    if (bwa_rg_id[0]) {
+        bam_aux_append(b, "RG", 'Z', (int)strlen(bwa_rg_id) + 1, (const uint8_t *)bwa_rg_id);
+    }
+    if (p.alt_sc > 0) {
+        float pa_f = (float)((double)p.score / (double)p.alt_sc);
+        bam_aux_append(b, "pa", 'f', sizeof(pa_f), (const uint8_t *)&pa_f);
+    }
+    /* SA:Z (other primary hits) — mirrors mem_aln2sam */
+    if (!(p.flag & 0x100)) {
+        int has_other = 0;
+        for (int i = 0; i < n_alns; ++i)
+            if (i != which && !(list[i].flag & 0x100)) { has_other = 1; break; }
+        if (has_other) {
+            kstring_t sa = {0, 0, NULL};
+            for (int i = 0; i < n_alns; ++i) {
+                const mem_aln_t *r = &list[i];
+                if (i == which || (r->flag & 0x100)) continue;
+                kputs(bns->anns[r->rid].name, &sa); kputc(',', &sa);
+                kputl(r->pos + 1, &sa); kputc(',', &sa);
+                kputc("+-"[r->is_rev], &sa); kputc(',', &sa);
+                for (int k = 0; k < r->n_cigar; ++k) {
+                    kputw(r->cigar[k] >> 4, &sa);
+                    kputc("MIDSH"[r->cigar[k] & 0xf], &sa);
+                }
+                kputc(',', &sa); kputw(r->mapq, &sa);
+                kputc(',', &sa); kputw(r->NM, &sa);
+                kputc(';', &sa);
+            }
+            if (sa.l > 0)
+                bam_aux_append(b, "SA", 'Z', (int)sa.l + 1, (const uint8_t *)sa.s);
+            free(sa.s);
+        }
+    }
+    if (p.XA != NULL) {
+        bam_aux_append(b, "XA", 'Z', (int)strlen(p.XA) + 1, (const uint8_t *)p.XA);
+    }
+
+    /* FASTQ-carried tags (-C). mem_aln2sam appends s->comment literally to
+     * the SAM line; here we parse it as SAM-text aux tokens and emit each as
+     * a packed BAM aux so the BAM and SAM paths carry the same tags. */
+    if (s->comment != NULL && s->comment[0] != '\0') {
+        append_sam_aux_tokens(b, s->comment);
+    }
+
+    /* Reference annotation (-V / MEM_F_REF_HDR). Mirrors mem_aln2sam: emit
+     * bns->anns[p.rid].anno as XR:Z, replacing TAB with SPACE. */
+    if ((opt->flag & MEM_F_REF_HDR) && p.rid >= 0 &&
+        bns != NULL && bns->anns[p.rid].anno != NULL &&
+        bns->anns[p.rid].anno[0] != '\0') {
+        const char *anno = bns->anns[p.rid].anno;
+        size_t alen = strlen(anno);
+        char *xr = (char *)malloc(alen + 1);
+        if (xr != NULL) {
+            for (size_t i = 0; i < alen; ++i)
+                xr[i] = (anno[i] == '\t') ? ' ' : anno[i];
+            xr[alen] = '\0';
+            bam_aux_append(b, "XR", 'Z', (int)alen + 1, (const uint8_t *)xr);
+            free(xr);
+        }
+    }
+
+    return 0;
+}
+
+int bam_writer_push_aln(bseq1_t *s,
+                        const mem_opt_t *opt, const bntseq_t *bns,
+                        int n_alns, const mem_aln_t *list, int which,
+                        const mem_aln_t *m)
+{
+    if (s == NULL) return -1;
+    bam1_t *b = bam_init1();
+    if (b == NULL) return -1;
+    if (mem_aln_to_bam(b, opt, bns, s, n_alns, list, which, m) < 0) {
+        bam_destroy1(b);
+        return -1;
+    }
+    if (s->n_bams == s->cap_bams) {
+        int new_cap = s->cap_bams ? s->cap_bams * 2 : 4;
+        void **nb = (void **)realloc(s->bams, (size_t)new_cap * sizeof(void *));
+        if (nb == NULL) { bam_destroy1(b); return -1; }
+        s->bams = nb;
+        s->cap_bams = new_cap;
+    }
+    s->bams[s->n_bams++] = (void *)b;
+    return 0;
+}

--- a/src/bam_writer.h
+++ b/src/bam_writer.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef BWAMEM2_BAM_WRITER_H
+#define BWAMEM2_BAM_WRITER_H
+
+#include <stdint.h>
+#include "bwa.h"
+#include "bwamem.h"
+#include "bntseq.h"
+
+/* htslib/sam.h and bwa-mem2's kstring.h share the KSTRING_H guard, so htslib
+ * headers are only included inside src/bam_writer.cpp. Callers get a
+ * forward-declared bam1_t and opaque writer handle. */
+struct bam1_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct bam_writer_s bam_writer_t;
+
+/* Open a BAM writer at `path` ("-" for stdout). compression_level 0 = no
+ * deflate (fast, same size as SAM), 1..9 = BGZF deflate levels. @SQ is
+ * built directly from `bns->anns`. `hdr_line` carries user-supplied header
+ * lines (e.g., `@RG` from `-R` and `-H` insertions, as accumulated by
+ * bwa_insert_header); it is inserted before `@PG`. `bwa_pg` is inserted
+ * as-is. Both may be NULL. Returns NULL on failure. */
+bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
+                              const char *hdr_line, const char *bwa_pg,
+                              int compression_level);
+
+/* Write one record. Returns 0 on success, -1 on error. */
+int bam_writer_write(bam_writer_t *w, struct bam1_t *b);
+
+/* Close the writer (flushes BGZF EOF marker). Returns 0 on success. */
+int bam_writer_close(bam_writer_t *w);
+
+/* bam1_t allocation wrappers — keep htslib out of callers that can't include
+ * <htslib/sam.h> because of the kstring.h guard collision. */
+struct bam1_t *bam_writer_alloc(void);
+void           bam_writer_free(struct bam1_t *b);
+
+/* Convert a mem_aln_t to a bam1_t. Analogous to mem_aln2sam but emits a
+ * bam1_t directly with no SAM-text intermediate. Caller owns `b`. */
+int mem_aln_to_bam(struct bam1_t *b,
+                   const mem_opt_t *opt, const bntseq_t *bns,
+                   const bseq1_t *s, int n_alns,
+                   const mem_aln_t *list, int which,
+                   const mem_aln_t *m);
+
+/* Allocate a bam1_t, fill via mem_aln_to_bam, and append to s->bams. */
+int bam_writer_push_aln(bseq1_t *s,
+                        const mem_opt_t *opt, const bntseq_t *bns,
+                        int n_alns, const mem_aln_t *list, int which,
+                        const mem_aln_t *m);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/bwa.h
+++ b/src/bwa.h
@@ -59,6 +59,12 @@ typedef struct {
 typedef struct {
 	int l_seq, id;
 	char *name, *comment, *seq, *qual, *sam;
+	/* --bam output: per-read list of bam1_t* produced by the worker
+	 * instead of SAM text. Typed as void* to keep htslib out of this
+	 * header. Populated only when opt->bam_mode is set. */
+	void **bams;
+	int    n_bams;
+	int    cap_bams;
 } bseq1_t;
 
 extern int bwa_verbose;

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -31,6 +31,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "bwamem.h"
 #include "FMI_search.h"
 #include "memcpy_bwamem.h"
+#include "bam_writer.h"
 
 //----------------
 extern uint64_t tprof[LIM_R][LIM_C];
@@ -1561,10 +1562,17 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
         mem_aln_t t;
         t = mem_reg2aln(opt, bns, pac, s->l_seq, s->seq, 0);
         t.flag |= extra_flag;
-        mem_aln2sam(opt, bns, &str, s, 1, &t, 0, m);
+        if (opt->bam_mode)
+            bam_writer_push_aln(s, opt, bns, 1, &t, 0, m);
+        else
+            mem_aln2sam(opt, bns, &str, s, 1, &t, 0, m);
     } else {
-        for (k = 0; k < aa.n; ++k)
-            mem_aln2sam(opt, bns, &str, s, aa.n, aa.a, k, m);
+        for (k = 0; k < aa.n; ++k) {
+            if (opt->bam_mode)
+                bam_writer_push_aln(s, opt, bns, aa.n, aa.a, k, m);
+            else
+                mem_aln2sam(opt, bns, &str, s, aa.n, aa.a, k, m);
+        }
         for (k = 0; k < aa.n; ++k) free(aa.a[k].cigar);
         free(aa.a);
     }

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -105,6 +105,8 @@ typedef struct mem_opt_t {
     int max_matesw;         // perform maximally max_matesw rounds of mate-SW for each end
     int max_XA_hits, max_XA_hits_alt; // if there are max_hits or fewer, output them all
     int8_t mat[25];         // scoring matrix; mat[0] == 0 if unset
+    int    bam_mode;        // 1 = emit BAM instead of SAM text (--bam)
+    int    bam_level;       // 0..9, BGZF deflate level (0 = uncompressed)
 } mem_opt_t;
 
 

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -35,6 +35,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include <math.h>
 #include "kstring.h"
 #include "bwamem.h"
+#include "bam_writer.h"
 #include "kvec.h"
 #include "utils.h"
 #include "ksw.h"
@@ -563,14 +564,20 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns,
                 aa[i][n_aa[i]++] = g[i];
             }
         }
-        for (i = 0; i < n_aa[0]; ++i)
-            mem_aln2sam(opt, bns, &str, &s[0], n_aa[0], aa[0], i, &h[1]); // write read1 hits
-
-        assert(str.s != 0);
-        s[0].sam = strdup(str.s); str.l = 0;
-        for (i = 0; i < n_aa[1]; ++i)
-            mem_aln2sam(opt, bns, &str, &s[1], n_aa[1], aa[1], i, &h[0]); // write read2 hits
-        s[1].sam = str.s;
+        if (opt->bam_mode) {
+            for (i = 0; i < n_aa[0]; ++i)
+                bam_writer_push_aln(&s[0], opt, bns, n_aa[0], aa[0], i, &h[1]);
+            for (i = 0; i < n_aa[1]; ++i)
+                bam_writer_push_aln(&s[1], opt, bns, n_aa[1], aa[1], i, &h[0]);
+        } else {
+            for (i = 0; i < n_aa[0]; ++i)
+                mem_aln2sam(opt, bns, &str, &s[0], n_aa[0], aa[0], i, &h[1]); // write read1 hits
+            assert(str.s != 0);
+            s[0].sam = strdup(str.s); str.l = 0;
+            for (i = 0; i < n_aa[1]; ++i)
+                mem_aln2sam(opt, bns, &str, &s[1], n_aa[1], aa[1], i, &h[0]); // write read2 hits
+            s[1].sam = str.s;
+        }
         if (strcmp(s[0].name, s[1].name) != 0) err_fatal(__func__, "paired reads have different names: \"%s\", \"%s\"\n", s[0].name, s[1].name);
         // free
         for (i = 0; i < 2; ++i) {
@@ -940,13 +947,20 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
                 aa[i][n_aa[i]++] = g[i];
             }
         }
-        for (i = 0; i < n_aa[0]; ++i)
-            mem_aln2sam(opt, bns, &str, &s[0], n_aa[0], aa[0], i, &h[1]); // write read1 hits
-        assert(str.s != 0);
-        s[0].sam = strdup(str.s); str.l = 0;
-        for (i = 0; i < n_aa[1]; ++i)
-            mem_aln2sam(opt, bns, &str, &s[1], n_aa[1], aa[1], i, &h[0]); // write read2 hits
-        s[1].sam = str.s;
+        if (opt->bam_mode) {
+            for (i = 0; i < n_aa[0]; ++i)
+                bam_writer_push_aln(&s[0], opt, bns, n_aa[0], aa[0], i, &h[1]);
+            for (i = 0; i < n_aa[1]; ++i)
+                bam_writer_push_aln(&s[1], opt, bns, n_aa[1], aa[1], i, &h[0]);
+        } else {
+            for (i = 0; i < n_aa[0]; ++i)
+                mem_aln2sam(opt, bns, &str, &s[0], n_aa[0], aa[0], i, &h[1]);
+            assert(str.s != 0);
+            s[0].sam = strdup(str.s); str.l = 0;
+            for (i = 0; i < n_aa[1]; ++i)
+                mem_aln2sam(opt, bns, &str, &s[1], n_aa[1], aa[1], i, &h[0]);
+            s[1].sam = str.s;
+        }
         if (strcmp(s[0].name, s[1].name) != 0) err_fatal(__func__, "paired reads have different names: \"%s\", \"%s\"\n", s[0].name, s[1].name);
         // free
         for (i = 0; i < 2; ++i) {

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -36,8 +36,10 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include <numa.h>
 #endif
 #include <sstream>
+#include <getopt.h>
 #include "fastmap.h"
 #include "FMI_search.h"
+#include "bam_writer.h"
 
 #if AFF && (__linux__)
 #include <sys/sysinfo.h>
@@ -399,8 +401,14 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                                  0,
                                  w);
 
-                for (int i = 0; i < n_sep[0]; ++i)
-                    ret->seqs[sep[0][i].id].sam = sep[0][i].sam;
+                for (int i = 0; i < n_sep[0]; ++i) {
+                    bseq1_t *dst = &ret->seqs[sep[0][i].id];
+                    bseq1_t *src = &sep[0][i];
+                    dst->sam      = src->sam;      src->sam      = NULL;
+                    dst->bams     = src->bams;     src->bams     = NULL;
+                    dst->n_bams   = src->n_bams;   src->n_bams   = 0;
+                    dst->cap_bams = src->cap_bams; src->cap_bams = 0;
+                }
             }
             if (n_sep[1]) {
                 tmp_opt.flag |= MEM_F_PE;
@@ -412,8 +420,14 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                                  aux->pes0,
                                  w);
 
-                for (int i = 0; i < n_sep[1]; ++i)
-                    ret->seqs[sep[1][i].id].sam = sep[1][i].sam;
+                for (int i = 0; i < n_sep[1]; ++i) {
+                    bseq1_t *dst = &ret->seqs[sep[1][i].id];
+                    bseq1_t *src = &sep[1][i];
+                    dst->sam      = src->sam;      src->sam      = NULL;
+                    dst->bams     = src->bams;     src->bams     = NULL;
+                    dst->n_bams   = src->n_bams;   src->n_bams   = 0;
+                    dst->cap_bams = src->cap_bams; src->cap_bams = 0;
+                }
             }
             free(sep[0]); free(sep[1]);
         }
@@ -438,8 +452,27 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
 
         for (int i = 0; i < ret->n_seqs; ++i)
         {
-            if (ret->seqs[i].sam) {
-                // err_fputs(ret->seqs[i].sam, stderr);
+            if (aux->bam_writer != NULL) {
+                /* BAM path: write each accumulated bam1_t* and free. A short
+                 * write here (broken pipe, full disk, BGZF error, ...) means
+                 * downstream output is corrupt; treat it as fatal rather than
+                 * silently dropping records. */
+                for (int j = 0; j < ret->seqs[i].n_bams; ++j) {
+                    struct bam1_t *b = (struct bam1_t *)ret->seqs[i].bams[j];
+                    if (bam_writer_write(aux->bam_writer, b) < 0) {
+                        fprintf(stderr,
+                                "[bam_writer] FATAL: write failed for read '%s' "
+                                "(record %d/%d) — aborting to avoid silent "
+                                "data loss.\n",
+                                ret->seqs[i].name ? ret->seqs[i].name : "?",
+                                j + 1, ret->seqs[i].n_bams);
+                        bam_writer_free(b);
+                        exit(EXIT_FAILURE);
+                    }
+                    bam_writer_free(b);
+                }
+                free(ret->seqs[i].bams);
+            } else if (ret->seqs[i].sam) {
                 fputs(ret->seqs[i].sam, aux->fp);
             }
             free(ret->seqs[i].name); free(ret->seqs[i].comment);
@@ -679,6 +712,8 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "Options:\n");
     fprintf(stderr, "  Algorithm options:\n");
     fprintf(stderr, "    -o STR        Output SAM file name\n");
+    fprintf(stderr, "    --bam[=N]     Emit BAM instead of SAM text. N=0 (default) = uncompressed;\n");
+    fprintf(stderr, "                  1..9 = BGZF deflate levels. Writes to stdout; redirect with `>`.\n");
     fprintf(stderr, "    -t INT        number of threads [%d]\n", opt->n_threads);
     fprintf(stderr, "    -k INT        minimum seed length [%d]\n", opt->min_seed_len);
     fprintf(stderr, "    -w INT        band width for banded alignment [%d]\n", opt->w);
@@ -690,7 +725,6 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -W INT        discard a chain if seeded bases shorter than INT [0]\n");
     fprintf(stderr, "    -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
     fprintf(stderr, "    -S            skip mate rescue\n");
-    fprintf(stderr, "    -o            output file name missing\n");
     fprintf(stderr, "    -P            skip pairing; mate rescue performed unless -S also in use\n");
     fprintf(stderr, "Scoring options:\n");
     fprintf(stderr, "   -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [%d]\n", opt->a);
@@ -739,7 +773,9 @@ int main_mem(int argc, char *argv[])
     int           fd, fd2;
     mem_pestat_t  pes[4];
     ktp_aux_t     aux;
-    bool          is_o    = 0;
+    bool          is_o       = 0;
+    const char   *out_path   = NULL;   /* -o/-f path; opened lazily so --bam can claim it */
+    bool          out_opened = false;  /* true iff aux.fp is a real fopen()'d FILE* we own */
     uint8_t      *ref_string;
 
     memset(&aux, 0, sizeof(ktp_aux_t));
@@ -753,7 +789,17 @@ int main_mem(int argc, char *argv[])
 
     /* Parse input arguments */
     // comment: added option '5' in the list
-    while ((c = getopt(argc, argv, "51qpaMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:o:f:")) >= 0)
+    // --bam[=LEVEL]: emit uncompressed (or BGZF-deflated) BAM instead of SAM text.
+    //   Without the optional =LEVEL, defaults to 0 (uncompressed, near-free CPU
+    //   and ~same size as SAM but binary — parses faster by downstream tools).
+    //   Levels 1..9 trigger BGZF deflate (slower, smaller).
+    enum { OPT_BAM = 1000 };
+    static struct option long_opts[] = {
+        {"bam", optional_argument, 0, OPT_BAM},
+        {0, 0, 0, 0}
+    };
+    while ((c = getopt_long(argc, argv, "51qpaMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:o:f:",
+                            long_opts, NULL)) >= 0)
     {
         if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
         else if (c == '1') no_mt_io = 1;
@@ -768,13 +814,11 @@ int main_mem(int argc, char *argv[])
             opt->n_threads = atoi(optarg), opt->n_threads = opt->n_threads > 1? opt->n_threads : 1, assert(opt->n_threads >= INT_MIN && opt->n_threads <= INT_MAX);
         else if (c == 'o' || c == 'f')
         {
+            /* Capture the path; defer opening until after --bam is parsed so
+             * BAM mode can hand the path to htslib instead of truncating it
+             * here as a SAM-text FILE*. */
             is_o = 1;
-            aux.fp = fopen(optarg, "w");
-            if (aux.fp == NULL) {
-                fprintf(stderr, "Error: can't open %s input file\n", optarg);
-                exit(EXIT_FAILURE);
-            }
-            /*fclose(aux.fp);*/
+            out_path = optarg;
         }
         else if (c == 'P') opt->flag |= MEM_F_NOPAIRING;
         else if (c == 'a') opt->flag |= MEM_F_ALL;
@@ -843,7 +887,7 @@ int main_mem(int argc, char *argv[])
         {
             if ((rg_line = bwa_set_rg(optarg)) == 0) {
                 free(opt);
-                if (is_o)
+                if (out_opened)
                     fclose(aux.fp);
                 return 1;
             }
@@ -870,6 +914,20 @@ int main_mem(int argc, char *argv[])
                 }
             } else hdr_line = bwa_insert_header(optarg, hdr_line);
         }
+        else if (c == OPT_BAM) {
+            opt->bam_mode = 1;
+            opt->bam_level = 0;
+            if (optarg != NULL && optarg[0] != '\0') {
+                int lvl = atoi(optarg);
+                if (lvl < 0 || lvl > 9) {
+                    fprintf(stderr, "ERROR: --bam level must be 0..9 (got '%s')\n", optarg);
+                    free(opt);
+                    if (out_opened) fclose(aux.fp);
+                    return 1;
+                }
+                opt->bam_level = lvl;
+            }
+        }
         else if (c == 'I')
         {
             aux.pes0 = pes;
@@ -888,7 +946,7 @@ int main_mem(int argc, char *argv[])
         }
         else {
             free(opt);
-            if (is_o)
+            if (out_opened)
                 fclose(aux.fp);
             return 1;
         }
@@ -905,7 +963,7 @@ int main_mem(int argc, char *argv[])
     if (optind + 2 != argc && optind + 3 != argc) {
         usage(opt);
         free(opt);
-        if (is_o)
+        if (out_opened)
             fclose(aux.fp);
         return 1;
     }
@@ -949,7 +1007,7 @@ int main_mem(int argc, char *argv[])
         {
             fprintf(stderr, "[E::%s] unknown read type '%s'\n", __func__, mode);
             free(opt);
-            if (is_o)
+            if (out_opened)
                 fclose(aux.fp);
             return 1;
         }
@@ -1009,7 +1067,7 @@ int main_mem(int argc, char *argv[])
 	if (ko == 0) {
 		fprintf(stderr, "[E::%s] fail to open file `%s'.\n", __func__, argv[optind + 1]);
         free(opt);
-        if (is_o)
+        if (out_opened)
             fclose(aux.fp);
         delete aux.fmi;
         // kclose(ko);
@@ -1036,7 +1094,7 @@ int main_mem(int argc, char *argv[])
                 free(ko);
                 err_gzclose(fp);
                 kseq_destroy(aux.ks);
-                if (is_o)
+                if (out_opened)
                     fclose(aux.fp);
                 delete aux.fmi;
                 kclose(ko);
@@ -1051,7 +1109,39 @@ int main_mem(int argc, char *argv[])
         }
     }
 
-    bwa_print_sam_hdr(aux.fmi->idx->bns, hdr_line, aux.fp);
+    /* Output header:
+     *  - SAM text: open -o/-f path (if any) as a FILE* now and run
+     *    bwa_print_sam_hdr to it; otherwise write to stdout.
+     *  - BAM: hand the -o/-f path (or "-" for stdout) directly to htslib;
+     *    bam_writer_open writes its own @HD + @SQ + @PG header. aux.fp is
+     *    left as stdout and unused in this branch. */
+    bam_writer_t *bam_writer = NULL;
+    if (opt->bam_mode) {
+        const char *bam_path = is_o ? out_path : "-";
+        extern char *bwa_pg;
+        bam_writer = bam_writer_open(bam_path, aux.fmi->idx->bns, hdr_line,
+                                     bwa_pg, opt->bam_level);
+        if (bam_writer == NULL) {
+            fprintf(stderr, "ERROR: failed to open BAM writer at '%s'\n", bam_path);
+            free(opt);
+            delete aux.fmi;
+            return 1;
+        }
+        aux.bam_writer = bam_writer;
+    } else {
+        aux.bam_writer = NULL;
+        if (is_o) {
+            aux.fp = fopen(out_path, "w");
+            if (aux.fp == NULL) {
+                fprintf(stderr, "Error: can't open %s output file\n", out_path);
+                free(opt);
+                delete aux.fmi;
+                return 1;
+            }
+            out_opened = true;
+        }
+        bwa_print_sam_hdr(aux.fmi->idx->bns, hdr_line, aux.fp);
+    }
 
     if (fixed_chunk_size > 0)
         aux.task_size = fixed_chunk_size;
@@ -1082,8 +1172,14 @@ int main_mem(int argc, char *argv[])
         err_gzclose(fp2); kclose(ko2);
     }
 
-    if (is_o) {
+    if (out_opened) {
         fclose(aux.fp);
+    }
+
+    if (bam_writer != NULL) {
+        if (bam_writer_close(bam_writer) != 0)
+            fprintf(stderr, "[bam_writer] WARNING: close returned non-zero\n");
+        aux.bam_writer = NULL;
     }
 
     // new bwt/FMI

--- a/src/fastmap.h
+++ b/src/fastmap.h
@@ -52,6 +52,9 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 
 KSEQ_DECLARE(gzFile)
 
+/* Forward-declared — keeps htslib out of this header. */
+struct bam_writer_s;
+
 typedef struct {
 	kseq_t *ks, *ks2;
 	mem_opt_t *opt;
@@ -64,7 +67,8 @@ typedef struct {
 	int64_t actual_chunk_size;
 	FILE *fp;
 	uint8_t *ref_string;
-	FMI_search *fmi;	
+	FMI_search *fmi;
+	struct bam_writer_s *bam_writer;  /* non-NULL when opt->bam_mode is set */
 } ktp_aux_t;
 
 typedef struct {


### PR DESCRIPTION
## Summary

Adds `--bam[=LEVEL]` to `bwa-mem2 mem` for direct BAM emission via htslib,
bypassing the SAM-text-then-convert round trip.

- `--bam` (no arg or `=0`): uncompressed BAM (BGZF framing only) — near-free CPU,
  smaller than SAM, fast downstream parsing
- `--bam=1..9`: BGZF deflate at that level
- no flag: SAM text on stdout (default, unchanged)

## Implementation

- `src/bam_writer.{h,cpp}` — new module owning htslib lifecycle. Converts
  `mem_aln_t` → `bam1_t` via `mem_aln_to_bam()` (structural sibling of
  `mem_aln2sam`: same fields, same aux tags, same semantics).
- `bseq1_t` gains per-read `bams`/`n_bams`/`cap_bams` fields for worker
  accumulation; `mem_opt_t` gains `bam_mode`/`bam_level`.
- `mem_reg2sam` (SE) and both PE emit sites in `bwamem_pair.cpp` route to
  `bam_writer_push_aln` vs `mem_aln2sam` on `opt->bam_mode`.
- `fastmap.cpp` opens the writer once, stashes it on `ktp_aux_t`, step-2
  writes accumulated `bam1_t` per seq via `sam_write1`.
- htslib v1.21 pulled in as a submodule at `ext/htslib` with a minimal
  configure (no lzma/bz2/curl/S3/GCS/plugins; zlib only — already required).

## Verification

Against bwa-meth `example/` fixture (92,961 records):

| mode | size |
|---|---|
| SAM text | 27.2 MB |
| `--bam` (uncompressed BAM) | 23.6 MB |
| `--bam=6` | 6.9 MB |

`samtools view` of `--bam` output vs SAM text: **0-line diff** across all 11
SAM columns plus NM/MD/MC/AS/XS/SA/XA/pa aux tags.

## Test plan

- [ ] `make` from clean checkout (submodule auto-init via `git submodule update --init --recursive`)
- [ ] `bwa-mem2 mem ref.fa R1.fq R2.fq > sam.sam` and
      `bwa-mem2 mem --bam ref.fa R1.fq R2.fq > bam.bam` produce byte-for-byte
      equivalent records (`diff <(samtools view bam.bam) <(grep -v ^@ sam.sam)`)
- [ ] `--bam=6` produces valid BGZF-compressed BAM readable by samtools/htsjdk
- [ ] CI passes on fg-main after rebase

## Notes

- `-o`/`-f` is currently ignored in `--bam` mode (emits to stdout; redirect
  with `>`). Path-aware BAM output is a natural follow-up.
- This PR is the foundation for a stacked `--meth` PR (bisulfite post-
  processing overlay) that reuses this BAM emission path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native BAM output mode (--bam[=N]) with selectable BGZF compression level (0–9)
  * Emit BAM to file or stdout with automatic BAM header emission
  * Per-read accumulation and correct emission of paired/supplementary BAM records
  * Integrated HTSlib-based BAM writing for native BAM creation

* **Chores**
  * CI now installs autoconf/automake to support the integrated build steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->