### PR TITLE
perf(fmi): madvise hugepages for FM-index and SA

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -28,12 +28,73 @@ Authors: Sanchit Misra <sanchit.misra@intel.com>; Vasimuddin Md <vasimuddin.md@i
 *****************************************************************************************/
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#if defined(__linux__)
+#include <sys/mman.h>
+#endif
 #include "sais.h"
 #include "FMI_search.h"
 #include "memcpy_bwamem.h"
 #include "profiling.h"
 
 #include "safestringlib.h"
+
+// ---------------------------------------------------------------------------
+// Huge-page allocation helpers for the FM-index hot regions.
+//
+// The FM-index's cp_occ (checkpoint blocks) and suffix-array arrays (sa_ms_byte
+// / sa_ls_word) are multi-GB on whole-genome references and accessed in a
+// near-random pattern during seeding. That pattern thrashes the TLB at the
+// default 4 KiB page size. Aligning the allocation to 2 MiB and advising the
+// kernel with MADV_HUGEPAGE lets transparent huge pages (THP) promote these
+// regions on demand, reducing TLB misses by ~512x.
+//
+// The madvise call is a hint only — if THP is disabled or unsupported the
+// allocation still works, we just don't get the speedup. On non-Linux
+// platforms (macOS / FreeBSD) MADV_HUGEPAGE does not exist, so we fall back
+// to the standard _mm_malloc / _mm_free path to keep the code portable.
+// ---------------------------------------------------------------------------
+
+// Use 2 MiB alignment (x86_64 and aarch64 THP size) when the region is large
+// enough to benefit; below this threshold we'd just waste memory on padding.
+#define FMI_HUGEPAGE_ALIGN  (2ULL * 1024ULL * 1024ULL)
+#define FMI_HUGEPAGE_THRESH (2ULL * 1024ULL * 1024ULL)
+
+static void *fmi_alloc_hugepage(size_t size)
+{
+#if defined(__linux__)
+    void *ptr = NULL;
+    // Round size up to the alignment so madvise covers the full mapping.
+    size_t rounded = (size + FMI_HUGEPAGE_ALIGN - 1) &
+                     ~(FMI_HUGEPAGE_ALIGN - 1);
+    int rc = posix_memalign(&ptr, FMI_HUGEPAGE_ALIGN, rounded);
+    if (rc != 0 || ptr == NULL) {
+        errno = rc;
+        return NULL;
+    }
+    // madvise is a hint; ignore failures (e.g. THP disabled system-wide)
+    // or when size is below the kernel's effective hugepage threshold.
+    if (size >= FMI_HUGEPAGE_THRESH) {
+        (void)madvise(ptr, rounded, MADV_HUGEPAGE);
+    }
+    return ptr;
+#else
+    // Fallback on non-Linux (macOS / FreeBSD): standard 64-byte aligned.
+    return _mm_malloc(size, 64);
+#endif
+}
+
+static void fmi_free_hugepage(void *ptr)
+{
+    if (ptr == NULL) return;
+#if defined(__linux__)
+    // posix_memalign pairs with free().
+    free(ptr);
+#else
+    _mm_free(ptr);
+#endif
+}
 
 FMI_search::FMI_search(const char *fname)
 {
@@ -51,12 +112,14 @@ FMI_search::FMI_search(const char *fname)
 
 FMI_search::~FMI_search()
 {
+    // sa_ms_byte / sa_ls_word / cp_occ are allocated via fmi_alloc_hugepage
+    // in load_index(); free via the matching helper.
     if(sa_ms_byte)
-        _mm_free(sa_ms_byte);
+        fmi_free_hugepage(sa_ms_byte);
     if(sa_ls_word)
-        _mm_free(sa_ls_word);
+        fmi_free_hugepage(sa_ls_word);
     if(cp_occ)
-        _mm_free(cp_occ);
+        fmi_free_hugepage(cp_occ);
     if(one_hot_mask_array)
         _mm_free(one_hot_mask_array);
 }
@@ -417,7 +480,7 @@ void FMI_search::load_index()
     cp_occ = NULL;
 
     err_fread_noeof(&count[0], sizeof(int64_t), 5, cpstream);
-    if ((cp_occ = (CP_OCC *)_mm_malloc(cp_occ_size * sizeof(CP_OCC), 64)) == NULL) {
+    if ((cp_occ = (CP_OCC *)fmi_alloc_hugepage(cp_occ_size * sizeof(CP_OCC))) == NULL) {
         fprintf(stderr, "ERROR! unable to allocated cp_occ memory\n");
         exit(EXIT_FAILURE);
     }
@@ -432,15 +495,19 @@ void FMI_search::load_index()
     #if SA_COMPRESSION
 
     int64_t reference_seq_len_ = (reference_seq_len >> SA_COMPX) + 1;
-    sa_ms_byte = (int8_t *)_mm_malloc(reference_seq_len_ * sizeof(int8_t), 64);
-    sa_ls_word = (uint32_t *)_mm_malloc(reference_seq_len_ * sizeof(uint32_t), 64);
+    sa_ms_byte = (int8_t *)fmi_alloc_hugepage(reference_seq_len_ * sizeof(int8_t));
+    sa_ls_word = (uint32_t *)fmi_alloc_hugepage(reference_seq_len_ * sizeof(uint32_t));
+    assert_not_null(sa_ms_byte, reference_seq_len_ * sizeof(int8_t), index_alloc);
+    assert_not_null(sa_ls_word, reference_seq_len_ * sizeof(uint32_t), index_alloc);
     err_fread_noeof(sa_ms_byte, sizeof(int8_t), reference_seq_len_, cpstream);
     err_fread_noeof(sa_ls_word, sizeof(uint32_t), reference_seq_len_, cpstream);
-    
+
     #else
-    
-    sa_ms_byte = (int8_t *)_mm_malloc(reference_seq_len * sizeof(int8_t), 64);
-    sa_ls_word = (uint32_t *)_mm_malloc(reference_seq_len * sizeof(uint32_t), 64);
+
+    sa_ms_byte = (int8_t *)fmi_alloc_hugepage(reference_seq_len * sizeof(int8_t));
+    sa_ls_word = (uint32_t *)fmi_alloc_hugepage(reference_seq_len * sizeof(uint32_t));
+    assert_not_null(sa_ms_byte, reference_seq_len * sizeof(int8_t), index_alloc);
+    assert_not_null(sa_ls_word, reference_seq_len * sizeof(uint32_t), index_alloc);
     err_fread_noeof(sa_ms_byte, sizeof(int8_t), reference_seq_len, cpstream);
     err_fread_noeof(sa_ls_word, sizeof(uint32_t), reference_seq_len, cpstream);
 


### PR DESCRIPTION
## Summary

Enables transparent huge pages (THP) for the FM-index hot regions to reduce TLB pressure on the ~4 GB random-access structures used during seeding. This is draft PR A of a three-PR performance push.

The change routes allocation of `cp_occ` (checkpoint blocks), `sa_ms_byte`, and `sa_ls_word` (suffix array split) through a helper that, on Linux, aligns the allocation to 2 MiB (`posix_memalign`) and calls `madvise(ptr, rounded_size, MADV_HUGEPAGE)` on the resulting mapping. The kernel's `khugepaged` thread then promotes these regions on demand to 2 MiB pages.

## Regions advised

- `cp_occ` (CP_OCC[]) - checkpoint blocks, ~1 GB on hs38 (primary hot region in SMEM loop)
- `sa_ms_byte` (int8_t[]) - suffix-array high byte, ~1 GB
- `sa_ls_word` (uint32_t[]) - suffix-array low 32 bits, ~4 GB

The BWT itself is not loaded at runtime in bwa-mem2 (the 2bit.64 checkpointed representation replaces raw BWT). The `count[5]` array is tiny and stays on stack-like allocation. The `.pac` sequence is loaded by bntseq and is lower priority - deferred to a follow-up.

## Platform gating

- `__linux__` path: `posix_memalign(2 MiB)` + `madvise(MADV_HUGEPAGE)`, freed via `free()`.
- Non-Linux (macOS, FreeBSD): falls back to existing `_mm_malloc` / `_mm_free`.
- `madvise` failure is silently ignored (e.g. THP set to \"never\" system-wide) - this is a hint, not a hard requirement, so no reserved hugepages needed.

## Parity status

Ran the CI's dwgsim parity test locally on macOS arm64:

- Reference: phiX174, 5386 bp
- `dwgsim -z 42 -N 500 -1 150 -2 150 -r 0.001 -S 2` (identical flags to CI)
- Compared bwa 0.7.19 vs bwa-mem2 (this branch) after stripping `@PG` / `@HD` headers and `MQ:i:` tags
- Result: **byte-identical**

CI will validate the same comparison on Linux x86_64 (SSE4.1, AVX2), Linux aarch64, and macOS aarch64. The code path on macOS exercises the fallback branch only; the hugepage path is exercised on Linux jobs.

## Benchmarks

Deferred. Expected 3-5% wall-clock on whole-genome alignment based on TLB-miss reduction from 4 KiB -> 2 MiB pages over a ~4 GB working set. Will benchmark on the c7g.4xlarge (Graviton3, aarch64) and follow up on this PR with numbers before marking ready.

## Known limitations / TODOs

- `MADV_HUGEPAGE` requires THP mode `madvise` or `always` on the host. On `never`, this PR is a no-op (but also harmless).
- 2 MiB round-up adds up to ~2 MiB of virtual-address waste per allocation - negligible against multi-GB sizes.
- The helper uses a static file-scope function pair; if other hot allocations emerge (e.g. the .pac sequence in bntseq), the helper should graduate to a shared utility header.
- Only `load_index()` is instrumented. The transient `cp_occ` buffer in `build_index()` is short-lived (write-then-free) and not worth advising.