### PR TITLE
perf(seed): batch SMEM extension across reads with prefetch and SIMD occ

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -676,7 +676,7 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                          int64_t *__numTotalSmem)
 {
     int16_t *query_pos_array = (int16_t *)_mm_malloc(numReads * sizeof(int16_t), 64);
-    
+
     int32_t i;
     for(i = 0; i < numReads; i++)
         query_pos_array[i] = 0;
@@ -696,9 +696,23 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                 rid_array[tail] = rid_array[head];
                 query_pos_array[tail] = query_pos_array[head];
                 min_intv_array[tail] = min_intv_array[head];
-                tail++;             
-            }               
+                tail++;
+            }
         }
+#if SMEM_BATCH_SIZE > 1
+        getSMEMsOnePosOneThread_batch(enc_qdb,
+                                      query_pos_array,
+                                      min_intv_array,
+                                      rid_array,
+                                      tail,
+                                      batch_size,
+                                      seq_,
+                                      query_cum_len_ar,
+                                      max_readlength,
+                                      minSeedLen,
+                                      matchArray,
+                                      __numTotalSmem);
+#else
         getSMEMsOnePosOneThread(enc_qdb,
                                 query_pos_array,
                                 min_intv_array,
@@ -711,10 +725,248 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                 minSeedLen,
                                 matchArray,
                                 __numTotalSmem);
+#endif
         numActive = tail;
     } while(numActive > 0);
 
     _mm_free(query_pos_array);
+}
+
+/*
+ * Batched variant of getSMEMsOnePosOneThread.
+ *
+ * Correctness: per-read computation is bit-identical to the scalar path; we
+ * only alter the prefetch pattern so cache-line fetches of cp_occ for reads
+ * i+1..i+SMEM_BATCH_SIZE-1 overlap with the compute-bound walk of read i.
+ * Writes into matchArray are in the same (read-major, seed-minor) order as
+ * the scalar path.
+ */
+void FMI_search::getSMEMsOnePosOneThread_batch(uint8_t *enc_qdb,
+                                               int16_t *query_pos_array,
+                                               int32_t *min_intv_array,
+                                               int32_t *rid_array,
+                                               int32_t numReads,
+                                               int32_t batch_size,
+                                               const bseq1_t *seq_,
+                                               int32_t *query_cum_len_ar,
+                                               int32_t max_readlength,
+                                               int32_t minSeedLen,
+                                               SMEM *matchArray,
+                                               int64_t *__numTotalSmem)
+{
+    int64_t numTotalSmem = *__numTotalSmem;
+    SMEM prevArray[max_readlength];
+
+#ifdef ENABLE_PREFETCH
+    /* Pre-prime: prefetch the initial cp_occ cache lines for the first
+     * SMEM_BATCH_SIZE reads. For read i, the starting bounds feed
+     * backwardExt(smem, 3-a) where smem.k = count[a], smem.l = count[3-a],
+     * smem.s = count[a+1]-count[a]. The first GET_OCC touches
+     * cp_occ[smem.k >> CP_SHIFT] and cp_occ[(smem.k+smem.s) >> CP_SHIFT]
+     * (i.e. cp_occ[count[a] >> CP_SHIFT] and cp_occ[count[a+1] >> CP_SHIFT]).
+     * The l-side (on the reverse-complement BWT) mirrors with count[3-a].
+     * Since count[] is small we simply prefetch both k and l planes. */
+    {
+        int32_t prime_upto = numReads < SMEM_BATCH_SIZE ? numReads : SMEM_BATCH_SIZE;
+        for(int32_t p = 0; p < prime_upto; p++)
+        {
+            int32_t rid_p = rid_array[p];
+            int x_p = query_pos_array[p];
+            int32_t offset_p = query_cum_len_ar[rid_p];
+            uint8_t a_p = enc_qdb[offset_p + x_p];
+            if(a_p < 4)
+            {
+                int64_t k0 = count[a_p];
+                int64_t k1 = count[a_p + 1];
+                int64_t l0 = count[3 - a_p];
+                int64_t l1 = count[3 - a_p + 1];
+                _mm_prefetch((const char *)(&cp_occ[k0 >> CP_SHIFT]), _MM_HINT_T0);
+                _mm_prefetch((const char *)(&cp_occ[k1 >> CP_SHIFT]), _MM_HINT_T0);
+                _mm_prefetch((const char *)(&cp_occ[l0 >> CP_SHIFT]), _MM_HINT_T0);
+                _mm_prefetch((const char *)(&cp_occ[l1 >> CP_SHIFT]), _MM_HINT_T0);
+            }
+        }
+    }
+#endif
+
+    uint32_t i;
+    // Perform SMEM for original reads
+    for(i = 0; i < numReads; i++)
+    {
+#ifdef ENABLE_PREFETCH
+        /* Slide the prefetch window forward: for read (i + SMEM_BATCH_SIZE),
+         * issue the same starting-position prefetches we primed above so that
+         * by the time the outer loop reaches it the cp_occ lines are warm. */
+        {
+            int32_t la = i + SMEM_BATCH_SIZE;
+            if((uint32_t)la < numReads)
+            {
+                int32_t rid_la = rid_array[la];
+                int x_la = query_pos_array[la];
+                int32_t offset_la = query_cum_len_ar[rid_la];
+                uint8_t a_la = enc_qdb[offset_la + x_la];
+                if(a_la < 4)
+                {
+                    int64_t k0 = count[a_la];
+                    int64_t k1 = count[a_la + 1];
+                    int64_t l0 = count[3 - a_la];
+                    int64_t l1 = count[3 - a_la + 1];
+                    _mm_prefetch((const char *)(&cp_occ[k0 >> CP_SHIFT]), _MM_HINT_T0);
+                    _mm_prefetch((const char *)(&cp_occ[k1 >> CP_SHIFT]), _MM_HINT_T0);
+                    _mm_prefetch((const char *)(&cp_occ[l0 >> CP_SHIFT]), _MM_HINT_T0);
+                    _mm_prefetch((const char *)(&cp_occ[l1 >> CP_SHIFT]), _MM_HINT_T0);
+                }
+            }
+        }
+#endif
+
+        int x = query_pos_array[i];
+        int32_t rid = rid_array[i];
+        int next_x = x + 1;
+
+        int readlength = seq_[rid].l_seq;
+        int offset = query_cum_len_ar[rid];
+        uint8_t a = enc_qdb[offset + x];
+
+        if(a < 4)
+        {
+            SMEM smem;
+            smem.rid = rid;
+            smem.m = x;
+            smem.n = x;
+            smem.k = count[a];
+            smem.l = count[3 - a];
+            smem.s = count[a+1] - count[a];
+            int numPrev = 0;
+
+            int j;
+            for(j = x + 1; j < readlength; j++)
+            {
+                a = enc_qdb[offset + j];
+                next_x = j + 1;
+                if(a < 4)
+                {
+                    SMEM smem_ = smem;
+
+                    // Forward extension is backward extension with the BWT of reverse complement
+                    smem_.k = smem.l;
+                    smem_.l = smem.k;
+                    SMEM newSmem_ = backwardExt(smem_, 3 - a);
+                    SMEM newSmem = newSmem_;
+                    newSmem.k = newSmem_.l;
+                    newSmem.l = newSmem_.k;
+                    newSmem.n = j;
+
+                    int32_t s_neq_mask = newSmem.s != smem.s;
+
+                    prevArray[numPrev] = smem;
+                    numPrev += s_neq_mask;
+                    if(newSmem.s < min_intv_array[i])
+                    {
+                        next_x = j;
+                        break;
+                    }
+                    smem = newSmem;
+#ifdef ENABLE_PREFETCH
+                    _mm_prefetch((const char *)(&cp_occ[(smem.k) >> CP_SHIFT]), _MM_HINT_T0);
+                    _mm_prefetch((const char *)(&cp_occ[(smem.l) >> CP_SHIFT]), _MM_HINT_T0);
+#endif
+                }
+                else
+                {
+                    break;
+                }
+            }
+            if(smem.s >= min_intv_array[i])
+            {
+                prevArray[numPrev] = smem;
+                numPrev++;
+            }
+
+            SMEM *prev;
+            prev = prevArray;
+
+            int p;
+            for(p = 0; p < (numPrev/2); p++)
+            {
+                SMEM temp = prev[p];
+                prev[p] = prev[numPrev - p - 1];
+                prev[numPrev - p - 1] = temp;
+            }
+
+            // Backward search
+            int cur_j = readlength;
+            for(j = x - 1; j >= 0; j--)
+            {
+                int numCurr = 0;
+                int curr_s = -1;
+                a = enc_qdb[offset + j];
+
+                if(a > 3)
+                {
+                    break;
+                }
+                for(p = 0; p < numPrev; p++)
+                {
+                    SMEM smem = prev[p];
+                    SMEM newSmem = backwardExt(smem, a);
+                    newSmem.m = j;
+
+                    if((newSmem.s < min_intv_array[i]) && ((smem.n - smem.m + 1) >= minSeedLen))
+                    {
+                        cur_j = j;
+
+                        matchArray[numTotalSmem++] = smem;
+                        break;
+                    }
+                    if((newSmem.s >= min_intv_array[i]) && (newSmem.s != curr_s))
+                    {
+                        curr_s = newSmem.s;
+                        prev[numCurr++] = newSmem;
+#ifdef ENABLE_PREFETCH
+                        _mm_prefetch((const char *)(&cp_occ[(newSmem.k) >> CP_SHIFT]), _MM_HINT_T0);
+                        _mm_prefetch((const char *)(&cp_occ[(newSmem.k + newSmem.s) >> CP_SHIFT]), _MM_HINT_T0);
+#endif
+                        break;
+                    }
+                }
+                p++;
+                for(; p < numPrev; p++)
+                {
+                    SMEM smem = prev[p];
+
+                    SMEM newSmem = backwardExt(smem, a);
+                    newSmem.m = j;
+
+                    if((newSmem.s >= min_intv_array[i]) && (newSmem.s != curr_s))
+                    {
+                        curr_s = newSmem.s;
+                        prev[numCurr++] = newSmem;
+#ifdef ENABLE_PREFETCH
+                        _mm_prefetch((const char *)(&cp_occ[(newSmem.k) >> CP_SHIFT]), _MM_HINT_T0);
+                        _mm_prefetch((const char *)(&cp_occ[(newSmem.k + newSmem.s) >> CP_SHIFT]), _MM_HINT_T0);
+#endif
+                    }
+                }
+                numPrev = numCurr;
+                if(numCurr == 0)
+                {
+                    break;
+                }
+            }
+            if(numPrev != 0)
+            {
+                SMEM smem = prev[0];
+                if(((smem.n - smem.m + 1) >= minSeedLen))
+                {
+                    matchArray[numTotalSmem++] = smem;
+                }
+                numPrev = 0;
+            }
+        }
+        query_pos_array[i] = next_x;
+    }
+    (*__numTotalSmem) = numTotalSmem;
 }
 
 int64_t FMI_search::bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -90,6 +90,15 @@ typedef struct smem_struct
 
 #define SAL_PFD 16
 
+/* Batch size for cross-read prefetch in SMEM extension. Each "read slot" in
+ * the batch contributes ~2 prefetches per step; a small window (8) is enough
+ * to keep the L1/L2 pipeline busy without blowing out the prefetch queue or
+ * evicting useful lines. Set to 1 to disable batched prefetch and fall back
+ * to the per-read scalar path. */
+#ifndef SMEM_BATCH_SIZE
+#define SMEM_BATCH_SIZE 8
+#endif
+
 class FMI_search: public indexEle
 {
     public:
@@ -121,7 +130,26 @@ class FMI_search: public indexEle
                                  int32_t minSeedLen,
                                  SMEM *matchArray,
                                  int64_t *__numTotalSmem);
-    
+
+    /* Batched variant of getSMEMsOnePosOneThread: per-read algorithm is
+     * byte-identical to the scalar path, but the outer loop pipelines the
+     * cp_occ cache-line fetches across a window of up to SMEM_BATCH_SIZE
+     * reads. The extension work itself is still scalar; only the prefetch
+     * pattern changes. Output in matchArray is written in the same
+     * (read, smem) order as the scalar path. */
+    void getSMEMsOnePosOneThread_batch(uint8_t *enc_qdb,
+                                       int16_t *query_pos_array,
+                                       int32_t *min_intv_array,
+                                       int32_t *rid_array,
+                                       int32_t numReads,
+                                       int32_t batch_size,
+                                       const bseq1_t *seq_,
+                                       int32_t *query_cum_len_ar,
+                                       int32_t  max_readlength,
+                                       int32_t minSeedLen,
+                                       SMEM *matchArray,
+                                       int64_t *__numTotalSmem);
+
     void getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                  int32_t *min_intv_array,
                                  int32_t *rid_array,

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -738,6 +738,20 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
     }
     #endif
     
+#if SMEM_BATCH_SIZE > 1
+    fmi->getSMEMsOnePosOneThread_batch(enc_qdb,
+                                       query_pos_ar,
+                                       min_intv_ar,
+                                       rid,
+                                       pos,
+                                       pos,
+                                       seq_,
+                                       query_cum_len_ar,
+                                       max_readlength,
+                                       opt->min_seed_len,
+                                       matchArray + num_smem1,
+                                       &num_smem2);
+#else
     fmi->getSMEMsOnePosOneThread(enc_qdb,
                                  query_pos_ar,
                                  min_intv_ar,
@@ -750,6 +764,7 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
                                  opt->min_seed_len,
                                  matchArray + num_smem1,
                                  &num_smem2);
+#endif
     // assert(mmc->wsize_mem[tid] > (num_smem1 + num_smem2));
     // fprintwsize_mem_rf(stderr, "num_smem2: %d\n", num_smem2);
     if (opt->max_mem_intv > 0)


### PR DESCRIPTION
## Summary

Batches the SMEM extension inner loop across a sliding window of reads
so that the cp_occ cache-line fetches for read *i + N* overlap with the
compute-bound walk of read *i*. The per-read algorithm is left
**bit-identical** to the scalar path; only the prefetch pattern
changes.

Draft PR B of a three-PR perf push.

## What landed

- **Scope (1): cross-read batched prefetch** — landed.
  - New `FMI_search::getSMEMsOnePosOneThread_batch` in `src/FMI_search.cpp` / `src/FMI_search.h` with a tunable `SMEM_BATCH_SIZE` (default 8, set at compile time via `-DSMEM_BATCH_SIZE=N`; `1` falls back to the scalar path).
  - Prefetch window: before each outer iteration the function issues `_mm_prefetch(_MM_HINT_T0)` on the four initial `cp_occ` planes (k-start, k-end, l-start, l-end) for read `i + SMEM_BATCH_SIZE`. The first `SMEM_BATCH_SIZE` reads are primed with an explicit pre-loop fetch.
  - `FMI_search::getSMEMsAllPosOneThread` and the direct call site in `src/bwamem.cpp` (`mem_kernel1_core`) dispatch to the `_batch` variant when `SMEM_BATCH_SIZE > 1`.
  - Existing per-step `#ifdef ENABLE_PREFETCH` hints are preserved; new prefetches are additive.

- **Scope (2): SIMD `GET_OCC` across the batch** — **not landed**. See TODO below.

## Design notes

The brief suggested true lockstep batching across the per-read body, with per-read state kept alive and advanced in parallel. I chose a more conservative shape for this draft:

- The per-read body is a byte-for-byte clone of `getSMEMsOnePosOneThread`, so any parity failure is bisectable to the prefetch hoisting alone.
- Cross-read overlap comes from issuing starting-position prefetches for the *upcoming* reads in the window; this keeps the L1/L2 pipeline busy without restructuring the inner loops.
- Because writes into `matchArray` and `numTotalSmem` happen from within the unchanged per-read body, output ordering is trivially preserved.

Trade-off: this gives up some of the potential speedup of true lockstep (peak ~2.5x per the brief) in exchange for a smaller parity surface. Follow-up PR could restructure to per-read state slots inside the batch window and interleave the inner `backwardExt` calls to recover the rest.

## Parity

Validated locally on macOS arm64:

- `dwgsim -z 42 -N 500 -1 150 -2 150 -r 0.001 -S 2` on phiX174.
- Normalized SAM (strip `@PG`/`@HD`, drop `MQ:i:`, sort) is byte-identical between:
  - upstream `bwa mem` (0.7.19-r1273),
  - this tree with default `SMEM_BATCH_SIZE=8`,
  - this tree rebuilt with `-DSMEM_BATCH_SIZE=1` (scalar fallback).
- All three agree (`diff` exit 0, 1000 aligned records each).

CI runs the same dwgsim-based parity test on Linux x86_64 (SSE4.1, AVX2) and Linux ARM64 in addition to macOS ARM64 — the canonical validation for the x86 paths.

## Build status per arch

- macOS arm64 (`make`): builds clean, parity passes.
- Linux x86_64 AVX2 (`make arch=avx2`): **not built locally** (cross-compile from macOS arm64 not supported by this Makefile). CI will validate; no AVX2-specific code was added, only additional `_mm_prefetch` calls which map to `__builtin_prefetch` on ARM via `simd_compat.h` and are native on x86.
- Linux ARM64 (`make`): same code path as macOS arm64, CI will validate.

## Known limitations / TODOs

- **TODO(perf): land SIMD `GET_OCC`**. The brief's scope (2) — SIMD popcount across 8 match-masks via `_mm512_popcnt_epi64` / NEON `vcntq_u8` — was skipped this round because the conservative prefetch-window shape (scope 1) does not expose N simultaneous `match_mask` uint64s at a single vectorization point. Delivering (2) cleanly requires restructuring to true lockstep batching (per-read state slots advanced in parallel) first; that restructure also un-stalls the inner `backwardExt` dependency chain, so the two optimizations are naturally paired in a follow-up.
- **TODO(perf): true lockstep batching**. The current shape leaves ~room between the prefetch and the consume; a version that keeps per-read SMEM state in an AoS/SoA batch buffer and interleaves `backwardExt` calls would widen the overlap window and enable (2).
- **TODO(bench): measure on Graviton c7g**. The user's benchmark target is c7g.4xlarge; local macOS-arm64 correctness run confirms parity but not the headline speedup.

## Test plan

- [ ] CI dwgsim parity test passes on all four matrix targets (Linux x86_64 SSE4.1, Linux x86_64 AVX2, Linux ARM64, macOS ARM64).
- [ ] Follow-up benchmarking run on c7g.4xlarge against the 29M-pair agilent-hs2 dataset.