### PR TITLE
build(make): add explicit arch=avx512bw target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,16 @@ else ifeq ($(arch),avx512)
 	ifeq ($(CXX), icpc)
 		ARCH_FLAGS=-xCORE-AVX512
 	else
-		ARCH_FLAGS=-mavx512bw
+		ARCH_FLAGS=-mavx512f -mavx512bw
+	endif
+else ifeq ($(arch),avx512bw)
+	# Explicit BW target: double the lane width vs AVX2 (64x8-bit / 32x16-bit).
+	# AVX-512BW implies AVX-512F; -mavx512bw alone enables BW+F on gcc/clang
+	# but we list both flags for clarity.
+	ifeq ($(CXX), icpc)
+		ARCH_FLAGS=-xCORE-AVX512
+	else
+		ARCH_FLAGS=-mavx512f -mavx512bw
 	endif
 else ifeq ($(arch),native)
 	ARCH_FLAGS=-march=native
@@ -211,7 +220,7 @@ else
 	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
 	$(MAKE) arch=avx2   EXE=bwa-mem2.avx2     CXX=$(CXX) all
 	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
-	$(MAKE) arch=avx512 EXE=bwa-mem2.avx512bw CXX=$(CXX) all
+	$(MAKE) arch=avx512bw EXE=bwa-mem2.avx512bw CXX=$(CXX) all
 	$(CXX) -Wall -O3 src/runsimd.cpp -Iext/safestringlib/include -Lext/safestringlib/ -lsafestring $(STATIC_GCC) -o bwa-mem2
 endif
 


### PR DESCRIPTION
## Summary

Adds `arch=avx512bw` as an explicit Makefile target and switches the
multi-binary AVX-512 build to use it. Purely a build-system change —
11 insertions / 2 deletions in `Makefile`, no C++ touched.

## Motivation

The AVX-512 Smith-Waterman kernels are guarded by `__AVX512BW__` (not
`__AVX512F__`):

- `src/bandedSWA.cpp:1818+` — `smithWaterman512_8` / `smithWaterman512_16`
- `src/kswv.cpp:1273+` — `kswv::kswv512_u8`
- `src/bandedSWA.h:273+` — declarations
- `src/runsimd.cpp:211` — CPUID dispatch selects `bwa-mem2.avx512bw`

But the only way to build them was `arch=avx512`, and `make multi` emitted
`bwa-mem2.avx512bw` via `arch=avx512 EXE=bwa-mem2.avx512bw`. The build
selector, the preprocessor guard, and the dispatcher suffix all disagreed.

This PR makes them agree.

## Changes

- Add `arch=avx512bw` with `-mavx512f -mavx512bw`.
- Keep `arch=avx512` as an alias with the same flags (`-mavx512bw` alone
  already implies `-mavx512f` on gcc/clang; flags listed explicitly now
  for clarity).
- `make multi` invokes `arch=avx512bw` when emitting `bwa-mem2.avx512bw`.

## Test plan

Verified with gcc 13 under linux/amd64 Docker on an Apple-Silicon host:

- [x] `arch=sse41` builds cleanly
- [x] `arch=avx2` builds cleanly; dwgsim parity vs bwa PASS
- [x] `arch=avx512` builds cleanly (preserved alias)
- [x] `arch=avx512bw` builds cleanly
- [x] `arch=native` builds cleanly
- [x] `make multi` emits `bwa-mem2.{sse41,sse42,avx,avx2,avx512bw}` plus
      the `runsimd.cpp` dispatcher

Native macOS / Apple Silicon (Darwin arm64 + clang):

- [x] `arch=` (default) builds `bwa-mem2.arm64`; dwgsim parity PASS

The AVX-512BW binary builds under qemu-x86_64 on the ARM host but cannot
execute there — qemu does not emulate AVX-512BW (expected).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized x86 architecture build configuration with expanded instruction set variant support and improved compiler toolchain compatibility for diverse deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->