### PR TITLE
[proto] NEON kswv mate-rescue — correctness + perf harness

### DIFF
--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -122,6 +122,10 @@ jobs:
             /tmp/ci-reads/reads
 
       - name: Run mem (port build)
+        # Port currently asserts in mem_reg2aln because NEON kswv phase=1
+        # (start-position pass) isn't producing correct qb/tb — the selftest
+        # only exercises phase=0 score correctness. `|| true` preserves CI
+        # signal while we iterate on the phase=1 fix.
         run: |
           mkdir -p /tmp/ci-out
           for rep in $(seq 1 "$N_REPS"); do
@@ -129,7 +133,7 @@ jobs:
               /tmp/ci-ref/chr17.fa \
               /tmp/ci-reads/reads.bwa.read1.fastq.gz /tmp/ci-reads/reads.bwa.read2.fastq.gz \
               > /tmp/ci-out/port.rep${rep}.sam \
-              2> /tmp/ci-out/port.rep${rep}.time
+              2> /tmp/ci-out/port.rep${rep}.time || true
           done
 
       - name: Run mem (control build)
@@ -175,9 +179,17 @@ jobs:
 
       - name: Sort + md5 port SAM for identity check
         run: |
-          samtools sort -@ "$(nproc)" -n /tmp/ci-out/port.rep1.sam -o /tmp/ci-out/port.sorted.bam
-          samtools view /tmp/ci-out/port.sorted.bam | md5sum | awk '{print $1}' > /tmp/ci-out/port.sam.md5
-          echo "ARM port SAM md5: $(cat /tmp/ci-out/port.sam.md5)" >> "$GITHUB_STEP_SUMMARY"
+          # Graceful no-op if port crashed and produced no usable SAM; the
+          # sam-identity job then reports the missing artifact rather than
+          # failing here.
+          if [ -s /tmp/ci-out/port.rep1.sam ] && grep -q '^[^@]' /tmp/ci-out/port.rep1.sam; then
+            samtools sort -@ "$(nproc)" -n /tmp/ci-out/port.rep1.sam -o /tmp/ci-out/port.sorted.bam
+            samtools view /tmp/ci-out/port.sorted.bam | md5sum | awk '{print $1}' > /tmp/ci-out/port.sam.md5
+            echo "ARM port SAM md5: $(cat /tmp/ci-out/port.sam.md5)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "(port build produced no alignment records — port crash expected during iteration)" > /tmp/ci-out/port.sam.md5
+            echo "ARM port SAM: (empty — port crashed before producing records)" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -122,10 +122,6 @@ jobs:
             /tmp/ci-reads/reads
 
       - name: Run mem (port build)
-        # Port currently asserts in mem_reg2aln because NEON kswv phase=1
-        # (start-position pass) isn't producing correct qb/tb — the selftest
-        # only exercises phase=0 score correctness. `|| true` preserves CI
-        # signal while we iterate on the phase=1 fix.
         run: |
           mkdir -p /tmp/ci-out
           for rep in $(seq 1 "$N_REPS"); do
@@ -133,13 +129,8 @@ jobs:
               /tmp/ci-ref/chr17.fa \
               /tmp/ci-reads/reads.bwa.read1.fastq.gz /tmp/ci-reads/reads.bwa.read2.fastq.gz \
               > /tmp/ci-out/port.rep${rep}.sam \
-              2> /tmp/ci-out/port.rep${rep}.time || true
+              2> /tmp/ci-out/port.rep${rep}.time
           done
-          echo "--- port rep1 tail (last 40 lines of stderr + timing) ---"
-          tail -40 /tmp/ci-out/port.rep1.time || true
-          echo "--- port rep1 SAM size + first 3 records ---"
-          wc -l /tmp/ci-out/port.rep1.sam || true
-          head -3 /tmp/ci-out/port.rep1.sam || true
 
       - name: Run mem (control build)
         run: |
@@ -184,17 +175,9 @@ jobs:
 
       - name: Sort + md5 port SAM for identity check
         run: |
-          # Graceful no-op if port crashed and produced no usable SAM; the
-          # sam-identity job then reports the missing artifact rather than
-          # failing here.
-          if [ -s /tmp/ci-out/port.rep1.sam ] && grep -q '^[^@]' /tmp/ci-out/port.rep1.sam; then
-            samtools sort -@ "$(nproc)" -n /tmp/ci-out/port.rep1.sam -o /tmp/ci-out/port.sorted.bam
-            samtools view /tmp/ci-out/port.sorted.bam | md5sum | awk '{print $1}' > /tmp/ci-out/port.sam.md5
-            echo "ARM port SAM md5: $(cat /tmp/ci-out/port.sam.md5)" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "(port build produced no alignment records — port crash expected during iteration)" > /tmp/ci-out/port.sam.md5
-            echo "ARM port SAM: (empty — port crashed before producing records)" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          samtools sort -@ "$(nproc)" -n /tmp/ci-out/port.rep1.sam -o /tmp/ci-out/port.sorted.bam
+          samtools view /tmp/ci-out/port.sorted.bam | md5sum | awk '{print $1}' > /tmp/ci-out/port.sam.md5
+          echo "ARM port SAM md5: $(cat /tmp/ci-out/port.sam.md5)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -318,17 +301,13 @@ jobs:
           {
             echo "## Cross-arch SAM identity"
             echo ""
-            echo "- ARM (port): \`$arm_md5\`"
-            echo "- x86 (reference): \`$x86_md5\`"
+            echo "- ARM (port, NEON batched mate-rescue): \`$arm_md5\`"
+            echo "- x86 (reference, scalar mate-rescue on AVX2 runners): \`$x86_md5\`"
             echo ""
             if [ "$arm_md5" = "$x86_md5" ]; then
               echo "PASS: byte-identical sorted SAM across arches."
             else
-              echo "FAIL: SAM md5 differs. Expected on scaffolding PR before port lands."
+              echo "FAIL: SAM md5 differs."
             fi
           } | tee -a "$GITHUB_STEP_SUMMARY"
-          # Soft-fail on scaffolding; the divergence is expected (ARM scalar
-          # mem_sam_pe vs x86 batched mem_sam_pe_batch produce equivalent but
-          # not byte-identical SAM in some rare PE cases). Flip to strict once
-          # the port lands.
-          if [ "$arm_md5" != "$x86_md5" ]; then exit 0; fi
+          [ "$arm_md5" = "$x86_md5" ] || exit 1

--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -25,8 +25,9 @@ on:
 
 env:
   CHR17_URL: "https://hgdownload.soe.ucsc.edu/goldenpath/hg38/chromosomes/chr17.fa.gz"
-  CHR17_MD5: "023ccefd298db339159a446e88d742ac"  # UCSC hg38 chr17.fa.gz, verified 2026-04-19
-  N_PAIRS: "100000"  # adaptive: bump to 500000 once the harness is green
+  CHR17_SHA256: "9acaede8d9b0a190489b49ebf38063bc69897c0d5f125c7549a6f7ee91a0b3c0"  # UCSC hg38 chr17.fa.gz
+  DWGSIM_REF: "dwgsim.0.1.16"  # pin for reproducible simulated reads
+  N_PAIRS: "500000"  # matches the 500k PE workload used for local A/B
   N_REPS: "3"
 
 jobs:
@@ -44,7 +45,9 @@ jobs:
 
       - name: Build dwgsim
         run: |
-          git clone --recursive https://github.com/nh13/DWGSIM.git /tmp/dwgsim-src
+          git clone https://github.com/nh13/DWGSIM.git /tmp/dwgsim-src
+          git -C /tmp/dwgsim-src checkout --detach "$DWGSIM_REF"
+          git -C /tmp/dwgsim-src submodule update --init --recursive
           make -C /tmp/dwgsim-src -j"$(nproc)"
 
       - name: Cache chr17 reference
@@ -52,16 +55,16 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /tmp/ci-ref/chr17.fa
-          key: chr17-${{ env.CHR17_MD5 }}
+          key: chr17-${{ env.CHR17_SHA256 }}
 
       - name: Download chr17 if cache miss
         if: steps.cache-chr17.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/ci-ref
           curl -sL "$CHR17_URL" -o /tmp/ci-ref/chr17.fa.gz
-          got_md5="$(md5sum /tmp/ci-ref/chr17.fa.gz | awk '{print $1}')"
-          if [ "$got_md5" != "$CHR17_MD5" ]; then
-            echo "chr17.fa.gz md5 mismatch: expected $CHR17_MD5, got $got_md5"
+          got_sha256="$(sha256sum /tmp/ci-ref/chr17.fa.gz | awk '{print $1}')"
+          if [ "$got_sha256" != "$CHR17_SHA256" ]; then
+            echo "chr17.fa.gz sha256 mismatch: expected $CHR17_SHA256, got $got_sha256"
             exit 1
           fi
           gunzip /tmp/ci-ref/chr17.fa.gz
@@ -105,7 +108,7 @@ jobs:
             /tmp/ci-ref/chr17.fa.ann
             /tmp/ci-ref/chr17.fa.bwt.2bit.64
             /tmp/ci-ref/chr17.fa.pac
-          key: chr17-bwamem2-index-${{ env.CHR17_MD5 }}
+          key: chr17-bwamem2-index-${{ env.CHR17_SHA256 }}
 
       - name: Build chr17 index if cache miss
         if: steps.cache-chr17-index.outputs.cache-hit != 'true'
@@ -220,7 +223,9 @@ jobs:
 
       - name: Build dwgsim
         run: |
-          git clone --recursive https://github.com/nh13/DWGSIM.git /tmp/dwgsim-src
+          git clone https://github.com/nh13/DWGSIM.git /tmp/dwgsim-src
+          git -C /tmp/dwgsim-src checkout --detach "$DWGSIM_REF"
+          git -C /tmp/dwgsim-src submodule update --init --recursive
           make -C /tmp/dwgsim-src -j"$(nproc)"
 
       - name: Cache chr17 reference
@@ -228,16 +233,16 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /tmp/ci-ref/chr17.fa
-          key: chr17-${{ env.CHR17_MD5 }}
+          key: chr17-${{ env.CHR17_SHA256 }}
 
       - name: Download chr17 if cache miss
         if: steps.cache-chr17.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/ci-ref
           curl -sL "$CHR17_URL" -o /tmp/ci-ref/chr17.fa.gz
-          got_md5="$(md5sum /tmp/ci-ref/chr17.fa.gz | awk '{print $1}')"
-          if [ "$got_md5" != "$CHR17_MD5" ]; then
-            echo "chr17.fa.gz md5 mismatch: expected $CHR17_MD5, got $got_md5"
+          got_sha256="$(sha256sum /tmp/ci-ref/chr17.fa.gz | awk '{print $1}')"
+          if [ "$got_sha256" != "$CHR17_SHA256" ]; then
+            echo "chr17.fa.gz sha256 mismatch: expected $CHR17_SHA256, got $got_sha256"
             exit 1
           fi
           gunzip /tmp/ci-ref/chr17.fa.gz

--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -135,6 +135,11 @@ jobs:
               > /tmp/ci-out/port.rep${rep}.sam \
               2> /tmp/ci-out/port.rep${rep}.time || true
           done
+          echo "--- port rep1 tail (last 40 lines of stderr + timing) ---"
+          tail -40 /tmp/ci-out/port.rep1.time || true
+          echo "--- port rep1 SAM size + first 3 records ---"
+          wc -l /tmp/ci-out/port.rep1.sam || true
+          head -3 /tmp/ci-out/port.rep1.sam || true
 
       - name: Run mem (control build)
         run: |

--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -89,10 +89,11 @@ jobs:
         id: selftest
         continue-on-error: true  # iterating; surface result without gating CI yet
         run: |
-          ./kswv_selftest 2>&1 | tee /tmp/selftest.log
+          mkdir -p /tmp/ci-out
+          ./kswv_selftest 2>&1 | tee /tmp/ci-out/selftest.log
           status=${PIPESTATUS[0]}
           echo "selftest_exit=$status" >> "$GITHUB_OUTPUT"
-          tail -25 /tmp/selftest.log >> "$GITHUB_STEP_SUMMARY"
+          tail -25 /tmp/ci-out/selftest.log >> "$GITHUB_STEP_SUMMARY"
           exit $status
 
       - name: Cache chr17 bwa-mem2 index
@@ -183,10 +184,12 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: arm-outputs
+          # All under /tmp/ci-out so the archive flattens to bare filenames
+          # rather than preserving a /tmp/... prefix.
           path: |
             /tmp/ci-out/port.sam.md5
             /tmp/ci-out/port.rep1.sam
-            /tmp/selftest.log
+            /tmp/ci-out/selftest.log
 
   reference-x86:
     name: x86 reference SAM (AVX-512)
@@ -202,6 +205,13 @@ jobs:
 
       - name: Check AVX-512 availability
         run: |
+          # AVX-512BW is required for the x86 batched mate-rescue path (gated
+          # by __AVX512BW__ in bwamem.cpp:1255 and bwamem_pair.cpp:657). Free
+          # GH runners typically do not expose it. When it's missing we fall
+          # back to AVX2, which takes the same scalar mem_sam_pe path as ARM
+          # today — so the cross-arch "SAM identity" step is then testing
+          # scalar-vs-scalar, not batched-vs-scalar. That's still useful once
+          # the port lands (ARM batched vs x86 scalar cross-check) but noted.
           if ! grep -q avx512bw /proc/cpuinfo; then
             echo "::warning::AVX-512BW not available on this runner; falling back to AVX2 reference"
             echo "USE_AVX=avx2" >> "$GITHUB_ENV"

--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -87,7 +87,6 @@ jobs:
 
       - name: Run kswv_selftest
         id: selftest
-        continue-on-error: true  # iterating; surface result without gating CI yet
         run: |
           mkdir -p /tmp/ci-out
           ./kswv_selftest 2>&1 | tee /tmp/ci-out/selftest.log

--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -1,0 +1,308 @@
+name: proto-neon-kswv
+
+# Correctness + perf harness for wiring NEON kswv into the mate-rescue path
+# on ARM. Runs on the proto/neon-kswv-* branches only. Not gated on main.
+#
+# Jobs:
+#   selftest-perf-arm  — build port + control, run kswv_selftest, run mem
+#                         on dwgsim/chr17 with both builds, report speedup.
+#   reference-x86      — build AVX-512 reference, run mem, produce reference SAM.
+#   sam-identity       — diff md5 of sorted SAM from arm (port build) vs x86.
+
+on:
+  push:
+    branches:
+      - 'proto/neon-kswv-**'
+  pull_request:
+    branches:
+      - 'fg-main'
+    paths:
+      - 'src/**'
+      - 'test/kswv_selftest.cpp'
+      - '.github/workflows/proto-neon-kswv.yml'
+      - 'Makefile'
+  workflow_dispatch:
+
+env:
+  CHR17_URL: "https://hgdownload.soe.ucsc.edu/goldenpath/hg38/chromosomes/chr17.fa.gz"
+  CHR17_MD5: "023ccefd298db339159a446e88d742ac"  # UCSC hg38 chr17.fa.gz, verified 2026-04-19
+  N_PAIRS: "100000"  # adaptive: bump to 500000 once the harness is green
+  N_REPS: "3"
+
+jobs:
+  selftest-perf-arm:
+    name: ARM selftest + port/control perf
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          submodules: recursive
+
+      - name: Install apt dependencies
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev samtools
+
+      - name: Build dwgsim
+        run: |
+          git clone --recursive https://github.com/nh13/DWGSIM.git /tmp/dwgsim-src
+          make -C /tmp/dwgsim-src -j"$(nproc)"
+
+      - name: Cache chr17 reference
+        id: cache-chr17
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: /tmp/ci-ref/chr17.fa
+          key: chr17-${{ env.CHR17_MD5 }}
+
+      - name: Download chr17 if cache miss
+        if: steps.cache-chr17.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/ci-ref
+          curl -sL "$CHR17_URL" -o /tmp/ci-ref/chr17.fa.gz
+          got_md5="$(md5sum /tmp/ci-ref/chr17.fa.gz | awk '{print $1}')"
+          if [ "$got_md5" != "$CHR17_MD5" ]; then
+            echo "chr17.fa.gz md5 mismatch: expected $CHR17_MD5, got $got_md5"
+            exit 1
+          fi
+          gunzip /tmp/ci-ref/chr17.fa.gz
+
+      - name: Build port (gates widened; no-op on this branch until the port lands)
+        run: |
+          make clean
+          make -j"$(nproc)" CXX=g++
+          mv bwa-mem2.arm64 bwa-mem2.port
+          cp libbwa.a libbwa.port.a
+
+      - name: Build control (DISABLE_BATCHED_MATESW=1)
+        run: |
+          make clean
+          make -j"$(nproc)" DISABLE_BATCHED_MATESW=1 CXX=g++
+          mv bwa-mem2.arm64 bwa-mem2.control
+
+      - name: Build kswv_selftest
+        run: |
+          # Use the 'port' libbwa; the selftest only exercises kswv regardless.
+          cp libbwa.port.a libbwa.a
+          make arch=arm64 kswv_selftest CXX=g++
+
+      - name: Run kswv_selftest
+        id: selftest
+        continue-on-error: true  # iterating; surface result without gating CI yet
+        run: |
+          ./kswv_selftest 2>&1 | tee /tmp/selftest.log
+          status=${PIPESTATUS[0]}
+          echo "selftest_exit=$status" >> "$GITHUB_OUTPUT"
+          tail -25 /tmp/selftest.log >> "$GITHUB_STEP_SUMMARY"
+          exit $status
+
+      - name: Cache chr17 bwa-mem2 index
+        id: cache-chr17-index
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            /tmp/ci-ref/chr17.fa.0123
+            /tmp/ci-ref/chr17.fa.amb
+            /tmp/ci-ref/chr17.fa.ann
+            /tmp/ci-ref/chr17.fa.bwt.2bit.64
+            /tmp/ci-ref/chr17.fa.pac
+          key: chr17-bwamem2-index-${{ env.CHR17_MD5 }}
+
+      - name: Build chr17 index if cache miss
+        if: steps.cache-chr17-index.outputs.cache-hit != 'true'
+        run: ./bwa-mem2.port index /tmp/ci-ref/chr17.fa
+
+      - name: Simulate dwgsim reads
+        run: |
+          mkdir -p /tmp/ci-reads
+          /tmp/dwgsim-src/dwgsim \
+            -z 42 \
+            -N "$N_PAIRS" -1 100 -2 100 \
+            -e 0.01 -E 0.01 -r 0.001 -R 0 \
+            /tmp/ci-ref/chr17.fa \
+            /tmp/ci-reads/reads
+
+      - name: Run mem (port build)
+        run: |
+          mkdir -p /tmp/ci-out
+          for rep in $(seq 1 "$N_REPS"); do
+            /usr/bin/time -v ./bwa-mem2.port mem -t "$(nproc)" \
+              /tmp/ci-ref/chr17.fa \
+              /tmp/ci-reads/reads.bwa.read1.fastq.gz /tmp/ci-reads/reads.bwa.read2.fastq.gz \
+              > /tmp/ci-out/port.rep${rep}.sam \
+              2> /tmp/ci-out/port.rep${rep}.time
+          done
+
+      - name: Run mem (control build)
+        run: |
+          for rep in $(seq 1 "$N_REPS"); do
+            /usr/bin/time -v ./bwa-mem2.control mem -t "$(nproc)" \
+              /tmp/ci-ref/chr17.fa \
+              /tmp/ci-reads/reads.bwa.read1.fastq.gz /tmp/ci-reads/reads.bwa.read2.fastq.gz \
+              > /tmp/ci-out/control.rep${rep}.sam \
+              2> /tmp/ci-out/control.rep${rep}.time
+          done
+
+      - name: Report speedup
+        run: |
+          extract_elapsed() {
+            awk '/Elapsed \(wall clock\) time/ { split($NF, t, ":"); if (length(t)==3) print t[1]*3600+t[2]*60+t[3]; else print t[1]*60+t[2] }' "$1"
+          }
+          median3() {
+            awk '{print $1}' "$1" | sort -n | head -2 | tail -1
+          }
+          {
+            echo "## ARM perf A/B (port vs control, DISABLE_BATCHED_MATESW)"
+            echo ""
+            echo "| rep | port (s) | control (s) |"
+            echo "| --- | --------:| -----------:|"
+            for rep in $(seq 1 "$N_REPS"); do
+              p=$(extract_elapsed /tmp/ci-out/port.rep${rep}.time)
+              c=$(extract_elapsed /tmp/ci-out/control.rep${rep}.time)
+              echo "| $rep | $p | $c |"
+              echo "$p" >> /tmp/ci-out/port.elapsed
+              echo "$c" >> /tmp/ci-out/control.elapsed
+            done
+            pm=$(median3 /tmp/ci-out/port.elapsed)
+            cm=$(median3 /tmp/ci-out/control.elapsed)
+            echo ""
+            echo "median port: ${pm}s, median control: ${cm}s"
+            if [ -n "$pm" ] && [ -n "$cm" ] && [ "$pm" != "0" ]; then
+              speedup=$(awk -v p="$pm" -v c="$cm" 'BEGIN { printf "%.2f", c/p }')
+              pct=$(awk -v p="$pm" -v c="$cm" 'BEGIN { printf "%+.1f%%", 100*(c-p)/c }')
+              echo "speedup (control / port): ${speedup}x  (${pct})"
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Sort + md5 port SAM for identity check
+        run: |
+          samtools sort -@ "$(nproc)" -n /tmp/ci-out/port.rep1.sam -o /tmp/ci-out/port.sorted.bam
+          samtools view /tmp/ci-out/port.sorted.bam | md5sum | awk '{print $1}' > /tmp/ci-out/port.sam.md5
+          echo "ARM port SAM md5: $(cat /tmp/ci-out/port.sam.md5)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: arm-outputs
+          path: |
+            /tmp/ci-out/port.sam.md5
+            /tmp/ci-out/port.rep1.sam
+            /tmp/selftest.log
+
+  reference-x86:
+    name: x86 reference SAM (AVX-512)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          submodules: recursive
+
+      - name: Install apt dependencies
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev samtools
+
+      - name: Check AVX-512 availability
+        run: |
+          if ! grep -q avx512bw /proc/cpuinfo; then
+            echo "::warning::AVX-512BW not available on this runner; falling back to AVX2 reference"
+            echo "USE_AVX=avx2" >> "$GITHUB_ENV"
+          else
+            echo "USE_AVX=avx512" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build dwgsim
+        run: |
+          git clone --recursive https://github.com/nh13/DWGSIM.git /tmp/dwgsim-src
+          make -C /tmp/dwgsim-src -j"$(nproc)"
+
+      - name: Cache chr17 reference
+        id: cache-chr17
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: /tmp/ci-ref/chr17.fa
+          key: chr17-${{ env.CHR17_MD5 }}
+
+      - name: Download chr17 if cache miss
+        if: steps.cache-chr17.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/ci-ref
+          curl -sL "$CHR17_URL" -o /tmp/ci-ref/chr17.fa.gz
+          got_md5="$(md5sum /tmp/ci-ref/chr17.fa.gz | awk '{print $1}')"
+          if [ "$got_md5" != "$CHR17_MD5" ]; then
+            echo "chr17.fa.gz md5 mismatch: expected $CHR17_MD5, got $got_md5"
+            exit 1
+          fi
+          gunzip /tmp/ci-ref/chr17.fa.gz
+
+      - name: Build bwa-mem2 (x86 reference)
+        run: make -j"$(nproc)" arch="$USE_AVX" CXX=g++
+
+      - name: Index chr17
+        run: ./bwa-mem2 index /tmp/ci-ref/chr17.fa
+
+      - name: Simulate dwgsim reads (same params as ARM job)
+        run: |
+          mkdir -p /tmp/ci-reads
+          /tmp/dwgsim-src/dwgsim \
+            -z 42 \
+            -N "$N_PAIRS" -1 100 -2 100 \
+            -e 0.01 -E 0.01 -r 0.001 -R 0 \
+            /tmp/ci-ref/chr17.fa \
+            /tmp/ci-reads/reads
+
+      - name: Run mem + sort + md5
+        run: |
+          mkdir -p /tmp/ci-out
+          ./bwa-mem2 mem -t "$(nproc)" \
+            /tmp/ci-ref/chr17.fa \
+            /tmp/ci-reads/reads.bwa.read1.fastq.gz /tmp/ci-reads/reads.bwa.read2.fastq.gz \
+            > /tmp/ci-out/x86.sam
+          samtools sort -@ "$(nproc)" -n /tmp/ci-out/x86.sam -o /tmp/ci-out/x86.sorted.bam
+          samtools view /tmp/ci-out/x86.sorted.bam | md5sum | awk '{print $1}' > /tmp/ci-out/x86.sam.md5
+          echo "x86 reference (${USE_AVX}) SAM md5: $(cat /tmp/ci-out/x86.sam.md5)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: x86-outputs
+          path: |
+            /tmp/ci-out/x86.sam.md5
+            /tmp/ci-out/x86.sam
+
+  sam-identity:
+    name: cross-arch SAM identity
+    needs: [selftest-perf-arm, reference-x86]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download ARM outputs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: arm-outputs
+          path: /tmp/arm-outputs
+
+      - name: Download x86 outputs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: x86-outputs
+          path: /tmp/x86-outputs
+
+      - name: Diff md5s
+        run: |
+          arm_md5="$(cat /tmp/arm-outputs/port.sam.md5)"
+          x86_md5="$(cat /tmp/x86-outputs/x86.sam.md5)"
+          {
+            echo "## Cross-arch SAM identity"
+            echo ""
+            echo "- ARM (port): \`$arm_md5\`"
+            echo "- x86 (reference): \`$x86_md5\`"
+            echo ""
+            if [ "$arm_md5" = "$x86_md5" ]; then
+              echo "PASS: byte-identical sorted SAM across arches."
+            else
+              echo "FAIL: SAM md5 differs. Expected on scaffolding PR before port lands."
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          # Soft-fail on scaffolding; the divergence is expected (ARM scalar
+          # mem_sam_pe vs x86 batched mem_sam_pe_batch produce equivalent but
+          # not byte-identical SAM in some rare PE cases). Flip to strict once
+          # the port lands.
+          if [ "$arm_md5" != "$x86_md5" ]; then exit 0; fi

--- a/Makefile
+++ b/Makefile
@@ -177,9 +177,19 @@ myall:arm64
 endif
 endif
 
-CXXFLAGS+=	-g -O3 -fpermissive $(ARCH_FLAGS) #-Wall ##-xSSE2
+CXXFLAGS+=	-g -O3 -std=gnu++14 -fpermissive $(ARCH_FLAGS) #-Wall ##-xSSE2
 
-.PHONY:all clean depend multi print-mimalloc-config
+# Control build flag for the batched mate-rescue SW port on ARM.
+# When set (e.g. `make arm64 DISABLE_BATCHED_MATESW=1`), the source gate for
+# the new batched path falls through to the legacy scalar mem_sam_pe. Used by
+# the proto-neon-kswv CI to A/B the same commit with the port on vs. off.
+# Pass the caller-supplied value through verbatim so `DISABLE_BATCHED_MATESW=0`
+# still selects the batched path (ifdef would be true even for =0).
+ifneq ($(strip $(DISABLE_BATCHED_MATESW)),)
+    CPPFLAGS += -DDISABLE_BATCHED_MATESW=$(DISABLE_BATCHED_MATESW)
+endif
+
+.PHONY:all clean depend multi print-mimalloc-config kswv_selftest test
 .SUFFIXES:.cpp .o
 
 .cpp.o:
@@ -214,6 +224,18 @@ arm64:
 
 $(EXE):$(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) $(if $(filter 1,$(USE_MIMALLOC)),$(MIMALLOC_LIB)) src/main.o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) src/main.o $(BWA_LIB) $(LIBS) $(MIMALLOC_LDFLAGS) -o $@
+
+# kswv self-consistency test: batched SIMD kswv vs scalar ksw_align2 reference.
+# Built by the proto-neon-kswv CI workflow; runnable standalone.
+kswv_selftest: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) test/kswv_selftest.o
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) test/kswv_selftest.o $(BWA_LIB) $(LIBS) -o $@
+
+# Run the in-tree tests. Currently just kswv_selftest; extend as more land.
+test: kswv_selftest
+	./kswv_selftest
+
+test/kswv_selftest.o: test/kswv_selftest.cpp
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 $(BWA_LIB):$(OBJS)
 	ar rcs $(BWA_LIB) $(OBJS)
@@ -257,7 +279,7 @@ $(MIMALLOC_LIB):
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
 clean:
-	rm -fr src/*.o $(BWA_LIB) $(EXE) bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
+	rm -fr src/*.o test/*.o $(BWA_LIB) $(EXE) kswv_selftest bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
 	cd ext/safestringlib/ && $(MAKE) clean
 	-[ -f ext/htslib/config.mk ] && cd ext/htslib && $(MAKE) distclean
 	rm -rf $(MIMALLOC_BUILD)

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1258,7 +1258,10 @@ static void worker_sam(void *data, int seqid, int batch_size, int tid)
         int end = seqid + batch_size;
         int pos = start >> 1;
 
-#if (((!__AVX512BW__) && (!__AVX2__)) || ((!__AVX512BW__) && (__AVX2__)))
+#if !BWAMEM_BATCHED_MATESW
+        // Scalar mem_sam_pe path. Selected when no SIMD kswv kernel is
+        // available (e.g. plain SSE2/AVX2 x86 builds, or forced via
+        // DISABLE_BATCHED_MATESW=1 for the proto-neon-kswv CI A/B).
         for (int i=start; i< end; i+=2)
         {
             // orig mem_sam_pe() function

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -718,12 +718,12 @@ int mem_sam_pe_batch(const mem_opt_t *opt, mem_cache *mmc,
     for (int i=0; i<pcnt-pcnt8; i++)
         seqPairArray[pcnt + MAX_LINE_LEN - 1 - i] = seqPairArray[pcnt-i-1];
     
-#if __AVX512BW__    
+#if BWAMEM_BATCHED_MATESW
     pwsw->getScores8(seqPairArray, seqBufRef, seqBufQer, aln, pcnt8, nthreads, 0);
     pwsw->getScores16(seqPairArray + pcnt8 + MAX_LINE_LEN, seqBufRef, seqBufQer,
                       aln, pcnt-pcnt8, nthreads, 0);
 #else
-    fprintf(stderr, "Error: This should not have happened!! \nPlease look in to AVX512 macros\n");
+    fprintf(stderr, "Error: mem_sam_pe_batch reached without a batched kswv kernel\n");
     exit(EXIT_FAILURE);
 #endif
 
@@ -767,11 +767,11 @@ int mem_sam_pe_batch(const mem_opt_t *opt, mem_cache *mmc,
     int pcnt2 = pos;
     assert(pos8 + pos16 == pcnt2);
 
-#if __AVX512BW__
+#if BWAMEM_BATCHED_MATESW
     pwsw->getScores16(seqPairArray + pos8, seqBufRef, seqBufQer, aln, pos16, nthreads, 1);
     pwsw->getScores8(seqPairArray, seqBufRef, seqBufQer, aln, pos8, nthreads, 1);
 #else
-    fprintf(stderr, "Error: This should not have happened!! \nPlease look in to AVX512 macros\n");
+    fprintf(stderr, "Error: mem_sam_pe_batch reached without a batched kswv kernel\n");
     exit(EXIT_FAILURE);
 #endif
     

--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -373,8 +373,32 @@ int kswv::kswv_neon_u8(uint8_t seq1SoA[],
     uint8x16_t oe_ins_vec = vdupq_n_u8(this->o_ins + this->e_ins);
     uint8x16_t five_vec = vdupq_n_u8(DUMMY5);
     uint8x16_t gmax_vec = zero_vec;
-    int16x8_t te_vec = vdupq_n_s16(-1);
+    // 8-bit SW processes 16 pairs per SIMD batch, but te must be tracked in
+    // 16-bit precision (ref positions > 255 are possible). Use two
+    // int16x8 vectors — _lo for pairs 0-7, _hi for pairs 8-15 — so every
+    // pair has its own te slot. The earlier single int16x8 te_vec plus
+    // hacky "duplicate on store" only tracked pairs 0-7 correctly; pairs
+    // 8-15 got copies of the wrong pair's te.
+    int16x8_t te_vec_lo = vdupq_n_s16(-1);
+    int16x8_t te_vec_hi = vdupq_n_s16(-1);
     uint8x16_t cmax_vec = vdupq_n_u8(255);
+    // "Frozen" mask: tracks which pairs have hit their KSW_XSTOP target
+    // in a prior row. Once frozen, a pair's gmax/te/qe must not be updated
+    // — otherwise later rows (which may contain untouched ref bytes when
+    // the caller only partially reversed the buffer) can add spurious
+    // matches, pushing phase-1's score above phase-0's and breaking the
+    // write-back gate `aln[ind].score == score[l]` at line ~538.
+    uint8x16_t frozen_vec = zero_vec;
+
+    /* Per-lane mask of "this lane has a real KSW_XSTOP target set" (derived
+     * from endsc_msk_a). endsc[i] defaults to 0 for lanes without a target,
+     * which would otherwise make vcgeq_u8(gmax, endsc_vec) trivially true
+     * and cause premature freezing. */
+    uint8_t _has_endsc_bytes[SIMD_WIDTH8];
+    for (int _i = 0; _i < SIMD_WIDTH8; _i++) {
+        _has_endsc_bytes[_i] = (endsc_msk_a & (1 << _i)) ? 0xFF : 0x00;
+    }
+    uint8x16_t has_endsc_vec = vld1q_u8(_has_endsc_bytes);
 
     uint16_t exit0 = 0xFFFF;
 
@@ -487,15 +511,51 @@ int kswv::kswv_neon_u8(uint8_t seq1SoA[],
         uint8x16_t cmp0 = vcgtq_u8(imax_vec, gmax_vec);
         uint16_t cmp0_msk = neon_movemask_u8(cmp0);
         cmp0_msk &= exit0;
-        gmax_vec = vmaxq_u8(gmax_vec, imax_vec);
-        /* Update te for elements where imax > gmax */
-        te_vec = vbslq_s16(vreinterpretq_u16_u8(cmp0), i_vec, te_vec);
-        qe_vec = vbslq_u8(cmp0, iqe_vec, qe_vec);
+
+        /* 16-bit-wide comparison mirrors cmp0 but with 0xFFFF/0x0000 per
+         * 16-bit lane, suitable for updating the two halves of te. Must be
+         * computed BEFORE the vmaxq_u8 update of gmax_vec (same as cmp0). */
+        uint16x8_t cmp_lo_16 = vcgtq_u16(vmovl_u8(vget_low_u8(imax_vec)),
+                                         vmovl_u8(vget_low_u8(gmax_vec)));
+        uint16x8_t cmp_hi_16 = vcgtq_u16(vmovl_u8(vget_high_u8(imax_vec)),
+                                         vmovl_u8(vget_high_u8(gmax_vec)));
+
+        /* 16-bit frozen masks (0xFFFF per lane where frozen, else 0x0000).
+         * Widen 0xFF/0x00 bytes: vtstq_u8-style check, but we can use
+         * vmovl_u8 + vcgtq to turn non-zero into 0xFFFF. */
+        uint16x8_t frozen_lo_16 = vcgtq_u16(
+            vmovl_u8(vget_low_u8(frozen_vec)), vdupq_n_u16(0));
+        uint16x8_t frozen_hi_16 = vcgtq_u16(
+            vmovl_u8(vget_high_u8(frozen_vec)), vdupq_n_u16(0));
+
+        /* Combine "imax > gmax" with "not frozen" for the final update masks */
+        cmp_lo_16 = vbicq_u16(cmp_lo_16, frozen_lo_16);
+        cmp_hi_16 = vbicq_u16(cmp_hi_16, frozen_hi_16);
+        uint8x16_t cmp0_active = vbicq_u8(cmp0, frozen_vec);
+
+        /* gmax: pick new max for active lanes, keep frozen lanes' stored
+         * value. This is what prevents later rows from inflating a lane's
+         * score beyond its phase-0 target once it's already "done". */
+        uint8x16_t new_gmax = vmaxq_u8(gmax_vec, imax_vec);
+        gmax_vec = vbslq_u8(frozen_vec, gmax_vec, new_gmax);
+
+        /* Update te/qe only for active lanes (imax > gmax AND not frozen) */
+        te_vec_lo = vbslq_s16(cmp_lo_16, i_vec, te_vec_lo);
+        te_vec_hi = vbslq_s16(cmp_hi_16, i_vec, te_vec_hi);
+        qe_vec = vbslq_u8(cmp0_active, iqe_vec, qe_vec);
 
         /* Check end score threshold */
         uint8x16_t cmp_end = vcgeq_u8(gmax_vec, endsc_vec);
         uint16_t cmp_end_msk = neon_movemask_u8(cmp_end);
         cmp_end_msk &= endsc_msk_a;
+
+        /* Freeze any lane that just hit its KSW_XSTOP target. From the
+         * next row onwards, frozen lanes will skip the gmax/te/qe updates
+         * above. has_endsc_vec ensures we only freeze lanes that actually
+         * set a target (endsc_vec defaults to 0 otherwise, which would
+         * match cmp_end trivially). */
+        uint8x16_t just_hit = vandq_u8(cmp_end, has_endsc_vec);
+        frozen_vec = vorrq_u8(frozen_vec, just_hit);
 
         /* Check for overflow */
         uint8x16_t left_vec = vqaddq_u8(gmax_vec, sft_vec);
@@ -521,8 +581,8 @@ int kswv::kswv_neon_u8(uint8_t seq1SoA[],
     uint8_t qe[SIMD_WIDTH8] __attribute((aligned(128)));
 
     vst1q_u8(score, gmax_vec);
-    vst1q_s16(te1, te_vec);
-    vst1q_s16(te1 + 8, te_vec);  // duplicate for 16-element access
+    vst1q_s16(te1, te_vec_lo);       // pairs 0-7
+    vst1q_s16(te1 + 8, te_vec_hi);   // pairs 8-15
     vst1q_u8(qe, qe_vec);
 
     int live = 0;
@@ -583,28 +643,96 @@ int kswv::kswv_neon_u8(uint8_t seq1SoA[],
     }
 
     uint8x16_t max2_vec = zero_vec;
-    int16x8_t te2_vec = vdupq_n_s16(-1);
+    /* te2 is per-lane int16 so ref positions > 255 round-trip correctly.
+     * Split into lo (lanes 0..7) and hi (lanes 8..15) to mirror the split
+     * te_vec_{lo,hi} tracking used in the primary-score loop. */
+    int16x8_t te2_vec_lo = vdupq_n_s16(-1);
+    int16x8_t te2_vec_hi = vdupq_n_s16(-1);
 
-    /* Find second best score outside primary alignment region */
-    for (int i = 0; i < maxl; i++)
-    {
-        uint8x16_t rmax_vec = vld1q_u8(rowMax + i * SIMD_WIDTH8);
-        uint8x16_t cmp = vcgtq_u8(rmax_vec, max2_vec);
-        max2_vec = vmaxq_u8(max2_vec, rmax_vec);
+    /* Per-lane scan vectors for correct score2 across heterogeneous
+     * batches. Three constraints per lane:
+     *   (1) i < len1[lane]            — in the pair's real ref
+     *   (2) i < low[lane]  OR  i > high[lane]
+     *                                  — outside the pair's own primary
+     *                                    region (low/high are precomputed
+     *                                    above as `te +/- val`)
+     *   (3) qe[lane] != 0             — the pair found a valid primary
+     * Updating max2_vec from rowMax[i] must respect all three. The earlier
+     * scan used a single `[minh+1, limit)` range derived from per-lane
+     * maxl/minh aggregates, which leaked one pair's primary-region scores
+     * into another pair's score2. That produced score2 == score on many
+     * batches, collapsing MAPQ to 0 downstream.
+     */
+    int16_t _len1_arr[SIMD_WIDTH8] __attribute__((aligned(16))) = {0};
+    for (int _l = 0; _l < SIMD_WIDTH8; _l++) {
+        _len1_arr[_l] = (int16_t)p[_l].len1;
     }
+    int16x8_t len1_lo = vld1q_s16(_len1_arr);
+    int16x8_t len1_hi = vld1q_s16(_len1_arr + 8);
+    int16x8_t low_lo  = vld1q_s16(low);
+    int16x8_t low_hi  = vld1q_s16(low + 8);
+    int16x8_t high_lo = vld1q_s16(high);
+    int16x8_t high_hi = vld1q_s16(high + 8);
 
-    for (int i = minh + 1; i < limit; i++)
-    {
+    /* qe_mask[lane] = 0xFF if qe[lane] != 0 else 0x00; used to zero out
+     * contributions from lanes without a primary alignment. */
+    uint8_t _qe_mask_arr[SIMD_WIDTH8] __attribute__((aligned(16)));
+    for (int _l = 0; _l < SIMD_WIDTH8; _l++) _qe_mask_arr[_l] = qe[_l] ? 0xFF : 0x00;
+    uint8x16_t qe_mask_vec = vld1q_u8(_qe_mask_arr);
+
+    auto scan_row = [&](int i) {
         uint8x16_t rmax_vec = vld1q_u8(rowMax + i * SIMD_WIDTH8);
-        uint8x16_t cmp = vcgtq_u8(rmax_vec, max2_vec);
+        int16x8_t iv = vdupq_n_s16((int16_t)i);
+
+        /* (1) in_bounds: len1 > i */
+        uint16x8_t ib_lo = vcgtq_s16(len1_lo, iv);
+        uint16x8_t ib_hi = vcgtq_s16(len1_hi, iv);
+
+        /* (2) outside primary region: i < low OR i > high */
+        uint16x8_t below_lo = vcltq_s16(iv, low_lo);
+        uint16x8_t below_hi = vcltq_s16(iv, low_hi);
+        uint16x8_t above_lo = vcgtq_s16(iv, high_lo);
+        uint16x8_t above_hi = vcgtq_s16(iv, high_hi);
+        uint16x8_t outside_lo = vorrq_u16(below_lo, above_lo);
+        uint16x8_t outside_hi = vorrq_u16(below_hi, above_hi);
+
+        uint16x8_t ok_lo = vandq_u16(ib_lo, outside_lo);
+        uint16x8_t ok_hi = vandq_u16(ib_hi, outside_hi);
+
+        uint8x16_t ok = vcombine_u8(vmovn_u16(ok_lo), vmovn_u16(ok_hi));
+        /* (3) only consider lanes with a valid primary */
+        ok = vandq_u8(ok, qe_mask_vec);
+
+        rmax_vec = vandq_u8(rmax_vec, ok);
+
+        /* (4) enforce minsc threshold: scalar ksw_align2 only records
+         * (score, te) pairs where gmax >= minsc. Our rowMax is dense
+         * (captures every row) so a late-stage plateau below minsc would
+         * otherwise leak in. Drop those to match scalar's behaviour. */
+        uint8x16_t ge_minsc = vcgeq_u8(rmax_vec, minsc_vec);
+        rmax_vec = vandq_u8(rmax_vec, ge_minsc);
+
+        /* Lanes where rmax strictly beats max2 take this row's i as their
+         * new te2. Widen the 8-bit per-lane mask to 16-bit halves so
+         * vbslq_s16 selects on the int16 te2 tracking vectors. */
+        uint8x16_t better = vcgtq_u8(rmax_vec, max2_vec);
+        uint16x8_t better_lo = vmovl_u8(vget_low_u8(better));
+        uint16x8_t better_hi = vmovl_u8(vget_high_u8(better));
+        te2_vec_lo = vbslq_s16(better_lo, iv, te2_vec_lo);
+        te2_vec_hi = vbslq_s16(better_hi, iv, te2_vec_hi);
+
         max2_vec = vmaxq_u8(max2_vec, rmax_vec);
-    }
+    };
+
+    /* Scan every row up to `limit` once, per-lane masking handles region. */
+    for (int i = 0; i < limit; i++) scan_row(i);
+    (void)maxl; (void)minh;  // now implicit in per-lane low/high
 
     uint8_t temp2[SIMD_WIDTH8] __attribute((aligned(128)));
     int16_t temp4[SIMD_WIDTH8] __attribute((aligned(128)));
     vst1q_u8(temp2, max2_vec);
-    vst1q_s16(temp4, te2_vec);
-    vst1q_s16(temp4 + 8, te2_vec);
+    vst1q_s16(temp4, te2_vec_lo);
+    vst1q_s16(temp4 + 8, te2_vec_hi);
 
     for (int i = 0; i < SIMD_WIDTH8 && (po_ind + i) < numPairs; i++)
     {

--- a/src/macro.h
+++ b/src/macro.h
@@ -46,6 +46,26 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #define MAX_SEEDS_PER_READ 500       /* Max seeds per read */
 #define AVG_SEEDS_PER_READ 64        /* Used for storing seeds in chains*/
 
+/* BWAMEM_BATCHED_MATESW:
+ *   1 -> worker_sam takes the batched mate-rescue SW path
+ *        (mem_sam_pe_batch_pre / mem_sam_pe_batch / mem_sam_pe_batch_post,
+ *        feeding kswv::getScores8 / getScores16).
+ *   0 -> worker_sam takes the legacy scalar mem_sam_pe + ksw_align2 path.
+ *
+ * Historically gated on __AVX512BW__ only, which routed all non-AVX-512
+ * builds (ARM included) to the scalar path even though NEON kswv kernels
+ * exist. DISABLE_BATCHED_MATESW is an escape hatch for the A/B test in
+ * the proto-neon-kswv CI workflow. */
+#ifndef BWAMEM_BATCHED_MATESW
+  #if DISABLE_BATCHED_MATESW
+    #define BWAMEM_BATCHED_MATESW 0
+  #elif __AVX512BW__ || defined(__aarch64__) || defined(APPLE_SILICON)
+    #define BWAMEM_BATCHED_MATESW 1
+  #else
+    #define BWAMEM_BATCHED_MATESW 0
+  #endif
+#endif
+
 /* Apple Silicon has larger L2 caches (4-16MB per cluster) and benefits from
  * larger batch sizes to better utilize cache locality. M1/M2/M3/M4 all have
  * significantly more L2 cache per core than typical x86 consumer CPUs. */

--- a/test/kswv_selftest.cpp
+++ b/test/kswv_selftest.cpp
@@ -29,10 +29,14 @@
 // Scoring (matches bwa-mem2 defaults)
 static const int8_t SCORE_MATCH    = 1;
 static const int8_t SCORE_MISMATCH = 4;
+static const int8_t SCORE_AMBIG    = 1;  // matches kswv's DEFAULT_AMBIG = -1 penalty
 static const int    GAP_OPEN       = 6;
 static const int    GAP_EXT        = 1;
 
-// 5x5 substitution matrix for ACGTN encoding 0..4
+// 5x5 substitution matrix for ACGTN encoding 0..4. N-cells use -SCORE_AMBIG
+// to match kswv's internal w_ambig = -1 rather than ksw_align2's default
+// mat behaviour; keeping the two code paths aligned is what lets the
+// selftest compare apples to apples.
 static int8_t g_mat[25];
 
 static void build_mat() {
@@ -40,10 +44,10 @@ static void build_mat() {
         for (int j = 0; j < 4; j++) {
             g_mat[i*5 + j] = (i == j) ? SCORE_MATCH : -SCORE_MISMATCH;
         }
-        g_mat[i*5 + 4] = 0;
-        g_mat[4*5 + i] = 0;
+        g_mat[i*5 + 4] = -SCORE_AMBIG;
+        g_mat[4*5 + i] = -SCORE_AMBIG;
     }
-    g_mat[24] = 0;
+    g_mat[24] = -SCORE_AMBIG;
 }
 
 struct TestPair {
@@ -144,6 +148,11 @@ static BatchResult run_batched(const std::vector<TestPair> &pairs,
     std::vector<uint8_t> seqBufQer(qer_total, 0);
     std::vector<SeqPair> pairArray(n + SIMD_WIDTH8);
 
+    // Production mate-rescue uses KSW_XBYTE (8-bit kernel) for short reads
+    // where `l_ms * w_match < 250`. With w_match=1 and qlen<=128 that covers
+    // all our test pairs; route everything through getScores8.
+    const int xtra_flags = KSW_XSUBO | KSW_XSTART | KSW_XBYTE;
+
     size_t ref_off = 0, qer_off = 0;
     for (int i = 0; i < n; i++) {
         const auto &p = pairs[i];
@@ -155,7 +164,7 @@ static BatchResult run_batched(const std::vector<TestPair> &pairs,
         sp.id     = i;
         sp.len1   = (int32_t)p.ref.size();
         sp.len2   = (int32_t)p.qry.size();
-        sp.h0     = KSW_XSTART | KSW_XSUBO;
+        sp.h0     = xtra_flags;
         sp.seqid  = i;
         sp.regid  = i;
         pairArray[i] = sp;
@@ -165,8 +174,8 @@ static BatchResult run_batched(const std::vector<TestPair> &pairs,
 
     kswv *pwsw = new kswv(GAP_OPEN, GAP_EXT, GAP_OPEN, GAP_EXT,
                           SCORE_MATCH, -SCORE_MISMATCH, 1, maxRefLen, maxQerLen);
-    pwsw->getScores16(pairArray.data(), seqBufRef.data(), seqBufQer.data(),
-                      out.aln.data(), n, 1, 0);
+    pwsw->getScores8(pairArray.data(), seqBufRef.data(), seqBufQer.data(),
+                     out.aln.data(), n, 1, 0);
     delete pwsw;
     out.aln.resize(n);
     return out;

--- a/test/kswv_selftest.cpp
+++ b/test/kswv_selftest.cpp
@@ -1,0 +1,269 @@
+// Self-consistency test for kswv::getScores8 versus scalar ksw_align2.
+//
+// Feeds deterministic random and edge-case SeqPair inputs through both the
+// batched SIMD kernel (kswv) and the scalar reference (ksw_align2), then
+// diffs kswr_t fields. Exits 0 on full match, nonzero on any divergence.
+//
+// Purpose: prove that the NEON kswv code path (kswv.cpp:175-628) is bit-
+// identical to the scalar reference. NEON kswv is currently unreachable
+// from production on ARM (gated by __AVX512BW__), so until we widen the
+// gate, this is the only way to exercise it.
+//
+// Usage:
+//   kswv_selftest                  # default: 10k random + ~40 edge cases
+//   kswv_selftest <n_random> <seed>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+#include <cstdarg>
+#include <random>
+#include <vector>
+#include <string>
+
+#include "ksw.h"
+#include "kswv.h"
+#include "macro.h"
+
+// Scoring (matches bwa-mem2 defaults)
+static const int8_t SCORE_MATCH    = 1;
+static const int8_t SCORE_MISMATCH = 4;
+static const int    GAP_OPEN       = 6;
+static const int    GAP_EXT        = 1;
+
+// 5x5 substitution matrix for ACGTN encoding 0..4
+static int8_t g_mat[25];
+
+static void build_mat() {
+    for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < 4; j++) {
+            g_mat[i*5 + j] = (i == j) ? SCORE_MATCH : -SCORE_MISMATCH;
+        }
+        g_mat[i*5 + 4] = 0;
+        g_mat[4*5 + i] = 0;
+    }
+    g_mat[24] = 0;
+}
+
+struct TestPair {
+    std::vector<uint8_t> ref;
+    std::vector<uint8_t> qry;
+    const char *tag;  // label for failure reporting
+};
+
+// --- pair generators --------------------------------------------------------
+
+static TestPair gen_random(std::mt19937 &rng, int qlen, int rlen) {
+    std::uniform_int_distribution<int> base(0, 3);
+    TestPair p;
+    p.ref.resize(rlen);
+    p.qry.resize(qlen);
+    p.tag = "random";
+    for (int i = 0; i < rlen; i++) p.ref[i] = base(rng);
+    for (int i = 0; i < qlen; i++) p.qry[i] = base(rng);
+    return p;
+}
+
+static TestPair gen_exact_match(int len) {
+    TestPair p;
+    p.ref.assign(len * 2, 0);  // AAAAA...
+    p.qry.assign(len, 0);
+    p.tag = "exact_match";
+    for (int i = 0; i < len * 2; i++) p.ref[i] = (i * 7 + 3) & 3;  // deterministic ACGT pattern
+    for (int i = 0; i < len;     i++) p.qry[i] = p.ref[len / 2 + i]; // embed query in middle
+    return p;
+}
+
+static TestPair gen_all_mismatch(int len) {
+    TestPair p;
+    p.ref.assign(len, 0);  // all A
+    p.qry.assign(len, 1);  // all C
+    p.tag = "all_mismatch";
+    return p;
+}
+
+static TestPair gen_homopolymer(int len, uint8_t base) {
+    TestPair p;
+    p.ref.assign(len, base);
+    p.qry.assign(len, base);
+    p.tag = "homopolymer";
+    return p;
+}
+
+static TestPair gen_with_indel(std::mt19937 &rng, int qlen, int rlen, int indel_pos, int indel_len) {
+    auto p = gen_random(rng, qlen, rlen);
+    p.tag = "with_indel";
+    if (indel_pos + indel_len <= (int)p.qry.size()) {
+        std::uniform_int_distribution<int> base(0, 3);
+        for (int i = 0; i < indel_len; i++) p.qry[indel_pos + i] = base(rng);
+    }
+    return p;
+}
+
+static TestPair gen_with_n_bases(std::mt19937 &rng, int qlen, int rlen, int n_frac_pct) {
+    auto p = gen_random(rng, qlen, rlen);
+    p.tag = "with_n_bases";
+    std::uniform_int_distribution<int> pct(0, 99);
+    for (int i = 0; i < qlen; i++) if (pct(rng) < n_frac_pct) p.qry[i] = 4;
+    for (int i = 0; i < rlen; i++) if (pct(rng) < n_frac_pct) p.ref[i] = 4;
+    return p;
+}
+
+// --- runners ----------------------------------------------------------------
+
+static kswr_t run_scalar(const TestPair &p) {
+    // ksw_align2 expects non-const pointers, but does not mutate.
+    return ksw_align2(p.qry.size(), const_cast<uint8_t*>(p.qry.data()),
+                      p.ref.size(), const_cast<uint8_t*>(p.ref.data()),
+                      5, g_mat, GAP_OPEN, GAP_EXT, GAP_OPEN, GAP_EXT,
+                      KSW_XSTART | KSW_XSUBO, nullptr);
+}
+
+// Pack a batch of pairs into kswv's flat seqBuf layout and run getScores8.
+// Returns aln array (length == pairs.size()); caller frees nothing.
+struct BatchResult {
+    std::vector<kswr_t> aln;
+};
+
+static BatchResult run_batched(const std::vector<TestPair> &pairs,
+                               int32_t maxRefLen, int32_t maxQerLen) {
+    BatchResult out;
+    int n = (int)pairs.size();
+    out.aln.assign(n + SIMD_WIDTH8, g_defr);
+
+    // Flatten into buffers. kswv's internal kernel reads [idr, idr+len1) and
+    // [idq, idq+len2) out of seqBufRef / seqBufQer.
+    size_t ref_total = 0, qer_total = 0;
+    for (const auto &p : pairs) { ref_total += p.ref.size(); qer_total += p.qry.size(); }
+    // round up for SIMD tail padding
+    ref_total += SIMD_WIDTH8 * maxRefLen;
+    qer_total += SIMD_WIDTH8 * maxQerLen;
+
+    std::vector<uint8_t> seqBufRef(ref_total, 0);
+    std::vector<uint8_t> seqBufQer(qer_total, 0);
+    std::vector<SeqPair> pairArray(n + SIMD_WIDTH8);
+
+    size_t ref_off = 0, qer_off = 0;
+    for (int i = 0; i < n; i++) {
+        const auto &p = pairs[i];
+        std::memcpy(seqBufRef.data() + ref_off, p.ref.data(), p.ref.size());
+        std::memcpy(seqBufQer.data() + qer_off, p.qry.data(), p.qry.size());
+        SeqPair sp = {};
+        sp.idr    = (int32_t)ref_off;
+        sp.idq    = (int32_t)qer_off;
+        sp.id     = i;
+        sp.len1   = (int32_t)p.ref.size();
+        sp.len2   = (int32_t)p.qry.size();
+        sp.h0     = KSW_XSTART | KSW_XSUBO;
+        sp.seqid  = i;
+        sp.regid  = i;
+        pairArray[i] = sp;
+        ref_off += p.ref.size();
+        qer_off += p.qry.size();
+    }
+
+    kswv *pwsw = new kswv(GAP_OPEN, GAP_EXT, GAP_OPEN, GAP_EXT,
+                          SCORE_MATCH, -SCORE_MISMATCH, 1, maxRefLen, maxQerLen);
+    pwsw->getScores16(pairArray.data(), seqBufRef.data(), seqBufQer.data(),
+                      out.aln.data(), n, 1, 0);
+    delete pwsw;
+    out.aln.resize(n);
+    return out;
+}
+
+// --- diffing ----------------------------------------------------------------
+
+struct Mismatch {
+    int idx;
+    std::string tag;
+    kswr_t scalar, batched;
+};
+
+static bool kswr_eq_score(const kswr_t &a, const kswr_t &b) {
+    return a.score == b.score;  // primary correctness bar
+}
+
+int main(int argc, char **argv) {
+    int n_random = (argc > 1) ? atoi(argv[1]) : 10000;
+    if (n_random < 0) n_random = 0;
+    uint32_t seed = (argc > 2) ? (uint32_t)atoi(argv[2]) : 42u;
+
+    build_mat();
+
+    std::mt19937 rng(seed);
+    std::vector<TestPair> pairs;
+    pairs.reserve((size_t)n_random + 64);
+
+    // Edge cases first (so failures point to them in index-order output).
+    pairs.push_back(gen_exact_match(50));
+    pairs.push_back(gen_exact_match(100));
+    pairs.push_back(gen_all_mismatch(50));
+    pairs.push_back(gen_all_mismatch(100));
+    pairs.push_back(gen_homopolymer(50, 0));  // all A
+    pairs.push_back(gen_homopolymer(50, 1));  // all C
+    pairs.push_back(gen_homopolymer(50, 2));  // all G
+    pairs.push_back(gen_homopolymer(50, 3));  // all T
+    pairs.push_back(gen_with_indel(rng, 100, 150, 40, 3));
+    pairs.push_back(gen_with_indel(rng, 100, 150, 40, 10));
+    pairs.push_back(gen_with_n_bases(rng, 100, 150, 5));
+    pairs.push_back(gen_with_n_bases(rng, 100, 150, 20));
+
+    // Minimum-length sanity
+    pairs.push_back(gen_random(rng, 20, 40));
+    pairs.push_back(gen_random(rng, 10, 30));
+
+    // Bulk random
+    std::uniform_int_distribution<int> qlen_d(50, 128);
+    std::uniform_int_distribution<int> rlen_d(100, 250);
+    for (int i = 0; i < n_random; i++) {
+        pairs.push_back(gen_random(rng, qlen_d(rng), rlen_d(rng)));
+    }
+
+    // Compute maxRefLen/maxQerLen for kswv sizing
+    int32_t maxRefLen = 0, maxQerLen = 0;
+    for (const auto &p : pairs) {
+        if ((int32_t)p.ref.size() > maxRefLen) maxRefLen = p.ref.size();
+        if ((int32_t)p.qry.size() > maxQerLen) maxQerLen = p.qry.size();
+    }
+
+    // Reference (scalar)
+    std::vector<kswr_t> scalar_aln(pairs.size());
+    for (size_t i = 0; i < pairs.size(); i++) scalar_aln[i] = run_scalar(pairs[i]);
+
+    // Batched (NEON kswv on ARM; AVX-512 kswv on x86)
+    BatchResult br = run_batched(pairs, maxRefLen, maxQerLen);
+
+    // Diff
+    std::vector<Mismatch> mism;
+    for (size_t i = 0; i < pairs.size(); i++) {
+        if (!kswr_eq_score(scalar_aln[i], br.aln[i])) {
+            Mismatch m{ (int)i, pairs[i].tag, scalar_aln[i], br.aln[i] };
+            mism.push_back(m);
+        }
+    }
+
+    fprintf(stderr, "kswv_selftest: %zu pairs tested (%d random + %zu edge), %zu score mismatch\n",
+            pairs.size(), n_random, pairs.size() - (size_t)n_random, mism.size());
+
+    if (!mism.empty()) {
+        int printed = 0;
+        for (const auto &m : mism) {
+            if (printed >= 20) {
+                fprintf(stderr, "  ... %zu more\n", mism.size() - (size_t)printed);
+                break;
+            }
+            ++printed;
+            fprintf(stderr, "  [%d] tag=%s scalar.score=%d batched.score=%d  "
+                            "scalar{tb=%d,te=%d,qb=%d,qe=%d}  batched{tb=%d,te=%d,qb=%d,qe=%d}\n",
+                    m.idx, m.tag.c_str(),
+                    m.scalar.score, m.batched.score,
+                    m.scalar.tb, m.scalar.te, m.scalar.qb, m.scalar.qe,
+                    m.batched.tb, m.batched.te, m.batched.qb, m.batched.qe);
+        }
+        return 1;
+    }
+
+    fprintf(stderr, "kswv_selftest: OK\n");
+    return 0;
+}

--- a/test/kswv_selftest.cpp
+++ b/test/kswv_selftest.cpp
@@ -116,12 +116,18 @@ static TestPair gen_with_n_bases(std::mt19937 &rng, int qlen, int rlen, int n_fr
 
 // --- runners ----------------------------------------------------------------
 
+// Scalar reference — pass the same xtra flags as the batched path so that
+// the minsc threshold (low 16 bits) filters score2 identically in both.
+static const int MIN_SEED_LEN = 19;
+static const int SELF_XTRA    = KSW_XSUBO | KSW_XSTART | KSW_XBYTE
+                                | (MIN_SEED_LEN * SCORE_MATCH);
+
 static kswr_t run_scalar(const TestPair &p) {
     // ksw_align2 expects non-const pointers, but does not mutate.
     return ksw_align2(p.qry.size(), const_cast<uint8_t*>(p.qry.data()),
                       p.ref.size(), const_cast<uint8_t*>(p.ref.data()),
                       5, g_mat, GAP_OPEN, GAP_EXT, GAP_OPEN, GAP_EXT,
-                      KSW_XSTART | KSW_XSUBO, nullptr);
+                      SELF_XTRA, nullptr);
 }
 
 // Pack a batch of pairs into kswv's flat seqBuf layout and run getScores8.
@@ -157,10 +163,11 @@ static BatchResult run_batched(const std::vector<TestPair> &pairs,
     std::vector<uint8_t> seqBufQer(qer_total, 0);
     std::vector<SeqPair> pairArray(n + SIMD_WIDTH8);
 
-    // Production mate-rescue uses KSW_XBYTE (8-bit kernel) for short reads
-    // where `l_ms * w_match < 250`. With w_match=1 and qlen<=128 that covers
-    // all our test pairs; route everything through getScores8.
-    const int xtra_flags = KSW_XSUBO | KSW_XSTART | KSW_XBYTE;
+    // Match production's mate-rescue h0 (bwamem_pair.cpp:1004):
+    //   KSW_XSUBO | KSW_XSTART | (l_ms*a<250 ? KSW_XBYTE : 0) | (min_seed_len*a)
+    // The low 16 bits carry the minsc threshold that gates which score2
+    // candidates the kernel admits — matching scalar ksw_align2.
+    const int xtra_flags = SELF_XTRA;
 
     size_t ref_off = 0, qer_off = 0;
     for (int i = 0; i < n; i++) {
@@ -200,12 +207,16 @@ static BatchResult run_batched(const std::vector<TestPair> &pairs,
         }
     }
 
-    // Between passes: replicate the production code at bwamem_pair.cpp:661-683.
+    // Between passes: replicate the production code at bwamem_pair.cpp:660-676.
     // For each pair, reverse seq prefixes up to (te+1, qe+1), set h0 to
-    // KSW_XSTOP | score, trim len2 to qe+1, keep the pair in the batch.
+    // KSW_XSTOP | score, trim len2 to qe+1. Repack survivors to the front of
+    // pairArray (copy, not reference) so phase 1 sees the same lane mix
+    // production builds — lane-mixing masking/freezing regressions only
+    // surface under the compacted layout.
+    int pos = 0;
     for (int i = 0; i < n; i++) {
         kswr_t r = out.aln[i];
-        SeqPair &sp = pairArray[i];
+        SeqPair sp = pairArray[i];
         int xtra = sp.h0;
         if ((xtra & KSW_XSTART) == 0 ||
             ((xtra & KSW_XSUBO) && r.score < (xtra & 0xffff))) {
@@ -217,11 +228,33 @@ static BatchResult run_batched(const std::vector<TestPair> &pairs,
         uint8_t *rs = seqBufRef.data() + sp.idr;
         revseq(r.qe + 1, qs);
         revseq(r.te + 1, rs);
+        pairArray[pos++] = sp;
     }
 
     // Phase 1: reverse pass → fills tb, qb by subtraction inside the kernel.
+    // For diagnosis, save pre-phase-1 kswr_t so we can see whether phase 1's
+    // score differs from the stored phase-0 score (that equality gates the
+    // tb/qb write-back at kswv.cpp:535).
+    std::vector<kswr_t> pre_phase1(out.aln.begin(), out.aln.begin() + n);
     pwsw->getScores8(pairArray.data(), seqBufRef.data(), seqBufQer.data(),
-                     out.aln.data(), n, 1, 1);
+                     out.aln.data(), pos, 1, 1);
+
+    if (const char *dbg = getenv("KSWV_SELFTEST_DEBUG_PHASE1")) {
+        (void)dbg;
+        int dumped = 0;
+        for (int i = 0; i < n && dumped < 10; i++) {
+            if (out.aln[i].tb == -1 && pre_phase1[i].score > 0) {
+                fprintf(stderr, "[debug-phase1] pair %d: phase0{score=%d te=%d qe=%d} "
+                        "post_phase1{score=%d te=%d qe=%d tb=%d qb=%d} "
+                        "len1_after_trim=%d len2_after_trim=%d\n",
+                        i, pre_phase1[i].score, pre_phase1[i].te, pre_phase1[i].qe,
+                        out.aln[i].score, out.aln[i].te, out.aln[i].qe,
+                        out.aln[i].tb, out.aln[i].qb,
+                        pairArray[i].len1, pairArray[i].len2);
+                dumped++;
+            }
+        }
+    }
 
     delete pwsw;
     out.aln.resize(n);
@@ -246,7 +279,22 @@ static bool kswr_eq_score(const kswr_t &a, const kswr_t &b) {
 // the kernel may not bother filling those.
 static bool kswr_eq_coords(const kswr_t &scalar, const kswr_t &batched) {
     if (scalar.score == 0) return true;  // degenerate, skip
+    // Scalar ksw_align2 short-circuits phase 2 when `score < minsc`
+    // (ksw.cpp:374), leaving tb/qb at -1. Production's downstream filter
+    // `aln.score >= opt->min_seed_len` drops these pairs before tb/qb is
+    // consulted. Exclude from the coord diff to match that reality.
+    if (scalar.score < MIN_SEED_LEN) return true;
     return scalar.qb == batched.qb && scalar.tb == batched.tb;
+}
+
+static bool kswr_eq_score2(const kswr_t &scalar, const kswr_t &batched) {
+    if (scalar.score == 0) return true;
+    // score2 is the sub-optimal score from KSW_XSUBO; it feeds MAPQ
+    // downstream via mem_alnreg_t::csub. Scalar sets -1 when absent;
+    // batched kernel may use 0 or -1; treat both as "no suboptimal".
+    int a = (scalar.score2 <= 0) ? -1 : scalar.score2;
+    int b = (batched.score2 <= 0) ? -1 : batched.score2;
+    return a == b;
 }
 
 int main(int argc, char **argv) {
@@ -299,9 +347,10 @@ int main(int argc, char **argv) {
     // Batched (NEON kswv on ARM; AVX-512 kswv on x86)
     BatchResult br = run_batched(pairs, maxRefLen, maxQerLen);
 
-    // Diff: both score and start-position correctness.
+    // Diff: score, start-position, and score2 (suboptimal) correctness.
     std::vector<Mismatch> score_mism;
     std::vector<Mismatch> coord_mism;
+    std::vector<Mismatch> score2_mism;
     for (size_t i = 0; i < pairs.size(); i++) {
         if (!kswr_eq_score(scalar_aln[i], br.aln[i])) {
             score_mism.push_back({(int)i, pairs[i].tag, scalar_aln[i], br.aln[i]});
@@ -309,13 +358,17 @@ int main(int argc, char **argv) {
         if (!kswr_eq_coords(scalar_aln[i], br.aln[i])) {
             coord_mism.push_back({(int)i, pairs[i].tag, scalar_aln[i], br.aln[i]});
         }
+        if (!kswr_eq_score2(scalar_aln[i], br.aln[i])) {
+            score2_mism.push_back({(int)i, pairs[i].tag, scalar_aln[i], br.aln[i]});
+        }
     }
 
     fprintf(stderr, "kswv_selftest: %zu pairs tested (%d random + %zu edge)\n"
                     "  score mismatches: %zu\n"
-                    "  coord (tb/qb) mismatches: %zu\n",
+                    "  coord (tb/qb) mismatches: %zu\n"
+                    "  score2 (suboptimal) mismatches: %zu\n",
             pairs.size(), n_random, pairs.size() - (size_t)n_random,
-            score_mism.size(), coord_mism.size());
+            score_mism.size(), coord_mism.size(), score2_mism.size());
 
     auto dump_mism = [](const char *label, const std::vector<Mismatch> &mism) {
         if (mism.empty()) return;
@@ -327,28 +380,23 @@ int main(int argc, char **argv) {
                 break;
             }
             ++printed;
-            fprintf(stderr, "  [%d] tag=%s  scalar{score=%d,tb=%d,te=%d,qb=%d,qe=%d}  "
-                            "batched{score=%d,tb=%d,te=%d,qb=%d,qe=%d}\n",
+            fprintf(stderr, "  [%d] tag=%s  scalar{s=%d,tb=%d,te=%d,qb=%d,qe=%d,s2=%d,te2=%d}  "
+                            "batched{s=%d,tb=%d,te=%d,qb=%d,qe=%d,s2=%d,te2=%d}\n",
                     m.idx, m.tag.c_str(),
                     m.scalar.score, m.scalar.tb, m.scalar.te, m.scalar.qb, m.scalar.qe,
-                    m.batched.score, m.batched.tb, m.batched.te, m.batched.qb, m.batched.qe);
+                    m.scalar.score2, m.scalar.te2,
+                    m.batched.score, m.batched.tb, m.batched.te, m.batched.qb, m.batched.qe,
+                    m.batched.score2, m.batched.te2);
         }
     };
     dump_mism("score", score_mism);
     dump_mism("coord", coord_mism);
+    dump_mism("score2", score2_mism);
 
-    // Gating: score correctness is required (proven working in earlier
-    // iteration). Coord correctness is currently broken on NEON phase=1 —
-    // reported as diagnostic, not gated. Once NEON kswv phase=1 is fixed,
-    // remove this soft-fail so coord mismatches also block CI.
-    if (!score_mism.empty()) {
-        fprintf(stderr, "\nkswv_selftest: FAIL (score mismatches present)\n");
+    if (!score_mism.empty() || !coord_mism.empty() || !score2_mism.empty()) {
+        fprintf(stderr, "\nkswv_selftest: FAIL\n");
         return 1;
     }
-    if (!coord_mism.empty()) {
-        fprintf(stderr, "\nkswv_selftest: partial OK — score correct, phase-1 coord bug known\n");
-        return 0;
-    }
-    fprintf(stderr, "kswv_selftest: OK (score + coord match)\n");
+    fprintf(stderr, "kswv_selftest: OK (score + coord + score2 match)\n");
     return 0;
 }

--- a/test/kswv_selftest.cpp
+++ b/test/kswv_selftest.cpp
@@ -188,6 +188,18 @@ static BatchResult run_batched(const std::vector<TestPair> &pairs,
     pwsw->getScores8(pairArray.data(), seqBufRef.data(), seqBufQer.data(),
                      out.aln.data(), n, 1, 0);
 
+    // Diagnostic: capture phase-0 output before phase 1 runs so we can
+    // distinguish "phase 0 never set te/qe" from "phase 1 clobbered them".
+    if (const char *dbg = getenv("KSWV_SELFTEST_DEBUG_PHASE0")) {
+        (void)dbg;
+        int nprint = (n < 5) ? n : 5;
+        for (int i = 0; i < nprint; i++) {
+            fprintf(stderr, "[debug-phase0] pair %d: score=%d te=%d qe=%d tb=%d qb=%d\n",
+                    i, out.aln[i].score, out.aln[i].te, out.aln[i].qe,
+                    out.aln[i].tb, out.aln[i].qb);
+        }
+    }
+
     // Between passes: replicate the production code at bwamem_pair.cpp:661-683.
     // For each pair, reverse seq prefixes up to (te+1, qe+1), set h0 to
     // KSW_XSTOP | score, trim len2 to qe+1, keep the pair in the batch.

--- a/test/kswv_selftest.cpp
+++ b/test/kswv_selftest.cpp
@@ -5,9 +5,9 @@
 // diffs kswr_t fields. Exits 0 on full match, nonzero on any divergence.
 //
 // Purpose: prove that the NEON kswv code path (kswv.cpp:175-628) is bit-
-// identical to the scalar reference. NEON kswv is currently unreachable
-// from production on ARM (gated by __AVX512BW__), so until we widen the
-// gate, this is the only way to exercise it.
+// identical to the scalar reference. BWAMEM_BATCHED_MATESW (src/macro.h)
+// now routes production mate-rescue through this kernel on AArch64, so the
+// selftest locks in correctness ahead of any further kernel work.
 //
 // Usage:
 //   kswv_selftest                  # default: 10k random + ~40 edge cases

--- a/test/kswv_selftest.cpp
+++ b/test/kswv_selftest.cpp
@@ -130,6 +130,15 @@ struct BatchResult {
     std::vector<kswr_t> aln;
 };
 
+// Reverse the first l elements of s in place (copy of revseq from bwamem_pair.cpp).
+static inline void revseq(int l, uint8_t *s) {
+    for (int i = 0; i < l >> 1; ++i) {
+        uint8_t t = s[i];
+        s[i] = s[l - 1 - i];
+        s[l - 1 - i] = t;
+    }
+}
+
 static BatchResult run_batched(const std::vector<TestPair> &pairs,
                                int32_t maxRefLen, int32_t maxQerLen) {
     BatchResult out;
@@ -174,8 +183,34 @@ static BatchResult run_batched(const std::vector<TestPair> &pairs,
 
     kswv *pwsw = new kswv(GAP_OPEN, GAP_EXT, GAP_OPEN, GAP_EXT,
                           SCORE_MATCH, -SCORE_MISMATCH, 1, maxRefLen, maxQerLen);
+
+    // Phase 0: forward pass → score, te, qe.
     pwsw->getScores8(pairArray.data(), seqBufRef.data(), seqBufQer.data(),
                      out.aln.data(), n, 1, 0);
+
+    // Between passes: replicate the production code at bwamem_pair.cpp:661-683.
+    // For each pair, reverse seq prefixes up to (te+1, qe+1), set h0 to
+    // KSW_XSTOP | score, trim len2 to qe+1, keep the pair in the batch.
+    for (int i = 0; i < n; i++) {
+        kswr_t r = out.aln[i];
+        SeqPair &sp = pairArray[i];
+        int xtra = sp.h0;
+        if ((xtra & KSW_XSTART) == 0 ||
+            ((xtra & KSW_XSUBO) && r.score < (xtra & 0xffff))) {
+            continue;
+        }
+        sp.h0    = KSW_XSTOP | r.score;
+        sp.len2  = r.qe + 1;
+        uint8_t *qs = seqBufQer.data() + sp.idq;
+        uint8_t *rs = seqBufRef.data() + sp.idr;
+        revseq(r.qe + 1, qs);
+        revseq(r.te + 1, rs);
+    }
+
+    // Phase 1: reverse pass → fills tb, qb by subtraction inside the kernel.
+    pwsw->getScores8(pairArray.data(), seqBufRef.data(), seqBufQer.data(),
+                     out.aln.data(), n, 1, 1);
+
     delete pwsw;
     out.aln.resize(n);
     return out;
@@ -191,6 +226,15 @@ struct Mismatch {
 
 static bool kswr_eq_score(const kswr_t &a, const kswr_t &b) {
     return a.score == b.score;  // primary correctness bar
+}
+
+// Phase-1 correctness: after two-pass, batched should have tb/qb set to the
+// same start positions scalar ksw_align2 reports. Skip pairs where scalar
+// produces a "no alignment" result (score==0 with tb<0 or similar), since
+// the kernel may not bother filling those.
+static bool kswr_eq_coords(const kswr_t &scalar, const kswr_t &batched) {
+    if (scalar.score == 0) return true;  // degenerate, skip
+    return scalar.qb == batched.qb && scalar.tb == batched.tb;
 }
 
 int main(int argc, char **argv) {
@@ -243,19 +287,27 @@ int main(int argc, char **argv) {
     // Batched (NEON kswv on ARM; AVX-512 kswv on x86)
     BatchResult br = run_batched(pairs, maxRefLen, maxQerLen);
 
-    // Diff
-    std::vector<Mismatch> mism;
+    // Diff: both score and start-position correctness.
+    std::vector<Mismatch> score_mism;
+    std::vector<Mismatch> coord_mism;
     for (size_t i = 0; i < pairs.size(); i++) {
         if (!kswr_eq_score(scalar_aln[i], br.aln[i])) {
-            Mismatch m{ (int)i, pairs[i].tag, scalar_aln[i], br.aln[i] };
-            mism.push_back(m);
+            score_mism.push_back({(int)i, pairs[i].tag, scalar_aln[i], br.aln[i]});
+        }
+        if (!kswr_eq_coords(scalar_aln[i], br.aln[i])) {
+            coord_mism.push_back({(int)i, pairs[i].tag, scalar_aln[i], br.aln[i]});
         }
     }
 
-    fprintf(stderr, "kswv_selftest: %zu pairs tested (%d random + %zu edge), %zu score mismatch\n",
-            pairs.size(), n_random, pairs.size() - (size_t)n_random, mism.size());
+    fprintf(stderr, "kswv_selftest: %zu pairs tested (%d random + %zu edge)\n"
+                    "  score mismatches: %zu\n"
+                    "  coord (tb/qb) mismatches: %zu\n",
+            pairs.size(), n_random, pairs.size() - (size_t)n_random,
+            score_mism.size(), coord_mism.size());
 
-    if (!mism.empty()) {
+    auto dump_mism = [](const char *label, const std::vector<Mismatch> &mism) {
+        if (mism.empty()) return;
+        fprintf(stderr, "\nFirst %s mismatches:\n", label);
         int printed = 0;
         for (const auto &m : mism) {
             if (printed >= 20) {
@@ -263,16 +315,28 @@ int main(int argc, char **argv) {
                 break;
             }
             ++printed;
-            fprintf(stderr, "  [%d] tag=%s scalar.score=%d batched.score=%d  "
-                            "scalar{tb=%d,te=%d,qb=%d,qe=%d}  batched{tb=%d,te=%d,qb=%d,qe=%d}\n",
+            fprintf(stderr, "  [%d] tag=%s  scalar{score=%d,tb=%d,te=%d,qb=%d,qe=%d}  "
+                            "batched{score=%d,tb=%d,te=%d,qb=%d,qe=%d}\n",
                     m.idx, m.tag.c_str(),
-                    m.scalar.score, m.batched.score,
-                    m.scalar.tb, m.scalar.te, m.scalar.qb, m.scalar.qe,
-                    m.batched.tb, m.batched.te, m.batched.qb, m.batched.qe);
+                    m.scalar.score, m.scalar.tb, m.scalar.te, m.scalar.qb, m.scalar.qe,
+                    m.batched.score, m.batched.tb, m.batched.te, m.batched.qb, m.batched.qe);
         }
+    };
+    dump_mism("score", score_mism);
+    dump_mism("coord", coord_mism);
+
+    // Gating: score correctness is required (proven working in earlier
+    // iteration). Coord correctness is currently broken on NEON phase=1 —
+    // reported as diagnostic, not gated. Once NEON kswv phase=1 is fixed,
+    // remove this soft-fail so coord mismatches also block CI.
+    if (!score_mism.empty()) {
+        fprintf(stderr, "\nkswv_selftest: FAIL (score mismatches present)\n");
         return 1;
     }
-
-    fprintf(stderr, "kswv_selftest: OK\n");
+    if (!coord_mism.empty()) {
+        fprintf(stderr, "\nkswv_selftest: partial OK — score correct, phase-1 coord bug known\n");
+        return 0;
+    }
+    fprintf(stderr, "kswv_selftest: OK (score + coord match)\n");
     return 0;
 }


### PR DESCRIPTION
**Status: ready for review** (still draft until a second set of eyes signs off).

Enables the batched mate-rescue SW path on arm64 via the existing (previously unreachable) NEON `kswv::getScores8` kernel. Four kernel bugs found and fixed along the way. See commit `e101d37` for the detailed writeup.

## Results

**Correctness** — NEON batched vs scalar reference, byte-identical sorted SAM:
- Local macOS arm64, 500k dwgsim/chr17, 3 seeds (42, 7, 123): all 0 diffs
- Linux arm64 CI, 500k dwgsim/chr17: PASS (cross-arch identity gate)

**kswv selftest** (test/kswv_selftest.cpp, 10014 pairs, random + edge cases):
- score mismatches: 0
- coord (tb/qb) mismatches: 0
- score2 (suboptimal) mismatches: 0

**Performance** (median of 3 reps):
- Local M-series, 8 threads, 500k PE 100bp dwgsim on chr17: **1.42× (-29.4% wall time)**
- Linux arm64 CI, 4 threads, 500k PE 100bp: 1.04× (slower runner; mate rescue dilutes at lower core count)

## What changed

- `src/macro.h` — `BWAMEM_BATCHED_MATESW` macro (replaces `__AVX512BW__` gate).
- `src/bwamem.cpp:1255` — dispatcher uses the new macro.
- `src/bwamem_pair.cpp:657, 706` — inner `pwsw->getScores8/16` gates use the new macro; fatal error branch replaced with a clearer message.
- `src/kswv.cpp` — four NEON kernel fixes (te width, freeze mask, per-pair score2 exclusion, minsc filter).
- `test/kswv_selftest.cpp` — self-consistency harness, production-matching h0, tight gate.
- `Makefile` — `kswv_selftest` target, `DISABLE_BATCHED_MATESW` control-build flag.
- `.github/workflows/proto-neon-kswv.yml` — ARM selftest + port/control perf A/B + cross-arch SAM identity diff, all strict gates.

## Merge plan

PR is draft. Suggested next steps before un-drafting:
1. One reviewer scan through the four kernel fixes in `src/kswv.cpp`.
2. (Optional) Confirm speedup on c7g Graviton3 via self-hosted runner if we want a "production-class" perf number vs the free CI runner.
3. Squash / re-author the noisier scaffolding commits into a clean history before merging to `fg-main`.

## The four bugs, in order

Each was masked by the previous one, so they surfaced only as the kernel got closer to correct:

1. `te_vec` tracked 16 pairs in 8 int16 slots (hacky duplicate store) → pairs 8–15 got copies of the wrong pair's te.
2. No per-lane freeze at `KSW_XSTOP` → once a pair hit the target score, untouched ref bytes in later rows kept inflating `gmax/te`, breaking the phase-1 write-back gate for `tb/qb`.
3. score2 scan used a single aggregate `[minh+1, limit)` range across the whole batch → one pair's primary region contaminated another's suboptimal.
4. score2 scan didn't enforce `minsc` → sub-threshold plateau scores from padding decay leaked in as false suboptimals, collapsing MAPQ on real reads.

Selftest caught each of these cleanly once the right fields were checked. Iteration worked as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI performance self-test workflow that benchmarks ARM vs x86, verifies SAM identity, and uploads artifacts.
  * Deterministic SIMD-vs-scalar self-test executable with a Make target; builds now use C++14.
* **Bug Fixes**
  * Fixed NEON alignment scoring to prevent inter-lane interference and improved secondary-score selection.
* **Chores**
  * Added build-time toggle to choose batched vs scalar mate-rescue and updated clean/test targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->