### PR TITLE
fix: zero bseq1_t in kseq2bseq1 — crash in stock mem on realloc growth

### DIFF
--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -61,6 +61,11 @@ static inline void trim_readno(kstring_t *s)
 
 static inline void kseq2bseq1(const kseq_t *ks, bseq1_t *s)
 { // TODO: it would be better to allocate one chunk of memory, but probably it does not matter in practice
+    // bseq_read/bseq_read_orig grow `seqs` with realloc, which leaves the
+    // new entries uninitialized. Zero first so sam/bams/n_bams/cap_bams
+    // start well-defined — the output loop at fastmap.cpp free()s them
+    // unconditionally, so garbage from realloc would otherwise be freed.
+    memset(s, 0, sizeof(*s));
     s->name = strdup(ks->name.s);
     s->comment = ks->comment.l? strdup(ks->comment.s) : 0;
     s->seq = strdup(ks->seq.s);


### PR DESCRIPTION
## Summary

- `bseq_read_orig` grows its seqs buffer with `realloc`, leaving tail entries uninitialized.
- `kseq2bseq1` only populated `name/comment/seq/qual/l_seq`, leaving `sam/bams/n_bams/cap_bams` holding realloc garbage.
- #13 added an unconditional `free(ret->seqs[i].bams)` in the output loop (fastmap.cpp:571), which turns that garbage into a crash in stock (no-flags) runs once input exceeds the initial 256-seq allocation.
- Fix: `memset(s, 0, sizeof(*s))` at the top of `kseq2bseq1`.

## Reproducer

```bash
# chr17 + 500k dwgsim pairs, any allocator
bwa-mem2 mem -t1 chr17.fa reads_1.fq.gz reads_2.fq.gz > /dev/null
# → abort (libmalloc: pointer being freed was not allocated)
#   or SIGSEGV under mimalloc
```

With system malloc the crashing call stack is:
```
kt_pipeline (fastmap.cpp:571)  ← free(bams)
libsystem_malloc ... ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
```

Crash is deterministic (reproduces with `-t1`) and is not allocator-specific; mimalloc just shows it as an access violation instead of an abort.

## Test plan

- [x] Stock mem on chr17 + 500k pairs: `EXIT=0`, 1,000,002 SAM lines (2 @SQ headers + 2 × 500k records), both with and without mimalloc.
- [ ] CI on this branch (proto-neon-kswv workflow inherited from fg-main).
- [ ] Follow-up: rebase PR #18 on top so its `proto-neon-kswv` CI goes green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory initialization issue that could cause crashes when processing sequence data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->