### PR TITLE
fix(kswv): gate AVX2 arch dispatch on !__AVX512BW__

### DIFF
--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -1061,7 +1061,7 @@ int kswv::kswv_neon_16(int16_t seq1SoA[],
     return 1;
 }
 
-#elif __AVX2__
+#elif ((!__AVX512BW__) & (__AVX2__))
 /* AVX2 kswv kernel — 256-bit vectors, 32 u8 lanes per batch.
  *
  * Direct port of the corrected NEON kernel (kswv_neon_u8 above) with all

--- a/src/kswv.h
+++ b/src/kswv.h
@@ -217,7 +217,7 @@ private:
                      int32_t numPairs,
                      int phase);
 
-#elif __AVX2__
+#elif ((!__AVX512BW__) & (__AVX2__))
 	/* AVX2 (256-bit, 32-lane u8) batched mate-rescue SW kernel.
 	 * Modeled on the corrected NEON kernel (not AVX-512, which has a
 	 * pre-existing coord/score2 bug class that the NEON port uncovered


### PR DESCRIPTION
## Summary
- Fixes #25 — the `a.cigar != NULL` assert in `mem_reg2aln` that fires on AVX-512BW dispatch (c7a/c7i).
- Root cause: GCC with `-mavx512bw` auto-defines `__AVX2__`, so the `#elif __AVX2__` branch in `src/kswv.h:220` / `src/kswv.cpp:1064` matched first. Every `arch=avx512bw` / `arch=multi` build silently ran the **256-bit AVX2 kswv kernel** while `src/bandedSWA.h` (correctly) set `SIMD_WIDTH8 = 64` under `__AVX512BW__`. The AVX2 kernel's `_mm256_storeu_si256` writes only 32 lanes of the `score[SIMD_WIDTH8]` / `te1[SIMD_WIDTH8]` / `qe[SIMD_WIDTH8]` output arrays; the 64-lane writeback loop then pushed the **uninitialized upper 32 slots** into `aln[regid].te`. `mem_matesw_batch_post` read those bogus `te` values, produced a `mem_alnreg_t` with `re < rb`, `bwa_gen_cigar2` correctly returned NULL, and the assert fired.
- Fix: qualify `#elif __AVX2__` with `!__AVX512BW__` in both files, matching the existing `bandedSWA.h` / `bandedSWA.cpp` pattern. `-mavx512bw` builds now compile (and run) the AVX-512BW kswv kernel whose `SIMD_WIDTH8=64` matches.
- Side effect: commit 2fd0e96 ("fix(kswv): apply NEON score2-scan fixes to AVX-512BW kernel") was fixing dead code until this PR. `kswv_selftest` happened to still pass because it links the kernel directly rather than via the production dispatch. With this PR, those fixes finally take effect.

## Verification
Repro + fix tested on `m5.2xlarge` (Intel Xeon Platinum 8175M, AVX-512BW, Ubuntu 24.04, gcc 13.3):

| Build | Exit | SAM records |
|-------|------|-------------|
| pre-fix, `arch=avx512bw` | 134 (SIGABRT in `mem_reg2aln`) | 0 |
| pre-fix, `arch=avx512bw DISABLE_BATCHED_MATESW=1` | 0 | 64763 |
| **post-fix**, `arch=avx512bw` | 0 | 64763 |
| post-fix, `arch=avx2` (control) | 0 | 64763 |

Reproducer: 1M PE reads (GRCh38 + decoys + ALTs, `-t 4`).

Primary alignment fields (POS / CIGAR / NM / MD / AS / SA / XA) are byte-identical between the post-fix `avx512bw` and the `avx2` control. 5 of 64 763 records differ only in MAPQ / XS — the AVX-512BW kernel's score2-scan fixes from 2fd0e96 (that were latent dead code) now produce a slightly more precise secondary-score estimate on those 5 reads, consistent with the NEON reference.

## Why CI didn't catch this
- `.github/workflows/ci.yml` matrix has no `arch=avx512bw` row and GitHub's `ubuntu-latest` x86 runners don't expose AVX-512BW, so the `.avx512bw` binary is never executed.
- `kswv_selftest` calls the kernel directly; the dispatch bug is invisible to it.
- Follow-up suggestion: add a matrix row that runs `.avx512bw` under Intel SDE (`sde -spr -- ./bwa-mem2.avx512bw mem ...`). SDE works on any Linux runner and faithfully emulates AVX-512BW. Tracked as out-of-scope here.

## Test plan
- [x] `arch=avx512bw` build runs to completion on an AVX-512BW host (m5.2xlarge, 1M PE vs hg38)
- [x] Assertion no longer fires
- [x] SAM record count matches AVX2 control (64 763 / 64 763)
- [x] Primary alignments byte-identical vs AVX2 control
- [x] ARM/NEON build unaffected (macOS ARM local build clean)
- [ ] Follow-up PR: Intel-SDE CI matrix entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SIMD kernel selection to prefer the correct implementation when multiple CPU instruction-set extensions are present.
  * Prevents an incorrect vectorized code path from being compiled/used on systems offering newer SIMD capabilities, improving runtime correctness and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->