### PR TITLE
fix(kswv): disable AVX2 batched mate-rescue pending kernel parity

### DIFF
--- a/src/macro.h
+++ b/src/macro.h
@@ -52,16 +52,18 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
  *        feeding kswv::getScores8 / getScores16).
  *   0 -> worker_sam takes the legacy scalar mem_sam_pe + ksw_align2 path.
  *
- * Historically gated on __AVX512BW__ only, which routed non-AVX-512 builds
- * (ARM, AVX2-only x86) to the scalar path even though batched kernels can
- * be implemented for those architectures. As of the NEON + AVX2 ports this
- * gate accepts any arch with a batched kswv kernel.
+ * Enabled on architectures whose batched kswv kernel has been validated
+ * end-to-end against scalar ksw_align2 on real reads: AVX-512BW (original
+ * upstream path) and NEON / Apple Silicon. AVX2 is intentionally held on
+ * the scalar path — the 256-bit kernel added in PR #20 passed
+ * kswv_selftest but diverged from bwa-mem2 v2.2.1 on smoke-1M with MAPQ
+ * regressions on 4/64763 reads via inflated mate-rescue `sub` scores;
+ * re-enable once the AVX2 kernel is bit-identical to scalar on real reads.
  * DISABLE_BATCHED_MATESW is an escape hatch for the A/B test in CI. */
 #ifndef BWAMEM_BATCHED_MATESW
   #if DISABLE_BATCHED_MATESW
     #define BWAMEM_BATCHED_MATESW 0
-  #elif __AVX512BW__ || __AVX2__ \
-        || defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)
+  #elif __AVX512BW__ || defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)
     #define BWAMEM_BATCHED_MATESW 1
   #else
     #define BWAMEM_BATCHED_MATESW 0


### PR DESCRIPTION
## Summary

PR #20 enabled the new 256-bit AVX2 kswv mate-rescue kernel for production AVX2 builds by adding `__AVX2__` to the `BWAMEM_BATCHED_MATESW` gate. That kernel passes `kswv_selftest` on synthetic pairs but produces mate-rescue suboptimal (`sub`) scores that diverge from scalar `ksw_align2` on some real reads, causing MAPQ regressions relative to upstream `v2.2.1`.

This PR drops `__AVX2__` from the gate so AVX2 builds stay on the scalar `mem_sam_pe` + `ksw_align2` path. NEON / Apple Silicon and AVX-512BW remain enabled.

## Reproducer

Smoke-1M (hg38, `Homo_sapiens_assembly38`) on an AVX2-only x86 host (c6a / m5.xlarge), fg-main @ `0bb9402` vs bwa-mem2 `v2.2.1` baseline. All four discordances are MAPQ-only; primary alignments are identical on every read (same `pos`, `CIGAR`, `AS`):

| qname | flag | MAPQ v2.2.1 → fg-main | Δ | XS v2.2.1 → fg-main |
|---|---|---|---|---|
| SRR34589119.740501 | 83 | 18 → 16 | −2 | 22 → 23 |
| SRR34589119.2064251 | 83 | 48 → 42 | −6 | 19 → 20 |
| SRR34589119.5063001 | 147 | 60 → 42 | −18 | 25 → 29 |
| SRR34589119.6108751 | 163 | 36 → 30 | −6 | 30 → 30 |

Reads 1–3: mate-rescue `XS` inflated by `+1 / +1 / +4`, which is the `raw_mapq(score - sub, a)` input, so MAPQ drops directly. Read 4: `XS` unchanged on the affected mate; its MAPQ drops because `mem_pair`'s `(o, subo)` inputs feed off the same rescue-modified `a[!i]`, which tightens the `q_pe` cap on that mate (`mem_approx_mapq_se + 40`).

## Localization

`git bisect run` with a MAPQ-equality oracle over the 4 target reads (40-commit range, `v2.2.1` → `0bb9402`, `~5` iterations on m5.xlarge) converged unambiguously:

```
# first bad commit: [2fddafd5bd62a1e435387fc33e5cdada25ff2cb7]
# [proto] AVX2 kswv mate-rescue — stacked on PR 18 (#20)
```

Confirmation the kernel is the cause (not another fg-main commit on the same path): building fg-main HEAD with `DISABLE_BATCHED_MATESW=1` forces the scalar path and restores all four MAPQs to the `v2.2.1` values. Sorted set-compare of the resulting BAM against the `v2.2.1` baseline shows **zero alignment differences** across all 64,763 records.

## Fix

```diff
-  #elif __AVX512BW__ || __AVX2__ \
-        || defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)
+  #elif __AVX512BW__ || defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)
```

AVX2 rejoins the scalar `mem_sam_pe` + `ksw_align2` path. AVX-512BW, NEON, and Apple Silicon gates are unchanged.

## Test plan

- [ ] `make arch=avx2` builds cleanly
- [ ] Smoke-1M AVX2 end-to-end parity against `v2.2.1` baseline: 0 MAPQ diffs, 0 alignment diffs (verified locally on m5.xlarge)
- [ ] NEON / AVX-512BW / Apple Silicon builds unaffected (gate untouched for those)
- [ ] CI `proto-neon-kswv` A/B on AVX2 will now show port ≈ control — the speedup claim only holds if the kernel is correct, so re-measure after kernel parity is restored

## Follow-ups (not in this PR)

1. Re-validate the 256-bit AVX2 kswv kernel against scalar `ksw_align2` on real reads (start with the four smoke-1M qnames above) before re-enabling. `kswv_selftest` on synthetic pairs was insufficient.
2. The sibling AVX-512BW kernel carries the same bug shapes that NEON/AVX2 inherited four fixes for; per PR #20's CI note, it is tracked separately.