### PR TITLE
chore(bench): performance porting harness + plan

### DIFF
--- a/PERF_PORTING_PLAN.md
+++ b/PERF_PORTING_PLAN.md
@@ -1,0 +1,152 @@
+# bwa-mem2 Performance Porting Plan
+
+Rank-ordered port of performance wins from `ksw2`, `minimap2`, `mm2-fast`, and `sassy` into `bwa-mem2`, one PR at a time. All ports are output-preserving (byte-identical sorted SAM) unless explicitly flag-gated in **Phase K**.
+
+Plan file maintained as a working tracker; updated after each phase (or each PR where relevant). Source audits are in the conversation transcript that produced this plan.
+
+## Status legend
+
+- `PENDING`  — not started
+- `ACTIVE`   — in progress, branch open
+- `PR`       — PR submitted, awaiting review/merge
+- `MERGED`   — merged to `fg-labs/fg-main`
+- `DROPPED`  — investigated and rejected (reason in ledger)
+- `BLOCKED`  — waiting on prerequisite or external factor
+
+## Execution protocol
+
+Between each PR:
+1. **Golden diff test**: SAM md5 must be byte-identical against `fg-main` baseline (except Phase K with flag ON).
+2. **Benchmark harness**: full run on the fixed harness input; record wall-clock, max RSS, per-stage `__rdtsc` counters (once PR 1 lands).
+3. **Ledger update**: commit delta (`delta_total_s`, `delta_stage_X`, `delta_rss`) to the **Execution ledger** below.
+4. **Plan update**: if the PR changed our understanding, update **Plan modifications** with the delta to the plan.
+5. **Branch hygiene**: one PR per worktree off `fg-labs/fg-main`, branch name `perf/<short-slug>`, no tracking until first push.
+
+A PR with <0.5% measured gain merges anyway if cheap — compounding is the whole point of the 2% bar — but the expectation miss is noted in the PR body and the ledger.
+
+## Worktree / branch conventions
+
+Per `/Users/nhomer/work/git/bwa-mem2/CLAUDE.md`:
+- New worktree per PR: `/Users/nhomer/work/git/bwa-mem2/perf-<slug>/`
+- Branch: `perf/<slug>`, off `fg-labs/fg-main`, upstream unset until first push
+- First push: `git push -u fg-labs HEAD`
+
+---
+
+## Phase A — Measurement foundation
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PR` | 0 | Benchmark harness + golden SAM diff test | Small | 0% (enables all) | — | Branch `perf/bench-harness`. Harness at `bench/` (`run.sh`, `compare.sh`, `normalize_sam.sh`, `README.md`, `config.env.example`, `.gitignore`). Baseline logged below. |
+| `PENDING` | 1 | `DISABLE_OUTPUT` compile flag + `__rdtsc` counters around seeding / chaining / DP / format | Trivial | 0% (telemetry) | mm2-fast `map.c:213-249` | Per-stage attribution so later PRs are correctly attributed. |
+| `PENDING` | 2 | `(size_t)` cast in large-allocation arithmetic in `bandedSWA.cpp` + `FMI_search.cpp` | Trivial | — | ksw2 commit `ebea754` | Correctness; prevents latent overflow on long reads. |
+| `PENDING` | 3 | `-flto=thin` + `-fno-semantic-interposition` + codegen-units=1 equivalent in Makefile | Trivial | 3–6% | sassy `[profile.dist]` | One Makefile PR. PGO deferred to **Phase I** #29. |
+| `PENDING` | 4 | Tune default `actual_chunk_size` / batch size (probe 2×, 4×) | Trivial | 1–5% | minimap2 `options.c:188` | Single-line default change + bench sweep. |
+
+## Phase B — Trivial microops
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PENDING` | 5 | `LIKELY`/`UNLIKELY` on skewed branches in `bandedSWA.cpp`, `kswv.cpp`, `FMI_search.cpp` | Trivial | 0.5–2% | minimap2 `ksw2_ll_sse.c` | `ksw.cpp` already has them; extend. |
+| `PENDING` | 6 | `__builtin_prefetch(&seeds[j-PFD])` in chain-predecessor scans | Trivial | 1–4% | idea | bandedSWA already prefetches; chaining does not. |
+| `PENDING` | 7 | Replace small `malloc`/`calloc` top-K arrays with stack VLAs | Trivial | 0.5–2% | sassy `seed.c:61` | Audit `bwamem.cpp` inner paths. |
+| `PENDING` | 8 | Fast `mg_log2` float-bit trick for `logf` in chain/score loops | Trivial | 1–3% | minimap2 `mmpriv.h:139-147` | Guard `len >= 2`; validate integer-cast preservation. |
+| `PENDING` | 9 | `objdump` check: does compiler already fold striped-profile `qp + target[i]*slen`? Code the hand-table only if not. | Trivial | 0–2% | sassy `tqueries.rs:16-22` | Skip-if-no-win PR. |
+
+## Phase C — Layout / allocator hygiene
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PENDING` | 10 | `perf c2c` audit; 64-byte-align + pad per-thread scratch in `kswv.cpp`, `bandedSWA.cpp` to kill false-sharing | Small | 1–5% on many-core | sassy `LaneState` | Diagnosis first, fix follows. |
+| `PENDING` | 11 | Per-worker reusable `kswq`/query-profile scratch on `worker_t` | Small | 1–3% | minimap2 `ksw2_ll_sse.c:37-83` | Eliminate per-extension allocator churn. |
+| `PENDING` | 12 | Single-block 64-byte-aligned DP scratch arena (fold multi `_mm_malloc` into one slab) | Small | 1–4% | ksw2 `ksw2_extz2_sse.c:84-96` | — |
+| `PENDING` | 13 | `KALLOC_POOL_INIT`-style freelist for kbtree nodes / `mem_chain_t` / cigar objects | Trivial | 0–3% | minimap2 `kalloc.h:64-93` | Macro-based, drop-in. |
+
+## Phase D — bandedSWA inner-loop microops (one kernel, four PRs, ordered so each is locally verifiable)
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PENDING` | 14 | Pre-reverse query/target once outside DP at extension call sites | Small | 1–3% | minimap2 `ksw2_extz2_sse.c:106-107` | Removes per-row bit-slicing. |
+| `PENDING` | 15 | Masked tail-store to fold scalar epilogue on partial tile (`_mm512_mask_storeu_epi8` + AVX2 analog) | Small | 1–3% | mm2-fast `ksw2_extd2_avx.c:104-105,290-299` | Do before #16/#17 — tidies boundaries. |
+| `PENDING` | 16 | XOR+shuffle `pmat` score-LUT (`_mm512_shuffle_epi8` of 16-entry table indexed by `q^t`, `N→8` remap) | Small | 2–5% | mm2-fast `ksw2_extd2_avx.c:201-209` | Local swap; trivial to validate. |
+| `PENDING` | 17 | Profile-generation loop fission (row score vector in its own pre-pass, DP core after) | Medium | 2–5% (biggest on AVX-512) | ksw2 `ksw2_extz2_sse.c:125-144` | After #16 so fissioned pre-pass uses shuffle-LUT. |
+
+## Phase E — IO / threading / formatting
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PENDING` | 18 | Inline integer + fixed-3-decimal SAM-tag formatter (replace `vsnprintf` for `pa:f:%.3f` etc.) | Small | 1–3% | minimap2 `format.c:27-66` | — |
+| `PENDING` | 19 | SIMD nibble-LUT base encoding / N-count (`_mm256_shuffle_epi8` + `PACKED_NIBBLES`) | Small | <2% unless hot | sassy `iupac.rs:71-131` | Gate on Phase A profiler data. |
+| `PENDING` | 20 | Split `kt_pipeline` into genuine 3-step reader / mapper / writer; `--2-io-threads` flag | Small | 2–6% wall-clock | minimap2 `kthread.c:78-159` | Order preservation already enforced in `fastmap.cpp`. |
+
+## Phase F — Thread-local allocator
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PENDING` | 21 | Thread-local `kalloc` arena on `worker_t` + `--cap-kalloc` reset; plumb `void *km` through chain/seed/ksw hot paths | Medium | 2–8% | minimap2 `kalloc.c/.h` | Coexists with mimalloc. Minimal-risk variant first: per-read scope only. |
+
+## Phase G — Seeding / FM-index cache work
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PENDING` | 22 | Radix sort for fully-unique 64-bit chain/region keys (`(score<<32)|id`) | Small | ~1% | minimap2 `ksort.h` | Audit tie-stability before each swap. |
+| `PENDING` | 23 | k-way heap merge of per-interval-sorted SMEM hit streams (avoid global resort) | Small-medium | 1–3% | minimap2 `collect_seed_hits_heap` | — |
+| `PENDING` | 24 | **Batched FM-index Occ/SA lookup with software prefetch** (mm2-fast pattern *without* RMI) | Medium | 2–5% | mm2-fast `seed.c:74-120` | Prior work check: `perf-smem-lockstep` worktree and locked `perf/smem-batch-prefetch` agent worktree may already prototype this. Inspect before starting. |
+
+## Phase H — Extension algorithmic (biggest scalar wins; strong diff-test required)
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PENDING` | 25 | Two-pass approximate-then-exact DP in `bandedSWA::getScores8/16` (`KSW_EZ_APPROX_MAX`/`APPROX_DROP` adaptation) | Medium | 3–7% overall | minimap2 `align.c:834-848` | Approximate first pass skips 32-bit H[] tracking; exact only on z-drop/success. |
+| `PENDING` | 26 | Ungapped fast-path: when `qe-qs == re-rs`, ungapped scorer before banded DP; fall back if ungapped can't provably beat gapped | Medium | 5–15% on clean reads, 3–7% overall | minimap2 `align.c:773-789` | Biggest single algorithmic win. Validate bit-identical on 10M+ reads. |
+
+## Phase I — Structural refactors & deployment consolidation
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PENDING` | 27 | SoA recast of `mem_seed_t` / `mem_chain_t` (with 16-elt head padding); update all scans in `mem_sort_dedup_patch`, `mem_chain_flt`, `mem_chain_weight` | Medium-large | 2–8% | mm2-fast `lchain.c:301-336` | Gate on Phase A showing LLC-bound. Touches many files. |
+| `PENDING` | 28 | In-process ISA dispatch via `__attribute__((target_clones(...)))` + IFUNC resolver; retire `runsimd.cpp` `execv` model → single binary | Medium | 5–30% on AVX-512 hosts + eliminates startup reindex cost | sassy | Late; don't juggle build system during inner-loop PRs. |
+| `PENDING` | 29 | PGO training + wiring in Makefile (training profile on Phase A harness) | Small + infra | 3–6% on top of LTO | sassy | After #28 so single-binary PGO is meaningful. |
+
+## Phase J — Learned index
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PENDING` | 30 | LISA / RMI learned-index for k-mer → SA-range lookup (trained via `learned-systems-rmi` crate, verified by byte-compare) | Large | 5–15% on top of #24 | mm2-fast `ext/TAL/lisa_hash.h` | Pull submodule first. Adds Rust build step to index pipeline. |
+
+## Phase K — Flag-gated, output-changing
+
+| Status | # | PR | Effort | Est. gain | Source | Notes |
+|---|---|---|---|---|---|---|
+| `PENDING` | 31 | `--fast-rng`: Wang-hash deterministic tie-break RNG (replaces `drand48_r`) | Small | 0.5–2% | minimap2 `map.c:246-248` | Changes output. Default off. |
+| `PENDING` | 32 | `--chain-max-skip` / `--chain-max-iter` heuristic bails | Small | 1–3% | minimap2 `lchain.c:168-207` | Changes output on repetitive reads. Default off. |
+| `PENDING` | 33 | `--seed-freq-filter`: 2-stage seed selection with top-K heap | Medium | 2–10% on repetitive reads | minimap2 `seed.c:5-132` | Changes chain set. Default off. |
+
+---
+
+## Aggregate expectation
+
+Output-identical (PRs 0–30): **≈ 30–50% wall-clock** on typical short-read workloads, with the bulk from #24, #25, #26, #28, #30.
+
+---
+
+## Execution ledger
+
+Format: `YYYY-MM-DD | PR # | status | wall Δ (harness) | RSS Δ | per-stage Δ | notes`
+
+| Date | PR | Status | Wall Δ | RSS Δ | Notes |
+|---|---|---|---|---|---|
+| 2026-04-23 | — | plan | — | — | Plan drafted. |
+| 2026-04-23 | 0 | `PR` | n/a (baseline) | n/a (baseline) | Harness + baseline on host `fg-nils-00005` (arm64, macOS) against `fg-main` at `61813ef`: 1M pairs hg38, 1-thread golden 28.82s, 4-thread wall median 15.90s (range 14.35–16.23 across 3 trials = 13% shared-laptop noise), golden md5 `e44035cc671c28f42e3ca84f10cf2e5a`, RSS ~16 GB. Representative ranking runs should re-measure on AVX-512 EC2 (`i-09b7c8ae622ba21e6`) with more trials + cold-cache discipline. |
+
+---
+
+## Plan modifications
+
+Log changes to the plan itself (reordering, scope shifts, dropped items). One entry per modification.
+
+| Date | Change | Reason |
+|---|---|---|
+| 2026-04-23 | Initial plan drafted. | — |
+| 2026-04-23 | Plan file moved into `perf/bench-harness` branch so it ships to `fg-main` with PR 0 and is visible from every future branch. | Survives across worktrees. |
+| 2026-04-23 | Noted that ranking-quality measurement requires an AVX-512 EC2 host; local arm64 macOS harness is for fast smoke iteration only. | Local host shows 13% wall-clock variance in 3 trials — too coarse for <5% perf deltas. |

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,2 @@
+config.env
+results.csv

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,42 @@
+# bwa-mem2 performance porting harness
+
+Minimal reproducible benchmark for the performance porting effort tracked in `PERF_PORTING_PLAN.md`. Each PR in that plan uses this harness to (a) gate byte-identical SAM output via a golden md5 and (b) measure wall-clock + max-RSS deltas.
+
+## Quick start
+
+```sh
+cp bench/config.env.example bench/config.env
+$EDITOR bench/config.env                 # point at your index + reads + binary
+bench/run.sh baseline                    # runs N trials, appends rows to bench/results.csv
+bench/run.sh candidate                   # runs N trials on the candidate binary
+bench/compare.sh baseline candidate      # prints wall-clock / RSS / md5 deltas
+```
+
+## What it measures
+
+For each run:
+- **Golden md5** — single-threaded, `@PG`-stripped SAM md5. Stable across builds when output is byte-identical.
+- **Wall clock** — N multi-threaded trials, median reported.
+- **Max RSS** — from `/usr/bin/time` (`-l` on macOS, `-v` on Linux). Median reported.
+
+Results append to `bench/results.csv` as rows:
+```
+tag,host,arch,binary,threads,trial,wall_s,max_rss_kb,md5
+```
+
+The md5 is populated only on the single-thread row (marked `trial=golden`).
+
+## Conventions
+
+- **Golden diff** uses `-t 1`. Multi-threaded output ordering is not stable across runs — only wall-clock is comparable.
+- `bench/config.env` is `.gitignore`'d. `config.env.example` is the template.
+- Inputs must stay fixed across PRs for comparability. The default config points at `/Volumes/scratch-00001/bwa-mem3-bench/data/smoke/1M` (1M read pairs) + hg38.
+- For representative multi-arch ranking, rerun the harness on an AVX-512 host (see `CLAUDE.md` AWS section).
+
+## Files
+
+- `run.sh` — main driver. Runs 1 golden + N perf trials against one binary.
+- `compare.sh` — diff two tags from `results.csv`.
+- `normalize_sam.sh` — `grep -v '^@PG' | md5sum` helper. Used by `run.sh`.
+- `config.env.example` — path template.
+- `results.csv` — append-only measurement log.

--- a/bench/compare.sh
+++ b/bench/compare.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Compare two tags in bench/results.csv.
+# Usage: bench/compare.sh <tag_a> <tag_b>
+# Emits a short report: golden md5 equality, median wall delta, median RSS delta.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <tag_a> <tag_b>" >&2
+  exit 2
+fi
+
+TAG_A="$1"; TAG_B="$2"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# Load config for BENCH_RESULTS path.
+# shellcheck disable=SC1091
+. "$HERE/config.env"
+
+RESULTS="$BENCH_RESULTS"
+[[ -f "$RESULTS" ]] || { echo "no results at $RESULTS" >&2; exit 2; }
+
+# Extract golden md5 for each tag (last occurrence wins, in case of reruns).
+md5_for() {
+  awk -F, -v t="$1" '$1==t && $6=="golden" {print $9}' "$RESULTS" | tail -1
+}
+
+# Extract median wall-clock over perf trials (simple sort-middle).
+median_wall() {
+  awk -F, -v t="$1" '$1==t && $6!="golden" && $6!="trial" {print $7}' "$RESULTS" \
+    | sort -n \
+    | awk '{a[NR]=$1} END{if(NR==0){print "NA"; exit} print (NR%2==1?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2)}'
+}
+
+median_rss() {
+  awk -F, -v t="$1" '$1==t && $6!="golden" && $6!="trial" {print $8}' "$RESULTS" \
+    | sort -n \
+    | awk '{a[NR]=$1} END{if(NR==0){print "NA"; exit} print (NR%2==1?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2)}'
+}
+
+MD5_A="$(md5_for "$TAG_A")"
+MD5_B="$(md5_for "$TAG_B")"
+WA="$(median_wall "$TAG_A")"
+WB="$(median_wall "$TAG_B")"
+RA="$(median_rss "$TAG_A")"
+RB="$(median_rss "$TAG_B")"
+
+echo "tag A: $TAG_A"
+echo "tag B: $TAG_B"
+echo ""
+echo "golden md5 A: $MD5_A"
+echo "golden md5 B: $MD5_B"
+if [[ -n "$MD5_A" && "$MD5_A" == "$MD5_B" ]]; then
+  echo "golden: MATCH (byte-identical SAM)"
+else
+  echo "golden: MISMATCH — output changed"
+fi
+echo ""
+echo "median wall A: ${WA}s"
+echo "median wall B: ${WB}s"
+if [[ "$WA" != "NA" && "$WB" != "NA" ]]; then
+  awk -v a="$WA" -v b="$WB" 'BEGIN{d=(b-a)/a*100; printf "wall delta: %+.2f%% (B vs A)\n", d}'
+fi
+echo ""
+echo "median RSS A: ${RA} kb"
+echo "median RSS B: ${RB} kb"
+if [[ "$RA" != "NA" && "$RB" != "NA" && "$RA" != "0" ]]; then
+  awk -v a="$RA" -v b="$RB" 'BEGIN{d=(b-a)/a*100; printf "RSS delta:  %+.2f%% (B vs A)\n", d}'
+fi

--- a/bench/config.env.example
+++ b/bench/config.env.example
@@ -1,0 +1,19 @@
+# Copy to bench/config.env (git-ignored) and edit for your host.
+
+# Binaries under test. The "baseline" is whatever fg-main head is built to;
+# "candidate" is the PR branch under test.
+BWA_MEM2_BASELINE="/Users/nhomer/work/git/bwa-mem2/fg-main/bwa-mem2"
+BWA_MEM2_CANDIDATE="/Users/nhomer/work/git/bwa-mem2/perf-bench-harness/bwa-mem2"
+
+# Index + reads.
+BENCH_INDEX="/Volumes/scratch-00001/bwa-mem3-bench/references/hg38/Homo_sapiens_assembly38.fasta"
+BENCH_R1="/Volumes/scratch-00001/bwa-mem3-bench/data/smoke/1M/r1.fq.gz"
+BENCH_R2="/Volumes/scratch-00001/bwa-mem3-bench/data/smoke/1M/r2.fq.gz"
+
+# Trials per tag (perf wall-clock); golden is always 1 extra single-thread trial.
+BENCH_THREADS=8
+BENCH_TRIALS=3
+
+# Output.
+BENCH_OUTDIR="/tmp/bwa-mem2-bench"
+BENCH_RESULTS="bench/results.csv"

--- a/bench/normalize_sam.sh
+++ b/bench/normalize_sam.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Normalize a SAM stream for golden md5 comparison across builds.
+# Strips @PG (contains version/cmdline) and md5sums the rest.
+# Usage: bwa-mem2 mem ... | bench/normalize_sam.sh
+set -euo pipefail
+grep -v '^@PG' | md5sum | awk '{print $1}'

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Run bwa-mem2 mem on a fixed harness input and append measurements to results.csv.
+# Usage: bench/run.sh <tag>
+#   <tag>  a label for this run (e.g. "baseline", "pr-15", "main-after-lto").
+#
+# Reads bench/config.env. Runs:
+#   - 1 single-thread trial (for golden md5)
+#   - BENCH_TRIALS multi-thread trials (for wall-clock + RSS)
+#
+# Each trial appends one CSV row to BENCH_RESULTS.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <tag>" >&2
+  exit 2
+fi
+
+TAG="$1"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# Load config.
+CONFIG="$HERE/config.env"
+if [[ ! -f "$CONFIG" ]]; then
+  echo "error: $CONFIG not found. copy from config.env.example and edit." >&2
+  exit 2
+fi
+# shellcheck disable=SC1090
+. "$CONFIG"
+
+# Resolve binary by tag. "baseline" -> BWA_MEM2_BASELINE; anything else -> BWA_MEM2_CANDIDATE.
+case "$TAG" in
+  baseline) BIN="$BWA_MEM2_BASELINE" ;;
+  *)        BIN="$BWA_MEM2_CANDIDATE" ;;
+esac
+
+for path in "$BIN" "$BENCH_INDEX" "$BENCH_R1" "$BENCH_R2"; do
+  [[ -e "$path" ]] || { echo "error: missing path: $path" >&2; exit 2; }
+done
+
+mkdir -p "$BENCH_OUTDIR"
+
+HOST="$(hostname -s)"
+ARCH="$(uname -m)"
+OS="$(uname -s)"
+
+# Pick /usr/bin/time invocation per OS. Both emit max RSS; units differ.
+if [[ "$OS" == "Darwin" ]]; then
+  TIME_CMD=(/usr/bin/time -l)
+  # macOS time -l:
+  #   "        1.01 real         0.00 user         0.00 sys"
+  #   "             5767168  maximum resident set size"
+  # RSS is in bytes; divide by 1024 → kB.
+  WALL_AWK='$2=="real" && $4=="user" && $6=="sys" {print $1; exit}'
+  RSS_AWK='/maximum resident set size/ {print $1; exit}'
+  RSS_SCALE=1024
+else
+  TIME_CMD=(/usr/bin/time -v)
+  # GNU time -v:
+  #   "        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:23.45"
+  #   "        Maximum resident set size (kbytes): 4567890"
+  WALL_AWK='/Elapsed \(wall clock\) time/ {print $NF; exit}'
+  RSS_AWK='/Maximum resident set size/ {print $NF; exit}'
+  RSS_SCALE=1
+fi
+
+# Ensure results header exists.
+RESULTS="$BENCH_RESULTS"
+if [[ ! -f "$RESULTS" ]]; then
+  mkdir -p "$(dirname "$RESULTS")"
+  echo "tag,host,arch,binary,threads,trial,wall_s,max_rss_kb,md5" > "$RESULTS"
+fi
+
+BIN_FP="$(md5sum "$BIN" | awk '{print $1}' | cut -c1-12)"
+
+run_trial() {
+  local trial="$1" threads="$2"
+  local time_file="$BENCH_OUTDIR/time.$TAG.$trial.$$"
+  local sam_file="$BENCH_OUTDIR/sam.$TAG.$trial.$$.sam"
+  local md5=""
+
+  # Warm filesystem cache on first trial only (optional — comment out for cold-cache runs).
+  # shellcheck disable=SC2034
+  local _warm_done=0
+
+  # Run. stdout → SAM; stderr → time_file (includes bwa-mem2 log + /usr/bin/time output).
+  # shellcheck disable=SC2086
+  "${TIME_CMD[@]}" "$BIN" mem -t "$threads" "$BENCH_INDEX" "$BENCH_R1" "$BENCH_R2" \
+      > "$sam_file" 2> "$time_file"
+
+  # Wall clock.
+  local wall
+  wall="$(awk "$WALL_AWK" "$time_file")"
+  # GNU time may emit h:mm:ss or m:ss — normalize.
+  case "$wall" in
+    *:*:*) wall=$(awk -F: '{print $1*3600+$2*60+$3}' <<<"$wall") ;;
+    *:*)   wall=$(awk -F: '{print $1*60+$2}' <<<"$wall") ;;
+  esac
+  [[ -n "$wall" ]] || wall=NA
+
+  # Max RSS.
+  local rss_raw rss_kb
+  rss_raw="$(awk "$RSS_AWK" "$time_file")"
+  if [[ -n "$rss_raw" ]]; then
+    rss_kb=$(( rss_raw / RSS_SCALE ))
+  else
+    rss_kb=NA
+  fi
+
+  # Golden md5 only on single-thread trial.
+  if [[ "$trial" == "golden" ]]; then
+    md5="$(grep -v '^@PG' "$sam_file" | md5sum | awk '{print $1}')"
+  fi
+
+  echo "$TAG,$HOST,$ARCH,$BIN_FP,$threads,$trial,$wall,$rss_kb,$md5" | tee -a "$RESULTS"
+
+  if [[ "${BENCH_KEEP_LOGS:-0}" == "1" ]]; then
+    mv "$time_file" "$BENCH_OUTDIR/time.$TAG.$trial.kept" || true
+  else
+    rm -f "$time_file"
+  fi
+  rm -f "$sam_file"
+}
+
+echo "# run.sh tag=$TAG bin=$BIN host=$HOST arch=$ARCH" >&2
+
+# 1 golden, single-thread.
+run_trial golden 1
+
+# BENCH_TRIALS perf trials, multi-thread.
+for i in $(seq 1 "$BENCH_TRIALS"); do
+  run_trial "perf$i" "$BENCH_THREADS"
+done


### PR DESCRIPTION
## Summary
- Adds `bench/` driver capturing per-trial wall-clock, max RSS, and a `@PG`-stripped SAM md5 so every subsequent perf PR can assert byte-identical output and measure its own delta.
- Adds `PERF_PORTING_PLAN.md` tracking the rank-ordered port of performance wins audited across ksw2, minimap2, mm2-fast, and sassy. All ports output-preserving unless explicitly flag-gated in Phase K.
- No runtime code changes.

## Baseline

Measured on local arm64 macOS against this branch's base (`fg-labs/fg-main` at `61813ef`):

| measurement | value |
|---|---|
| dataset | 1M pairs, hg38 full index (\`bwa-mem3-bench/data/smoke/1M\`) |
| 1-thread golden wall | 28.82s |
| 1-thread golden md5 | \`e44035cc671c28f42e3ca84f10cf2e5a\` |
| 4-thread median wall | 15.90s (range 14.35–16.23, 3 trials) |
| max RSS | ~16 GB |

Local-laptop noise ~13% across 3 trials — ranking runs for later perf PRs should be re-measured on the AVX-512 EC2 host with more trials and cold-cache discipline. Noted in the plan's modification log.

## Test plan
- [x] \`bench/run.sh baseline\` end-to-end green on arm64 macOS (golden md5 captured, wall + RSS parse correctly)
- [ ] Dry-run on AVX-512 EC2 host before PR 1 lands
- [ ] Verify \`bench/compare.sh\` asserts MATCH when fed identical tags