### PR TITLE
perf(seed): lockstep SMEM batching across N reads

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -663,6 +663,271 @@ void FMI_search::getSMEMsOnePosOneThread(uint8_t *enc_qdb,
     (*__numTotalSmem) = numTotalSmem;
 }
 
+// ===== Lockstep SMEM batching (scaffolding — see plan Task 5) =====
+// Per-slot state for the lockstep SMEM walk. One instance per in-flight read
+// in the batch. Every field mirrors a per-read local in the scalar
+// getSMEMsOnePosOneThread body, so parity with the scalar path follows from
+// composing the existing primitives (backwardExt, count[], cp_occ) in the
+// same sequence the scalar would.
+//
+// MAX_READ_LEN_FOR_LOCKSTEP caps per-slot buffer sizes so the whole slot
+// lives on the caller's stack. Override via -DMAX_READ_LEN_FOR_LOCKSTEP=N
+// at build time if running with reads longer than the default.
+#ifndef MAX_READ_LEN_FOR_LOCKSTEP
+#define MAX_READ_LEN_FOR_LOCKSTEP 512
+#endif
+
+enum LockstepPhase : uint8_t {
+    PH_FWD      = 0,  // forward extension inner loop active
+    PH_BWD_INIT = 1,  // between-phases housekeeping pending
+    PH_BWD      = 2,  // backward search outer loop active
+    PH_DONE     = 3   // slot finished; match_buf ready for flush
+};
+
+struct FMI_search::BatchSlot {
+    // Input identity — copied at init, never mutated thereafter.
+    int32_t input_idx;           // index into the caller's input arrays
+    int32_t rid;                 // rid_array[input_idx]
+    int16_t start_pos;           // query_pos_array[input_idx] (saved for bwd init)
+    int32_t min_intv;            // min_intv_array[input_idx]
+    int32_t readlength;          // seq_[rid].l_seq
+    int32_t offset;              // query_cum_len_ar[rid]
+
+    // Output for query_pos_array[input_idx] write-back at flush time.
+    int16_t next_x;
+
+    // Walk state (mirrors scalar locals).
+    SMEM smem;                   // current SA interval
+    int32_t j;                   // current query position in the active phase's inner loop
+    int32_t cur_j;               // backward phase bookkeeping (scalar's cur_j)
+    LockstepPhase phase;
+
+    // Backward-search state. numCurr/curr_s are loop-local in
+    // ls_advance_backward_step — they don't live across outer-j steps,
+    // so they don't appear here.
+    int32_t numPrev;
+    SMEM    prev[MAX_READ_LEN_FOR_LOCKSTEP];
+
+    // Per-slot match buffer + reorder-buffer ready flag for in-order flush.
+    SMEM    match_buf[MAX_READ_LEN_FOR_LOCKSTEP];
+    int32_t match_count;
+    bool    ready;
+};
+
+void FMI_search::ls_prefetch_cp_occ(const BatchSlot *s)
+{
+#ifdef ENABLE_PREFETCH
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.k) >> CP_SHIFT]), _MM_HINT_T0);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.l) >> CP_SHIFT]), _MM_HINT_T0);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.k + s->smem.s) >> CP_SHIFT]), _MM_HINT_T0);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.l + s->smem.s) >> CP_SHIFT]), _MM_HINT_T0);
+#else
+    (void)s;
+#endif
+}
+
+// Populate a slot from the caller's input arrays at the given input_idx.
+// After this call either:
+//   phase == PH_FWD  — slot is ready to step the forward-extension inner loop
+//   phase == PH_DONE — the first base is non-ACGT; scalar skips this read, so
+//                      we match that (zero matches emitted, ready to flush).
+void FMI_search::ls_init_slot(BatchSlot *s,
+                              int32_t input_idx,
+                              const int16_t *query_pos_array,
+                              const int32_t *min_intv_array,
+                              const int32_t *rid_array,
+                              const bseq1_t *seq_,
+                              const int32_t *query_cum_len_ar,
+                              const uint8_t *enc_qdb)
+{
+    s->input_idx   = input_idx;
+    s->rid         = rid_array[input_idx];
+    s->start_pos   = query_pos_array[input_idx];
+    s->min_intv    = min_intv_array[input_idx];
+    s->readlength  = seq_[s->rid].l_seq;
+    assert(s->readlength <= MAX_READ_LEN_FOR_LOCKSTEP &&
+           "SMEM lockstep buffer overflow: recompile with -DMAX_READ_LEN_FOR_LOCKSTEP=<n>");
+    s->offset      = query_cum_len_ar[s->rid];
+    s->next_x      = s->start_pos + 1;
+    s->numPrev     = 0;
+    s->match_count = 0;
+    s->ready       = false;
+
+    int32_t x = s->start_pos;
+    uint8_t a = enc_qdb[s->offset + x];
+    if (a < 4) {
+        s->smem.rid = s->rid;
+        s->smem.m   = x;
+        s->smem.n   = x;
+        s->smem.k   = count[a];
+        s->smem.l   = count[3 - a];
+        s->smem.s   = count[a + 1] - count[a];
+        s->j        = x + 1;
+        s->phase    = PH_FWD;
+    } else {
+        // Scalar path skips the whole read when the first base is N.
+        // Match that by going straight to DONE with zero matches.
+        s->phase = PH_DONE;
+        s->ready = true;
+    }
+}
+// Advance one slot through one step of forward extension.
+// Mirrors the inner j-loop body of the scalar getSMEMsOnePosOneThread
+// (src/FMI_search.cpp — the for(j = x+1; j < readlength; j++) loop).
+// On the step that exits forward-ext (end-of-read, non-ACGT at j, or
+// s < min_intv), transitions phase to PH_BWD_INIT.
+void FMI_search::ls_advance_forward_step(BatchSlot *s, const uint8_t *enc_qdb)
+{
+    if (s->j >= s->readlength) {
+        // Ran off the end of the read; keep the still-valid smem if any.
+        if (s->smem.s >= s->min_intv) {
+            s->prev[s->numPrev++] = s->smem;
+        }
+        s->phase = PH_BWD_INIT;
+        return;
+    }
+
+    uint8_t a = enc_qdb[s->offset + s->j];
+    s->next_x = s->j + 1;
+    if (a >= 4) {
+        // Non-ACGT base terminates forward ext.
+        if (s->smem.s >= s->min_intv) {
+            s->prev[s->numPrev++] = s->smem;
+        }
+        s->phase = PH_BWD_INIT;
+        return;
+    }
+
+    SMEM smem_ = s->smem;
+    smem_.k = s->smem.l;
+    smem_.l = s->smem.k;
+    SMEM newSmem_ = backwardExt(smem_, 3 - a);
+    SMEM newSmem  = newSmem_;
+    newSmem.k = newSmem_.l;
+    newSmem.l = newSmem_.k;
+    newSmem.n = s->j;
+
+    int32_t s_neq_mask = (newSmem.s != s->smem.s);
+    s->prev[s->numPrev] = s->smem;
+    s->numPrev += s_neq_mask;
+
+    if (newSmem.s < s->min_intv) {
+        s->next_x = s->j;
+        s->phase = PH_BWD_INIT;
+        return;
+    }
+
+    s->smem = newSmem;
+    s->j++;
+#ifdef ENABLE_PREFETCH
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.k) >> CP_SHIFT]), _MM_HINT_T0);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.l) >> CP_SHIFT]), _MM_HINT_T0);
+#endif
+}
+
+// Between-phases housekeeping: reverse prev[] and set up backward-phase
+// cursors. After this call the slot is either PH_BWD (ready for
+// ls_advance_backward_step) or PH_DONE (nothing to do — backward outer
+// loop would terminate on the first step, so we short-circuit to the
+// final prev[0] emit and done).
+void FMI_search::ls_prepare_backward(BatchSlot *s)
+{
+    // Reverse prev[] in place (matches scalar behavior before backward loop).
+    for (int p = 0; p < (s->numPrev / 2); p++) {
+        SMEM tmp = s->prev[p];
+        s->prev[p] = s->prev[s->numPrev - p - 1];
+        s->prev[s->numPrev - p - 1] = tmp;
+    }
+    s->cur_j = s->readlength;
+    s->j = s->start_pos - 1;  // first position for the backward outer loop
+
+    if (s->numPrev == 0) {
+        // Nothing to emit; scalar's final `if (numPrev != 0)` block is a no-op.
+        s->phase = PH_DONE;
+        s->ready = true;
+        return;
+    }
+    if (s->j < 0) {
+        // Backward outer loop cannot execute (start_pos == 0). Transition to
+        // PH_BWD so the first ls_advance_backward_step call sees j < 0, jumps
+        // to DONE, and runs the final prev[0] emit with the correct minSeedLen.
+        s->phase = PH_BWD;
+        return;
+    }
+    s->phase = PH_BWD;
+}
+
+// Advance one slot through ONE outer-j iteration of backward search.
+// Mirrors the body of the scalar `for (j = x-1; j >= 0; j--)` outer loop
+// in getSMEMsOnePosOneThread. On terminating conditions (numCurr == 0,
+// j < 0 after decrement, or non-ACGT at j), runs the scalar's final
+// prev[0] emit and transitions to PH_DONE.
+void FMI_search::ls_advance_backward_step(BatchSlot *s,
+                                          const uint8_t *enc_qdb,
+                                          int32_t minSeedLen)
+{
+    if (s->j < 0) goto DONE;
+
+    {
+        int32_t numCurr = 0;
+        int32_t curr_s = -1;
+        uint8_t a = enc_qdb[s->offset + s->j];
+        if (a > 3) goto DONE;
+
+        int p;
+        for (p = 0; p < s->numPrev; p++) {
+            SMEM smem = s->prev[p];
+            SMEM newSmem = backwardExt(smem, a);
+            newSmem.m = s->j;
+            if ((newSmem.s < s->min_intv) && ((smem.n - smem.m + 1) >= minSeedLen)) {
+                s->cur_j = s->j;
+                s->match_buf[s->match_count++] = smem;
+                break;
+            }
+            if ((newSmem.s >= s->min_intv) && (newSmem.s != curr_s)) {
+                curr_s = newSmem.s;
+                s->prev[numCurr++] = newSmem;
+#ifdef ENABLE_PREFETCH
+                _mm_prefetch((const char *)(&cp_occ[(newSmem.k) >> CP_SHIFT]), _MM_HINT_T0);
+                _mm_prefetch((const char *)(&cp_occ[(newSmem.k + newSmem.s) >> CP_SHIFT]), _MM_HINT_T0);
+#endif
+                break;
+            }
+        }
+        p++;
+        for (; p < s->numPrev; p++) {
+            SMEM smem = s->prev[p];
+            SMEM newSmem = backwardExt(smem, a);
+            newSmem.m = s->j;
+            if ((newSmem.s >= s->min_intv) && (newSmem.s != curr_s)) {
+                curr_s = newSmem.s;
+                s->prev[numCurr++] = newSmem;
+#ifdef ENABLE_PREFETCH
+                _mm_prefetch((const char *)(&cp_occ[(newSmem.k) >> CP_SHIFT]), _MM_HINT_T0);
+                _mm_prefetch((const char *)(&cp_occ[(newSmem.k + newSmem.s) >> CP_SHIFT]), _MM_HINT_T0);
+#endif
+            }
+        }
+        s->numPrev = numCurr;
+        s->j--;                // advance for the next outer step
+        if (numCurr == 0) goto DONE;
+        return;                // stay in PH_BWD; next call continues
+    }
+
+DONE:
+    // Scalar end-of-function final prev[0] emit (lines ~650-659 of scalar).
+    if (s->numPrev != 0) {
+        SMEM smem = s->prev[0];
+        if ((smem.n - smem.m + 1) >= minSeedLen) {
+            s->match_buf[s->match_count++] = smem;
+        }
+        s->numPrev = 0;
+    }
+    s->phase = PH_DONE;
+    s->ready = true;
+}
+// ===== End lockstep scaffolding =====
+
 void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                          int32_t *min_intv_array,
                                          int32_t *rid_array,
@@ -699,6 +964,20 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                 tail++;             
             }               
         }
+#if SMEM_LOCKSTEP_N > 1
+        getSMEMsOnePosOneThread_lockstep(enc_qdb,
+                                         query_pos_array,
+                                         min_intv_array,
+                                         rid_array,
+                                         tail,
+                                         batch_size,
+                                         seq_,
+                                         query_cum_len_ar,
+                                         max_readlength,
+                                         minSeedLen,
+                                         matchArray,
+                                         __numTotalSmem);
+#else
         getSMEMsOnePosOneThread(enc_qdb,
                                 query_pos_array,
                                 min_intv_array,
@@ -711,10 +990,112 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                 minSeedLen,
                                 matchArray,
                                 __numTotalSmem);
+#endif
         numActive = tail;
     } while(numActive > 0);
 
     _mm_free(query_pos_array);
+}
+
+void FMI_search::getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
+                                                   int16_t *query_pos_array,
+                                                   int32_t *min_intv_array,
+                                                   int32_t *rid_array,
+                                                   int32_t numReads,
+                                                   int32_t batch_size,
+                                                   const bseq1_t *seq_,
+                                                   int32_t *query_cum_len_ar,
+                                                   int32_t max_readlength,
+                                                   int32_t minSeedLen,
+                                                   SMEM *matchArray,
+                                                   int64_t *__numTotalSmem)
+{
+    (void)batch_size;
+    (void)max_readlength;
+
+    if (numReads == 0) return;
+
+    const int32_t N = SMEM_LOCKSTEP_N;
+    // Stack footprint: each BatchSlot holds two SMEM[MAX_READ_LEN_FOR_LOCKSTEP]
+    // buffers (SMEM ≈ 32 B), so default N=4 × 512 ≈ 128 KB on the stack.
+    // Bumping both knobs scales multiplicatively: e.g., N=8 + readlen=4096
+    // ≈ 2 MB, which can exceed some OMP/container/embedded stack limits.
+    BatchSlot slots[SMEM_LOCKSTEP_N];
+
+    // Seed the first min(N, numReads) slots.
+    int32_t initial = (numReads < N) ? numReads : N;
+    for (int32_t s = 0; s < initial; s++) {
+        ls_init_slot(&slots[s], s, query_pos_array, min_intv_array,
+                     rid_array, seq_, query_cum_len_ar, enc_qdb);
+        if (slots[s].phase == PH_FWD) ls_prefetch_cp_occ(&slots[s]);
+    }
+    // Any unused slots (numReads < N) are marked DONE with invalid input_idx
+    // so the stepping pass skips them and the flush pass ignores them.
+    for (int32_t s = initial; s < N; s++) {
+        slots[s].phase = PH_DONE;
+        slots[s].ready = false;
+        slots[s].input_idx = -1;
+    }
+
+    int32_t next_input   = initial;
+    int32_t flush_cursor = 0;
+    int64_t numTotalSmem = *__numTotalSmem;
+
+    while (flush_cursor < numReads) {
+        // --- Stepping pass: advance each non-DONE slot by one phase-step. ---
+        for (int32_t s = 0; s < N; s++) {
+            switch (slots[s].phase) {
+                case PH_FWD:
+                    ls_advance_forward_step(&slots[s], enc_qdb);
+                    // If forward just transitioned to PH_BWD_INIT, run the
+                    // between-phases housekeeping immediately. prepare_backward
+                    // may transition straight to PH_DONE (e.g. empty prev[]).
+                    if (slots[s].phase == PH_BWD_INIT) {
+                        ls_prepare_backward(&slots[s]);
+                    }
+                    break;
+                case PH_BWD_INIT:
+                    ls_prepare_backward(&slots[s]);
+                    break;
+                case PH_BWD:
+                    ls_advance_backward_step(&slots[s], enc_qdb, minSeedLen);
+                    break;
+                case PH_DONE:
+                    break;
+            }
+        }
+
+        // --- Flush pass: in-order emit + slot recycle. ---
+        bool progress = true;
+        while (progress) {
+            progress = false;
+            for (int32_t s = 0; s < N; s++) {
+                if (slots[s].phase == PH_DONE &&
+                    slots[s].ready &&
+                    slots[s].input_idx == flush_cursor) {
+                    for (int32_t m = 0; m < slots[s].match_count; m++) {
+                        matchArray[numTotalSmem++] = slots[s].match_buf[m];
+                    }
+                    query_pos_array[slots[s].input_idx] = slots[s].next_x;
+                    flush_cursor++;
+
+                    if (next_input < numReads) {
+                        ls_init_slot(&slots[s], next_input,
+                                     query_pos_array, min_intv_array,
+                                     rid_array, seq_, query_cum_len_ar, enc_qdb);
+                        if (slots[s].phase == PH_FWD) ls_prefetch_cp_occ(&slots[s]);
+                        next_input++;
+                    } else {
+                        slots[s].input_idx = -1;  // retired
+                        slots[s].ready = false;
+                    }
+                    progress = true;
+                }
+            }
+        }
+    }
+
+    *__numTotalSmem = numTotalSmem;
 }
 
 int64_t FMI_search::bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -90,6 +90,10 @@ typedef struct smem_struct
 
 #define SAL_PFD 16
 
+#ifndef SMEM_LOCKSTEP_N
+#define SMEM_LOCKSTEP_N 4
+#endif
+
 class FMI_search: public indexEle
 {
     public:
@@ -121,7 +125,27 @@ class FMI_search: public indexEle
                                  int32_t minSeedLen,
                                  SMEM *matchArray,
                                  int64_t *__numTotalSmem);
-    
+
+    /* Lockstep-batched variant of getSMEMsOnePosOneThread: advances
+     * SMEM_LOCKSTEP_N reads' SMEM walks in slot-interleaved order to expose
+     * N independent backwardExt dependency chains to the CPU's out-of-order
+     * engine. Per-read algorithm is byte-identical to the scalar path; only
+     * the cross-read interleaving is new. Output in matchArray is written
+     * in the same (read, smem) order as the scalar path via per-slot match
+     * buffers flushed by input-index cursor. */
+    void getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
+                                          int16_t *query_pos_array,
+                                          int32_t *min_intv_array,
+                                          int32_t *rid_array,
+                                          int32_t numReads,
+                                          int32_t batch_size,
+                                          const bseq1_t *seq_,
+                                          int32_t *query_cum_len_ar,
+                                          int32_t  max_readlength,
+                                          int32_t minSeedLen,
+                                          SMEM *matchArray,
+                                          int64_t *__numTotalSmem);
+
     void getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                  int32_t *min_intv_array,
                                  int32_t *rid_array,
@@ -191,6 +215,25 @@ private:
                                int64_t *sa_bwt,
                                int64_t *count);
         SMEM backwardExt(SMEM smem, uint8_t a);
+
+    // ----- Lockstep SMEM batching internals -----
+    // Defined in FMI_search.cpp. Phases and per-slot state are scoped to
+    // the lockstep driver; not used anywhere else.
+    struct BatchSlot;
+
+    void ls_init_slot(BatchSlot *s, int32_t input_idx,
+                      const int16_t *query_pos_array,
+                      const int32_t *min_intv_array,
+                      const int32_t *rid_array,
+                      const bseq1_t *seq_,
+                      const int32_t *query_cum_len_ar,
+                      const uint8_t *enc_qdb);
+    void ls_prefetch_cp_occ(const BatchSlot *s);
+    void ls_advance_forward_step(BatchSlot *s, const uint8_t *enc_qdb);
+    void ls_prepare_backward(BatchSlot *s);
+    void ls_advance_backward_step(BatchSlot *s,
+                                  const uint8_t *enc_qdb,
+                                  int32_t minSeedLen);
 };
 
 #endif

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -744,6 +744,20 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
     }
     #endif
     
+#if SMEM_LOCKSTEP_N > 1
+    fmi->getSMEMsOnePosOneThread_lockstep(enc_qdb,
+                                          query_pos_ar,
+                                          min_intv_ar,
+                                          rid,
+                                          pos,
+                                          pos,
+                                          seq_,
+                                          query_cum_len_ar,
+                                          max_readlength,
+                                          opt->min_seed_len,
+                                          matchArray + num_smem1,
+                                          &num_smem2);
+#else
     fmi->getSMEMsOnePosOneThread(enc_qdb,
                                  query_pos_ar,
                                  min_intv_ar,
@@ -756,6 +770,7 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
                                  opt->min_seed_len,
                                  matchArray + num_smem1,
                                  &num_smem2);
+#endif
     // assert(mmc->wsize_mem[tid] > (num_smem1 + num_smem2));
     // fprintwsize_mem_rf(stderr, "num_smem2: %d\n", num_smem2);
     if (opt->max_mem_intv > 0)

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,7 +29,7 @@
 ##*****************************************************************************************/
 
 
-EXE=		fmi_test smem2_test bwt_seed_strategy_test sa2ref_test xeonbsw
+EXE=		fmi_test smem2_test bwt_seed_strategy_test sa2ref_test xeonbsw smem_lockstep_parity_test
 
 # Match the parent Makefile's compiler + flag selection. Detect ARM
 # (Apple Silicon arm64 and Linux aarch64) and wire in OpenMP, sse2neon
@@ -98,6 +98,9 @@ bwt_seed_strategy_test:bwt_seed_strategy_test.o
 xeonbsw:main_banded.o
 	$(CXX) -o $@ $^ $(LIBS)
 
+smem_lockstep_parity_test: smem_lockstep_parity_test.o
+	$(CXX) -o $@ $^ $(LIBS)
+
 clean:
 	rm -fr *.o $(EXE)
 
@@ -113,3 +116,5 @@ sa2ref_test.o: ../src/FMI_search.h ../src/bntseq.h ../src/read_index_ele.h
 sa2ref_test.o: ../src/bwa.h ../src/bwt.h ../src/utils.h ../src/macro.h
 smem2_test.o: ../src/FMI_search.h ../src/bntseq.h ../src/read_index_ele.h
 smem2_test.o: ../src/bwa.h ../src/bwt.h ../src/utils.h ../src/macro.h
+smem_lockstep_parity_test.o: ../src/FMI_search.h ../src/bntseq.h ../src/read_index_ele.h
+smem_lockstep_parity_test.o: ../src/bwa.h ../src/bwt.h ../src/utils.h ../src/macro.h

--- a/test/smem_lockstep_parity_test.cpp
+++ b/test/smem_lockstep_parity_test.cpp
@@ -1,0 +1,513 @@
+/* Parity harness: scalar getSMEMsOnePosOneThread vs getSMEMsOnePosOneThread_lockstep.
+ * Both functions are given identical inputs; outputs (matchArray bytes,
+ * numTotalSmem, query_pos_array write-back) must be byte-identical.
+ *
+ * Usage: smem_lockstep_parity_test <bwa-mem2 index prefix>
+ *   e.g. smem_lockstep_parity_test /Volumes/scratch-00001/bench/pr-15/ref/hg38.fa
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "FMI_search.h"
+#include "bwa.h"
+
+/* A degenerate N=1 build would invoke getSMEMsOnePosOneThread_lockstep as a
+ * single-slot path, so the cases below would trivially pass without ever
+ * exercising slot-interleaving. Fail the build early in that case. */
+#if SMEM_LOCKSTEP_N <= 1
+#error "smem_lockstep_parity_test requires SMEM_LOCKSTEP_N > 1 to exercise the lockstep path"
+#endif
+
+/* Field-by-field SMEM equality. memcmp is unsuitable because the SMEM struct
+ * has implicit padding between `n` and `k` that upstream leaves
+ * uninitialized — the padding bytes are not part of the semantic contract. */
+static bool smem_fields_equal(const SMEM &a, const SMEM &b) {
+    return a.rid == b.rid &&
+           a.m   == b.m   &&
+           a.n   == b.n   &&
+           a.k   == b.k   &&
+           a.l   == b.l   &&
+           a.s   == b.s;
+}
+
+static int64_t smem_array_first_mismatch(const SMEM *a, const SMEM *b, int64_t n) {
+    for (int64_t i = 0; i < n; i++) {
+        if (!smem_fields_equal(a[i], b[i])) return i;
+    }
+    return -1;
+}
+
+static int32_t total_cases = 0;
+static int32_t passed_cases = 0;
+
+static bool run_case(FMI_search *fmi,
+                     const char *case_name,
+                     int32_t numReads,
+                     int32_t max_readlength,
+                     int32_t minSeedLen,
+                     uint8_t *enc_qdb,
+                     int16_t *query_pos_array_in,
+                     int32_t *min_intv_array_in,
+                     int32_t *rid_array_in,
+                     const bseq1_t *seq_,
+                     int32_t *query_cum_len_ar)
+{
+    // Tight upper bound: the scalar path emits at most O(readlength) SMEMs per
+    // read (one per backward-step decision plus the final prev[0]), so
+    // numReads * max_readlength safely caps both scalar_out and lockstep_out.
+    const int32_t max_out = numReads * max_readlength;
+    SMEM *scalar_out   = (SMEM *)_mm_malloc(max_out * sizeof(SMEM), 64);
+    SMEM *lockstep_out = (SMEM *)_mm_malloc(max_out * sizeof(SMEM), 64);
+
+    int16_t *qpa_s = (int16_t *)malloc(numReads * sizeof(int16_t));
+    int16_t *qpa_l = (int16_t *)malloc(numReads * sizeof(int16_t));
+    int32_t *mia_s = (int32_t *)malloc(numReads * sizeof(int32_t));
+    int32_t *mia_l = (int32_t *)malloc(numReads * sizeof(int32_t));
+    int32_t *rid_s = (int32_t *)malloc(numReads * sizeof(int32_t));
+    int32_t *rid_l = (int32_t *)malloc(numReads * sizeof(int32_t));
+    memcpy(qpa_s, query_pos_array_in, numReads * sizeof(int16_t));
+    memcpy(qpa_l, query_pos_array_in, numReads * sizeof(int16_t));
+    memcpy(mia_s, min_intv_array_in, numReads * sizeof(int32_t));
+    memcpy(mia_l, min_intv_array_in, numReads * sizeof(int32_t));
+    memcpy(rid_s, rid_array_in, numReads * sizeof(int32_t));
+    memcpy(rid_l, rid_array_in, numReads * sizeof(int32_t));
+
+    int64_t n_scalar = 0, n_lockstep = 0;
+
+    fmi->getSMEMsOnePosOneThread(enc_qdb, qpa_s, mia_s, rid_s,
+                                 numReads, numReads, seq_, query_cum_len_ar,
+                                 max_readlength, minSeedLen, scalar_out, &n_scalar);
+    fmi->getSMEMsOnePosOneThread_lockstep(enc_qdb, qpa_l, mia_l, rid_l,
+                                          numReads, numReads, seq_, query_cum_len_ar,
+                                          max_readlength, minSeedLen, lockstep_out, &n_lockstep);
+
+    total_cases++;
+    bool ok = true;
+    if (n_scalar != n_lockstep) {
+        fprintf(stderr, "[FAIL] %s: numTotalSmem mismatch: scalar=%lld lockstep=%lld\n",
+                case_name, (long long)n_scalar, (long long)n_lockstep);
+        ok = false;
+    } else {
+        int64_t mism = smem_array_first_mismatch(scalar_out, lockstep_out, n_scalar);
+        if (mism >= 0) {
+            const SMEM &a = scalar_out[mism];
+            const SMEM &b = lockstep_out[mism];
+            fprintf(stderr, "[FAIL] %s: SMEM field mismatch at index %lld:\n"
+                    "  scalar   rid=%d m=%u n=%u k=%lld l=%lld s=%lld\n"
+                    "  lockstep rid=%d m=%u n=%u k=%lld l=%lld s=%lld\n",
+                    case_name, (long long)mism,
+                    a.rid, a.m, a.n, (long long)a.k, (long long)a.l, (long long)a.s,
+                    b.rid, b.m, b.n, (long long)b.k, (long long)b.l, (long long)b.s);
+            ok = false;
+        } else if (memcmp(qpa_s, qpa_l, numReads * sizeof(int16_t)) != 0) {
+            fprintf(stderr, "[FAIL] %s: query_pos_array write-back differs\n", case_name);
+            ok = false;
+        } else {
+            fprintf(stderr, "[PASS] %s  (n_smem=%lld)\n", case_name, (long long)n_scalar);
+            passed_cases++;
+        }
+    }
+
+    _mm_free(scalar_out);
+    _mm_free(lockstep_out);
+    free(qpa_s); free(qpa_l); free(mia_s); free(mia_l); free(rid_s); free(rid_l);
+    return ok;
+}
+
+/* Encode a vector of read strings (ACGT->0123, N->4) into the flat enc_qdb
+ * + bseq1_t[] + query_cum_len_ar[] layout getSMEMsOnePosOneThread expects. */
+static void encode_reads(const char * const *reads, int32_t numReads,
+                         uint8_t **out_enc_qdb,
+                         bseq1_t **out_seq,
+                         int32_t **out_cum_len)
+{
+    int32_t total_len = 0;
+    for (int i = 0; i < numReads; i++) total_len += (int32_t)strlen(reads[i]);
+    uint8_t *enc = (uint8_t *)calloc(total_len > 0 ? total_len : 1, 1);
+    bseq1_t *seq = (bseq1_t *)calloc(numReads, sizeof(bseq1_t));
+    int32_t *cum = (int32_t *)calloc(numReads + 1, sizeof(int32_t));
+    int32_t off = 0;
+    for (int i = 0; i < numReads; i++) {
+        int32_t l = (int32_t)strlen(reads[i]);
+        cum[i] = off;
+        for (int j = 0; j < l; j++) {
+            char c = reads[i][j];
+            uint8_t e = 4;
+            if (c == 'A' || c == 'a') e = 0;
+            else if (c == 'C' || c == 'c') e = 1;
+            else if (c == 'G' || c == 'g') e = 2;
+            else if (c == 'T' || c == 't') e = 3;
+            enc[off + j] = e;
+        }
+        seq[i].l_seq = l;
+        off += l;
+    }
+    cum[numReads] = off;
+    *out_enc_qdb = enc;
+    *out_seq = seq;
+    *out_cum_len = cum;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <bwa-mem2 index prefix>\n", argv[0]);
+        return 2;
+    }
+
+    fprintf(stderr, "smem_lockstep_parity_test: SMEM_LOCKSTEP_N=%d\n",
+            (int)SMEM_LOCKSTEP_N);
+
+    FMI_search *fmi = new FMI_search(argv[1]);
+    fmi->load_index();
+
+    /* Case 1: two simple reads, start at position 0, minSeedLen 19. */
+    {
+        const char *reads[] = {
+            "ACGTACGTACGTACGTACGTACGTACGTACGT",
+            "TGCATGCATGCATGCATGCATGCATGCATGCA",
+        };
+        int32_t numReads = 2;
+        int32_t max_readlength = 32;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        int16_t qpa[] = {0, 0};
+        int32_t mia[] = {1, 1};
+        int32_t rid[] = {0, 1};
+        run_case(fmi, "Case 1: two simple reads",
+                 numReads, max_readlength, 19,
+                 enc_qdb, qpa, mia, rid, seq_, cum_len);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    /* Case 2: numReads < N (default N=4 → use 2 reads). Exercises the
+     * "unused slots" path where the driver must mark slot indices >= numReads
+     * as DONE/invalid at entry so the flush pass skips them. */
+    {
+        const char *reads[] = {
+            "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT",
+            "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT",
+        };
+        int32_t numReads = 2;
+        int32_t max_readlength = 40;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        int16_t qpa[] = {0, 0};
+        int32_t mia[] = {1, 1};
+        int32_t rid[] = {0, 1};
+        run_case(fmi, "Case 2: numReads < N",
+                 numReads, max_readlength, 19,
+                 enc_qdb, qpa, mia, rid, seq_, cum_len);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    /* Case 3: numReads == N (single full batch, no slot recycle).
+     * Exercises the steady state where every slot is occupied and no
+     * retirement of slots happens before flush. */
+    {
+        const char *reads[] = {
+            "ACGTACGTACGTACGTACGTACGTACGTACGT",
+            "TGCATGCATGCATGCATGCATGCATGCATGCA",
+            "AAAACCCCGGGGTTTTAAAACCCCGGGGTTTT",
+            "GATCGATCGATCGATCGATCGATCGATCGATC",
+        };
+        int32_t numReads = 4;
+        int32_t max_readlength = 32;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        int16_t qpa[] = {0, 0, 0, 0};
+        int32_t mia[] = {1, 1, 1, 1};
+        int32_t rid[] = {0, 1, 2, 3};
+        run_case(fmi, "Case 3: numReads == N",
+                 numReads, max_readlength, 19,
+                 enc_qdb, qpa, mia, rid, seq_, cum_len);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    /* Case 4: numReads == N+1 (exactly one slot recycle).
+     * Exercises the flush-then-pull-next-input path. */
+    {
+        const char *reads[] = {
+            "ACGTACGTACGTACGTACGTACGTACGTACGT",
+            "TGCATGCATGCATGCATGCATGCATGCATGCA",
+            "AAAACCCCGGGGTTTTAAAACCCCGGGGTTTT",
+            "GATCGATCGATCGATCGATCGATCGATCGATC",
+            "CAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGT",
+        };
+        int32_t numReads = 5;
+        int32_t max_readlength = 32;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        int16_t qpa[] = {0, 0, 0, 0, 0};
+        int32_t mia[] = {1, 1, 1, 1, 1};
+        int32_t rid[] = {0, 1, 2, 3, 4};
+        run_case(fmi, "Case 4: numReads == N+1",
+                 numReads, max_readlength, 19,
+                 enc_qdb, qpa, mia, rid, seq_, cum_len);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    /* Case 5: first base non-ACGT (N character). The scalar path skips the
+     * whole read when enc_qdb[offset + x] >= 4; lockstep must match by
+     * going straight to PH_DONE with zero matches, without writing anything
+     * to matchArray for this read. Mixed with valid reads to ensure the
+     * zero-match case doesn't corrupt the flush cursor. */
+    {
+        const char *reads[] = {
+            "NACGTACGTACGTACGTACGTACGTACGTACG",
+            "TGCATGCATGCATGCATGCATGCATGCATGCA",
+            "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN",
+            "GATCGATCGATCGATCGATCGATCGATCGATC",
+        };
+        int32_t numReads = 4;
+        int32_t max_readlength = 32;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        int16_t qpa[] = {0, 0, 0, 0};
+        int32_t mia[] = {1, 1, 1, 1};
+        int32_t rid[] = {0, 1, 2, 3};
+        run_case(fmi, "Case 5: first base non-ACGT",
+                 numReads, max_readlength, 19,
+                 enc_qdb, qpa, mia, rid, seq_, cum_len);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    /* Case 6: numReads not divisible by N (tail partial batch).
+     * After filling N=4 slots, 3 more reads get pulled in as slots retire.
+     * When only fewer-than-N reads remain and the last ones finish, the
+     * driver must correctly mark the slots retired (input_idx = -1) without
+     * trying to recycle from an exhausted queue. */
+    {
+        const char *reads[] = {
+            "ACGTACGTACGTACGTACGTACGTACGTACGT",
+            "TGCATGCATGCATGCATGCATGCATGCATGCA",
+            "AAAACCCCGGGGTTTTAAAACCCCGGGGTTTT",
+            "GATCGATCGATCGATCGATCGATCGATCGATC",
+            "CAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGT",
+            "TTTACCCAGGGCTTTACCCAGGGCTTTACCCA",
+            "ATATATATATATATATATATATATATATATAT",
+        };
+        int32_t numReads = 7;  /* 4 initial + 3 recycles; not divisible by N=4 */
+        int32_t max_readlength = 32;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        int16_t qpa[] = {0, 0, 0, 0, 0, 0, 0};
+        int32_t mia[] = {1, 1, 1, 1, 1, 1, 1};
+        int32_t rid[] = {0, 1, 2, 3, 4, 5, 6};
+        run_case(fmi, "Case 6: numReads not divisible by N",
+                 numReads, max_readlength, 19,
+                 enc_qdb, qpa, mia, rid, seq_, cum_len);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    /* Case 7: mixed start_pos (some reads start mid-read rather than at 0).
+     * Exercises the forward-ext `j = start_pos + 1` initialization and the
+     * backward-ext `j = start_pos - 1` initialization for non-zero starts.
+     * The scalar path uses `query_pos_array[i]` directly; lockstep carries
+     * it in slot.start_pos, which must round-trip correctly. */
+    {
+        const char *reads[] = {
+            "ACGTACGTACGTACGTACGTACGTACGTACGT",
+            "TGCATGCATGCATGCATGCATGCATGCATGCA",
+            "AAAACCCCGGGGTTTTAAAACCCCGGGGTTTT",
+            "GATCGATCGATCGATCGATCGATCGATCGATC",
+        };
+        int32_t numReads = 4;
+        int32_t max_readlength = 32;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        int16_t qpa[] = {5, 10, 0, 15};   /* mixed start positions */
+        int32_t mia[] = {1, 1, 1, 1};
+        int32_t rid[] = {0, 1, 2, 3};
+        run_case(fmi, "Case 7: mixed start_pos",
+                 numReads, max_readlength, 19,
+                 enc_qdb, qpa, mia, rid, seq_, cum_len);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    /* Case 8: real 300bp Illumina WGS read pair from SRR6109255
+     * (SRR6109255.100035 R1/R2). Exercises long SMEM walks through adapter
+     * contamination (AGATCGGAAGAG around base ~22-24) and low-complexity
+     * A-run tails — patterns the synthetic Cases 1-7 don't hit. Regression
+     * coverage for real-world read composition. */
+    {
+        /* SRR6109255.100035 R1 (300bp) */
+        const char *r1 =
+            "ATGACCTCCCTAATATCTTCAGAATAGATCGGAAGAGCACACGTCTGAACTCCAGTCACT"
+            "ACAAGATCTCGTATGCCGTCTTCTGCTTGAAAAAAAAAAAAAAAAAATGAGTAACTCTAT"
+            "GAATCGAACTCAAACATTCCACACACGTTTATGCCACTACTTCTATCGTGCTTTCATATT"
+            "ATACTACTCCCCCTTCCCCCTCCATCTTCACCTCTCCTCCAATCTCCACTCACCTCTACC"
+            "TCAACACGTACTTTACACACATCTCTCCCCCACGGACCACAATACCTCTCCTCTCAATTA";
+        /* SRR6109255.100035 R2 (300bp) */
+        const char *r2 =
+            "ATTCTGAAGATATTAGGGAGGTCATAGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTAG"
+            "ATCTCGGTGGTCGCCGTATCATTAAAAAAAAAAAAAATAAAAACAGAAGCAGTGTCAGTA"
+            "GCATAGTGATGAATATAGCAATAAACGCACAGCTTGAAACCTACCGTTTGCGACAGCATC"
+            "TCTACAGACGTCTGTTTATCTACTTTGAAAGTGGCTACGTGGAACACTCATAGTCATACC"
+            "ACTAATCAATATCATGAAATTACCAGGTTAGTCTGTATACTACGATAAAGACACAGACTT";
+        const char *reads[] = { r1, r2 };
+        int32_t numReads = 2;
+        int32_t max_readlength = 300;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        int16_t qpa[] = {0, 0};
+        int32_t mia[] = {1, 1};
+        int32_t rid[] = {0, 1};
+        run_case(fmi, "Case 8: real 300bp SRR6109255.100035",
+                 numReads, max_readlength, 19,
+                 enc_qdb, qpa, mia, rid, seq_, cum_len);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    /* Case 9: same real 300bp pair, driven through the outer
+     * `getSMEMsAllPosOneThread` do/while loop. The outer driver compacts
+     * active reads and re-calls the inner function with updated
+     * query_pos_array[i]; a bug in the inner function's write-back of
+     * next_x (slot.next_x via ls_advance_forward_step / ls_init_slot) would
+     * show up here even if Case 8 passes. We run the scalar and lockstep
+     * outer drivers locally rather than via getSMEMsAllPosOneThread, since
+     * that one dispatches based on the SMEM_LOCKSTEP_N macro at compile
+     * time — both sides would take the same branch. */
+    {
+        const char *r1 =
+            "ATGACCTCCCTAATATCTTCAGAATAGATCGGAAGAGCACACGTCTGAACTCCAGTCACT"
+            "ACAAGATCTCGTATGCCGTCTTCTGCTTGAAAAAAAAAAAAAAAAAATGAGTAACTCTAT"
+            "GAATCGAACTCAAACATTCCACACACGTTTATGCCACTACTTCTATCGTGCTTTCATATT"
+            "ATACTACTCCCCCTTCCCCCTCCATCTTCACCTCTCCTCCAATCTCCACTCACCTCTACC"
+            "TCAACACGTACTTTACACACATCTCTCCCCCACGGACCACAATACCTCTCCTCTCAATTA";
+        const char *r2 =
+            "ATTCTGAAGATATTAGGGAGGTCATAGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTAG"
+            "ATCTCGGTGGTCGCCGTATCATTAAAAAAAAAAAAAATAAAAACAGAAGCAGTGTCAGTA"
+            "GCATAGTGATGAATATAGCAATAAACGCACAGCTTGAAACCTACCGTTTGCGACAGCATC"
+            "TCTACAGACGTCTGTTTATCTACTTTGAAAGTGGCTACGTGGAACACTCATAGTCATACC"
+            "ACTAATCAATATCATGAAATTACCAGGTTAGTCTGTATACTACGATAAAGACACAGACTT";
+        const char *reads[] = { r1, r2 };
+        int32_t numReads = 2;
+        int32_t max_readlength = 300;
+        int32_t minSeedLen = 19;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        const int32_t max_out = numReads * max_readlength;
+        SMEM *scalar_out   = (SMEM *)_mm_malloc(max_out * sizeof(SMEM), 64);
+        SMEM *lockstep_out = (SMEM *)_mm_malloc(max_out * sizeof(SMEM), 64);
+
+        /* The two do/while blocks below intentionally mirror the compaction
+         * logic in FMI_search::getSMEMsAllPosOneThread (see src/FMI_search.cpp),
+         * in particular the `query_pos_array[head] < seq_[rid].l_seq` predicate
+         * that keeps reads active. If that predicate or the surrounding loop
+         * structure changes in production, update both drivers here to match. */
+        /* Scalar outer driver. */
+        int64_t n_s = 0;
+        int16_t qpa_s[2] = {0, 0};
+        {
+            int32_t rid_work[2] = {0, 1};
+            int32_t mia_work[2] = {1, 1};
+            int32_t numActive = numReads;
+            do {
+                int32_t head = 0, tail = 0;
+                for (head = 0; head < numActive; head++) {
+                    int rl = seq_[rid_work[head]].l_seq;
+                    if (qpa_s[head] < rl) {
+                        rid_work[tail] = rid_work[head];
+                        qpa_s[tail] = qpa_s[head];
+                        mia_work[tail] = mia_work[head];
+                        tail++;
+                    }
+                }
+                fmi->getSMEMsOnePosOneThread(enc_qdb, qpa_s, mia_work, rid_work,
+                                             tail, tail, seq_, cum_len,
+                                             max_readlength, minSeedLen, scalar_out, &n_s);
+                numActive = tail;
+            } while (numActive > 0);
+        }
+
+        /* Lockstep outer driver. */
+        int64_t n_l = 0;
+        int16_t qpa_l[2] = {0, 0};
+        {
+            int32_t rid_work[2] = {0, 1};
+            int32_t mia_work[2] = {1, 1};
+            int32_t numActive = numReads;
+            do {
+                int32_t head = 0, tail = 0;
+                for (head = 0; head < numActive; head++) {
+                    int rl = seq_[rid_work[head]].l_seq;
+                    if (qpa_l[head] < rl) {
+                        rid_work[tail] = rid_work[head];
+                        qpa_l[tail] = qpa_l[head];
+                        mia_work[tail] = mia_work[head];
+                        tail++;
+                    }
+                }
+                fmi->getSMEMsOnePosOneThread_lockstep(enc_qdb, qpa_l, mia_work, rid_work,
+                                                     tail, tail, seq_, cum_len,
+                                                     max_readlength, minSeedLen, lockstep_out, &n_l);
+                numActive = tail;
+            } while (numActive > 0);
+        }
+
+        total_cases++;
+        if (n_s != n_l) {
+            fprintf(stderr, "[FAIL] Case 9 AllPos driver: numTotalSmem mismatch: scalar=%lld lockstep=%lld\n",
+                    (long long)n_s, (long long)n_l);
+        } else {
+            int64_t mism = smem_array_first_mismatch(scalar_out, lockstep_out, n_s);
+            if (mism >= 0) {
+                const SMEM &a = scalar_out[mism];
+                const SMEM &b = lockstep_out[mism];
+                fprintf(stderr, "[FAIL] Case 9 AllPos driver: SMEM mismatch at %lld:\n"
+                        "  scalar   rid=%d m=%u n=%u k=%lld l=%lld s=%lld\n"
+                        "  lockstep rid=%d m=%u n=%u k=%lld l=%lld s=%lld\n",
+                        (long long)mism,
+                        a.rid, a.m, a.n, (long long)a.k, (long long)a.l, (long long)a.s,
+                        b.rid, b.m, b.n, (long long)b.k, (long long)b.l, (long long)b.s);
+            } else {
+                fprintf(stderr, "[PASS] Case 9 AllPos driver  (n_smem=%lld)\n", (long long)n_s);
+                passed_cases++;
+            }
+        }
+        _mm_free(scalar_out); _mm_free(lockstep_out);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    /* Case 10: exercises the forward-ext `newSmem.s < min_intv` exit path
+     * by using the real 300bp reads with a large min_intv (mimicking what
+     * mem_collect_smem uses for phase-2 re-seeding: min_intv = prev_smem.s
+     * + 1). Synthetic Cases 1-7 use min_intv=1, which rarely triggers this
+     * exit path. This case guards the post-loop "push smem if smem.s >=
+     * min_intv" behavior on the min_intv branch. */
+    {
+        const char *r1 =
+            "ATGACCTCCCTAATATCTTCAGAATAGATCGGAAGAGCACACGTCTGAACTCCAGTCACT"
+            "ACAAGATCTCGTATGCCGTCTTCTGCTTGAAAAAAAAAAAAAAAAAATGAGTAACTCTAT"
+            "GAATCGAACTCAAACATTCCACACACGTTTATGCCACTACTTCTATCGTGCTTTCATATT"
+            "ATACTACTCCCCCTTCCCCCTCCATCTTCACCTCTCCTCCAATCTCCACTCACCTCTACC"
+            "TCAACACGTACTTTACACACATCTCTCCCCCACGGACCACAATACCTCTCCTCTCAATTA";
+        const char *r2 =
+            "ATTCTGAAGATATTAGGGAGGTCATAGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTAG"
+            "ATCTCGGTGGTCGCCGTATCATTAAAAAAAAAAAAAATAAAAACAGAAGCAGTGTCAGTA"
+            "GCATAGTGATGAATATAGCAATAAACGCACAGCTTGAAACCTACCGTTTGCGACAGCATC"
+            "TCTACAGACGTCTGTTTATCTACTTTGAAAGTGGCTACGTGGAACACTCATAGTCATACC"
+            "ACTAATCAATATCATGAAATTACCAGGTTAGTCTGTATACTACGATAAAGACACAGACTT";
+        const char *reads[] = { r1, r2 };
+        int32_t numReads = 2;
+        int32_t max_readlength = 300;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        /* Start mid-read (past adapter) and use a large min_intv so the
+         * forward walk will terminate via the newSmem.s < min_intv branch. */
+        int16_t qpa[] = {100, 100};
+        int32_t mia[] = {1000, 1000};
+        int32_t rid[] = {0, 1};
+        run_case(fmi, "Case 10: forward-ext min_intv break",
+                 numReads, max_readlength, 19,
+                 enc_qdb, qpa, mia, rid, seq_, cum_len);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    fprintf(stderr, "%d / %d cases passed\n", passed_cases, total_cases);
+    delete fmi;
+    return (passed_cases == total_cases) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Refactors SMEM seeding into a lockstep batch driver that advances `SMEM_LOCKSTEP_N` reads' SMEM walks in slot-interleaved order, exposing memory-level parallelism across slots so the CPU's out-of-order engine can overlap `cp_occ` cache-miss loads.

- **Parity-correct** — byte-identical SAM output at every scale we've tested (unit cases, 10K slice, 1M pairs on hg38). Scalar `getSMEMsOnePosOneThread` is kept as the `SMEM_LOCKSTEP_N=1` bisectable baseline.
- **Supersedes #15** (cross-read `_mm_prefetch`-only shape).
- **~6% wall-time improvement** on 150bp NovaSeq WGS on Graviton3 (8T, 1M pairs, hg38).

## Design

- Per-read state (`BatchSlot`) with its own `prev[]` walk buffer and `match_buf[]` reorder buffer.
- Round-robin driver: each outer iteration advances each non-DONE slot by one phase-step (forward-ext step, backward-init, or one outer-j of backward-search).
- Tight slot recycling — finished slots immediately pick up the next input. Match-emit cursor enforces input-index order so the output order is identical to scalar.
- Initial-load `_mm_prefetch` hint at slot-seed time for cold cp_occ lines.
- `SMEM_LOCKSTEP_N` is compile-time tunable (default `4`). `N=1` dispatches to the unchanged scalar path.
- Drops PR #15's cross-read prefetch hints (those regressed on Graviton3). Scalar's intra-iteration prefetch hints are unchanged.

## Bench data (Graviton3 r7g.4xlarge, 8T)

### 150bp NovaSeq WGS (wgs-5M, 1M-pair subset, hg38)

| metric | fg-main | lockstep | Δ |
|---|---:|---:|---:|
| wall time | 82 s | **77 s** | **−6.1%** |
| \`backwardExt\` (% of cycles) | 18.80% | 14.30% | −4.5 pp |
| SMEM phase (% of cycles) | ~23% | ~18% | −5.0 pp |
| \`backwardExt\` hot \`cp_occ\` load (% of function) | 65.48% | 53.25% | −12.2 pp |

The reduced hot-load share of \`backwardExt\` function-time is direct evidence that the OoO engine is overlapping cross-slot \`cp_occ\` loads — the MLP the design aimed for.

### 300bp MiSeq WGS (SRR6109255, 1M-pair subset, hg38)

Workload is SW-dominated (~85% cycles in \`kswv_neon_16\` + \`smithWaterman128_16\`), leaving only ~8% of cycles in SMEM. Lockstep is perf-neutral here (within noise) — not a regression. Parity holds.

## Relationship to PR #15

PR #15 implemented only "scope 1" (cross-read \`_mm_prefetch\`). On Graviton3 that shape regressed by +2.61% wall + +13.85% \`stall_backend_mem\`. This PR replaces that shape with true lockstep batching, which is perf-neutral-to-positive (no regression on either platform) and is a cleaner substrate for any future SMEM work.

## Parity

- 10 unit parity cases in \`test/smem_lockstep_parity_test.cpp\` (N boundaries, non-ACGT first base, mixed start_pos, real 300bp reads through both the inner function and the outer \`getSMEMsAllPosOneThread\` driver).
- Existing CI dwgsim-on-phiX174 SAM diff unchanged.
- Local 1M-pair hg38 normalized+sorted SAM: byte-identical vs fg-main on both macOS arm64 and Graviton3.

## Known limitations / what's NOT in this PR

- **No SIMD popcount (was "scope 2" in PR #15's description).** Profile evidence shows popcount (\`cnt\` / \`addv\` instructions in \`backwardExt\`) is <0.3% per instruction — it's already essentially free. The hot spot in \`backwardExt\` is the \`cp_occ\` load (65% of function time on fg-main), which is what this PR addresses via MLP.
- **Further SMEM optimization has diminishing returns.** SW extension is 54% of cycles on 150bp and 85% on 300bp. Any future perf work should target the SW kernel, not seeding.
- **macOS arm64 local bench was I/O-bound** at measurement time (host low on free RAM, FM-index cold on every trial). Parity PASS, perf delta inconclusive there — Graviton data is the load-bearing result.

## Test plan

- [x] CI matrix (Linux x86_64 SSE4.1, AVX2, Linux ARM64, macOS arm64) — dwgsim-on-phiX174 parity
- [x] \`test/smem_lockstep_parity_test\` — 10/10 cases pass
- [x] 1M-pair hg38 SAM byte-identical (macOS + Graviton)
- [x] Graviton perf profiling confirms expected MLP recovery in \`backwardExt\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced lockstep SMEM batching optimization to improve seed matching throughput when processing multiple reads simultaneously.
  * Added configurable batch size parameter (default: 4).

* **Tests**
  * Added comprehensive validation test ensuring functional equivalence between scalar and optimized seed matching implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->