### PR TITLE
chore: port four nh13 lh3/bwa PRs into bwa-mem2 (-z, -u/XB, MQ, @HD order)

### DIFF
--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -277,6 +277,10 @@ int mem_aln_to_bam(struct bam1_t *b,
             bam_aux_append(b, "MC", 'Z', (int)mc.l + 1, (const uint8_t *)mc.s);
         free(mc.s);
     }
+    if (mp) {
+        int32_t mq = (int32_t)mp->mapq;
+        bam_aux_append(b, "MQ", 'i', sizeof(mq), (const uint8_t *)&mq);
+    }
     if (p.score >= 0) {
         int32_t as = (int32_t)p.score;
         bam_aux_append(b, "AS", 'i', sizeof(as), (const uint8_t *)&as);

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -26,19 +26,83 @@ void           bam_writer_free(struct bam1_t *b)  { if (b) bam_destroy1(b); }
 }
 
 bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
+                              const char *idx_hdr_lines,
                               const char *hdr_line, const char *bwa_pg,
                               int compression_level)
 {
     if (path == NULL || bns == NULL) return NULL;
 
+    // Detect whether the index .hdr/.dict content already supplies @SQ or
+    // @HD records. If @SQ: skip auto-generating @SQ from `bns` — adding
+    // both would hit htslib's "duplicate SN" de-dup and fail. If @HD:
+    // skip the default @HD — htslib's sam_hdr_add_lines does not de-dup
+    // @HD records, so emitting both would produce two @HD lines. The
+    // caller (fastmap.cpp) has already nulled `idx_hdr_lines` when the
+    // user's -H supplies @SQ, so if we see @SQ here, they're authoritative.
+    int idx_has_sq = 0, idx_has_hd = 0;
+    if (idx_hdr_lines != NULL && idx_hdr_lines[0] != '\0') {
+        if (strncmp(idx_hdr_lines, "@SQ\t", 4) == 0 ||
+            strstr(idx_hdr_lines, "\n@SQ\t") != NULL)
+            idx_has_sq = 1;
+        if (strncmp(idx_hdr_lines, "@HD\t", 4) == 0 ||
+            strstr(idx_hdr_lines, "\n@HD\t") != NULL)
+            idx_has_hd = 1;
+    }
+    int user_has_hd = 0;
+    if (hdr_line != NULL && hdr_line[0] != '\0') {
+        if (strncmp(hdr_line, "@HD\t", 4) == 0 ||
+            strstr(hdr_line, "\n@HD\t") != NULL)
+            user_has_hd = 1;
+    }
+
     sam_hdr_t *hdr = sam_hdr_init();
     if (hdr == NULL) return NULL;
-    if (sam_hdr_add_line(hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL) < 0) goto fail;
-    for (int i = 0; i < bns->n_seqs; ++i) {
-        char len_buf[32];
-        snprintf(len_buf, sizeof(len_buf), "%lld", (long long)bns->anns[i].len);
-        if (sam_hdr_add_line(hdr, "SQ", "SN", bns->anns[i].name, "LN", len_buf, NULL) < 0)
-            goto fail;
+    // Emit a default @HD only when neither the user's -H nor the index's
+    // .hdr/.dict supplies one. Precedence (user > index > default) is
+    // enforced by ordering: we add idx_hdr_lines before hdr_line, and the
+    // SAM text path uses the same precedence via bwa_print_sam_hdr2.
+    if (!idx_has_hd && !user_has_hd &&
+        sam_hdr_add_line(hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL) < 0) goto fail;
+    if (!idx_has_sq) {
+        for (int i = 0; i < bns->n_seqs; ++i) {
+            char len_buf[32];
+            snprintf(len_buf, sizeof(len_buf), "%lld", (long long)bns->anns[i].len);
+            if (sam_hdr_add_line(hdr, "SQ", "SN", bns->anns[i].name, "LN", len_buf, NULL) < 0)
+                goto fail;
+        }
+    }
+    // Merge the index's .hdr/.dict records after the default @HD (and
+    // auto-generated @SQ, when the index didn't supply its own) but before
+    // the user's -H lines. If the user has an @HD in -H, strip the @HD
+    // records from idx_hdr_lines first — htslib's sam_hdr_add_lines does
+    // not de-dup @HD, so without filtering we'd emit two @HD records. This
+    // matches the SAM text path's precedence: user > index > default.
+    if (idx_hdr_lines != NULL && idx_hdr_lines[0] != '\0') {
+        const char *to_add = idx_hdr_lines;
+        char *filtered = NULL;
+        if (user_has_hd && idx_has_hd) {
+            // Copy idx_hdr_lines, dropping any @HD records.
+            size_t n = strlen(idx_hdr_lines);
+            filtered = (char *)malloc(n + 1);
+            if (filtered == NULL) goto fail;
+            size_t w = 0;
+            const char *p = idx_hdr_lines;
+            while (*p) {
+                const char *eol = strchr(p, '\n');
+                size_t len = eol ? (size_t)(eol - p) : strlen(p);
+                int is_hd = (len >= 4 && strncmp(p, "@HD\t", 4) == 0);
+                if (!is_hd && len > 0) {
+                    memcpy(filtered + w, p, len); w += len;
+                    filtered[w++] = '\n';
+                }
+                p = eol ? eol + 1 : p + len;
+            }
+            filtered[w] = '\0';
+            to_add = filtered;
+        }
+        int rc = (to_add[0] != '\0') ? sam_hdr_add_lines(hdr, to_add, 0) : 0;
+        free(filtered);
+        if (rc < 0) goto fail;
     }
     if (hdr_line != NULL && hdr_line[0] != '\0' && sam_hdr_add_lines(hdr, hdr_line, 0) < 0)
         goto fail;

--- a/src/bam_writer.h
+++ b/src/bam_writer.h
@@ -20,11 +20,18 @@ typedef struct bam_writer_s bam_writer_t;
 
 /* Open a BAM writer at `path` ("-" for stdout). compression_level 0 = no
  * deflate (fast, same size as SAM), 1..9 = BGZF deflate levels. @SQ is
- * built directly from `bns->anns`. `hdr_line` carries user-supplied header
- * lines (e.g., `@RG` from `-R` and `-H` insertions, as accumulated by
- * bwa_insert_header); it is inserted before `@PG`. `bwa_pg` is inserted
- * as-is. Both may be NULL. Returns NULL on failure. */
+ * built directly from `bns->anns`. `idx_hdr_lines` carries header records
+ * loaded from <prefix>.hdr or <baseprefix>.dict (or NULL if neither exists,
+ * or if the user's `hdr_line` supplies @SQ records — in which case the index
+ * file is ignored entirely, matching the SAM text path). These are inserted
+ * after the default @HD/@SQ but before user `hdr_line`, so user -H entries
+ * win on any @HD/@SQ collision via htslib's header de-dup rules. `hdr_line`
+ * carries user-supplied header lines (e.g., `@RG` from `-R` and `-H`
+ * insertions, as accumulated by bwa_insert_header); it is inserted before
+ * `@PG`. `bwa_pg` is inserted as-is. All three may be NULL. Returns NULL on
+ * failure. */
 bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
+                              const char *idx_hdr_lines,
                               const char *hdr_line, const char *bwa_pg,
                               int compression_level);
 

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -519,59 +519,165 @@ int bwa_idx2mem(bwaidx_t *idx)
  * SAM header routines *
  ***********************/
 
-void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line, FILE *fp)
+// Write the first line from `lines` to `fp` if print is nonzero, and return
+// a pointer to the remainder (or NULL when consumed). `lines` is newline-
+// separated but not required to be newline-terminated.
+static const char *remove_line(const char *lines, int print, FILE *fp)
 {
-    int i, n_SQ = 0, n_HD = 0;
-    extern char *bwa_pg;
-    if (hdr_line) {
-        const char *p = hdr_line;
+    const char *nl = strchr(lines, '\n');
+    if (nl) {
+        if (print) {
+            err_fwrite(lines, 1, (size_t)(nl - lines), fp);
+            err_fputc('\n', fp);
+        }
+        return nl + 1;
+    } else {
+        if (print) {
+            err_fputs(lines, fp);
+            err_fputc('\n', fp);
+        }
+        return NULL;
+    }
+}
+
+// Return 1 iff `lines` contains any @SQ header records.
+static int has_SQ(const char *lines)
+{
+    if (lines == NULL) return 0;
+    if (strncmp(lines, "@SQ\t", 4) == 0) return 1;
+    return strstr(lines, "\n@SQ\t") != NULL;
+}
+
+// Count the number of @SQ header records in `lines`.
+static int count_SQ(const char *lines)
+{
+    int n_SQ = 0;
+    if (lines) {
+        const char *p = lines;
         while ((p = strstr(p, "@SQ\t")) != 0) {
-            if (p == hdr_line || *(p-1) == '\n') ++n_SQ;
+            if (p == lines || *(p - 1) == '\n') ++n_SQ;
             p += 4;
-        }
-        p = hdr_line;
-        while ((p = strstr(p, "@HD\t")) != 0) {
-            if (p == hdr_line || *(p-1) == '\n') ++n_HD;
-            p += 4;
-        }
-        // emit the user-supplied @HD first if present
-        if (n_HD > 0) {
-            err_fputs(hdr_line, fp);
-            err_fputs("\n", fp);
         }
     }
-    // emit a default @HD when the user did not supply one
+    return n_SQ;
+}
+
+// Emit the full SAM header, merging (in precedence order) user `hdr_line`
+// (from -H), `bns_hdr` (loaded from <prefix>.hdr or <baseprefix>.dict), and
+// the index's @SQ records. Precedence mirrors lh3/bwa#348:
+//   @HD : user's > index's > default "@HD\tVN:1.5\tSO:unsorted\tGO:query".
+//   @SQ : if user supplies any, use user's alone (index .hdr was already
+//         skipped by the caller); else index's @SQ; else generated from bns.
+//   Other: all remaining lines from bns_hdr, then hdr_line, then bwa_pg.
+static void print_sam_hdr(const bntseq_t *bns, const char *bns_hdr,
+                          const char *hdr_line, FILE *fp)
+{
+    int i, n_HD = 0, n_SQ = count_SQ(hdr_line);
+    extern char *bwa_pg;
+
+    // Emit an @HD record — prefer user's, else index's, else default — and
+    // consume any leading @HD from both streams so they are not re-emitted.
+    if (hdr_line && strncmp(hdr_line, "@HD\t", 4) == 0) {
+        hdr_line = remove_line(hdr_line, n_HD == 0, fp);
+        ++n_HD;
+    }
+    if (bns_hdr && strncmp(bns_hdr, "@HD\t", 4) == 0) {
+        bns_hdr = remove_line(bns_hdr, n_HD == 0, fp);
+        ++n_HD;
+    }
     if (n_HD == 0)
         err_fputs("@HD\tVN:1.5\tSO:unsorted\tGO:query\n", fp);
-    // @SQ lines follow @HD
-    if (n_SQ == 0) {
-        for (i = 0; i < bns->n_seqs; ++i) {
-#if ORIG
-            err_printf("@SQ\tSN:%s\tLN:%d", bns->anns[i].name, bns->anns[i].len);
-            if (bns->anns[i].is_alt) err_printf("\tAH:*\n");
-            else err_fputc('\n', stdout);
-#else
-            char buf[500];
-            sprintf(buf, "@SQ\tSN:%s\tLN:%d", bns->anns[i].name, bns->anns[i].len);
-            err_fputs(buf, fp);
-            if (bns->anns[i].is_alt) {
-                sprintf(buf, "\tAH:*\n");
-                err_fputs(buf, fp);
-            } else
-                err_fputc('\n', fp);
-#endif
-        }
-    } else if (n_SQ != bns->n_seqs && bwa_verbose >= 2)
-        fprintf(stderr, "[W::%s] %d @SQ lines provided with -H; %d sequences in the index. "
-               "Continue anyway.\n", __func__, n_SQ, bns->n_seqs);
 
-    // emit the rest of hdr_line (e.g. @CO, @RG, @PG) after @SQ, but only
-    // when it did not already carry an @HD that we printed up front.
-    if (hdr_line && n_HD == 0) {
-        err_fputs(hdr_line, fp);
-        err_fputs("\n", fp);
+    // Generate @SQ from bns only when neither hdr_line nor bns_hdr supply any.
+    if (n_SQ == 0 && !has_SQ(bns_hdr)) {
+        for (i = 0; i < bns->n_seqs; ++i) {
+            char buf[512];
+            snprintf(buf, sizeof(buf), "@SQ\tSN:%s\tLN:%d",
+                     bns->anns[i].name, bns->anns[i].len);
+            err_fputs(buf, fp);
+            if (bns->anns[i].is_alt) err_fputs("\tAH:*\n", fp);
+            else                     err_fputc('\n', fp);
+        }
     }
+
+    if (n_SQ != 0 && n_SQ != bns->n_seqs && bwa_verbose >= 2)
+        fprintf(stderr, "[W::%s] %d @SQ lines provided with -H; %d sequences in the index. "
+                "Continue anyway.\n", __func__, n_SQ, bns->n_seqs);
+
+    if (bns_hdr) { err_fputs(bns_hdr, fp); err_fputc('\n', fp); }
+    if (hdr_line) { err_fputs(hdr_line, fp); err_fputc('\n', fp); }
     if (bwa_pg) err_fputs(bwa_pg, fp);
+}
+
+void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line, FILE *fp)
+{
+    print_sam_hdr(bns, NULL, hdr_line, fp);
+}
+
+// Load the contents of `<prefix>.hdr` if present, else `<baseprefix>.dict`
+// (where baseprefix strips a trailing .fa/.fna/.fasta, optionally .gz), into
+// a newly-allocated, newline-separated but not newline-terminated string.
+// Returns NULL if neither file exists (or is empty). Caller owns the result
+// and must free() it.
+char *bwa_load_hdr_from_index(const char *prefix)
+{
+    if (prefix == NULL) return NULL;
+
+    kstring_t path = { 0, 0, NULL };
+    ksprintf(&path, "%s.hdr", prefix);
+    FILE *fp = fopen(path.s, "r");
+    if (!fp) {
+        // Try <baseprefix>.dict: drop the ".hdr" we just appended, then drop
+        // a trailing ".gz" (if any) and the final dotted suffix inside the
+        // basename — e.g. foo.fa -> foo, foo.fasta.gz -> foo — before
+        // appending ".dict".
+        size_t l;
+        path.l -= 4; // drop ".hdr"
+        if (path.l >= 3 && strncmp(&path.s[path.l - 3], ".gz", 3) == 0)
+            path.l -= 3;
+        for (l = path.l; l > 0 && path.s[l - 1] != '/'; --l) {
+            if (path.s[l - 1] == '.') { path.l = l - 1; break; }
+        }
+        ksprintf(&path, ".dict");
+        fp = fopen(path.s, "r");
+    }
+
+    char *out = NULL;
+    if (fp) {
+        kstring_t buf = { 0, 0, NULL };
+        int c;
+        while ((c = getc(fp)) != EOF)
+            if (c != '\r') kputc(c, &buf);
+        fclose(fp);
+
+        while (buf.l > 0 && buf.s[buf.l - 1] == '\n') --buf.l;
+        if (buf.l > 0) {
+            buf.s[buf.l] = '\0';
+            out = buf.s; // transfer ownership
+        } else {
+            free(buf.s);
+        }
+    }
+
+    free(path.s);
+    return out;
+}
+
+void bwa_print_sam_hdr2(const bntseq_t *bns, const char *idx_hdr_lines,
+                        const char *hdr_line, FILE *fp)
+{
+    // If the user's -H supplies any @SQ, ignore the index .hdr/.dict content
+    // entirely — the user has taken responsibility for the @SQ block.
+    const char *bns_hdr = has_SQ(hdr_line) ? NULL : idx_hdr_lines;
+
+    if (bns_hdr) {
+        int n_SQ = count_SQ(bns_hdr);
+        if (n_SQ != 0 && n_SQ != bns->n_seqs && bwa_verbose >= 2)
+            fprintf(stderr,
+                    "[W::%s] %d @SQ lines loaded from index; %d sequences in the index. "
+                    "Continue anyway.\n", __func__, n_SQ, bns->n_seqs);
+    }
+    print_sam_hdr(bns, bns_hdr, hdr_line, fp);
 }
 
 static char *bwa_escape(char *s)

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -521,7 +521,7 @@ int bwa_idx2mem(bwaidx_t *idx)
 
 void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line, FILE *fp)
 {
-    int i, n_SQ = 0;
+    int i, n_SQ = 0, n_HD = 0;
     extern char *bwa_pg;
     if (hdr_line) {
         const char *p = hdr_line;
@@ -529,7 +529,21 @@ void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line, FILE *fp)
             if (p == hdr_line || *(p-1) == '\n') ++n_SQ;
             p += 4;
         }
+        p = hdr_line;
+        while ((p = strstr(p, "@HD\t")) != 0) {
+            if (p == hdr_line || *(p-1) == '\n') ++n_HD;
+            p += 4;
+        }
+        // emit the user-supplied @HD first if present
+        if (n_HD > 0) {
+            err_fputs(hdr_line, fp);
+            err_fputs("\n", fp);
+        }
     }
+    // emit a default @HD when the user did not supply one
+    if (n_HD == 0)
+        err_fputs("@HD\tVN:1.5\tSO:unsorted\tGO:query\n", fp);
+    // @SQ lines follow @HD
     if (n_SQ == 0) {
         for (i = 0; i < bns->n_seqs; ++i) {
 #if ORIG
@@ -550,17 +564,14 @@ void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line, FILE *fp)
     } else if (n_SQ != bns->n_seqs && bwa_verbose >= 2)
         fprintf(stderr, "[W::%s] %d @SQ lines provided with -H; %d sequences in the index. "
                "Continue anyway.\n", __func__, n_SQ, bns->n_seqs);
-    
-#if ORIG
-    if (hdr_line) err_printf("%s\n", hdr_line);
-    if (bwa_pg) err_printf("%s\n", bwa_pg);
-#else
-    if (hdr_line) {
+
+    // emit the rest of hdr_line (e.g. @CO, @RG, @PG) after @SQ, but only
+    // when it did not already carry an @HD that we printed up front.
+    if (hdr_line && n_HD == 0) {
         err_fputs(hdr_line, fp);
         err_fputs("\n", fp);
     }
     if (bwa_pg) err_fputs(bwa_pg, fp);
-#endif
 }
 
 static char *bwa_escape(char *s)

--- a/src/bwa.h
+++ b/src/bwa.h
@@ -108,6 +108,9 @@ extern "C" {
 	
 	void bwa_idx_destroy(bwaidx_t *idx);
 	void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line, FILE *fp);
+	void bwa_print_sam_hdr2(const bntseq_t *bns, const char *idx_hdr_lines,
+	                        const char *hdr_line, FILE *fp);
+	char *bwa_load_hdr_from_index(const char *prefix);
 	char *bwa_set_rg(const char *s);
 	char *bwa_insert_header(const char *s, char *hdr);
 #ifdef __cplusplus

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1716,6 +1716,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
 #if V17
     if (m && m->n_cigar) { kputsn("\tMC:Z:", 6, str); add_cigar(opt, m, str, which); }
 #endif
+    if (m) { kputsn("\tMQ:i:", 6, str); kputw(m->mapq, str); }
     if (p->score >= 0) { kputsn("\tAS:i:", 6, str); kputw(p->score, str); }
     if (p->sub >= 0) { kputsn("\tXS:i:", 6, str); kputw(p->sub, str); }
     if (bwa_rg_id[0]) { kputsn("\tRG:Z:", 6, str); kputs(bwa_rg_id, str); }

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -71,6 +71,7 @@ typedef struct __smem_i smem_i;
 // V17
 #define MEM_F_PRIMARY5  0x800
 #define MEM_F_KEEP_SUPP_MAPQ 0x1000
+#define MEM_F_XB        0x2000
 
 
 typedef struct mem_opt_t {

--- a/src/bwamem_extra.cpp
+++ b/src/bwamem_extra.cpp
@@ -168,6 +168,10 @@ char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 			kputc("MIDSHN"[t.cigar[k]&0xf], &str);
 		}
 		kputc(',', &str); kputw(t.NM, &str);
+		if (opt->flag & MEM_F_XB) {
+			kputc(',', &str); kputw(t.score, &str);
+			kputc(',', &str); kputw(t.mapq, &str);
+		}
 		kputc(';', &str);
 		free(t.cigar);
 		kputsn(str.s, str.l, &aln[r]);

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -840,7 +840,9 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "   -K INT        process INT input bases in each batch regardless of nThreads (for reproducibility) []\n");
     fprintf(stderr, "   -v INT        verbose level: 1=error, 2=warning, 3=message, 4+=debugging [%d]\n", bwa_verbose);
     fprintf(stderr, "   -T INT        minimum score to output [%d]\n", opt->T);
-    fprintf(stderr, "   -h INT[,INT]  if there are <INT hits with score >80%% of the max score, output all in XA [%d,%d]\n", opt->max_XA_hits, opt->max_XA_hits_alt);
+    fprintf(stderr, "   -h INT[,INT]  if there are <INT hits with score >%.2f%% of the max score, output all in XA [%d,%d]\n",
+            opt->XA_drop_ratio * 100.0, opt->max_XA_hits, opt->max_XA_hits_alt);
+    fprintf(stderr, "   -z FLOAT      the fraction of the max score to use with -h [%.2f]\n", opt->XA_drop_ratio);
     fprintf(stderr, "   -a            output all alignments for SE or unpaired PE\n");
     fprintf(stderr, "   -C            append FASTA/FASTQ comment to SAM output\n");
     fprintf(stderr, "   -V            output the reference FASTA header in the XR tag\n");
@@ -909,7 +911,7 @@ int main_mem(int argc, char *argv[])
         {"do-not-penalize-chimeras", no_argument,       0, OPT_METH_NO_CHIMERA},
         {0, 0, 0, 0}
     };
-    while ((c = getopt_long(argc, argv, "51qpaMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:o:f:",
+    while ((c = getopt_long(argc, argv, "51qpaMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:o:f:z:",
                             long_opts, NULL)) >= 0)
     {
         if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
@@ -967,6 +969,7 @@ int main_mem(int argc, char *argv[])
             if (*p != 0 && ispunct(*p) && isdigit(p[1]))
                 opt->max_XA_hits_alt = strtol(p+1, &p, 10);
         }
+        else if (c == 'z') opt->XA_drop_ratio = atof(optarg);
         else if (c == 'Q')
         {
             opt0.mapQ_coef_len = 1;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -843,6 +843,7 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "   -h INT[,INT]  if there are <INT hits with score >%.2f%% of the max score, output all in XA [%d,%d]\n",
             opt->XA_drop_ratio * 100.0, opt->max_XA_hits, opt->max_XA_hits_alt);
     fprintf(stderr, "   -z FLOAT      the fraction of the max score to use with -h [%.2f]\n", opt->XA_drop_ratio);
+    fprintf(stderr, "   -u            output XB instead of XA; XB is XA with the alignment score and mapping quality added\n");
     fprintf(stderr, "   -a            output all alignments for SE or unpaired PE\n");
     fprintf(stderr, "   -C            append FASTA/FASTQ comment to SAM output\n");
     fprintf(stderr, "   -V            output the reference FASTA header in the XR tag\n");
@@ -911,7 +912,7 @@ int main_mem(int argc, char *argv[])
         {"do-not-penalize-chimeras", no_argument,       0, OPT_METH_NO_CHIMERA},
         {0, 0, 0, 0}
     };
-    while ((c = getopt_long(argc, argv, "51qpaMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:o:f:z:",
+    while ((c = getopt_long(argc, argv, "51qpaMCSPVYjuk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:o:f:z:",
                             long_opts, NULL)) >= 0)
     {
         if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
@@ -942,6 +943,7 @@ int main_mem(int argc, char *argv[])
         else if (c == 'V') opt->flag |= MEM_F_REF_HDR;
         else if (c == '5') opt->flag |= MEM_F_PRIMARY5 | MEM_F_KEEP_SUPP_MAPQ; // always apply MEM_F_KEEP_SUPP_MAPQ with -5
         else if (c == 'q') opt->flag |= MEM_F_KEEP_SUPP_MAPQ;
+        else if (c == 'u') opt->flag |= MEM_F_XB;
         else if (c == 'c') opt->max_occ = atoi(optarg), opt0.max_occ = 1;
         else if (c == 'd') opt->zdrop = atoi(optarg), opt0.zdrop = 1;
         else if (c == 'v') bwa_verbose = atoi(optarg);

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1280,12 +1280,19 @@ int main_mem(int argc, char *argv[])
         }
     }
 
+    /* Look up optional per-index header records (<prefix>.hdr or
+     * <baseprefix>.dict) once and route them into both output paths. The
+     * SAM text path merges these with user -H per lh3/bwa#348 precedence;
+     * the --bam path forwards them to htslib's sam_hdr_add_lines so the
+     * rich @SQ (AS/M5/SP/AH/…) also makes it into the BAM header. */
+    char *idx_hdr_lines = bwa_load_hdr_from_index(ref_prefix);
+
     /* Output path:
      *  - --meth: open meth_bam_writer with strand-consolidated SQ headers.
      *    Honors -o/-f (target path) or stdout ("-").
      *  - --bam (no --meth): open generic bam_writer; htslib writes its own
      *    @HD + @SQ + @PG header. Honors -o/-f or stdout.
-     *  - SAM text: open -o/-f path (if any) as a FILE*; bwa_print_sam_hdr. */
+     *  - SAM text: open -o/-f path (if any) as a FILE*; bwa_print_sam_hdr2. */
     bam_writer_t *bam_writer = NULL;
     if (opt->meth_mode) {
         g_meth_cmap = meth_chrom_map_build_from_bns(aux.fmi->idx->bns);
@@ -1309,7 +1316,16 @@ int main_mem(int argc, char *argv[])
     } else if (opt->bam_mode) {
         const char *bam_path = is_o ? out_path : "-";
         extern char *bwa_pg;
-        bam_writer = bam_writer_open(bam_path, aux.fmi->idx->bns, hdr_line,
+        /* Suppress idx .hdr/.dict records entirely when the user's -H
+         * supplies any @SQ, matching bwa_print_sam_hdr2's SAM precedence. */
+        const char *bam_idx_hdr = idx_hdr_lines;
+        if (hdr_line != NULL) {
+            if (strncmp(hdr_line, "@SQ\t", 4) == 0 ||
+                strstr(hdr_line, "\n@SQ\t") != NULL)
+                bam_idx_hdr = NULL;
+        }
+        bam_writer = bam_writer_open(bam_path, aux.fmi->idx->bns,
+                                     bam_idx_hdr, hdr_line,
                                      bwa_pg, opt->bam_level);
         if (bam_writer == NULL) {
             fprintf(stderr, "ERROR: failed to open BAM writer at '%s'\n", bam_path);
@@ -1330,7 +1346,7 @@ int main_mem(int argc, char *argv[])
             }
             out_opened = true;
         }
-        bwa_print_sam_hdr(aux.fmi->idx->bns, hdr_line, aux.fp);
+        bwa_print_sam_hdr2(aux.fmi->idx->bns, idx_hdr_lines, hdr_line, aux.fp);
     }
 
     if (fixed_chunk_size > 0)
@@ -1355,6 +1371,7 @@ int main_mem(int argc, char *argv[])
     int32_t nt = aux.opt->n_threads;
     _mm_free(ref_string);
     free(hdr_line);
+    free(idx_hdr_lines);
     free(opt);
     kseq_destroy(aux.ks);
     err_gzclose(fp); kclose(ko);


### PR DESCRIPTION
## Summary

Back-ports four small, self-contained patches authored upstream (by the same author) against `lh3/bwa` that the `bwa-mem2` codebase never picked up. Each is a single commit so they can be reviewed independently.

| Commit | Upstream | What |
|---|---|---|
| \`feat(mem): add -z FLOAT option to set XA_drop_ratio\` | [lh3/bwa#294](https://github.com/lh3/bwa/pull/294) (merged) | \`mem_opt_t::XA_drop_ratio\` already existed (default 0.80) but no CLI knob. Adds \`-z FLOAT\`. |
| \`feat(mem): add -u flag to emit score,mapq in XA records (XB)\` | [lh3/bwa#293](https://github.com/lh3/bwa/pull/293) (merged) | Adds \`MEM_F_XB\` (\`0x2000\`) + \`-u\` switch. When set, \`mem_gen_alt\` appends \`,<score>,<mapq>\` to each \`XA:Z\` record. The tag name stays \`XA:Z\` for downstream compat (matches upstream). BAM path inherits via \`p.XA\` passthrough. |
| \`feat(mem): emit MQ:i: mate mapping quality tag\` | [lh3/bwa#330](https://github.com/lh3/bwa/pull/330) (merged) | Adds \`MQ:i:\` next to the existing \`MC:Z:\` in both \`mem_aln2sam\` and \`mem_aln_to_bam\` for SAM/BAM parity. |
| \`fix(sam): emit @HD before @SQ in bwa_print_sam_hdr\` | [lh3/bwa#345](https://github.com/lh3/bwa/pull/345) (closed in lh3 but fix is valid) | SAM spec requires \`@HD\` before \`@SQ\`. Previously \`-H '@HD\\t...'\` was appended after \`@SQ\`. Count \`@HD\` in \`hdr_line\`, emit user's \`@HD\` first (default \`@HD\\tVN:1.5\\tSO:unsorted\\tGO:query\` otherwise), then \`@SQ\`, then any non-HD remainder of \`hdr_line\`. The BAM path was already correct (uses \`sam_hdr_add_line\`). |

Each port was cross-checked against the current state of \`src/\` so no feature was duplicated:
- \`-K\` (deterministic chunk size) is already present — did **not** re-port \`lh3/bwa#27\`.
- \`MC:Z:\` is already present — \`MQ\` only was needed.
- \`-H\` header line insertion is already present — just not in the right order (#345 fix).
- \`bwa aln\`-only upstream PRs (#438, #439) do not apply to bwa-mem2.

## Test plan

- [x] \`make\` (arm64) succeeds.
- [x] \`make test\` (kswv_selftest: 10014 pairs, 0 mismatches) passes.
- [x] \`./bwa-mem2 mem\` help shows new \`-z FLOAT\` and \`-u\` lines with correct defaults.
- [x] Default invocation emits \`@HD\\tVN:1.5\\tSO:unsorted\\tGO:query\` as the first line, followed by \`@SQ\`.
- [x] \`-H '@HD\\tVN:1.6\\tSO:queryname'\` is emitted first, no duplicate default \`@HD\`, \`@SQ\` follows.
- [x] \`-H '@CO\\tjustacomment'\` keeps the default \`@HD\` at top, \`@SQ\` next, \`@CO\` after \`@SQ\`.
- [x] Paired-end smoke test shows \`MC:Z:\` and \`MQ:i:\` together.
- [x] \`-z 0.1\` flows through into the help banner (\`>10.00%\` and \`[0.10]\`).
- [ ] Regression run against a real FASTQ under \`fg-main\` parity (reviewer-suggested, if desired).

## Notes for reviewers

- \`-u\` keeps the \`XA:Z\` tag name even though upstream help calls it "XB". That's what upstream ships; the field widens from \`chr,pos,CIGAR,NM\` to \`chr,pos,CIGAR,NM,score,mapq\`. Tools that parse XA fields need to be aware.
- The \`@HD\` fix drops a dead \`#if ORIG\` / \`#else\` / \`#endif\` block in this function; the non-ORIG branch was the only correct one anyway.
- No changes to the \`--bam\` or \`--meth\` code paths beyond adding \`MQ\` to the aux-tag list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SAM output now includes mate mapping quality (MQ) tag for enhanced alignment quality reporting.
  * Improved SAM header handling for header description records.
  * Added `-z` option to configure the XA drop ratio threshold.
  * Added `-u` option to enable XB output format for alternative alignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->