### PR TITLE
feat(mem): emit HN:i tag with total hit count per primary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,13 @@ jobs:
         run: |
           cd /tmp/ci-test
 
-          # Strip @PG and @HD headers (tool-specific), and MQ tag (added in bwa >0.7.17)
+          # Strip @PG and @HD headers (tool-specific), and MQ / HN tags
+          # (MQ was added in bwa >0.7.17; HN is a bwa-mem2-only aggregate of
+          # hits-under-XA-drop-ratio and has no analog in lh3/bwa mem).
           normalize() {
-            grep -v '^@PG' "$1" | grep -v '^@HD' | sed 's/\tMQ:i:[0-9]*//'
+            grep -v '^@PG' "$1" | grep -v '^@HD' \
+              | sed 's/\tMQ:i:[0-9]*//' \
+              | sed 's/\tHN:i:[0-9]*//'
           }
 
           normalize bwa.sam | sort > bwa.normalized.sam
@@ -248,7 +252,7 @@ jobs:
         if: matrix.canonical == true
         run: |
           cd /tmp/chr22-sim
-          normalize() { grep -v '^@PG' "$1" | grep -v '^@HD' | sed 's/\tMQ:i:[0-9]*//'; }
+          normalize() { grep -v '^@PG' "$1" | grep -v '^@HD' | sed 's/\tMQ:i:[0-9]*//' | sed 's/\tHN:i:[0-9]*//'; }
           normalize bwa.sam | sort > bwa.normalized.sam
           normalize bwamem2.sam | sort > bwamem2.normalized.sam
           echo "bwa records: $(grep -cv '^@' bwa.normalized.sam)"

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -321,6 +321,10 @@ int mem_aln_to_bam(struct bam1_t *b,
     if (p.XA != NULL) {
         bam_aux_append(b, "XA", 'Z', (int)strlen(p.XA) + 1, (const uint8_t *)p.XA);
     }
+    if (p.HN >= 0) {
+        int32_t hn = (int32_t)p.HN;
+        bam_aux_append(b, "HN", 'i', sizeof(hn), (const uint8_t *)&hn);
+    }
 
     bam_writer_append_generic_aux(b, s, opt, bns, p.rid);
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1533,9 +1533,10 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
     kvec_t(mem_aln_t) aa;
     int k, l;
     char **XA = 0;
+    int *HN = 0;
 
     if (!(opt->flag & MEM_F_ALL))
-        XA = mem_gen_alt(opt, bns, pac, a, s->l_seq, s->seq);
+        XA = mem_gen_alt(opt, bns, pac, a, s->l_seq, s->seq, &HN);
 
     kv_init(aa);
     str.l = str.m = 0; str.s = 0;
@@ -1554,6 +1555,7 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
         *q = mem_reg2aln(opt, bns, pac, s->l_seq, s->seq, p);
         assert(q->rid >= 0); // this should not happen with the new code
         q->XA = XA? XA[k] : 0;
+        q->HN = HN? HN[k] : -1;
         q->flag |= extra_flag; // flag secondary
         if (p->secondary >= 0) q->sub = -1; // don't output sub-optimal score
         if (l && p->secondary < 0) // if supplementary
@@ -1582,6 +1584,7 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
         for (k = 0; k < a->n; ++k) free(XA[k]);
         free(XA);
     }
+    free(HN);
 }
 
 static inline void add_cigar(const mem_opt_t *opt, mem_aln_t *p, kstring_t *str, int which)
@@ -1744,6 +1747,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
     }
 
     if (p->XA) { kputsn("\tXA:Z:", 6, str); kputs(p->XA, str); }
+    if (p->HN >= 0) { kputsn("\tHN:i:", 6, str); kputw(p->HN, str); }
 
     if (s->comment) { kputc('\t', str); kputs(s->comment, str); }
     if ((opt->flag&MEM_F_REF_HDR) && p->rid >= 0 && bns->anns[p->rid].anno != 0 && bns->anns[p->rid].anno[0] != 0) {
@@ -1765,6 +1769,7 @@ mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *
     uint8_t *query;
 
     memset(&a, 0, sizeof(mem_aln_t));
+    a.HN = -1; // sentinel: HN not computed unless caller fills from mem_gen_alt out_hn
     if (ar == 0 || ar->rb < 0 || ar->re < 0) { // generate an unmapped record
         a.rid = -1; a.pos = -1; a.flag |= 0x4;
         return a;

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -178,6 +178,7 @@ typedef struct { // This struct is only used for the convenience of API.
     int n_cigar;     // number of CIGAR operations
     uint32_t *cigar; // CIGAR in the BAM encoding: opLen<<4|op; op to integer mapping: MIDSH=>01234
     char *XA;        // alternative mappings
+    int HN;          // total # of hits clustered with this primary under XA_drop_ratio; -1 when not computed (e.g., MEM_F_ALL)
 
     int score, sub, alt_sc;
 } mem_aln_t;
@@ -259,7 +260,8 @@ int mem_mark_primary_se(const mem_opt_t *opt, int n, mem_alnreg_t *a, int64_t id
 static void mem_mark_primary_se_core(const mem_opt_t *opt, int n, mem_alnreg_t *a, int_v *z);
 
 char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
-                   const mem_alnreg_v *a, int l_query, const char *query); // ONLY work after mem_mark_primary_se()
+                   const mem_alnreg_v *a, int l_query, const char *query,
+                   int **out_hn); // ONLY work after mem_mark_primary_se(); out_hn may be NULL
 void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str, bseq1_t *s,
                  int n, const mem_aln_t *list, int which, const mem_aln_t *m_);
 

--- a/src/bwamem_extra.cpp
+++ b/src/bwamem_extra.cpp
@@ -127,7 +127,9 @@ static inline int get_pri_idx(double XA_drop_ratio, const mem_alnreg_t *a, int i
 }
 
 // Okay, returning strings is bad, but this has happened a lot elsewhere. If I have time, I need serious code cleanup.
-char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, const mem_alnreg_v *a, int l_query, const char *query) // ONLY work after mem_mark_primary_se()
+// When out_hn is non-NULL, it is set to a newly-allocated int[a->n] of per-primary
+// hit counts (cnt[r]) so callers can emit the HN:i tag; caller owns the buffer.
+char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, const mem_alnreg_v *a, int l_query, const char *query, int **out_hn) // ONLY work after mem_mark_primary_se()
 {
 	int i, k, r, *cnt, tot;
 	kstring_t *aln = 0, str = {0,0,0};
@@ -143,6 +145,15 @@ char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 			++cnt[r], ++tot;
 			if (a->a[i].is_alt) has_alt[r] = 1;
 		}
+	}
+	// Publish per-primary hit counts for HN:i emission before the XA_hits cap
+	// can truncate the XA string; HN should reflect what *would* have been in
+	// XA, not what was actually emitted.
+	if (out_hn) {
+		int *hn = (int *) calloc(a->n, sizeof(int));
+		assert(hn != NULL);
+		for (i = 0; i < a->n; ++i) hn[i] = cnt[i];
+		*out_hn = hn;
 	}
 	if (tot == 0) goto end_gen_alt;
 	aln = (kstring_t*) calloc(a->n, sizeof(kstring_t));

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -527,7 +527,7 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns,
                uint64_t id, bseq1_t s[2], mem_alnreg_v a[2])
 {
     extern void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, bseq1_t *s, mem_alnreg_v *a, int extra_flag, const mem_aln_t *m);
-    extern char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, const mem_alnreg_v *a, int l_query, const char *query);
+    extern char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, const mem_alnreg_v *a, int l_query, const char *query, int **out_hn);
 
     int i, j, z[2], extra_flag, n_pri[2], q_se[2], n_aa[2], paired;
     kstring_t str;
@@ -543,9 +543,10 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns,
 
     if (paired) {
         char **XA[2];
+        int *HN[2] = { 0, 0 };
         if (!(opt->flag & MEM_F_ALL)) {
             for (i = 0; i < 2; ++i)
-                XA[i] = mem_gen_alt(opt, bns, pac, &a[i], s[i].l_seq, s[i].seq);
+                XA[i] = mem_gen_alt(opt, bns, pac, &a[i], s[i].l_seq, s[i].seq, &HN[i]);
         } else XA[0] = XA[1] = 0;
         // write SAM
         for (i = 0; i < 2; ++i) {
@@ -554,6 +555,7 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns,
 
             h[i].flag |= 0x40<<i | extra_flag;
             h[i].XA = XA[i]? XA[i][z[i]] : 0;
+            h[i].HN = HN[i]? HN[i][z[i]] : -1;
             aa[i][n_aa[i]++] = h[i];
             if (n_pri[i] < a[i].n) { // the read has ALT hits
                 mem_alnreg_t *p = &a[i].a[n_pri[i]];
@@ -561,6 +563,7 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns,
                 g[i] = mem_reg2aln(opt, bns, pac, s[i].l_seq, s[i].seq, p);
                 g[i].flag |= 0x800 | 0x40<<i | extra_flag;
                 g[i].XA = XA[i]? XA[i][n_pri[i]] : 0;
+                g[i].HN = HN[i]? HN[i][n_pri[i]] : -1;
                 aa[i][n_aa[i]++] = g[i];
             }
         }
@@ -587,6 +590,7 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns,
         // free
         for (i = 0; i < 2; ++i) {
             free(h[i].cigar); free(g[i].cigar);
+            free(HN[i]);
             if (XA[i] == 0) continue;
             for (j = 0; j < a[i].n; ++j) free(XA[i][j]);
             free(XA[i]);
@@ -796,7 +800,8 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
     extern void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
                             bseq1_t *s, mem_alnreg_v *a, int extra_flag, const mem_aln_t *m);
     extern char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
-                              const mem_alnreg_v *a, int l_query, const char *query);
+                              const mem_alnreg_v *a, int l_query, const char *query,
+                              int **out_hn);
     #if MATE_SORT
     extern void sort_alnreg_re(int n, mem_alnreg_t* a);
     extern void sort_alnreg_score(int n, mem_alnreg_t* a);
@@ -935,9 +940,10 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
                 a[i].a[z[i]].secondary_all = -1;
             }
         }
+        int *HN[2] = { 0, 0 };
         if (!(opt->flag & MEM_F_ALL)) {
             for (i = 0; i < 2; ++i)
-                XA[i] = mem_gen_alt(opt, bns, pac, &a[i], s[i].l_seq, s[i].seq);
+                XA[i] = mem_gen_alt(opt, bns, pac, &a[i], s[i].l_seq, s[i].seq, &HN[i]);
         } else XA[0] = XA[1] = 0;
         // write SAM
         for (i = 0; i < 2; ++i) {
@@ -946,6 +952,7 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
 
             h[i].flag |= 0x40<<i | extra_flag;
             h[i].XA = XA[i]? XA[i][z[i]] : 0;
+            h[i].HN = HN[i]? HN[i][z[i]] : -1;
             aa[i][n_aa[i]++] = h[i];
             if (n_pri[i] < a[i].n) { // the read has ALT hits
                 mem_alnreg_t *p = &a[i].a[n_pri[i]];
@@ -953,6 +960,7 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
                 g[i] = mem_reg2aln(opt, bns, pac, s[i].l_seq, s[i].seq, p);
                 g[i].flag |= 0x800 | 0x40<<i | extra_flag;
                 g[i].XA = XA[i]? XA[i][n_pri[i]] : 0;
+                g[i].HN = HN[i]? HN[i][n_pri[i]] : -1;
                 aa[i][n_aa[i]++] = g[i];
             }
         }
@@ -979,6 +987,7 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
         // free
         for (i = 0; i < 2; ++i) {
             free(h[i].cigar); free(g[i].cigar);
+            free(HN[i]);
             if (XA[i] == 0) continue;
             for (j = 0; j < a[i].n; ++j) free(XA[i][j]);
             free(XA[i]);


### PR DESCRIPTION
## Summary

Adds an \`HN:i:<int>\` tag to every primary SAM/BAM record emitted by \`bwa-mem2 mem\`. HN carries the count of hits clustered with this primary under \`XA_drop_ratio\` — i.e. the number of records that *would* have populated \`XA:Z\` for this read, **before** the \`-h/max_XA_hits\` cap truncates the string.

Motivated by [lh3/bwa#438](https://github.com/lh3/bwa/pull/438), which adds HN to \`bwa aln\`. There's no direct port because bwa-mem2 ships \`mem\` only, so this is a small analog for the same use case: distinguish "no alternates" (HN:i:0, no XA) from "too many alternates to emit" (HN:i:N with N > -h, no XA).

## Behavior

| Scenario | XA | HN |
|---|---|---|
| Unique mapper | absent | \`HN:i:0\` |
| Multi-mapper, alternates <= \`-h\` | \`XA:Z:...\` with N records | \`HN:i:N\` |
| Multi-mapper, alternates > \`-h\` (cap hit) | **absent** | \`HN:i:N\` ← the win |
| \`-a\` (\`MEM_F_ALL\`: all hits get their own SAM line) | absent | absent (sentinel -1 retained) |
| Unmapped | absent | absent |

No CLI flag. HN is always emitted when the XA computation ran (i.e. \`!MEM_F_ALL\`). Matches the \`bwa aln\` behavior of unconditional emission. Consumers that don't want HN can filter it downstream.

## Implementation

- \`mem_aln_t\` gains \`int HN\` (sentinel \`-1\` for "not computed"). \`mem_reg2aln\` initializes it after its \`memset\`, so any record produced outside the XA path stays at \`-1\` and skips emission.
- \`mem_gen_alt\` takes a new trailing \`int **out_hn\`. When non-NULL, it allocates \`int[a->n]\` containing the per-primary \`cnt[]\` values and publishes them via the out-parameter. The count is captured **before** the cap check, so HN reflects what would have been in XA.
- Single-end (\`mem_reg2sam\` in \`bwamem.cpp\`) and paired-end (both \`mem_sam_pe\` call sites in \`bwamem_pair.cpp\`) allocate HN alongside XA, assign \`q->HN = HN[k]\` in the mem_aln_t assembly loop, free at teardown. \`extern\` declarations updated to match the new signature.
- \`mem_aln2sam\` emits \`\\tHN:i:%d\` right after the \`XA:Z:\` block, only when \`p->HN >= 0\`.
- \`mem_aln_to_bam\` emits HN as \`'i'\` aux via \`bam_aux_append\`, only when \`p.HN >= 0\`. SAM text and BAM stay at parity.

## Test plan

All performed locally on this branch (arm64, macOS):

- [x] \`make -j8\` clean build, no new warnings.
- [x] \`make test\` (\`kswv_selftest\`: 10014 pairs, 0 mismatches).
- [x] Smoke test with a 3-contig reference carrying the same 300bp region on each:
  - [x] SE default: \`XA:Z:\` with 2 alternates + \`HN:i:2\`.
  - [x] SE \`-h 0\` (cap suppresses XA): \`HN:i:2\` still emitted, no \`XA:Z\`.
  - [x] SE \`-a\` (\`MEM_F_ALL\`): neither \`XA:Z\` nor \`HN:i\` emitted.
  - [x] Unique-mapper control: \`HN:i:0\`, no \`XA:Z\`.
  - [x] Paired-end: \`HN:i:2\` on both mates alongside \`XA:Z:\`.
  - [x] \`--bam\`: \`HN:i:2\` and \`XA:Z:\` both round-trip through htslib.

## Notes for reviewers

- HN is a per-primary aggregate, so it's only meaningful on records produced by \`mem_reg2sam\`/\`mem_sam_pe\`. \`MEM_F_ALL\` explicitly does not call \`mem_gen_alt\`, so there's no surprise in that path.
- \`q->HN = HN? HN[k] : -1\` is safe: \`HN\` is only non-NULL when the XA computation ran (same as \`XA\`). The \`-1\` fallback in that branch is defensive — in practice both arrays are NULL together.
- BAM aux \`HN:i\` is stored as a 32-bit int, matching \`XS\`/\`NM\` elsewhere in \`mem_aln_to_bam\`.
- The \`mem_gen_alt\` signature change is API-visible (declared in \`bwamem.h\`). No out-of-tree consumers are known; all three call sites in the bwa-mem2 codebase are updated.
- Orthogonal to the four ports in fg-labs/bwa-mem2#35 — this PR branches off \`fg-main\` directly and does not share any commits with that stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional HN tag to alignment output that reports clustered hit counts for each mapped sequence.

* **Tests**
  * Updated test normalization to handle HN tag when comparing alignment output across different tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->