### PR TITLE
perf(header): batch -H ingestion to fix O(n^2) header read (closes #37)

### DIFF
--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -622,3 +622,60 @@ char *bwa_insert_header(const char *s, char *hdr)
     bwa_escape(hdr + len);
     return hdr;
 }
+
+char *bwa_insert_header_file(FILE *fp, char *hdr)
+{
+    // Batched counterpart to bwa_insert_header: copy every @-prefixed line
+    // from fp into a single buffer, then call bwa_insert_header once on the
+    // whole thing. The per-line loop in fastmap.cpp was O(n^2) because
+    // bwa_insert_header strlen's and realloc's hdr on every call — this
+    // makes ingestion of large (~70 MB, ~1.5 M-line) headers linear.
+    //
+    // Semantics match the old loop: non-@ lines are dropped; bwa_escape is
+    // applied to the assembled string (equivalent to per-line because
+    // bwa_escape only rewrites backslash-escape pairs and copies every other
+    // byte through).
+    long file_size;
+    if (fseek(fp, 0L, SEEK_END) != 0) return hdr;
+    file_size = ftell(fp);
+    rewind(fp);
+    if (file_size <= 0) return hdr;
+
+    char *buf = (char *) calloc(1, (size_t) file_size + 1);
+    assert(buf != NULL);
+    char *p = buf;
+    // Budget for the per-call fgets: use LINE_MAX'ish 64 KiB minus 1 to
+    // match the pre-patch loop. Bound each read by the remaining buffer so
+    // a pathologically long line cannot overrun the file-sized allocation.
+    while (1) {
+        long remaining = (buf + file_size + 1) - p;
+        if (remaining <= 1) break;
+        int cap = (remaining > 0xffff) ? 0xffff : (int) remaining;
+        if (fgets(p, cap, fp) == NULL) break;
+        size_t i = strlen(p);
+        // If we hit the 64 KiB per-call budget without seeing a newline,
+        // the line is too long to fit in one fgets call. The next chunk
+        // would not start with '@' and would be silently dropped,
+        // truncating the line. Match the pre-patch assert(buf[i-1] ==
+        // '\n') behavior and fail loudly. (We only check this when cap
+        // was bounded by the 0xffff budget, not when it was bounded by
+        // the remaining buffer — the latter case is the legitimate
+        // no-trailing-newline-on-last-line scenario.)
+        if (cap >= 0xffff && i > 0 && p[i - 1] != '\n') {
+            err_fatal(__func__, "header line exceeds %d-byte read budget", cap - 1);
+        }
+        if (p[0] == '@') {
+            // bwa_insert_header strips the trailing '\n' from its input
+            // before concatenating, so preserving the newline here is what
+            // produces the between-line separator in the assembled buffer.
+            // Lines without a trailing newline (last line of a file that
+            // lacks one) are kept as-is; the final p[-1] fixup below only
+            // triggers when the final byte we wrote is '\n'.
+            p += i;
+        }
+    }
+    if (p != buf && p[-1] == '\n') p[-1] = '\0';
+    hdr = bwa_insert_header(buf, hdr);
+    free(buf);
+    return hdr;
+}

--- a/src/bwa.h
+++ b/src/bwa.h
@@ -32,6 +32,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #define BWA_H_
 
 #include <stdint.h>
+#include <stdio.h>
 #include <zlib.h>
 #include "bntseq.h"
 #include "bwt.h"
@@ -110,6 +111,7 @@ extern "C" {
 	void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line, FILE *fp);
 	char *bwa_set_rg(const char *s);
 	char *bwa_insert_header(const char *s, char *hdr);
+	char *bwa_insert_header_file(FILE *fp, char *hdr);
 #ifdef __cplusplus
 }
 #endif

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1010,17 +1010,7 @@ int main_mem(int argc, char *argv[])
                 FILE *fp;
                 if ((fp = fopen(optarg, "r")) != 0)
                 {
-                    char *buf;
-                    buf = (char *) calloc(1, 0x10000);
-                    assert(buf != NULL);
-                    while (fgets(buf, 0xffff, fp))
-                    {
-                        i = strlen(buf);
-                        assert(buf[i-1] == '\n');
-                        buf[i-1] = 0;
-                        hdr_line = bwa_insert_header(buf, hdr_line);
-                    }
-                    free(buf);
+                    hdr_line = bwa_insert_header_file(fp, hdr_line);
                     fclose(fp);
                 }
             } else hdr_line = bwa_insert_header(optarg, hdr_line);

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,7 +29,7 @@
 ##*****************************************************************************************/
 
 
-EXE=		fmi_test smem2_test bwt_seed_strategy_test sa2ref_test xeonbsw smem_lockstep_parity_test
+EXE=		fmi_test smem2_test bwt_seed_strategy_test sa2ref_test xeonbsw smem_lockstep_parity_test header_insert_test
 
 # Match the parent Makefile's compiler + flag selection. Detect ARM
 # (Apple Silicon arm64 and Linux aarch64) and wire in OpenMP, sse2neon
@@ -101,6 +101,9 @@ xeonbsw:main_banded.o
 smem_lockstep_parity_test: smem_lockstep_parity_test.o
 	$(CXX) -o $@ $^ $(LIBS)
 
+header_insert_test:header_insert_test.o
+	$(CXX) -o $@ $^ $(LIBS)
+
 clean:
 	rm -fr *.o $(EXE)
 
@@ -118,3 +121,4 @@ smem2_test.o: ../src/FMI_search.h ../src/bntseq.h ../src/read_index_ele.h
 smem2_test.o: ../src/bwa.h ../src/bwt.h ../src/utils.h ../src/macro.h
 smem_lockstep_parity_test.o: ../src/FMI_search.h ../src/bntseq.h ../src/read_index_ele.h
 smem_lockstep_parity_test.o: ../src/bwa.h ../src/bwt.h ../src/utils.h ../src/macro.h
+header_insert_test.o: ../src/bwa.h

--- a/test/header_insert_test.cpp
+++ b/test/header_insert_test.cpp
@@ -1,0 +1,184 @@
+// Regression test for bwa_insert_header_file.
+//
+// bwa_insert_header_file reads all @-prefixed lines from a file, assembles
+// them into a single buffer, and calls bwa_insert_header once instead of
+// once per line — turning the -H ingestion path from O(n^2) into O(n).
+// This test proves the batched path produces byte-identical output to the
+// per-line baseline across the cases the old code supported.
+//
+// Usage:
+//   header_insert_test          # runs all cases, exits 0 on success
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+#include "bwa.h"
+
+static char *per_line_baseline(const std::vector<std::string> &lines, char *hdr)
+{
+    // Mirrors the pre-patch fastmap.cpp loop: strip trailing '\n' from each
+    // line then call bwa_insert_header. Any line not starting with '@' is
+    // silently skipped by bwa_insert_header itself.
+    for (const auto &raw : lines) {
+        std::string line = raw;
+        if (!line.empty() && line.back() == '\n') line.pop_back();
+        hdr = bwa_insert_header(line.c_str(), hdr);
+    }
+    return hdr;
+}
+
+static std::string write_tmp(const std::vector<std::string> &lines)
+{
+    char tmpl[] = "/tmp/bwa_hdr_test_XXXXXX";
+    int fd = mkstemp(tmpl);
+    assert(fd >= 0);
+    FILE *fp = fdopen(fd, "w");
+    assert(fp != nullptr);
+    for (const auto &l : lines) fputs(l.c_str(), fp);
+    fclose(fp);
+    return std::string(tmpl);
+}
+
+static void run_case(const char *name,
+                     const std::vector<std::string> &lines,
+                     const char *seed_hdr)
+{
+    std::string path = write_tmp(lines);
+
+    // Baseline: walk lines through per-line bwa_insert_header.
+    char *expected = seed_hdr ? strdup(seed_hdr) : nullptr;
+    expected = per_line_baseline(lines, expected);
+
+    // Batched path: open file and hand it to bwa_insert_header_file.
+    char *actual = seed_hdr ? strdup(seed_hdr) : nullptr;
+    FILE *fp = fopen(path.c_str(), "r");
+    assert(fp != nullptr);
+    actual = bwa_insert_header_file(fp, actual);
+    fclose(fp);
+    unlink(path.c_str());
+
+    // Both null is a valid outcome (empty / no-@ file, no seed).
+    if (expected == nullptr && actual == nullptr) {
+        fprintf(stderr, "OK:   %s (both null)\n", name);
+        return;
+    }
+    if (expected == nullptr || actual == nullptr) {
+        fprintf(stderr, "FAIL: %s: null mismatch (expected=%p actual=%p)\n",
+                name, (void *)expected, (void *)actual);
+        exit(1);
+    }
+    if (strcmp(expected, actual) != 0) {
+        fprintf(stderr, "FAIL: %s\n  expected: %s\n  actual:   %s\n",
+                name, expected, actual);
+        exit(1);
+    }
+    fprintf(stderr, "OK:   %s\n", name);
+    free(expected);
+    free(actual);
+}
+
+int main(int, char **)
+{
+    // Case 1: multiple @SQ lines, no prior header.
+    run_case("multi-SQ",
+             {"@HD\tVN:1.6\tSO:coordinate\n",
+              "@SQ\tSN:chr1\tLN:1000\n",
+              "@SQ\tSN:chr2\tLN:2000\n",
+              "@SQ\tSN:chrM\tLN:16569\n"},
+             nullptr);
+
+    // Case 2: seed hdr non-null (simulates a prior -H @RG line), then read
+    // file. Batched path must produce the same concatenation as per-line.
+    run_case("seeded",
+             {"@SQ\tSN:chr1\tLN:1000\n",
+              "@SQ\tSN:chr2\tLN:2000\n"},
+             "@RG\tID:foo\tSM:bar");
+
+    // Case 3: non-@ lines interleaved — baseline skips them (bwa_insert_header
+    // early-returns), batched must skip them too.
+    run_case("mixed-non-at",
+             {"@HD\tVN:1.6\n",
+              "not a header line\n",
+              "@SQ\tSN:chr1\tLN:1000\n",
+              "# comment\n",
+              "@SQ\tSN:chr2\tLN:2000\n"},
+             nullptr);
+
+    // Case 4: escape sequences — bwa_insert_header calls bwa_escape, which
+    // translates \\t, \\n, \\r, \\\\. Running it once on the concatenation
+    // must match running it per line.
+    run_case("escapes",
+             {"@CO\tfield1\\tfield2\\nwith\\\\backslash\n",
+              "@SQ\tSN:chr1\tLN:1000\n"},
+             nullptr);
+
+    // Case 5: empty file — calloc(1, 0) edge case. Must leave hdr unchanged
+    // (null in / null out).
+    run_case("empty-file", {}, nullptr);
+
+    // Case 6: empty file but seed hdr non-null — must return the seed string
+    // unchanged.
+    run_case("empty-file-seeded", {}, "@RG\tID:only");
+
+    // Case 7: file with only non-@ lines — baseline produces hdr unchanged,
+    // batched must too.
+    run_case("no-at-lines",
+             {"not a header\n",
+              "also not a header\n"},
+             "@RG\tID:seed");
+
+    // Case 8: single @-line without trailing newline on last line — SAM
+    // tools commonly emit a trailing newline, but verify we don't blow up
+    // if the last line lacks one.
+    run_case("no-trailing-newline",
+             {"@HD\tVN:1.6\n",
+              "@SQ\tSN:chr1\tLN:1000"},
+             nullptr);
+
+    // Case 9: a single @-line longer than the 64 KiB fgets budget. The pre-
+    // patch loop asserted on buf[i-1] == '\n' and aborted; the batched path
+    // must also fail loudly rather than silently truncate. We fork because
+    // bwa_insert_header_file calls err_fatal -> exit(EXIT_FAILURE).
+    {
+        std::string huge_line = "@CO\t";
+        huge_line.append(70000, 'x');
+        huge_line.push_back('\n');
+        std::string path = write_tmp({huge_line});
+        pid_t pid = fork();
+        assert(pid >= 0);
+        if (pid == 0) {
+            // Silence the expected stderr from err_fatal so the test output
+            // stays clean.
+            FILE *devnull = freopen("/dev/null", "w", stderr);
+            (void) devnull;
+            FILE *fp = fopen(path.c_str(), "r");
+            assert(fp != nullptr);
+            char *out = bwa_insert_header_file(fp, nullptr);
+            // Should not return — err_fatal must exit before we get here.
+            (void) out;
+            fclose(fp);
+            _exit(0);
+        }
+        int status = 0;
+        waitpid(pid, &status, 0);
+        unlink(path.c_str());
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != EXIT_FAILURE) {
+            fprintf(stderr,
+                    "FAIL: oversize-line: expected exit(EXIT_FAILURE), got "
+                    "exited=%d status=%d signaled=%d signal=%d\n",
+                    WIFEXITED(status), WEXITSTATUS(status),
+                    WIFSIGNALED(status), WTERMSIG(status));
+            exit(1);
+        }
+        fprintf(stderr, "OK:   oversize-line\n");
+    }
+
+    fprintf(stderr, "ALL HEADER INSERT TESTS PASSED\n");
+    return 0;
+}

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -51,10 +51,17 @@ ok "bwt_seed_strategy_test"
 # --- sa2ref_test -----------------------------------------------------------
 OUT_FILE="$(mktemp)"
 FKSW="$HERE/fksw.txt"
-trap 'rm -f "$OUT_FILE" "$FKSW"' EXIT
+HEADER_OUT="$(mktemp)"
+trap 'rm -f "$OUT_FILE" "$FKSW" "$HEADER_OUT"' EXIT
 (cd "$HERE" && ./sa2ref_test "$FIXTURES/phix.fa" "$FIXTURES/sa2ref_input.txt" "$OUT_FILE" 20 >/dev/null 2>&1) || fail "sa2ref_test crashed"
 [[ -s "$OUT_FILE" ]] || fail "sa2ref_test: output file empty"
 ok "sa2ref_test (wrote $(wc -l < "$OUT_FILE" | tr -d ' ') coords)"
+
+# --- header_insert_test ----------------------------------------------------
+(cd "$HERE" && ./header_insert_test 2>&1) | tee "$HEADER_OUT" >/dev/null || fail "header_insert_test crashed"
+grep -q 'ALL HEADER INSERT TESTS PASSED' "$HEADER_OUT" \
+    || fail "header_insert_test: final banner missing ($(tail -n1 "$HEADER_OUT"))"
+ok "header_insert_test"
 
 # --- xeonbsw (main_banded) -------------------------------------------------
 (cd "$HERE" && ./xeonbsw -pairs "$FIXTURES/pairs.txt" >/dev/null 2>&1) || fail "xeonbsw crashed"


### PR DESCRIPTION
## Summary

- Fix the O(n²) header read in the `-H` path by introducing `bwa_insert_header_file`, a batched helper that sizes a single buffer to the file, copies all `@`-prefixed lines into it, and calls `bwa_insert_header` once. Upstream reported >10 min → <1 s on a ~70 MB / ~1.5 M-line header.
- Ports upstream [bwa-mem2/bwa-mem2#204](https://github.com/bwa-mem2/bwa-mem2/pull/204) with four follow-up fixes the upstream PR needed (see below).
- Adds a regression test (`test/header_insert_test`) that diffs the batched path against the pre-patch per-line baseline across eight edge cases.

Closes fg-labs/bwa-mem2#37.

## Fixes applied on top of upstream PR #204

1. **Capture the return value.** Upstream replaced `hdr_line = bwa_insert_header(buf, hdr_line);` with `bwa_insert_header_file(fp, hdr_line);`, dropping the assignment — since the function reallocs `hdr` and returns the (possibly moved) pointer, this leaked the buffer and left `hdr_line` stale. Callers must now do `hdr_line = bwa_insert_header_file(fp, hdr_line);`.
2. **Drop `const` on `FILE *`.** Upstream's `const FILE *fp` triggered a warning because `fseek`/`ftell`/`rewind`/`fgets` all take non-const `FILE *`.
3. **Guard empty files.** `calloc(1, 0)` is implementation-defined; the helper now early-returns when `file_size <= 0`.
4. **Bound each `fgets` by the remaining buffer.** Upstream always passed `0xffff`, which in theory could overrun the file-sized allocation for a pathologically long line. Each read is now clamped to the remaining bytes.

## Perf sanity check

200 k `@SQ` lines / 5.2 MB header runs end-to-end in ~20 ms user time on an M-series Mac — linear, as expected. (The full 70 MB scenario from the upstream bug report isn't reproducible locally, but the regression test pins correctness and the asymptotic fix is what the upstream patch proved.)

## Test plan

- [x] `./test/run_unit_tests.sh` passes locally (ARM64, macOS): `fmi_test`, `smem2_test`, `bwt_seed_strategy_test`, `sa2ref_test`, `header_insert_test`, `xeonbsw` all OK.
- [x] `./bwa-mem2 mem -H <small-header.sam> <ref> <reads>` emits the injected `@HD` / `@SQ` / `@CO` lines in output (unchanged behavior).
- [x] `./bwa-mem2 mem -H <200k-line-header.sam> <ref> <reads>` completes in ~1 s wall-clock (was effectively unbounded under the old O(n²) path at this size).
- [ ] CI green on Linux x86 (icpc/g++) — I've only tested the ARM/macOS build locally.

## Review order

1. `src/bwa.h` / `src/bwa.cpp` — new `bwa_insert_header_file`.
2. `src/fastmap.cpp` — call site collapsed to the batched helper.
3. `test/header_insert_test.cpp` — regression test; see the per-case comments for what each exercises.
4. `test/Makefile` / `test/run_unit_tests.sh` — harness wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a file-based header insertion API to ingest and apply SAM/BWA headers from a file stream.

* **Tests**
  * Added a regression test executable verifying file-based header insertion matches existing per-line behavior, including handling of overlong lines.

* **Chores**
  * Updated test build and test-run scripts to include and exercise the new header-insertion test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->