### PR TITLE
fix(kswv): guard post-loop rowMax store on nrow==0 batches

### DIFF
--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -22,6 +22,7 @@ on:
     paths:
       - 'src/**'
       - 'test/kswv_selftest.cpp'
+      - 'test/kswv_nrow_zero_test.cpp'
       - '.github/workflows/proto-neon-kswv.yml'
       - 'Makefile'
   workflow_dispatch:
@@ -100,6 +101,20 @@ jobs:
           echo "selftest_exit=$status" >> "$GITHUB_OUTPUT"
           tail -25 /tmp/ci-out/selftest.log >> "$GITHUB_STEP_SUMMARY"
           exit $status
+
+      - name: Build kswv_nrow_zero_test (ASan)
+        # issue 38 / upstream PR 289: all-len1==0 batches used to walk past
+        # the rowMax allocation prefix. Build with asan so the pre-fix write
+        # trips heap-buffer-overflow and fails the job rather than silently
+        # corrupting memory. `make clean` forces libbwa to recompile under
+        # asan instrumentation — the pre-asan objects left by earlier steps
+        # would otherwise satisfy the make graph and run uninstrumented.
+        run: |
+          make clean
+          make ASAN=1 arch=arm64 kswv_nrow_zero_test CXX=g++
+
+      - name: Run kswv_nrow_zero_test
+        run: ./kswv_nrow_zero_test
 
       - name: Cache chr17 bwa-mem2 index
         id: cache-chr17-index
@@ -274,6 +289,17 @@ jobs:
         # (te split, freeze, per-lane score2, minsc filter) are applied
         # on both paths — AVX2 from PR 20, AVX-512BW by this PR.
         run: ./kswv_selftest
+
+      - name: Build kswv_nrow_zero_test (x86, ASan)
+        # issue 38 / upstream PR 289 regression. Covers the AVX2 u8 kernel
+        # and the AVX-512BW u8+16 kernels on whichever $USE_AVX is selected.
+        # `make clean` forces libbwa to recompile under asan instrumentation.
+        run: |
+          make clean
+          make ASAN=1 arch="$USE_AVX" kswv_nrow_zero_test CXX=g++
+
+      - name: Run kswv_nrow_zero_test (x86)
+        run: ./kswv_nrow_zero_test
 
       - name: Index chr17
         # Use the port binary for indexing (indexing code is arch-agnostic).

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,19 @@ else ifeq ($(CXX), g++)
 	CC=gcc
 endif
 
+# AddressSanitizer support for catching kswv rowMax / SIMD store overruns
+# in regression tests (e.g. kswv_nrow_zero_test). Opt-in with `make ASAN=1 ...`
+# Forces USE_MIMALLOC off: mimalloc's malloc override interposes before asan
+# and the two can't coexist cleanly. Must be set before the mimalloc block so
+# USE_MIMALLOC=0 actually takes effect there. CXXFLAGS picks up $(ASAN_FLAGS)
+# unconditionally later in the file; it stays empty when ASAN is unset.
+ifneq ($(strip $(ASAN)),)
+    USE_MIMALLOC = 0
+    ASAN_FLAGS   = -fsanitize=address -fno-omit-frame-pointer -O1
+    LDFLAGS     += -fsanitize=address
+    CFLAGS      += $(ASAN_FLAGS)
+endif
+
 # mimalloc integration. Default on — see FG-MAIN.md.
 # Override with USE_MIMALLOC=0 to build a stock bwa-mem2 without mimalloc.
 USE_MIMALLOC ?= 1
@@ -186,7 +199,7 @@ myall:arm64
 endif
 endif
 
-CXXFLAGS+=	-g -O3 -std=gnu++14 -fpermissive $(ARCH_FLAGS) #-Wall ##-xSSE2
+CXXFLAGS+=	-g -O3 -std=gnu++14 -fpermissive $(ARCH_FLAGS) $(ASAN_FLAGS) #-Wall ##-xSSE2
 
 # Control build flag for the batched mate-rescue SW port on ARM.
 # When set (e.g. `make arm64 DISABLE_BATCHED_MATESW=1`), the source gate for
@@ -198,7 +211,7 @@ ifneq ($(strip $(DISABLE_BATCHED_MATESW)),)
     CPPFLAGS += -DDISABLE_BATCHED_MATESW=$(DISABLE_BATCHED_MATESW)
 endif
 
-.PHONY:all clean depend multi print-mimalloc-config kswv_selftest test
+.PHONY:all clean depend multi print-mimalloc-config kswv_selftest kswv_nrow_zero_test test
 .SUFFIXES:.cpp .o
 
 .cpp.o:
@@ -239,11 +252,24 @@ $(EXE):$(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) $(if $(filter 1,$(USE_MIMALLOC)),$(
 kswv_selftest: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) test/kswv_selftest.o
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) test/kswv_selftest.o $(BWA_LIB) $(LIBS) -o $@
 
-# Run the in-tree tests. Currently just kswv_selftest; extend as more land.
-test: kswv_selftest
+# Regression test for issue 38 / upstream PR 289: exercises an all-len1==0
+# batch that drives each SIMD kswv kernel through the nrow==0 path. Without
+# the post-loop `if (i > 0)` guard, the rowMax store writes SIMD_WIDTH* bytes
+# before the allocation and aborts at a later allocator operation; under
+# asan the write is reported directly.
+kswv_nrow_zero_test: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) test/kswv_nrow_zero_test.o
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) test/kswv_nrow_zero_test.o $(BWA_LIB) $(LIBS) -o $@
+
+# Run the in-tree tests. Currently kswv_selftest + kswv_nrow_zero_test;
+# extend as more land.
+test: kswv_selftest kswv_nrow_zero_test
 	./kswv_selftest
+	./kswv_nrow_zero_test
 
 test/kswv_selftest.o: test/kswv_selftest.cpp
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
+
+test/kswv_nrow_zero_test.o: test/kswv_nrow_zero_test.cpp
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 $(BWA_LIB):$(OBJS)
@@ -288,7 +314,7 @@ $(MIMALLOC_LIB):
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
 clean:
-	rm -fr src/*.o test/*.o $(BWA_LIB) $(EXE) kswv_selftest bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
+	rm -fr src/*.o test/*.o $(BWA_LIB) $(EXE) kswv_selftest kswv_nrow_zero_test bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
 	cd ext/safestringlib/ && $(MAKE) clean
 	-[ -f ext/htslib/config.mk ] && cd ext/htslib && $(MAKE) distclean
 	rm -rf $(MIMALLOC_BUILD)

--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -572,8 +572,12 @@ int kswv::kswv_neon_u8(uint8_t seq1SoA[],
         uint8_t *S = H1; H1 = H0; H0 = S;
     }
 
-    /* Store final row max */
-    vst1q_u8(rowMax + (i - 1) * SIMD_WIDTH8, pimax_vec);
+    /* Store final row max. Guard on i > 0: when every pair in the batch
+     * has len1 == 0, nrow == 0, the DP loop never runs, and `i - 1`
+     * underflows into the allocation prefix. Upstream PR 289 / issue 38. */
+    if (i > 0) {
+        vst1q_u8(rowMax + (i - 1) * SIMD_WIDTH8, pimax_vec);
+    }
 
     /* Extract results */
     uint8_t score[SIMD_WIDTH8] __attribute((aligned(128)));
@@ -1059,8 +1063,11 @@ int kswv::kswv_neon_16(int16_t seq1SoA[],
         int16_t *S = H1; H1 = H0; H0 = S;
     }
 
-    /* Store final row's pimax. */
-    vst1q_s16(rowMax + (i - 1) * SIMD_WIDTH16, pimax_vec);
+    /* Store final row's pimax. Guard on i > 0 for all-padding batches
+     * (nrow == 0 → i stays at 0 → underflow). See issue 38 / PR 289. */
+    if (i > 0) {
+        vst1q_s16(rowMax + (i - 1) * SIMD_WIDTH16, pimax_vec);
+    }
 
     /* Extract primary results. */
     int16_t score[SIMD_WIDTH16] __attribute((aligned(128)));
@@ -1445,7 +1452,12 @@ int kswv::kswv256_u8(uint8_t seq1SoA[],
         uint8_t *S = H1; H1 = H0; H0 = S;
     }
 
-    _mm256_storeu_si256((__m256i*)(rowMax + (i - 1) * SIMD_WIDTH8), pimax_vec);
+    /* Guard on i > 0: when every pair in the batch has len1 == 0, nrow
+     * is 0, the DP loop never runs, and `i - 1` underflows into the
+     * rowMax allocation prefix. See issue 38 / upstream PR 289. */
+    if (i > 0) {
+        _mm256_storeu_si256((__m256i*)(rowMax + (i - 1) * SIMD_WIDTH8), pimax_vec);
+    }
 
     /* Extract results. */
     uint8_t score[SIMD_WIDTH8] __attribute__((aligned(64)));
@@ -2079,7 +2091,11 @@ int kswv::kswv512_u8(uint8_t seq1SoA[],
     pimax512 = _mm512_mask_blend_epi8(mask512, pimax512, zero512);
     pimax512 = _mm512_mask_blend_epi8(minsc_msk, zero512, pimax512);
     pimax512 = _mm512_mask_blend_epi8(exit0, zero512, pimax512);
-    _mm512_store_si512((__m512i *) (rowMax + (i-1) * SIMD_WIDTH8), pimax512);
+    /* Guard on i > 0: all-len1==0 batches give nrow == 0 and would
+     * otherwise underflow into the rowMax allocation. issue 38 / PR 289. */
+    if (i > 0) {
+        _mm512_store_si512((__m512i *) (rowMax + (i-1) * SIMD_WIDTH8), pimax512);
+    }
 
     /******************* DP loop over *****************************/
     /**************** Partial output setting **********************/
@@ -2623,7 +2639,11 @@ int kswv::kswv512_16(int16_t seq1SoA[],
     pimax512 = _mm512_mask_blend_epi16(mask512, pimax512, minus1);
     pimax512 = _mm512_mask_blend_epi16(minsc_msk, minus1, pimax512);
     pimax512 = _mm512_mask_blend_epi16(exit0, minus1, pimax512);
-    _mm512_store_si512((__m512i *) (rowMax + (i-1) * SIMD_WIDTH16), pimax512);
+    /* Guard on i > 0: all-len1==0 batches give nrow == 0 and would
+     * otherwise underflow into the rowMax allocation. issue 38 / PR 289. */
+    if (i > 0) {
+        _mm512_store_si512((__m512i *) (rowMax + (i-1) * SIMD_WIDTH16), pimax512);
+    }
     // __m512i max512_ = max512;
 
     /******************* DP loop over *****************************/

--- a/test/kswv_nrow_zero_test.cpp
+++ b/test/kswv_nrow_zero_test.cpp
@@ -1,0 +1,120 @@
+// Regression test for issue 38 / upstream PR 289.
+//
+// When every real pair in a SIMD-aligned batch has len1 == 0, the kswv DP
+// loop never executes (nrow == 0), yet the post-loop rowMax store still
+// writes SIMD_WIDTH* bytes to `rowMax + (i - 1) * SIMD_WIDTH*` with i == 0.
+// That stomps the allocation prefix, producing `free(): invalid pointer`
+// on glibc and asan-reportable heap-buffer-overflow (negative offset).
+//
+// This test exercises the 8-bit and 16-bit entry points with batches of
+// all-len1==0 pairs. Without the kernel-side `if (i > 0)` guard, each
+// kswv destructor / allocator touch after the overwrite is likely to
+// abort. Exits 0 only when all five kernels short-circuit cleanly.
+//
+// Arch coverage is implicit in the build: NEON builds compile kswv_neon_u8
+// and kswv_neon_16; AVX2 builds compile kswv256_u8 (getScores16 is a scalar
+// fallback on AVX2 and won't trigger the crash); AVX-512BW builds compile
+// kswv512_u8 and kswv512_16.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+#include <vector>
+
+#include "ksw.h"
+#include "kswv.h"
+
+static const int8_t SCORE_MATCH    = 1;
+static const int8_t SCORE_MISMATCH = 4;
+static const int    GAP_OPEN       = 6;
+static const int    GAP_EXT        = 1;
+static const int    MIN_SEED_LEN   = 19;
+
+// Match production mate-rescue xtra: forces the kernel through the same
+// KSW_XSTART/KSW_XSUBO paths that the crash reporter hit.
+static const int XTRA_FLAGS = KSW_XSUBO | KSW_XSTART | KSW_XBYTE
+                              | (MIN_SEED_LEN * SCORE_MATCH);
+
+static void run_8(int n_pairs, int phase) {
+    const int32_t maxRefLen = 128;
+    const int32_t maxQerLen = 128;
+
+    std::vector<SeqPair> pairs(n_pairs + SIMD_WIDTH8);
+    std::vector<uint8_t> refBuf(64, 0);
+    std::vector<uint8_t> qerBuf(64, 0);
+    std::vector<kswr_t>  aln(n_pairs + SIMD_WIDTH8, g_defr);
+
+    // Every real pair has len1 == 0 so maxLen1 across the batch is 0 and
+    // the kernel runs with nrow == 0. len2 is irrelevant for the guard
+    // but set to zero to keep the SoA packing trivial.
+    for (int i = 0; i < n_pairs; i++) {
+        SeqPair sp = {};
+        sp.idr    = 0;
+        sp.idq    = 0;
+        sp.id     = i;
+        sp.len1   = 0;
+        sp.len2   = 0;
+        sp.h0     = XTRA_FLAGS;
+        sp.seqid  = i;
+        sp.regid  = i;
+        pairs[i] = sp;
+    }
+
+    kswv *pwsw = new kswv(GAP_OPEN, GAP_EXT, GAP_OPEN, GAP_EXT,
+                          SCORE_MATCH, -SCORE_MISMATCH, 1, maxRefLen, maxQerLen);
+    pwsw->getScores8(pairs.data(), refBuf.data(), qerBuf.data(),
+                     aln.data(), n_pairs, 1, phase);
+    delete pwsw;
+}
+
+static void run_16(int n_pairs, int phase) {
+    const int32_t maxRefLen = 128;
+    const int32_t maxQerLen = 128;
+
+    std::vector<SeqPair> pairs(n_pairs + SIMD_WIDTH16);
+    std::vector<uint8_t> refBuf(64, 0);
+    std::vector<uint8_t> qerBuf(64, 0);
+    std::vector<kswr_t>  aln(n_pairs + SIMD_WIDTH16, g_defr);
+
+    for (int i = 0; i < n_pairs; i++) {
+        SeqPair sp = {};
+        sp.idr    = 0;
+        sp.idq    = 0;
+        sp.id     = i;
+        sp.len1   = 0;
+        sp.len2   = 0;
+        sp.h0     = XTRA_FLAGS;
+        sp.seqid  = i;
+        sp.regid  = i;
+        pairs[i] = sp;
+    }
+
+    kswv *pwsw = new kswv(GAP_OPEN, GAP_EXT, GAP_OPEN, GAP_EXT,
+                          SCORE_MATCH, -SCORE_MISMATCH, 1, maxRefLen, maxQerLen);
+    pwsw->getScores16(pairs.data(), refBuf.data(), qerBuf.data(),
+                      aln.data(), n_pairs, 1, phase);
+    delete pwsw;
+}
+
+// Exercise both phases. Production batched mate-rescue calls getScores8/16
+// with phase == 0 followed by phase == 1 on the same compacted batch; the
+// guarded post-loop store fires on both, so cover both explicitly.
+int main() {
+    for (int phase = 0; phase <= 1; phase++) {
+        fprintf(stderr, "[nrow-zero-test] 8-bit numPairs=1 phase=%d ...\n", phase);
+        run_8(1, phase);
+        fprintf(stderr, "[nrow-zero-test] 8-bit numPairs=SIMD_WIDTH8+1 (=%d) phase=%d ...\n",
+                SIMD_WIDTH8 + 1, phase);
+        run_8(SIMD_WIDTH8 + 1, phase);
+
+        fprintf(stderr, "[nrow-zero-test] 16-bit numPairs=1 phase=%d ...\n", phase);
+        run_16(1, phase);
+        fprintf(stderr, "[nrow-zero-test] 16-bit numPairs=SIMD_WIDTH16+1 (=%d) phase=%d ...\n",
+                SIMD_WIDTH16 + 1, phase);
+        run_16(SIMD_WIDTH16 + 1, phase);
+    }
+
+    fprintf(stderr, "kswv_nrow_zero_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Port of upstream [bwa-mem2#289](https://github.com/bwa-mem2/bwa-mem2/pull/289), broadened to the three additional SIMD kswv kernels this tree carries (NEON u8/16, AVX2 u8) on top of the two upstream patched (AVX-512BW u8/16). Closes #38.
- Wraps the post-DP-loop `rowMax + (i - 1) * SIMD_WIDTH*` store in `if (i > 0)` on all five kernels. Without the guard, an all-`len1 == 0` batch drives `nrow == 0`, the DP loop skips, and the SIMD store walks SIMD_WIDTH* bytes before the allocation prefix — reproducibly aborting with `free(): invalid pointer` on glibc and silently corrupting the heap on macOS libc.
- Adds `test/kswv_nrow_zero_test.cpp`, a regression test that builds all-padding batches and invokes `getScores8` / `getScores16`. Under the new `make ASAN=1 ...` build, the pre-fix code trips `heap-buffer-overflow` at `kswv.cpp:576` (16 bytes before the rowMax allocation); post-fix the test runs clean.
- Wires the new test into both legs of the `proto-neon-kswv` workflow (arm64 + x86 AVX2/AVX-512BW) so the guard stays in place across future kernel edits.

## Kernel coverage

| Kernel | Post-loop store | Source of the fix |
|---|---|---|
| NEON u8      | `src/kswv.cpp:576`  | this PR (not in upstream #289) |
| NEON 16      | `src/kswv.cpp:1063` | this PR (not in upstream #289) |
| AVX2 u8      | `src/kswv.cpp:1448` | this PR (not in upstream #289) |
| AVX-512BW u8 | `src/kswv.cpp:2082` | upstream #289, ported |
| AVX-512BW 16 | `src/kswv.cpp:2626` | upstream #289, ported |

The in-loop rowMax stores are already guarded by `if (i > 0)` and need no change. Downstream score2 scans are bounded by `processed_rows = i = 0` when `nrow == 0`, so the early skip is semantically a no-op.

## Test plan

- [x] Write regression test that triggers the nrow==0 path on every arch's SIMD kernel.
- [x] Confirm RED: ASan reports `heap-buffer-overflow` at `kswv.cpp:576` pre-fix (NEON arm64, local).
- [x] Confirm GREEN: regression test exits 0 with fix applied, under ASan and release builds (NEON arm64, local).
- [x] Confirm no correctness regression: `kswv_selftest` — 10014 pairs, 0 score / coord / score2 mismatches post-fix (NEON arm64, local).
- [ ] CI `proto-neon-kswv` selftest-perf-arm leg green (runs both `kswv_selftest` and new ASan `kswv_nrow_zero_test`).
- [ ] CI `proto-neon-kswv` x86 leg green (AVX2 + AVX-512BW matrix, both tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in AddressSanitizer support for stricter memory debugging during builds.

* **Bug Fixes**
  * Prevented out-of-bounds write in SIMD kernel when processing zero-length sequences.

* **Tests**
  * Added a regression test covering the zero-row/zero-length sequence case.
  * CI extended to run the new test on both ARM and x86 build jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->