### PR TITLE
chore(version): stamp PACKAGE_VERSION from git describe at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.dSYM
 .*.swp
 a.out
+src/version.h

--- a/FG-MAIN.md
+++ b/FG-MAIN.md
@@ -27,6 +27,22 @@ land upstream.
 
 [pr288]: https://github.com/bwa-mem2/bwa-mem2/pull/288
 
+## Version stamping
+
+`PACKAGE_VERSION` (the value reported by `bwa-mem2 version` and written to
+the `@PG VN:` SAM header field) is generated at build time by the Makefile
+from `git describe --tags --dirty`, e.g. `v2.3-30-g61813ef` for a tree 30
+commits past upstream tag `v2.3` at commit `61813ef`.
+
+- No manual bumping required: cut a fresh release by tagging the commit
+  (`git tag -a vX.Y-fg-labs.N -m …`) and the next build picks it up.
+- Builds where `git describe --tags` fails (source-tarball extractions, or
+  shallow clones / checkouts with no tag reachable from `HEAD` — including
+  CI's default `actions/checkout` fetch-depth of 1) fall back to the static
+  `FG_LABS_VERSION_FALLBACK` in `Makefile`. Bump that when cutting a
+  release that will be consumed as a tarball, or in CI artifacts.
+- `src/version.h` is generated and `.gitignore`d; `make clean` removes it.
+
 ## Branching and update policy
 
 - `master` tracks upstream unchanged.

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,13 @@ endif
 
 MEM_FLAGS=	-DSAIS=1
 CPPFLAGS+=	-DENABLE_PREFETCH -DV17=1 -DMATE_SORT=0 $(MEM_FLAGS)
+
+# Version string for `bwa-mem2 version` and the @PG VN: field. Prefer
+# `git describe` (e.g. v2.3-30-g61813ef, with -dirty suffix for modified
+# trees) so the stamped version always reflects the actual build. Fall
+# back to a static tag for source-tarball / shallow-clone builds.
+FG_LABS_VERSION_FALLBACK := 2.3-fg-labs
+VERSION_STRING := $(shell git describe --tags --dirty 2>/dev/null || echo $(FG_LABS_VERSION_FALLBACK))
 INCLUDES+=   -Isrc -Iext/safestringlib/include -Iext/htslib
 ifeq ($(USE_MIMALLOC),1)
     INCLUDES += -Iext/mimalloc/include
@@ -211,13 +218,25 @@ ifneq ($(strip $(DISABLE_BATCHED_MATESW)),)
     CPPFLAGS += -DDISABLE_BATCHED_MATESW=$(DISABLE_BATCHED_MATESW)
 endif
 
-.PHONY:all clean depend multi print-mimalloc-config kswv_selftest kswv_nrow_zero_test test
+.PHONY:all clean depend multi print-mimalloc-config kswv_selftest kswv_nrow_zero_test test FORCE
 .SUFFIXES:.cpp .o
 
 .cpp.o:
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 all:$(EXE)
+
+# Regenerate src/version.h on every invocation, but only touch the file
+# (and thus trigger a main.o rebuild) when the string actually changed.
+# Must be declared after `all:$(EXE)` so FORCE is never picked as the
+# default goal when the caller supplies `arch=...` (which skips the
+# `myall:` dispatch branch).
+FORCE:
+src/version.h: FORCE
+	@printf '#ifndef BWA_MEM2_VERSION_H\n#define BWA_MEM2_VERSION_H\n#define PACKAGE_VERSION "%s"\n#endif\n' '$(VERSION_STRING)' > $@.tmp
+	@if ! cmp -s $@.tmp $@ 2>/dev/null; then mv $@.tmp $@; else rm -f $@.tmp; fi
+
+src/main.o: src/version.h
 
 multi: $(if $(filter 1,$(USE_MIMALLOC)),$(MIMALLOC_LIB))
 ifneq ($(IS_ARM),)
@@ -314,7 +333,7 @@ $(MIMALLOC_LIB):
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
 clean:
-	rm -fr src/*.o test/*.o $(BWA_LIB) $(EXE) kswv_selftest kswv_nrow_zero_test bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
+	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_selftest kswv_nrow_zero_test bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
 	cd ext/safestringlib/ && $(MAKE) clean
 	-[ -f ext/htslib/config.mk ] && cd ext/htslib && $(MAKE) distclean
 	rm -rf $(MIMALLOC_BUILD)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,10 +30,7 @@ Contacts: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@
 
 // ----------------------------------
 #include "main.h"
-
-#ifndef PACKAGE_VERSION
-#define PACKAGE_VERSION "2.2.1"
-#endif
+#include "version.h"
 
 #ifdef USE_MIMALLOC
 #include <mimalloc.h>


### PR DESCRIPTION
## Summary
- Replace hardcoded `PACKAGE_VERSION "2.2.1"` in `src/main.cpp` with a generated `src/version.h` written by the Makefile from `git describe --tags --always --dirty` (e.g. `v2.3-31-g8dc753b`), with a static `FG_LABS_VERSION_FALLBACK = 2.3-fg-labs` for source-tarball / shallow-clone builds where `git describe` fails.
- The `src/version.h` rule uses a `FORCE` prereq + write-if-changed (`cmp -s` + `mv`) so the file regenerates on every invocation but only bumps its mtime — and thus only triggers a `main.o` rebuild — when the stamped string actually changes.
- `src/version.h` is `.gitignore`d and removed by `make clean`; scheme is documented in `FG-MAIN.md`.

Fixes #40. Related upstream threads: bwa-mem2/bwa-mem2#283 (stale version), bwa-mem2/bwa-mem2#284 (static bump).

## Why `git describe` over a static bump
The issue explicitly calls out "so drift doesn't recur" — a one-shot bump to `2.3` would leave us in the same spot the next time upstream releases. `git describe` never drifts: every build stamps its own commit identity (`v2.3-31-g8dc753b`, with `-dirty` for modified trees), and future fg-labs tags (`vX.Y-fg-labs.N`) are picked up automatically with no code changes.

## Test plan
- [x] `make src/version.h` twice — file mtime stable on second run (write-if-changed works)
- [x] Full arm64 build on macOS (USE_MIMALLOC=1) — links and runs
- [x] `./bwa-mem2 version` reports `v2.3-31-g8dc753b` (real describe, post-commit)
- [x] Simulated stale `src/version.h` → only `main.o` rebuilds on next `make`, not the whole tree
- [x] `make clean` removes `src/version.h`
- [x] Fallback `2.3-fg-labs` confirmed in a non-git directory
- [ ] CI matrix green (Linux/macOS × USE_MIMALLOC × arch variants)
- [ ] `@PG VN:` field in a real alignment output shows the new string (same macro as `version` subcommand; not separately verified)

## Notes for reviewers
- CI uses `actions/checkout@v4` with default `fetch-depth: 1` (no tags), so CI-built binaries will report the fallback `2.3-fg-labs` rather than a describe string. That's fine for throwaway test runs — tighten `fetch-depth: 0` later if we want CI artifacts to carry real provenance.
- Pre-existing duplicate `ext/htslib/libhts.a` rule in the Makefile (lines 252 / 272) triggers a warning on every invocation; out of scope for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added explanation of build-time version stamping, including derivation from git tags, example output, fallback behavior, and lifecycle of the generated version artifact.

* **Chores**
  * Build now embeds generated version metadata into releases and the program's reported version.
  * Generation is optimized to avoid unnecessary rebuilds and the generated artifact is cleaned and ignored by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->