### PR TITLE
fix(sam): escape tabs in -R when embedding into @PG CL: field (upstream #293)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,21 @@ int usage()
     return 1;
 }
 
+// Append a single argv token to the @PG CL: value. Tabs inside the token
+// (common when the caller passes e.g. `-R $'@RG\tID:x\tSM:y'`) would
+// otherwise bleed into the @PG line as extra tag-separators, producing
+// SAM that strict validators reject (issue #45 / upstream bwa-mem2#293).
+// Newlines and carriage returns would be worse still: a literal \n
+// terminates the @PG record mid-line and corrupts the whole header.
+// Replace any of these with a single space; do not mutate argv itself.
+static void append_pg_cl_arg(kstring_t *pg, const char *arg)
+{
+    kputc(' ', pg);
+    for (const char *c = arg; *c != '\0'; ++c) {
+        kputc((*c == '\t' || *c == '\n' || *c == '\r') ? ' ' : *c, pg);
+    }
+}
+
 int main(int argc, char* argv[])
 {
         
@@ -99,7 +114,7 @@ int main(int argc, char* argv[])
         
         ksprintf(&pg, "@PG\tID:bwa-mem2\tPN:bwa-mem2\tVN:%s\tCL:%s", PACKAGE_VERSION, argv[0]);
 
-        for (int i = 1; i < argc; ++i) ksprintf(&pg, " %s", argv[i]);
+        for (int i = 1; i < argc; ++i) append_pg_cl_arg(&pg, argv[i]);
         ksprintf(&pg, "\n");
         bwa_pg = pg.s;
         ret = main_mem(argc-1, argv+1);

--- a/test/pg_cl_escape_test.sh
+++ b/test/pg_cl_escape_test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# test/pg_cl_escape_test.sh
+#
+# Asserts that `bwa-mem2 mem -R $'@RG\tID:x\tSM:y\tLB:z' ...` produces a
+# SAM header whose `@PG` line contains no literal tabs, newlines, or
+# carriage returns inside the `CL:` value. Regression for issue #45 /
+# upstream #293: without escaping, whitespace from the user-supplied `-R`
+# argument bleeds into the `@PG` line and strict SAM validators
+# (noodles, some fgbio configs) reject it.
+#
+# The assertion is structural, not textual:
+#   * The @PG line must have exactly 5 tab-separated fields
+#     (@PG, ID:bwa-mem2, PN:bwa-mem2, VN:..., CL:...).
+#   * There must be exactly one @PG line.
+#   * The CL: value must be free of raw \t, \n, and \r.
+#   * The @RG line must still contain the user's tab-separated fields
+#     (tab-only case), because argv itself is not mutated.
+#
+# Usage: test/pg_cl_escape_test.sh <bwa-mem2-binary> <fixtures-dir>
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <bwa-mem2-binary> <fixtures-dir>" >&2
+    exit 2
+fi
+
+bin="$1"
+fixtures="$2"
+ref="$fixtures/phix.fa"
+reads="$fixtures/reads.fa"
+
+[[ -x "$bin" ]]   || { echo "FAIL: bwa-mem2 binary not executable at $bin" >&2; exit 1; }
+[[ -s "$ref" ]]   || { echo "FAIL: phix.fa missing at $ref" >&2; exit 1; }
+[[ -s "$reads" ]] || { echo "FAIL: reads.fa missing at $reads" >&2; exit 1; }
+
+# Build the phiX FMI index if not already present.
+if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.0123" || ! -s "$ref.amb" \
+      || ! -s "$ref.ann"       || ! -s "$ref.pac" ]]; then
+    "$bin" index "$ref" >/dev/null 2>&1 || { echo "FAIL: bwa-mem2 index on phix.fa failed" >&2; exit 1; }
+fi
+
+sam="$(mktemp)"
+err="$(mktemp)"
+trap 'rm -f "$sam" "$err"' EXIT
+
+# Run `bwa-mem2 mem` with the given -R value and assert that the emitted
+# @PG line is structurally well-formed. $1 is a short label used in
+# failure messages; $2 is the -R string.
+assert_pg_well_formed() {
+    local label="$1"
+    local rg="$2"
+
+    "$bin" mem -R "$rg" "$ref" "$reads" >"$sam" 2>"$err" || {
+        echo "FAIL [$label]: bwa-mem2 mem exited non-zero" >&2
+        echo "---- stderr ----" >&2
+        cat "$err" >&2
+        echo "----------------" >&2
+        exit 1
+    }
+
+    local pg_lines
+    pg_lines="$(grep -c '^@PG' "$sam" || true)"
+    if [[ "$pg_lines" -ne 1 ]]; then
+        echo "FAIL [$label]: expected exactly one @PG line, got $pg_lines" >&2
+        grep '^@PG' "$sam" >&2 || true
+        exit 1
+    fi
+
+    local pg_line
+    pg_line="$(grep '^@PG' "$sam")"
+
+    # Field count: @PG plus 4 tags (ID, PN, VN, CL) = 5 tab-separated columns.
+    # Any extra column means a tab leaked into one of the tag values.
+    local pg_field_count
+    pg_field_count="$(awk -F'\t' '{print NF}' <<<"$pg_line")"
+    if [[ "$pg_field_count" -ne 5 ]]; then
+        echo "FAIL [$label]: @PG line has $pg_field_count tab-separated fields, expected 5" >&2
+        echo "---- @PG line (tabs shown as <TAB>) ----" >&2
+        printf '%s\n' "$pg_line" | sed $'s/\t/<TAB>/g' >&2
+        echo "----------------------------------------" >&2
+        exit 1
+    fi
+
+    # Belt-and-braces: exactly one `ID:` tag and exactly one `CL:` tag.
+    # Stray tabs from -R would produce a second `ID:` tag (from the RG).
+    local id_count cl_count
+    id_count="$(grep -o $'\tID:' <<<"$pg_line" | wc -l | tr -d ' ')"
+    cl_count="$(grep -o $'\tCL:' <<<"$pg_line" | wc -l | tr -d ' ')"
+    if [[ "$id_count" -ne 1 || "$cl_count" -ne 1 ]]; then
+        echo "FAIL [$label]: @PG line has ID:=$id_count CL:=$cl_count (expected 1 of each)" >&2
+        printf '%s\n' "$pg_line" | sed $'s/\t/<TAB>/g' >&2
+        exit 1
+    fi
+
+    # Extract the CL: value. grep above was line-oriented, so if the raw
+    # argv contained a \n it would have terminated $pg_line early and
+    # $cl_value would be missing the trailing argv tokens. Assert that
+    # the CL: value ends with the reads path (the last argv token) —
+    # this catches an embedded \n that truncated the @PG line.
+    local cl_value
+    cl_value="$(awk -F'\t' '{for (i=1;i<=NF;i++) if ($i ~ /^CL:/) { sub(/^CL:/, "", $i); print $i; exit }}' <<<"$pg_line")"
+    if [[ "$cl_value" != *"$reads" ]]; then
+        echo "FAIL [$label]: CL: value does not end with reads path '$reads'" >&2
+        echo "CL: was: $cl_value" >&2
+        exit 1
+    fi
+    if [[ "$cl_value" == *$'\t'* ]]; then
+        echo "FAIL [$label]: CL: value contains a literal tab" >&2; exit 1
+    fi
+    if [[ "$cl_value" == *$'\r'* ]]; then
+        echo "FAIL [$label]: CL: value contains a literal carriage return" >&2; exit 1
+    fi
+}
+
+# --- @PG checks: embed each whitespace variant in -R and verify CL: clean -
+# All three values parse as a valid @RG (they start with "@RG\tID:" before
+# the injected character); bwa-mem2 will emit a @RG line but we only
+# assert @PG structure here — that is the fix under test.
+assert_pg_well_formed "tab"             $'@RG\tID:x\tSM:y\tLB:z'
+assert_pg_well_formed "newline"         $'@RG\tID:x\tSM:y\tLB:z\nTRAIL'
+assert_pg_well_formed "carriage-return" $'@RG\tID:x\tSM:y\tLB:z\rTRAIL'
+
+# --- @RG assertions (tab-only case) ----------------------------------------
+# argv is not mutated, so the @RG line the user asked for must still be
+# well-formed and carry ID:x, SM:y, LB:z as distinct tab-separated tags.
+# Re-run with the plain tab-only -R; $sam already has output from the
+# "tab" call above but re-running keeps the test self-contained if the
+# call order above ever changes.
+rg=$'@RG\tID:x\tSM:y\tLB:z'
+"$bin" mem -R "$rg" "$ref" "$reads" >"$sam" 2>"$err" || {
+    echo "FAIL: bwa-mem2 mem exited non-zero (@RG assertion)" >&2
+    echo "---- stderr ----" >&2
+    cat "$err" >&2
+    echo "----------------" >&2
+    exit 1
+}
+rg_line="$(grep '^@RG' "$sam" || true)"
+[[ -n "$rg_line" ]] || { echo "FAIL: no @RG line in output" >&2; exit 1; }
+
+for tag in $'\tID:x' $'\tSM:y' $'\tLB:z'; do
+    if ! grep -qF -- "$tag" <<<"$rg_line"; then
+        echo "FAIL: @RG line missing tag '${tag//$'\t'/<TAB>}'" >&2
+        printf '%s\n' "$rg_line" | sed $'s/\t/<TAB>/g' >&2
+        exit 1
+    fi
+done
+
+echo "PASS: @PG line contains no embedded tabs/newlines/CRs; @RG preserved"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -63,4 +63,11 @@ LINES="$(wc -l < "$FKSW" | tr -d ' ')"
 [[ "$LINES" -eq 3 ]] || fail "xeonbsw: expected 3 lines in fksw.txt, got $LINES"
 ok "xeonbsw ($LINES pair scores emitted)"
 
+# --- pg_cl_escape_test ----------------------------------------------------
+# Regression for issue #45 / upstream #293: tabs inside `-R` must not
+# bleed into the @PG CL: value. Uses the same phiX fixture as the rest
+# of the harness (indexed above if needed).
+"$HERE/pg_cl_escape_test.sh" "$BWAMEM2" "$FIXTURES" || fail "pg_cl_escape_test failed"
+ok "pg_cl_escape_test"
+
 echo "ALL UNIT TESTS PASSED"


### PR DESCRIPTION
## Summary

- Replace tabs with spaces when appending each `argv[i]` to the `@PG` `CL:` value in `src/main.cpp`. `argv` itself is untouched, so the `@RG` line still carries the original tab-separated tags.
- Adds `test/pg_cl_escape_test.sh` (structural assertions: `@PG` field count == 5, exactly one `ID:`/`CL:`, `@RG` preserved) wired into `test/run_unit_tests.sh`.

## Why

Passing `-R $'@RG\tID:x\tSM:y\tLB:z'` copied the tabs verbatim into the `@PG` `CL:` value, producing SAM whose `@PG` line looked like it carried extra TAG:value fields — including a spurious second `ID:`. Lenient parsers (samtools, htsjdk) tolerated it; strict parsers (noodles, some fgbio configs) reject the file as invalid.

Closes fg-labs/bwa-mem2#45. Upstream reference: bwa-mem2/bwa-mem2#293.

## Before / after

Same invocation, `bwa-mem2 mem -R $'@RG\tID:x\tSM:y\tLB:z' phix.fa reads.fa`:

**Before** (tabs shown as `<TAB>`):
```
@PG<TAB>ID:bwa-mem2<TAB>PN:bwa-mem2<TAB>VN:2.2.1<TAB>CL:./bwa-mem2 mem -R @RG<TAB>ID:x<TAB>SM:y<TAB>LB:z phix.fa reads.fa
```
8 tab-separated fields — the `-R` tabs bled into `CL:`.

**After:**
```
@PG<TAB>ID:bwa-mem2<TAB>PN:bwa-mem2<TAB>VN:2.2.1<TAB>CL:./bwa-mem2 mem -R @RG ID:x SM:y LB:z phix.fa reads.fa
@RG<TAB>ID:x<TAB>SM:y<TAB>LB:z
```
5 tab-separated fields on `@PG`; `@RG` unchanged.

## Test plan

- [x] New `test/pg_cl_escape_test.sh` fails on the pre-fix binary (RED: 8 `@PG` fields, expected 5) and passes on the patched binary (GREEN).
- [x] `bash test/run_unit_tests.sh` — all unit tests pass locally (macOS arm64), including the new test.
- [x] Normal invocation without `-R` still emits a clean 5-field `@PG` line (no behavior change for the common case).
- [ ] CI matrix (Linux x86_64 SSE4.1 / AVX2 / AVX2 clang / AVX2 no-mimalloc / multi, Linux ARM64, macOS ARM64) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented SAM header corruption by sanitizing control characters (tabs, newlines, carriage returns) in command-line fields so the program header remains well-formed.

* **Tests**
  * Added a regression test that verifies command-line special characters are sanitized and that SAM header lines contain the expected fields and counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->