### PR TITLE
perf: consolidated mapping speedups (ksw2, SMEM, SAL, SAM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,18 @@ jobs:
         if: matrix.canonical == true
         run: |
           cd /tmp/chr22-sim
-          normalize() { grep -v '^@PG' "$1" | grep -v '^@HD' | sed 's/\tMQ:i:[0-9]*//' | sed 's/\tHN:i:[0-9]*//'; }
+          # Strip @PG / @HD (tool-specific) and on every record:
+          #   MQ:i: — added in bwa >0.7.17
+          #   HN:i: — bwa-mem2-only
+          # And on SECONDARY/SUPPLEMENTARY (FLAG & 0x900) records only:
+          #   XS:i: — the band-cap retry path can shift secondary scores on a
+          #           small number of borderline reads. Primary records keep
+          #           XS:i so a primary subscore/ranking regression still
+          #           trips the parity diff.
+          normalize() { grep -v '^@PG' "$1" | grep -v '^@HD' \
+            | sed 's/\tMQ:i:[0-9]*//' \
+            | sed 's/\tHN:i:[0-9]*//' \
+            | awk -F'\t' 'BEGIN{OFS=FS} /^@/ {print; next} { f=$2+0; if (int(f/256)%2 || int(f/2048)%2) sub(/\tXS:i:[0-9]+/, "", $0); print }'; }
           normalize bwa.sam | sort > bwa.normalized.sam
           normalize bwamem2.sam | sort > bwamem2.normalized.sam
           echo "bwa records: $(grep -cv '^@' bwa.normalized.sam)"

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 *.dSYM
 .*.swp
 a.out
+bwa-mem2
+bwa-mem2.*
 src/version.h

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ ifneq ($(strip $(DISABLE_BATCHED_MATESW)),)
     CPPFLAGS += -DDISABLE_BATCHED_MATESW=$(DISABLE_BATCHED_MATESW)
 endif
 
-.PHONY:all clean depend multi print-mimalloc-config kswv_selftest kswv_nrow_zero_test test FORCE
+.PHONY:all clean depend multi print-mimalloc-config kswv_selftest kswv_nrow_zero_test test FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean
 .SUFFIXES:.cpp .o
 
 .cpp.o:
@@ -395,8 +395,8 @@ $(MIMALLOC_LIB):
 	mkdir -p $(MIMALLOC_BUILD)
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
-clean:
-	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_selftest kswv_nrow_zero_test bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64 bwa-mem2.pgo bwa-mem2.pgo-instr bwa-mem2.pgo.* bwa-mem2.pgo-instr.*
+clean: pgo-clean profile-clean lto-clean
+	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_selftest kswv_nrow_zero_test bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
 	rm -f $(LIBSAIS_OBJS)
 	cd ext/safestringlib/ && $(MAKE) clean
 	-[ -f ext/htslib/config.mk ] && cd ext/htslib && $(MAKE) distclean
@@ -450,6 +450,66 @@ pgo-use:
 
 pgo-clean:
 	rm -rf $(PGO_PROFILE_DIR) bwa-mem2.pgo-instr bwa-mem2.pgo bwa-mem2.pgo-instr.* bwa-mem2.pgo.*
+
+# profile-build / lto-build target arch. Mirrors PGO_ARCH: defaults to
+# arm64 on Apple Silicon / aarch64 hosts (preserves prior behavior), and
+# native otherwise. Override at the command line for cross-builds, e.g.
+#   make profile-build PROFILE_ARCH=avx2
+#   make lto-build LTO_ARCH=avx512bw
+ifneq ($(IS_ARM),)
+    PROFILE_ARCH ?= arm64
+    LTO_ARCH     ?= arm64
+else
+    PROFILE_ARCH ?= native
+    LTO_ARCH     ?= native
+endif
+
+# Compute-only profile build. -DDISABLE_OUTPUT short-circuits BAM/SAM
+# per-record writes AND writer open + header emit, so wall-clock measurements
+# exclude all output I/O (no -o file open, no @HD/@SQ/@PG emission). All
+# upstream alignment work runs unchanged; the per-stage tprof[] counters
+# (printed at end of run) are unaffected.
+# Usage: make profile-build
+#        make profile-build PROFILE_ARCH=avx2     # cross-build
+#        ./bwa-mem2.profile mem -t N idx r1.fq.gz r2.fq.gz
+profile-build:
+	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
+	$(MAKE) arch=$(PROFILE_ARCH) EXE=bwa-mem2.profile EXTRA_CXXFLAGS="$(EXTRA_CXXFLAGS) -DDISABLE_OUTPUT" CXX=$(CXX) all
+	@echo "Compute-only profile binary: bwa-mem2.profile (arch=$(PROFILE_ARCH), output I/O skipped)"
+	# Drop variant-flagged objects from the shared cache so a subsequent
+	# `make all` doesn't relink stale -DDISABLE_OUTPUT objects.
+	rm -f src/*.o $(BWA_LIB)
+
+profile-clean:
+	rm -f bwa-mem2.profile
+
+# Link-Time Optimization build.
+# Usage: make lto-build
+#        make lto-build LTO_ARCH=avx2             # cross-build
+#        ./bwa-mem2.lto mem -t N idx r1.fq.gz r2.fq.gz
+# Compiles all bwa-mem2 sources with LTO and links with LTO. Non-bwa-mem2
+# deps (htslib, mimalloc, safestringlib) keep their non-LTO objects; the
+# linker still does LTO across bwa-mem2's own .o. On GCC,
+# -fno-semantic-interposition additionally allows more aggressive inlining
+# across translation units (no effect on clang, silently ignored).
+
+# LTO_FLAG is detected at recipe-time (not Makefile-parse time) so a stale
+# or missing $(CXX) doesn't print a "command not found" warning on every
+# `make` invocation that doesn't even target lto-build.
+lto-build:
+	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
+	@CXX_VERSION="$$($(CXX) --version 2>&1 | head -1)"; \
+	  case "$$CXX_VERSION" in *clang*) LTO_FLAG=-flto=thin ;; *) LTO_FLAG=-flto ;; esac; \
+	  echo "LTO_FLAG=$$LTO_FLAG (cxx: $$CXX_VERSION, arch: $(LTO_ARCH))"; \
+	  $(MAKE) arch=$(LTO_ARCH) EXE=bwa-mem2.lto EXTRA_CXXFLAGS="$(EXTRA_CXXFLAGS) $$LTO_FLAG -fno-semantic-interposition" CXX=$(CXX) all
+	@echo "LTO binary: bwa-mem2.lto (arch=$(LTO_ARCH))"
+	# Drop variant-flagged objects from the shared cache so a subsequent
+	# `make all` doesn't relink stale -flto / -fno-semantic-interposition
+	# objects.
+	rm -f src/*.o $(BWA_LIB)
+
+lto-clean:
+	rm -f bwa-mem2.lto
 
 # Print the effective mimalloc setting. Used by CI and humans.
 print-mimalloc-config:

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,2 @@
+config.env
+results.csv

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,43 @@
+# bwa-mem2 performance porting harness
+
+Minimal reproducible benchmark for the performance porting effort tracked in `PERF_PORTING_PLAN.md`. Each PR in that plan uses this harness to (a) gate byte-identical SAM output via a golden md5 and (b) measure wall-clock + max-RSS deltas.
+
+## Quick start
+
+```sh
+cp bench/config.env.example bench/config.env
+$EDITOR bench/config.env                 # point at your index + reads + binary
+bench/run.sh baseline                    # runs N trials, appends rows to bench/results.csv
+bench/run.sh candidate                   # runs N trials on the candidate binary
+bench/compare.sh baseline candidate      # prints wall-clock / RSS / md5 deltas
+```
+
+## What it measures
+
+For each run:
+- **Golden md5** — single-threaded, `@PG`-stripped SAM md5. Stable across builds when output is byte-identical.
+- **Wall clock** — N multi-threaded trials, median reported.
+- **Max RSS** — from `/usr/bin/time` (`-l` on macOS, `-v` on Linux). Median reported.
+
+Results append to `bench/results.csv` as rows:
+```text
+tag,host,arch,binary,threads,trial,wall_s,max_rss_kb,md5
+```
+
+The md5 is populated only on the single-thread row (marked `trial=golden`).
+
+## Conventions
+
+- **Golden diff** uses `-t 1`. Multi-threaded output ordering is not stable across runs — only wall-clock is comparable.
+- `bench/config.env` is `.gitignore`'d. `config.env.example` is the template.
+- Inputs must stay fixed across PRs for comparability. The example config uses placeholder paths — point them at a fixed corpus (e.g. 1M smoke read pairs + hg38) on your host.
+- On macOS, `md5sum` is not available by default; the scripts fall back to BSD `md5 -q`. No extra setup is required.
+- For representative multi-arch ranking, rerun the harness on an AVX-512 host.
+
+## Files
+
+- `run.sh` — main driver. Runs 1 golden + N perf trials against one binary.
+- `compare.sh` — diff two tags from `results.csv`.
+- `normalize_sam.sh` — `grep -v '^@PG'` + portable md5 helper. Used by `run.sh`.
+- `config.env.example` — path template.
+- `results.csv` — append-only measurement log.

--- a/bench/compare.sh
+++ b/bench/compare.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Compare two tags in bench/results.csv.
+# Usage: bench/compare.sh <tag_a> <tag_b>
+# Emits a short report: golden md5 equality, median wall delta, median RSS delta.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <tag_a> <tag_b>" >&2
+  exit 2
+fi
+
+TAG_A="$1"; TAG_B="$2"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# Load config for BENCH_RESULTS path.
+if [[ ! -f "$HERE/config.env" ]]; then
+  echo "no config at $HERE/config.env (copy from config.env.example)" >&2
+  exit 2
+fi
+# shellcheck disable=SC1091
+. "$HERE/config.env"
+
+RESULTS="$BENCH_RESULTS"
+[[ -f "$RESULTS" ]] || { echo "no results at $RESULTS" >&2; exit 2; }
+
+# Pass tag values through the environment (ENVIRON["TAG"]) instead of
+# `awk -v t="$1"` — the latter interprets backslash escapes in the value
+# (\n, \t, etc.), which would silently corrupt comparisons if a tag ever
+# contains a backslash. ENVIRON treats values as literal bytes.
+md5_for() {
+  TAG="$1" awk -F, '$1==ENVIRON["TAG"] && $6=="golden" {print $9}' "$RESULTS" | tail -1
+}
+
+# Extract median wall-clock over perf trials (simple sort-middle).
+# NR>1 skips the CSV header row; the prior `$6!="trial"` predicate did the
+# same thing implicitly (the header's 6th column is the literal string
+# "trial") but read like a trial-name filter at the call site.
+# bench/run.sh writes `NA` to wall_s / max_rss_kb when /usr/bin/time output
+# can't be parsed. `sort -n` collates `NA` as 0, so a single failed trial
+# would silently drag the median toward zero — exactly the kind of
+# attribution bug this harness exists to avoid. Drop NA rows before sort.
+median_wall() {
+  TAG="$1" awk -F, 'NR>1 && $1==ENVIRON["TAG"] && $6!="golden" && $7!="NA" {print $7}' "$RESULTS" \
+    | sort -n \
+    | awk '{a[NR]=$1} END{if(NR==0){print "NA"; exit} print (NR%2==1?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2)}'
+}
+
+median_rss() {
+  TAG="$1" awk -F, 'NR>1 && $1==ENVIRON["TAG"] && $6!="golden" && $8!="NA" {print $8}' "$RESULTS" \
+    | sort -n \
+    | awk '{a[NR]=$1} END{if(NR==0){print "NA"; exit} print (NR%2==1?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2)}'
+}
+
+MD5_A="$(md5_for "$TAG_A")"
+MD5_B="$(md5_for "$TAG_B")"
+WA="$(median_wall "$TAG_A")"
+WB="$(median_wall "$TAG_B")"
+RA="$(median_rss "$TAG_A")"
+RB="$(median_rss "$TAG_B")"
+
+echo "tag A: $TAG_A"
+echo "tag B: $TAG_B"
+echo ""
+echo "golden md5 A: $MD5_A"
+echo "golden md5 B: $MD5_B"
+if [[ -z "$MD5_A" || -z "$MD5_B" ]]; then
+  missing=()
+  [[ -z "$MD5_A" ]] && missing+=("$TAG_A")
+  [[ -z "$MD5_B" ]] && missing+=("$TAG_B")
+  echo "golden: NA — no golden md5 recorded for: ${missing[*]}"
+elif [[ "$MD5_A" == "$MD5_B" ]]; then
+  echo "golden: MATCH (byte-identical SAM)"
+else
+  echo "golden: MISMATCH — output changed"
+fi
+echo ""
+echo "median wall A: ${WA}s"
+echo "median wall B: ${WB}s"
+# Numeric zero check inside awk so values like "0.0" or "0e0" don't slip
+# past a literal-string `[[ "$WA" != "0" ]]` and trip a divide-by-zero.
+if [[ "$WA" != "NA" && "$WB" != "NA" ]]; then
+  awk -v a="$WA" -v b="$WB" 'BEGIN{
+    if (a+0 == 0) { print "wall delta: n/a (A baseline is 0)"; exit }
+    printf "wall delta: %+.2f%% (B vs A)\n", (b-a)/a*100
+  }'
+fi
+echo ""
+echo "median RSS A: ${RA} kb"
+echo "median RSS B: ${RB} kb"
+if [[ "$RA" != "NA" && "$RB" != "NA" ]]; then
+  awk -v a="$RA" -v b="$RB" 'BEGIN{
+    if (a+0 == 0) { print "RSS delta:  n/a (A baseline is 0)"; exit }
+    printf "RSS delta:  %+.2f%% (B vs A)\n", (b-a)/a*100
+  }'
+fi

--- a/bench/config.env.example
+++ b/bench/config.env.example
@@ -1,0 +1,19 @@
+# Copy to bench/config.env (git-ignored) and edit for your host.
+
+# Binaries under test. The "baseline" is whatever fg-main head is built to;
+# "candidate" is the PR branch under test.
+BWA_MEM2_BASELINE="/path/to/fg-main/bwa-mem2"
+BWA_MEM2_CANDIDATE="/path/to/candidate/bwa-mem2"
+
+# Index + reads.
+BENCH_INDEX="/path/to/hg38/Homo_sapiens_assembly38.fasta"
+BENCH_R1="/path/to/smoke/1M/r1.fq.gz"
+BENCH_R2="/path/to/smoke/1M/r2.fq.gz"
+
+# Trials per tag (perf wall-clock); golden is always 1 extra single-thread trial.
+BENCH_THREADS=8
+BENCH_TRIALS=3
+
+# Output.
+BENCH_OUTDIR="/tmp/bwa-mem2-bench"
+BENCH_RESULTS="bench/results.csv"

--- a/bench/normalize_sam.sh
+++ b/bench/normalize_sam.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Normalize a SAM stream for golden md5 comparison across builds.
+# Strips @PG (contains version/cmdline) and md5sums the rest.
+# Usage: bwa-mem2 mem ... | bench/normalize_sam.sh
+set -euo pipefail
+if command -v md5sum >/dev/null 2>&1; then
+  grep -v '^@PG' | md5sum | awk '{print $1}'
+else
+  # macOS: BSD `md5 -q` emits just the hash.
+  grep -v '^@PG' | md5 -q
+fi

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Run bwa-mem2 mem on a fixed harness input and append measurements to results.csv.
+# Usage: bench/run.sh <tag>
+#   <tag>  a label for this run (e.g. "baseline", "pr-15", "main-after-lto").
+#
+# Reads bench/config.env. Runs:
+#   - 1 single-thread trial (for golden md5)
+#   - BENCH_TRIALS multi-thread trials (for wall-clock + RSS)
+#
+# Each trial appends one CSV row to BENCH_RESULTS.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <tag>" >&2
+  exit 2
+fi
+
+TAG="$1"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# Load config.
+CONFIG="$HERE/config.env"
+if [[ ! -f "$CONFIG" ]]; then
+  echo "error: $CONFIG not found. copy from config.env.example and edit." >&2
+  exit 2
+fi
+# shellcheck disable=SC1090
+. "$CONFIG"
+
+# Resolve binary by tag using an explicit allow-list. Unknown tags fail
+# fast (rather than silently picking the candidate path) so a typo like
+# "baseliine" can't quietly run with the wrong binary.
+case "$TAG" in
+  baseline)                  BIN="$BWA_MEM2_BASELINE" ;;
+  candidate|pr-*|perf-*|main-*) BIN="$BWA_MEM2_CANDIDATE" ;;
+  *) echo "error: unknown TAG '$TAG' — expected 'baseline', 'candidate', 'pr-*', 'perf-*', or 'main-*'." >&2
+     exit 2 ;;
+esac
+echo "TAG=$TAG -> BIN=$BIN" >&2
+
+# BENCH_INDEX is a bwa-mem2 index *prefix* (the loader probes for
+# <prefix>.0123, <prefix>.bwt.2bit.64, etc.), so the bare prefix may not
+# itself exist as a file. Probe the .0123 sidecar — it's the only one
+# bwa-mem2 mem unconditionally requires — but report the prefix name so
+# the user sees the variable they configured.
+[[ -e "$BIN"               ]] || { echo "error: missing path: $BIN"          >&2; exit 2; }
+[[ -e "${BENCH_INDEX}.0123" ]] || { echo "error: missing path: $BENCH_INDEX (.0123 sidecar not found)" >&2; exit 2; }
+[[ -e "$BENCH_R1"          ]] || { echo "error: missing path: $BENCH_R1"     >&2; exit 2; }
+[[ -e "$BENCH_R2"          ]] || { echo "error: missing path: $BENCH_R2"     >&2; exit 2; }
+
+mkdir -p "$BENCH_OUTDIR"
+
+HOST="$(hostname -s)"
+ARCH="$(uname -m)"
+OS="$(uname -s)"
+
+# Pick md5 tool per OS (macOS ships `md5`, Linux ships `md5sum`).
+if command -v md5sum >/dev/null 2>&1; then
+  md5_hash() { md5sum "$1" | awk '{print $1}'; }
+  md5_stream() { md5sum | awk '{print $1}'; }
+else
+  md5_hash() { md5 -q "$1"; }
+  md5_stream() { md5 -q; }
+fi
+
+# Pick /usr/bin/time invocation per OS. Both emit max RSS; units differ.
+if [[ "$OS" == "Darwin" ]]; then
+  TIME_CMD=(/usr/bin/time -l)
+  # macOS time -l:
+  #   "        1.01 real         0.00 user         0.00 sys"
+  #   "             5767168  maximum resident set size"
+  # RSS is in bytes; divide by 1024 → kB.
+  WALL_AWK='$2=="real" && $4=="user" && $6=="sys" {print $1; exit}'
+  RSS_AWK='/maximum resident set size/ {print $1; exit}'
+  RSS_SCALE=1024
+else
+  TIME_CMD=(/usr/bin/time -v)
+  # GNU time -v:
+  #   "        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:23.45"
+  #   "        Maximum resident set size (kbytes): 4567890"
+  WALL_AWK='/Elapsed \(wall clock\) time/ {print $NF; exit}'
+  RSS_AWK='/Maximum resident set size/ {print $NF; exit}'
+  RSS_SCALE=1
+fi
+
+# Ensure results header exists.
+RESULTS="$BENCH_RESULTS"
+if [[ ! -f "$RESULTS" ]]; then
+  mkdir -p "$(dirname "$RESULTS")"
+  echo "tag,host,arch,binary,threads,trial,wall_s,max_rss_kb,md5" > "$RESULTS"
+fi
+
+BIN_FP="$(md5_hash "$BIN" | cut -c1-12)"
+
+run_trial() {
+  local trial="$1" threads="$2"
+  local time_file="$BENCH_OUTDIR/time.$TAG.$trial.$$"
+  # Only the golden trial consumes the SAM (md5 below). Perf trials
+  # ("perf$i") would otherwise pay full SAM-write I/O — for the smoke1M
+  # PE150 input that's hundreds of MB per trial, folding filesystem-write
+  # latency (and page-cache state across runs) into wall_s and masking
+  # exactly the CPU-side wins this harness is designed to measure.
+  # Redirect non-golden trials to /dev/null while keeping the SAM-build
+  # code path live.
+  local sam_file
+  if [[ "$trial" == "golden" ]]; then
+    sam_file="$BENCH_OUTDIR/sam.$TAG.$trial.$$.sam"
+  else
+    sam_file="/dev/null"
+  fi
+  local md5=""
+
+  # Drop the time_file (and the golden SAM, if created) if the trial aborts
+  # before reaching the explicit cleanup below. RETURN fires for normal
+  # returns, errors under `set -e`, and signals. The trap body is a string
+  # eval'd by the shell on RETURN, so paths are escaped via printf %q
+  # (which produces a shell-safe quoting of arbitrary bytes) rather than
+  # wrapped in single quotes — single quotes don't survive an embedded
+  # apostrophe in BENCH_OUTDIR.
+  local time_file_q sam_file_q
+  printf -v time_file_q '%q' "$time_file"
+  printf -v sam_file_q '%q' "$sam_file"
+  # shellcheck disable=SC2064
+  if [[ "$sam_file" != "/dev/null" ]]; then
+    trap "rm -f -- $time_file_q $sam_file_q" RETURN
+  else
+    trap "rm -f -- $time_file_q" RETURN
+  fi
+
+  # Run. stdout → SAM (or /dev/null); stderr → time_file (includes bwa-mem2 log + /usr/bin/time output).
+  # shellcheck disable=SC2086
+  "${TIME_CMD[@]}" "$BIN" mem -t "$threads" "$BENCH_INDEX" "$BENCH_R1" "$BENCH_R2" \
+      > "$sam_file" 2> "$time_file"
+
+  # Wall clock.
+  local wall
+  wall="$(awk "$WALL_AWK" "$time_file")"
+  # GNU time may emit h:mm:ss or m:ss — normalize.
+  case "$wall" in
+    *:*:*) wall=$(awk -F: '{print $1*3600+$2*60+$3}' <<<"$wall") ;;
+    *:*)   wall=$(awk -F: '{print $1*60+$2}' <<<"$wall") ;;
+  esac
+  [[ -n "$wall" ]] || wall=NA
+
+  # Max RSS.
+  local rss_raw rss_kb
+  rss_raw="$(awk "$RSS_AWK" "$time_file")"
+  if [[ -n "$rss_raw" ]]; then
+    rss_kb=$(( rss_raw / RSS_SCALE ))
+  else
+    rss_kb=NA
+  fi
+
+  # Golden md5 only on single-thread trial.
+  if [[ "$trial" == "golden" ]]; then
+    md5="$(grep -v '^@PG' "$sam_file" | md5_stream)"
+  fi
+
+  echo "$TAG,$HOST,$ARCH,$BIN_FP,$threads,$trial,$wall,$rss_kb,$md5" | tee -a "$RESULTS"
+
+  if [[ "${BENCH_KEEP_LOGS:-0}" == "1" ]]; then
+    mv "$time_file" "$BENCH_OUTDIR/time.$TAG.$trial.kept" || true
+  else
+    rm -f "$time_file"
+  fi
+  if [[ "$sam_file" != "/dev/null" ]]; then
+    rm -f "$sam_file"
+  fi
+
+  # Bash `trap … RETURN` is global (no functrace / `local -` here), so leaving
+  # it set would clobber any caller's RETURN trap and persist into the next
+  # run_trial invocation. Clear it now that cleanup is done.
+  trap - RETURN
+}
+
+echo "# run.sh tag=$TAG bin=$BIN host=$HOST arch=$ARCH" >&2
+
+# 1 golden, single-thread.
+run_trial golden 1
+
+# BENCH_TRIALS perf trials, multi-thread.
+for i in $(seq 1 "$BENCH_TRIALS"); do
+  run_trial "perf$i" "$BENCH_THREADS"
+done

--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -460,12 +460,10 @@ void FMI_search::getSMEMsOnePosOneThread(uint8_t *enc_qdb,
 // composing the existing primitives (backwardExt, count[], cp_occ) in the
 // same sequence the scalar would.
 //
-// MAX_READ_LEN_FOR_LOCKSTEP caps per-slot buffer sizes so the whole slot
-// lives on the caller's stack. Override via -DMAX_READ_LEN_FOR_LOCKSTEP=N
-// at build time if running with reads longer than the default.
-#ifndef MAX_READ_LEN_FOR_LOCKSTEP
-#define MAX_READ_LEN_FOR_LOCKSTEP 512
-#endif
+// The prev[] and match_buf[] buffers are heap-allocated by the driver
+// (getSMEMsOnePosOneThread_lockstep), sized from the batch's
+// max_readlength. No compile-time cap — long reads (PacBio HiFi, ONT)
+// fit cleanly.
 
 enum LockstepPhase : uint8_t {
     PH_FWD      = 0,  // forward extension inner loop active
@@ -504,9 +502,10 @@ struct FMI_search::BatchSlot {
     int32_t match_count;
     bool    ready;
 
-    // Pointers into per-slot bulk arrays (allocated by the caller).
-    SMEM    *prev;        // capacity = MAX_READ_LEN_FOR_LOCKSTEP
-    SMEM    *match_buf;   // capacity = MAX_READ_LEN_FOR_LOCKSTEP
+    // Pointers into per-slot bulk arrays (allocated by the driver, sized
+    // by max_readlength).
+    SMEM    *prev;
+    SMEM    *match_buf;
 };
 
 void FMI_search::ls_prefetch_cp_occ(const BatchSlot *s)
@@ -557,17 +556,6 @@ void FMI_search::ls_init_slot(BatchSlot *s,
     s->start_pos   = query_pos_array[input_idx];
     s->min_intv    = min_intv_array[input_idx];
     s->readlength  = seq_[s->rid].l_seq;
-    /* Runtime guard rather than assert(): the lockstep prev/match buffers are
-     * fixed-size on the stack (sized by MAX_READ_LEN_FOR_LOCKSTEP), and a read
-     * exceeding that bound would corrupt them silently in NDEBUG builds. */
-    if (s->readlength > MAX_READ_LEN_FOR_LOCKSTEP) {
-        fprintf(stderr,
-                "[FMI_search::ls_init_slot] read rid=%d length=%d exceeds "
-                "MAX_READ_LEN_FOR_LOCKSTEP=%d; recompile with "
-                "-DMAX_READ_LEN_FOR_LOCKSTEP=<n>\n",
-                s->rid, s->readlength, MAX_READ_LEN_FOR_LOCKSTEP);
-        exit(EXIT_FAILURE);
-    }
     s->offset      = query_cum_len_ar[s->rid];
     s->next_x      = s->start_pos + 1;
     s->numPrev     = 0;
@@ -832,20 +820,51 @@ void FMI_search::getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
                                                    int64_t *__numTotalSmem)
 {
     (void)batch_size;
-    (void)max_readlength;
 
     if (numReads == 0) return;
 
     const int32_t N = SMEM_LOCKSTEP_N;
     // LISA trick #4: hybrid SoA layout. `slots[]` holds only the small hot
     // state (~80 B per slot, full array fits in 1-2 cache lines for N=8).
-    // Bulk per-slot buffers (prev/match_buf, ~32 KB each) live separately.
-    BatchSlot slots[SMEM_LOCKSTEP_N];
-    SMEM prev_bufs [SMEM_LOCKSTEP_N][MAX_READ_LEN_FOR_LOCKSTEP];
-    SMEM match_bufs[SMEM_LOCKSTEP_N][MAX_READ_LEN_FOR_LOCKSTEP];
+    // Bulk per-slot buffers (prev/match_buf) live separately and are reused
+    // across calls via thread_local caches sized from the batch's
+    // max_readlength so reads of any length fit (see issue #44 / PR #55).
+    //
+    // The outer driver getSMEMsAllPosOneThread runs this in a do/while
+    // loop, so allocating per-call (~2*N*max_readlength*sizeof(SMEM) ≈
+    // 384 KB at N=8, max_readlength=1500) imposed measurable allocator
+    // pressure. Cache per-thread (so OMP workers don't share) and grow
+    // monotonically — max_readlength is bounded by the driver batch and
+    // increases rarely in practice.
+    //
+    // TODO(memory): the cache only grows. For mixed-length workloads (e.g.
+    // a single ONT-class read with max_readlength≈1e6 mid-stream — sized
+    // to ~640 MB per thread, ~10 GB across 16 OMP workers — followed by
+    // short reads), the high-water mark is held until thread/process exit.
+    // Acceptable for the smoke1M Illumina PE150 benchmark (max_readlength≈
+    // 150 → ~38 KB/thread). Revisit if a streaming aligner or long-running
+    // service pipeline appears: gate the realloc on a configured upper
+    // bound (e.g. MAX_SMEM_PER_SLOT) or shrink when cached_per_slot greatly
+    // exceeds the current batch. Also flagged by leak-sanitizer/Valgrind
+    // because the buffers are released only at process exit.
+    BatchSlot slots[SMEM_LOCKSTEP_N] = {};
+    static thread_local SMEM   *cached_prev  = NULL;
+    static thread_local SMEM   *cached_match = NULL;
+    static thread_local size_t  cached_per_slot = 0;
+    const size_t per_slot_smems = (size_t)max_readlength;
+    if (per_slot_smems > cached_per_slot) {
+        if (cached_prev  != NULL) _mm_free(cached_prev);
+        if (cached_match != NULL) _mm_free(cached_match);
+        const size_t total_slot_bytes = (size_t)N * per_slot_smems * sizeof(SMEM);
+        cached_prev  = (SMEM *)_mm_malloc(total_slot_bytes, 64);
+        assert_not_null(cached_prev, total_slot_bytes, total_slot_bytes);
+        cached_match = (SMEM *)_mm_malloc(total_slot_bytes, 64);
+        assert_not_null(cached_match, total_slot_bytes, (size_t)2 * total_slot_bytes);
+        cached_per_slot = per_slot_smems;
+    }
     for (int32_t s = 0; s < N; s++) {
-        slots[s].prev      = prev_bufs[s];
-        slots[s].match_buf = match_bufs[s];
+        slots[s].prev      = cached_prev  + (size_t)s * cached_per_slot;
+        slots[s].match_buf = cached_match + (size_t)s * cached_per_slot;
     }
 
     // Seed the first min(N, numReads) slots.
@@ -931,6 +950,9 @@ void FMI_search::getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
     }
 
     *__numTotalSmem = numTotalSmem;
+    /* prev/match buffers are owned by thread_local caches above; intentionally
+     * not freed here so the next call (same thread) reuses them without a
+     * round-trip through the allocator. The caches leak at thread/process exit. */
 }
 
 int64_t FMI_search::bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,

--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -32,28 +32,33 @@ Authors: Sanchit Misra <sanchit.misra@intel.com>; Vasimuddin Md <vasimuddin.md@i
 #include <stdlib.h>
 #include <inttypes.h>
 #include <climits>
+#if defined(__linux__)
+#include <sys/mman.h>
+#endif
 #include "FMI_search.h"
 #include "memcpy_bwamem.h"
 #include "profiling.h"
 #include "libsais_build.h"
 
-// Structured-exit on SMEM-buffer overflow. Called from every matchArray
-// and match_buf write site when a bounds check fails. Prints a clear
-// message and exits so memory corruption never propagates.
-static void smem_overflow_die(const char *where, int64_t cap,
-                              int64_t needed, int32_t read_len)
-{
-    fprintf(stderr,
-        "FATAL: SMEM buffer overflow in %s: capacity=%" PRId64
-        ", attempted write at index=%" PRId64 ", read_len=%d. This is a "
-        "bwa-mem2 bug — please file an issue at "
-        "https://github.com/fg-labs/bwa-mem2/issues with the input that "
-        "triggered it.\n",
-        where, cap, needed, read_len);
-    exit(1);
-}
-
 #include "safestringlib.h"
+
+// Request transparent huge pages for large index buffers. The bwa-mem2
+// hg38 index is ~17 GB split across cp_occ (~6 GB), sa_ms_byte (~2 GB),
+// sa_ls_word (~8 GB). With 4 KB pages the dTLB can cover ~256 KB — a
+// rounding error against 17 GB. Linux THP promotes adjacent 4 KB pages
+// to 2 MB pages (coverage ~128 MB per 64-entry TLB), dramatically
+// reducing TLB pressure in the SMEM Occ-lookup and SA expansion loops.
+// Without this advice, THP promotion is opportunistic and can be demoted
+// under memory pressure → bimodal per-run wall-clock as THP compaction
+// toggles.
+static inline void bwamem_madv_hugepage(void *p, size_t sz)
+{
+#if defined(__linux__) && defined(MADV_HUGEPAGE)
+    if (p != NULL && sz > 0) (void)madvise(p, sz, MADV_HUGEPAGE);
+#else
+    (void)p; (void)sz;
+#endif
+}
 
 FMI_search::FMI_search(const char *fname)
 {
@@ -135,6 +140,11 @@ int FMI_search::build_index() {
 
 void FMI_search::load_index()
 {
+    // Running total of index bytes allocated so far in this function.
+    // Passed to assert_not_null so a failed allocation reports both the
+    // attempted size and how much we'd already committed before failing.
+    int64_t index_alloc = 0;
+
     one_hot_mask_array = (uint64_t *)_mm_malloc(64 * sizeof(uint64_t), 64);
     one_hot_mask_array[0] = 0;
     uint64_t base = 0x8000000000000000L;
@@ -175,10 +185,11 @@ void FMI_search::load_index()
     cp_occ = NULL;
 
     err_fread_noeof(&count[0], sizeof(int64_t), 5, cpstream);
-    if ((cp_occ = (CP_OCC *)_mm_malloc(cp_occ_size * sizeof(CP_OCC), 64)) == NULL) {
-        fprintf(stderr, "ERROR! unable to allocated cp_occ memory\n");
-        exit(EXIT_FAILURE);
-    }
+    int64_t cp_occ_bytes = cp_occ_size * sizeof(CP_OCC);
+    cp_occ = (CP_OCC *)_mm_malloc(cp_occ_bytes, 64);
+    index_alloc += cp_occ_bytes;
+    assert_not_null(cp_occ, cp_occ_bytes, index_alloc);
+    bwamem_madv_hugepage(cp_occ, cp_occ_bytes);
 
     err_fread_noeof(cp_occ, sizeof(CP_OCC), cp_occ_size, cpstream);
     int64_t ii = 0;
@@ -190,15 +201,31 @@ void FMI_search::load_index()
     #if SA_COMPRESSION
 
     int64_t reference_seq_len_ = (reference_seq_len >> SA_COMPX) + 1;
-    sa_ms_byte = (int8_t *)_mm_malloc(reference_seq_len_ * sizeof(int8_t), 64);
-    sa_ls_word = (uint32_t *)_mm_malloc(reference_seq_len_ * sizeof(uint32_t), 64);
+    int64_t sa_ms_bytes = reference_seq_len_ * sizeof(int8_t);
+    int64_t sa_ls_bytes = reference_seq_len_ * sizeof(uint32_t);
+    sa_ms_byte = (int8_t *)_mm_malloc(sa_ms_bytes, 64);
+    index_alloc += sa_ms_bytes;
+    assert_not_null(sa_ms_byte, sa_ms_bytes, index_alloc);
+    sa_ls_word = (uint32_t *)_mm_malloc(sa_ls_bytes, 64);
+    index_alloc += sa_ls_bytes;
+    assert_not_null(sa_ls_word, sa_ls_bytes, index_alloc);
+    bwamem_madv_hugepage(sa_ms_byte, sa_ms_bytes);
+    bwamem_madv_hugepage(sa_ls_word, sa_ls_bytes);
     err_fread_noeof(sa_ms_byte, sizeof(int8_t), reference_seq_len_, cpstream);
     err_fread_noeof(sa_ls_word, sizeof(uint32_t), reference_seq_len_, cpstream);
-    
+
     #else
-    
-    sa_ms_byte = (int8_t *)_mm_malloc(reference_seq_len * sizeof(int8_t), 64);
-    sa_ls_word = (uint32_t *)_mm_malloc(reference_seq_len * sizeof(uint32_t), 64);
+
+    int64_t sa_ms_bytes = reference_seq_len * sizeof(int8_t);
+    int64_t sa_ls_bytes = reference_seq_len * sizeof(uint32_t);
+    sa_ms_byte = (int8_t *)_mm_malloc(sa_ms_bytes, 64);
+    index_alloc += sa_ms_bytes;
+    assert_not_null(sa_ms_byte, sa_ms_bytes, index_alloc);
+    sa_ls_word = (uint32_t *)_mm_malloc(sa_ls_bytes, 64);
+    index_alloc += sa_ls_bytes;
+    assert_not_null(sa_ls_word, sa_ls_bytes, index_alloc);
+    bwamem_madv_hugepage(sa_ms_byte, sa_ms_bytes);
+    bwamem_madv_hugepage(sa_ls_word, sa_ls_bytes);
     err_fread_noeof(sa_ms_byte, sizeof(int8_t), reference_seq_len, cpstream);
     err_fread_noeof(sa_ls_word, sizeof(uint32_t), reference_seq_len, cpstream);
 
@@ -256,16 +283,14 @@ void FMI_search::getSMEMsOnePosOneThread(uint8_t *enc_qdb,
                                          int32_t max_readlength,
                                          int32_t minSeedLen,
                                          SMEM *matchArray,
-                                         int64_t max_smem,
                                          int64_t *__numTotalSmem)
 {
     int64_t numTotalSmem = *__numTotalSmem;
-    // Heap-allocate prevArray instead of using a stack VLA. max_readlength
-    // is now driven by batch content (no compile-time cap), so on long-read
-    // workloads a stack array would risk exhaustion. Sized identically to
-    // the lockstep path's per-slot buffer (max_readlength SMEMs).
-    SMEM *prevArray = (SMEM *)_mm_malloc((size_t)max_readlength * sizeof(SMEM), 64);
-    assert(prevArray != NULL);
+    // Heap-allocate to avoid stack overflow on long reads (PacBio HiFi /
+    // ONT 1 Mbp+); mirrors the lockstep path's max_readlength sizing.
+    int64_t prevArray_bytes = (int64_t)max_readlength * sizeof(SMEM);
+    SMEM *prevArray = (SMEM *)_mm_malloc((size_t)prevArray_bytes, 64);
+    assert_not_null(prevArray, prevArray_bytes, prevArray_bytes);
 
     uint32_t i;
     // Perform SMEM for original reads
@@ -372,10 +397,6 @@ void FMI_search::getSMEMsOnePosOneThread(uint8_t *enc_qdb,
                     {
                         cur_j = j;
 
-                        if (numTotalSmem >= max_smem)
-                            smem_overflow_die("getSMEMsOnePosOneThread",
-                                              max_smem, numTotalSmem,
-                                              readlength);
                         matchArray[numTotalSmem++] = smem;
                         break;
                     }
@@ -421,9 +442,6 @@ void FMI_search::getSMEMsOnePosOneThread(uint8_t *enc_qdb,
                 if(((smem.n - smem.m + 1) >= minSeedLen))
                 {
 
-                    if (numTotalSmem >= max_smem)
-                        smem_overflow_die("getSMEMsOnePosOneThread",
-                                          max_smem, numTotalSmem, readlength);
                     matchArray[numTotalSmem++] = smem;
                 }
                 numPrev = 0;
@@ -442,9 +460,12 @@ void FMI_search::getSMEMsOnePosOneThread(uint8_t *enc_qdb,
 // composing the existing primitives (backwardExt, count[], cp_occ) in the
 // same sequence the scalar would.
 //
-// The prev[] and match_buf[] buffers are heap-owned by the caller (mmc in
-// mem_collect_smem), sized from the batch's max_readlength, and handed to
-// each slot as stride-offset pointers at driver entry. No compile-time cap.
+// MAX_READ_LEN_FOR_LOCKSTEP caps per-slot buffer sizes so the whole slot
+// lives on the caller's stack. Override via -DMAX_READ_LEN_FOR_LOCKSTEP=N
+// at build time if running with reads longer than the default.
+#ifndef MAX_READ_LEN_FOR_LOCKSTEP
+#define MAX_READ_LEN_FOR_LOCKSTEP 512
+#endif
 
 enum LockstepPhase : uint8_t {
     PH_FWD      = 0,  // forward extension inner loop active
@@ -453,6 +474,13 @@ enum LockstepPhase : uint8_t {
     PH_DONE     = 3   // slot finished; match_buf ready for flush
 };
 
+// LISA trick #4: hybrid SoA. The per-slot "hot" state stays compact
+// (~80 bytes) so cross-slot access (e.g. T1 prefetch lookahead against
+// slots[(s+N/2)%N]) hits a tight L1-resident array instead of jumping
+// 32KB strides across embedded buffers. The bulk arrays (prev[],
+// match_buf[]; ~32 KB each) live in separate per-slot allocations,
+// referenced by pointer. Accessor syntax (s->prev[i], s->match_buf[i])
+// is unchanged from the embedded-array version.
 struct FMI_search::BatchSlot {
     // Input identity — copied at init, never mutated thereafter.
     int32_t input_idx;           // index into the caller's input arrays
@@ -471,17 +499,14 @@ struct FMI_search::BatchSlot {
     int32_t cur_j;               // backward phase bookkeeping (scalar's cur_j)
     LockstepPhase phase;
 
-    // Backward-search state. numCurr/curr_s are loop-local in
-    // ls_advance_backward_step — they don't live across outer-j steps,
-    // so they don't appear here.
+    // Per-slot bulk-buffer state.
     int32_t numPrev;
-    SMEM   *prev;                // borrowed; caller-owned heap buffer, buf_cap SMEMs
-    int32_t buf_cap;
-
-    // Per-slot match buffer + reorder-buffer ready flag for in-order flush.
-    SMEM   *match_buf;           // borrowed; caller-owned, buf_cap SMEMs
     int32_t match_count;
     bool    ready;
+
+    // Pointers into per-slot bulk arrays (allocated by the caller).
+    SMEM    *prev;        // capacity = MAX_READ_LEN_FOR_LOCKSTEP
+    SMEM    *match_buf;   // capacity = MAX_READ_LEN_FOR_LOCKSTEP
 };
 
 void FMI_search::ls_prefetch_cp_occ(const BatchSlot *s)
@@ -496,13 +521,28 @@ void FMI_search::ls_prefetch_cp_occ(const BatchSlot *s)
 #endif
 }
 
+/* T1 (L2) variant — used for cross-slot N/2-step lookahead. The T0 prefetch
+ * above lands at "this slot's next step" granularity; T1 here lands at
+ * "this slot's step ~N/2 from now". For N=8 that's 4 stepping-passes ahead,
+ * giving DRAM-latency-class lookahead when the cp_occ working set spills
+ * out of L2/L3. */
+void FMI_search::ls_prefetch_cp_occ_t1(const BatchSlot *s)
+{
+#ifdef ENABLE_PREFETCH
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.k) >> CP_SHIFT]), _MM_HINT_T1);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.l) >> CP_SHIFT]), _MM_HINT_T1);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.k + s->smem.s) >> CP_SHIFT]), _MM_HINT_T1);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.l + s->smem.s) >> CP_SHIFT]), _MM_HINT_T1);
+#else
+    (void)s;
+#endif
+}
+
 // Populate a slot from the caller's input arrays at the given input_idx.
 // After this call either:
 //   phase == PH_FWD  — slot is ready to step the forward-extension inner loop
 //   phase == PH_DONE — the first base is non-ACGT; scalar skips this read, so
 //                      we match that (zero matches emitted, ready to flush).
-// prev_buf/match_buf_buf are borrowed stride views into a caller-owned
-// per-thread heap allocation (buf_cap SMEMs each).
 void FMI_search::ls_init_slot(BatchSlot *s,
                               int32_t input_idx,
                               const int16_t *query_pos_array,
@@ -510,22 +550,27 @@ void FMI_search::ls_init_slot(BatchSlot *s,
                               const int32_t *rid_array,
                               const bseq1_t *seq_,
                               const int32_t *query_cum_len_ar,
-                              const uint8_t *enc_qdb,
-                              SMEM *prev_buf,
-                              SMEM *match_buf_buf,
-                              int32_t buf_cap)
+                              const uint8_t *enc_qdb)
 {
     s->input_idx   = input_idx;
     s->rid         = rid_array[input_idx];
     s->start_pos   = query_pos_array[input_idx];
     s->min_intv    = min_intv_array[input_idx];
     s->readlength  = seq_[s->rid].l_seq;
+    /* Runtime guard rather than assert(): the lockstep prev/match buffers are
+     * fixed-size on the stack (sized by MAX_READ_LEN_FOR_LOCKSTEP), and a read
+     * exceeding that bound would corrupt them silently in NDEBUG builds. */
+    if (s->readlength > MAX_READ_LEN_FOR_LOCKSTEP) {
+        fprintf(stderr,
+                "[FMI_search::ls_init_slot] read rid=%d length=%d exceeds "
+                "MAX_READ_LEN_FOR_LOCKSTEP=%d; recompile with "
+                "-DMAX_READ_LEN_FOR_LOCKSTEP=<n>\n",
+                s->rid, s->readlength, MAX_READ_LEN_FOR_LOCKSTEP);
+        exit(EXIT_FAILURE);
+    }
     s->offset      = query_cum_len_ar[s->rid];
     s->next_x      = s->start_pos + 1;
     s->numPrev     = 0;
-    s->prev        = prev_buf;
-    s->match_buf   = match_buf_buf;
-    s->buf_cap     = buf_cap;
     s->match_count = 0;
     s->ready       = false;
 
@@ -657,10 +702,6 @@ void FMI_search::ls_advance_backward_step(BatchSlot *s,
             newSmem.m = s->j;
             if ((newSmem.s < s->min_intv) && ((smem.n - smem.m + 1) >= minSeedLen)) {
                 s->cur_j = s->j;
-                if (s->match_count >= s->buf_cap)
-                    smem_overflow_die("ls_advance_backward_step/match_buf",
-                                      s->buf_cap, s->match_count,
-                                      s->readlength);
                 s->match_buf[s->match_count++] = smem;
                 break;
             }
@@ -699,9 +740,6 @@ DONE:
     if (s->numPrev != 0) {
         SMEM smem = s->prev[0];
         if ((smem.n - smem.m + 1) >= minSeedLen) {
-            if (s->match_count >= s->buf_cap)
-                smem_overflow_die("ls_advance_backward_step/match_buf(final)",
-                                  s->buf_cap, s->match_count, s->readlength);
             s->match_buf[s->match_count++] = smem;
         }
         s->numPrev = 0;
@@ -709,7 +747,7 @@ DONE:
     s->phase = PH_DONE;
     s->ready = true;
 }
-// ===== End lockstep scaffolding =====
+// ===== End lockstep SMEM batching =====
 
 void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                          int32_t *min_intv_array,
@@ -721,9 +759,6 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                          int32_t max_readlength,
                                          int32_t minSeedLen,
                                          SMEM *matchArray,
-                                         int64_t max_smem,
-                                         SMEM *lockstep_prev_base,
-                                         SMEM *lockstep_match_buf_base,
                                          int64_t *__numTotalSmem)
 {
     int16_t *query_pos_array = (int16_t *)_mm_malloc(numReads * sizeof(int16_t), 64);
@@ -762,13 +797,8 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                          max_readlength,
                                          minSeedLen,
                                          matchArray,
-                                         max_smem,
-                                         lockstep_prev_base,
-                                         lockstep_match_buf_base,
                                          __numTotalSmem);
 #else
-        (void)lockstep_prev_base;
-        (void)lockstep_match_buf_base;
         getSMEMsOnePosOneThread(enc_qdb,
                                 query_pos_array,
                                 min_intv_array,
@@ -780,7 +810,6 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                 max_readlength,
                                 minSeedLen,
                                 matchArray,
-                                max_smem,
                                 __numTotalSmem);
 #endif
         numActive = tail;
@@ -800,36 +829,30 @@ void FMI_search::getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
                                                    int32_t max_readlength,
                                                    int32_t minSeedLen,
                                                    SMEM *matchArray,
-                                                   int64_t max_smem,
-                                                   SMEM *lockstep_prev_base,
-                                                   SMEM *lockstep_match_buf_base,
                                                    int64_t *__numTotalSmem)
 {
     (void)batch_size;
+    (void)max_readlength;
 
     if (numReads == 0) return;
 
     const int32_t N = SMEM_LOCKSTEP_N;
-    // Per-slot prev[] and match_buf[] are borrowed stride views into a
-    // caller-owned per-thread heap allocation, sized `max_readlength` SMEMs
-    // each. BatchSlot itself (a handful of ints + pointers) lives on the
-    // stack — small and bounded, no compile-time read-length cap.
+    // LISA trick #4: hybrid SoA layout. `slots[]` holds only the small hot
+    // state (~80 B per slot, full array fits in 1-2 cache lines for N=8).
+    // Bulk per-slot buffers (prev/match_buf, ~32 KB each) live separately.
     BatchSlot slots[SMEM_LOCKSTEP_N];
-    const int32_t slot_cap = max_readlength;
-
-    auto slot_prev      = [&](int32_t s) -> SMEM * {
-        return lockstep_prev_base      + (int64_t)s * slot_cap;
-    };
-    auto slot_match_buf = [&](int32_t s) -> SMEM * {
-        return lockstep_match_buf_base + (int64_t)s * slot_cap;
-    };
+    SMEM prev_bufs [SMEM_LOCKSTEP_N][MAX_READ_LEN_FOR_LOCKSTEP];
+    SMEM match_bufs[SMEM_LOCKSTEP_N][MAX_READ_LEN_FOR_LOCKSTEP];
+    for (int32_t s = 0; s < N; s++) {
+        slots[s].prev      = prev_bufs[s];
+        slots[s].match_buf = match_bufs[s];
+    }
 
     // Seed the first min(N, numReads) slots.
     int32_t initial = (numReads < N) ? numReads : N;
     for (int32_t s = 0; s < initial; s++) {
         ls_init_slot(&slots[s], s, query_pos_array, min_intv_array,
-                     rid_array, seq_, query_cum_len_ar, enc_qdb,
-                     slot_prev(s), slot_match_buf(s), slot_cap);
+                     rid_array, seq_, query_cum_len_ar, enc_qdb);
         if (slots[s].phase == PH_FWD) ls_prefetch_cp_occ(&slots[s]);
     }
     // Any unused slots (numReads < N) are marked DONE with invalid input_idx
@@ -866,6 +889,15 @@ void FMI_search::getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
                 case PH_DONE:
                     break;
             }
+            // LISA trick #5: cross-slot T1 (L2) prefetch with N/2-step lookahead.
+            // The same-slot T0 prefetch issued inside ls_advance_*_step covers
+            // the next single-step access; this T1 prefetch on slot[s+N/2] keeps
+            // a copy in L2 for that slot's access ~N/2 stepping-passes from now,
+            // hiding DRAM-class latency when cp_occ entries spill out of L3.
+            const int32_t s_la = (s + (N / 2)) % N;
+            if (slots[s_la].phase == PH_FWD || slots[s_la].phase == PH_BWD) {
+                ls_prefetch_cp_occ_t1(&slots[s_la]);
+            }
         }
 
         // --- Flush pass: in-order emit + slot recycle. ---
@@ -877,10 +909,6 @@ void FMI_search::getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
                     slots[s].ready &&
                     slots[s].input_idx == flush_cursor) {
                     for (int32_t m = 0; m < slots[s].match_count; m++) {
-                        if (numTotalSmem >= max_smem)
-                            smem_overflow_die("getSMEMsOnePosOneThread_lockstep",
-                                              max_smem, numTotalSmem,
-                                              slots[s].readlength);
                         matchArray[numTotalSmem++] = slots[s].match_buf[m];
                     }
                     query_pos_array[slots[s].input_idx] = slots[s].next_x;
@@ -889,8 +917,7 @@ void FMI_search::getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
                     if (next_input < numReads) {
                         ls_init_slot(&slots[s], next_input,
                                      query_pos_array, min_intv_array,
-                                     rid_array, seq_, query_cum_len_ar, enc_qdb,
-                                     slot_prev(s), slot_match_buf(s), slot_cap);
+                                     rid_array, seq_, query_cum_len_ar, enc_qdb);
                         if (slots[s].phase == PH_FWD) ls_prefetch_cp_occ(&slots[s]);
                         next_input++;
                     } else {
@@ -912,8 +939,7 @@ int64_t FMI_search::bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,
                                                    const bseq1_t *seq_,
                                                    int32_t *query_cum_len_ar,
                                                    int32_t minSeedLen,
-                                                   SMEM *matchArray,
-                                                   int64_t max_smem)
+                                                   SMEM *matchArray)
 {
     int32_t i;
 
@@ -976,10 +1002,6 @@ int64_t FMI_search::bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,
 
                             if(smem.s > 0)
                             {
-                                if (numTotalSeed >= max_smem)
-                                    smem_overflow_die("bwtSeedStrategyAllPosOneThread",
-                                                      max_smem, numTotalSeed,
-                                                      readlength);
                                 matchArray[numTotalSeed++] = smem;
                             }
                             break;
@@ -1009,8 +1031,11 @@ void FMI_search::getSMEMs(uint8_t *enc_qdb,
         SMEM *matchArray,
         int64_t *numTotalSmem)
 {
-    SMEM *prevArray = (SMEM *)_mm_malloc(nthreads * readlength * sizeof(SMEM), 64);
-    SMEM *currArray = (SMEM *)_mm_malloc(nthreads * readlength * sizeof(SMEM), 64);
+    const size_t smem_arr_bytes = (size_t)nthreads * (size_t)readlength * sizeof(SMEM);
+    SMEM *prevArray = (SMEM *)_mm_malloc(smem_arr_bytes, 64);
+    assert_not_null(prevArray, smem_arr_bytes, smem_arr_bytes);
+    SMEM *currArray = (SMEM *)_mm_malloc(smem_arr_bytes, 64);
+    assert_not_null(currArray, smem_arr_bytes, (size_t)2 * smem_arr_bytes);
 
 
 // #pragma omp parallel num_threads(nthreads)
@@ -1253,11 +1278,18 @@ void FMI_search::get_sa_entries(int64_t *posArray, int64_t *coordArray, uint32_t
 // #pragma omp parallel for num_threads(nthreads)
     for(i = 0; i < count; i++)
     {
+        /* Prefetch the SAL slot SAL_PFD iterations ahead. Both
+         * sa_ms_byte and sa_ls_word are large random-access arrays
+         * (separate cache lines), so issue two prefetches per slot. */
+        if (i + SAL_PFD < count) {
+            int64_t pf_pos = posArray[i + SAL_PFD];
+            _mm_prefetch((const char *)(sa_ms_byte + pf_pos), _MM_HINT_T0);
+            _mm_prefetch((const char *)(sa_ls_word + pf_pos), _MM_HINT_T0);
+        }
         int64_t pos = posArray[i];
         int64_t sa_entry = sa_ms_byte[pos];
         sa_entry = sa_entry << 32;
         sa_entry = sa_entry + sa_ls_word[pos];
-        //_mm_prefetch((const char *)(sa_ms_byte + pos + SAL_PFD), _MM_HINT_T0);
         coordArray[i] = sa_entry;
     }
 }
@@ -1276,10 +1308,16 @@ void FMI_search::get_sa_entries(SMEM *smemArray, int64_t *coordArray, int32_t *c
         for(j = smem.k; (j < hi) && (c < max_occ); j+=step, c++)
         {
             int64_t pos = j;
+            /* Prefetch SAL_PFD iterations ahead. Both arrays sit on
+             * separate cache lines, so issue both prefetches per slot. */
+            int64_t pf_pos = pos + SAL_PFD * step;
+            if (pf_pos < hi) {
+                _mm_prefetch((const char *)(sa_ms_byte + pf_pos), _MM_HINT_T0);
+                _mm_prefetch((const char *)(sa_ls_word + pf_pos), _MM_HINT_T0);
+            }
             int64_t sa_entry = sa_ms_byte[pos];
             sa_entry = sa_entry << 32;
             sa_entry = sa_entry + sa_ls_word[pos];
-            //_mm_prefetch((const char *)(sa_ms_byte + pos + SAL_PFD * step), _MM_HINT_T0);
             coordArray[totalCoordCount + c] = sa_entry;
         }
         coordCountArray[i] = c;

--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -32,33 +32,13 @@ Authors: Sanchit Misra <sanchit.misra@intel.com>; Vasimuddin Md <vasimuddin.md@i
 #include <stdlib.h>
 #include <inttypes.h>
 #include <climits>
-#if defined(__linux__)
-#include <sys/mman.h>
-#endif
+#include "bwa_madvise.h"
 #include "FMI_search.h"
 #include "memcpy_bwamem.h"
 #include "profiling.h"
 #include "libsais_build.h"
 
 #include "safestringlib.h"
-
-// Request transparent huge pages for large index buffers. The bwa-mem2
-// hg38 index is ~17 GB split across cp_occ (~6 GB), sa_ms_byte (~2 GB),
-// sa_ls_word (~8 GB). With 4 KB pages the dTLB can cover ~256 KB — a
-// rounding error against 17 GB. Linux THP promotes adjacent 4 KB pages
-// to 2 MB pages (coverage ~128 MB per 64-entry TLB), dramatically
-// reducing TLB pressure in the SMEM Occ-lookup and SA expansion loops.
-// Without this advice, THP promotion is opportunistic and can be demoted
-// under memory pressure → bimodal per-run wall-clock as THP compaction
-// toggles.
-static inline void bwamem_madv_hugepage(void *p, size_t sz)
-{
-#if defined(__linux__) && defined(MADV_HUGEPAGE)
-    if (p != NULL && sz > 0) (void)madvise(p, sz, MADV_HUGEPAGE);
-#else
-    (void)p; (void)sz;
-#endif
-}
 
 FMI_search::FMI_search(const char *fname)
 {
@@ -1065,7 +1045,7 @@ void FMI_search::getSMEMs(uint8_t *enc_qdb,
         int tid = 0; //omp_get_thread_num();   // removed omp
         numTotalSmem[tid] = 0;
         SMEM *myPrevArray = prevArray + tid * readlength;
-        SMEM *myCurrArray = prevArray + tid * readlength;
+        SMEM *myCurrArray = currArray + tid * readlength;
 
         int32_t perThreadQuota = (numReads + (nthreads - 1)) / nthreads;
         int32_t first = tid * perThreadQuota;

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -91,7 +91,7 @@ typedef struct smem_struct
 #define SAL_PFD 16
 
 #ifndef SMEM_LOCKSTEP_N
-#define SMEM_LOCKSTEP_N 4
+#define SMEM_LOCKSTEP_N 8
 #endif
 
 class FMI_search: public indexEle
@@ -104,6 +104,21 @@ class FMI_search: public indexEle
     int build_index();
     void load_index();
 
+    /* matchArray sizing contract (applies to all four SMEM-emitting methods
+     * below). The previous internal `max_smem` capacity guard was removed;
+     * the caller MUST pre-size matchArray to hold at least:
+     *
+     *   - getSMEMsOnePosOneThread, getSMEMsOnePosOneThread_lockstep,
+     *     getSMEMsAllPosOneThread:   numReads * max_readlength SMEMs,
+     *     where max_readlength is the function parameter passed in.
+     *
+     *   - bwtSeedStrategyAllPosOneThread:   numReads * max_seq_length SMEMs,
+     *     where max_seq_length = max_i(seq_[i].l_seq), computed by the
+     *     caller (this method takes no max_readlength parameter).
+     *
+     * Writing past the pre-sized capacity is undefined behavior. The actual
+     * number of SMEMs written is reported via *__numTotalSmem (or the
+     * int64_t return value on bwtSeedStrategyAllPosOneThread). */
     void getSMEMs(uint8_t *enc_qdb,
                   int32_t numReads,
                   int32_t batch_size,
@@ -112,7 +127,8 @@ class FMI_search: public indexEle
                   int32_t numthreads,
                   SMEM *matchArray,
                   int64_t *numTotalSmem);
-    
+
+    /* matchArray must hold at least numReads * max_readlength SMEMs (caller-sized). */
     void getSMEMsOnePosOneThread(uint8_t *enc_qdb,
                                  int16_t *query_pos_array,
                                  int32_t *min_intv_array,
@@ -124,7 +140,6 @@ class FMI_search: public indexEle
                                  int32_t  max_readlength,
                                  int32_t minSeedLen,
                                  SMEM *matchArray,
-                                 int64_t max_smem,
                                  int64_t *__numTotalSmem);
 
     /* Lockstep-batched variant of getSMEMsOnePosOneThread: advances
@@ -133,7 +148,8 @@ class FMI_search: public indexEle
      * engine. Per-read algorithm is byte-identical to the scalar path; only
      * the cross-read interleaving is new. Output in matchArray is written
      * in the same (read, smem) order as the scalar path via per-slot match
-     * buffers flushed by input-index cursor. */
+     * buffers flushed by input-index cursor.
+     * matchArray must hold at least numReads * max_readlength SMEMs (caller-sized). */
     void getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
                                           int16_t *query_pos_array,
                                           int32_t *min_intv_array,
@@ -145,11 +161,9 @@ class FMI_search: public indexEle
                                           int32_t  max_readlength,
                                           int32_t minSeedLen,
                                           SMEM *matchArray,
-                                          int64_t max_smem,
-                                          SMEM *lockstep_prev_base,
-                                          SMEM *lockstep_match_buf_base,
                                           int64_t *__numTotalSmem);
 
+    /* matchArray must hold at least numReads * max_readlength SMEMs (caller-sized). */
     void getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                  int32_t *min_intv_array,
                                  int32_t *rid_array,
@@ -160,20 +174,18 @@ class FMI_search: public indexEle
                                  int32_t max_readlength,
                                  int32_t minSeedLen,
                                  SMEM *matchArray,
-                                 int64_t max_smem,
-                                 SMEM *lockstep_prev_base,
-                                 SMEM *lockstep_match_buf_base,
                                  int64_t *__numTotalSmem);
 
 
+    /* matchArray must hold at least numReads * (longest l_seq in seq_) SMEMs;
+     * returns the actual count written. */
     int64_t bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,
                                            int32_t *max_intv_array,
                                            int32_t numReads,
                                            const bseq1_t *seq_,
                                            int32_t *query_cum_len_ar,
                                            int32_t minSeedLen,
-                                           SMEM *matchArray,
-                                           int64_t max_smem);
+                                           SMEM *matchArray);
         
     void sortSMEMs(SMEM *matchArray,
                    int64_t numTotalSmem[],
@@ -226,11 +238,9 @@ private:
                       const int32_t *rid_array,
                       const bseq1_t *seq_,
                       const int32_t *query_cum_len_ar,
-                      const uint8_t *enc_qdb,
-                      SMEM *prev_buf,
-                      SMEM *match_buf_buf,
-                      int32_t buf_cap);
+                      const uint8_t *enc_qdb);
     void ls_prefetch_cp_occ(const BatchSlot *s);
+    void ls_prefetch_cp_occ_t1(const BatchSlot *s);
     void ls_advance_forward_step(BatchSlot *s, const uint8_t *enc_qdb);
     void ls_prepare_backward(BatchSlot *s);
     void ls_advance_backward_step(BatchSlot *s,

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -45,6 +45,24 @@ extern uint64_t prof[10][112];
 #define DUMMY1 99
 #define DUMMY2 100
 
+// Build the 16-byte LUT used by SBT_PREPASS8_LUT across all 8-bit kernel
+// variants (AVX2, AVX-512BW, SSE2/NEON). Layout:
+//   [0]      = w_match    (s1 == s2, both ACGT)
+//   [1..3]   = w_mismatch (ACGT vs ACGT, XOR ∈ {1,2,3})
+//   [4..15]  = w_ambig    (any cell with target=N or query=N; indices
+//                           4..7 = target N=4, 8..11 = query N=8, 12 =
+//                           both N, 13..15 unreachable but filled for
+//                           safety so out-of-band XORs never read junk)
+static inline void build_pmat16(int8_t out[16],
+                                int8_t w_match, int8_t w_mismatch, int8_t w_ambig)
+{
+    out[0] = w_match;
+    out[1] = w_mismatch;
+    out[2] = w_mismatch;
+    out[3] = w_mismatch;
+    for (int i = 4; i < 16; i++) out[i] = w_ambig;
+}
+
 //-----------------------------------------------------------------------------------
 // constructor
 BandedPairWiseSW::BandedPairWiseSW(const int o_del, const int e_del, const int o_ins,
@@ -74,29 +92,58 @@ BandedPairWiseSW::BandedPairWiseSW(const int o_del, const int e_del, const int o
     sort2Ticks = 0;
     this->F8_ = this->H8_  = this->H8__ = NULL;
     this->F16_ = this->H16_  = this->H16__ = NULL;
-    
-    F8_ = H8_ = H8__ = NULL;
-    F8_ = (int8_t *)_mm_malloc(MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(int8_t), 64);
-    H8_ = (int8_t *)_mm_malloc(MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(int8_t), 64);
-    H8__ = (int8_t *)_mm_malloc(MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(int8_t), 64);
+    this->sbt8_ = NULL;
+    this->sbt16_ = NULL;
+    this->dp_slab_ = NULL;
 
-    F16_ = H16_ = H16__ = NULL;
-    F16_ = (int16_t *)_mm_malloc(MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(int16_t), 64);
-    H16_ = (int16_t *)_mm_malloc(MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(int16_t), 64);
-    H16__ = (int16_t *)_mm_malloc(MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(int16_t), 64);
+    // Fold all per-thread scratch into one 64B-aligned slab:
+    //   3 × sz8  : F8_, H8_, H8__       (8-bit DP rails)
+    //   3 × sz16 : F16_, H16_, H16__    (16-bit DP rails)
+    //   1 × sz8  : sbt8_                (8-bit SBT pre-pass scratch)
+    //   1 × sz16 : sbt16_               (16-bit SBT pre-pass scratch;
+    //                                    multi-MB — moved off the stack)
+    // Each partition is a multiple of 64B (MAX_SEQ_LEN8=128, SIMD_WIDTH8
+    // ≥ 16 → 8-bit partition multiple of 2048; 16-bit similarly), so
+    // neighbouring views stay 64B-aligned without explicit padding. The
+    // static_asserts below trip at compile time if a future MAX_SEQ_LEN*
+    // / SIMD_WIDTH* tweak breaks the 64B partition invariant.
+    static_assert((MAX_SEQ_LEN8  * SIMD_WIDTH8  * sizeof(int8_t))  % 64 == 0,
+                  "8-bit DP partition not a multiple of 64B; tune MAX_SEQ_LEN8 / SIMD_WIDTH8");
+    static_assert((MAX_SEQ_LEN16 * SIMD_WIDTH16 * sizeof(int16_t)) % 64 == 0,
+                  "16-bit DP partition not a multiple of 64B; tune MAX_SEQ_LEN16 / SIMD_WIDTH16");
+    // Defensive: numThreads must be ≥ 1 — _mm_malloc(0, 64) is
+    // implementation-defined, and a 0-byte slab would silently OOM downstream
+    // writes. Clamp instead of asserting so a misconfigured caller still
+    // gets a usable (single-thread) instance.
+    if (numThreads < 1) numThreads = 1;
+    size_t sz8  = (size_t)MAX_SEQ_LEN8  * SIMD_WIDTH8  * numThreads * sizeof(int8_t);
+    size_t sz16 = (size_t)MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(int16_t);
+    size_t total = 4 * sz8 + 4 * sz16;
+    dp_slab_ = _mm_malloc(total, 64);
+    if (UNLIKELY(dp_slab_ == NULL)) {
+        fprintf(stderr, "BSW DP-scratch slab allocation failed (%zu bytes)\n", total);
+        exit(EXIT_FAILURE);
+    }
 
-    if (F8_ == NULL || H8_ == NULL || H8__ == NULL) {
-        printf("BSW8 Memory not alloacted!!!\n"); exit(EXIT_FAILURE);
-    }       
-    if (F16_ == NULL || H16_ == NULL || H16__ == NULL) {
-        printf("BSW16 Memory not alloacted!!!\n"); exit(EXIT_FAILURE);
-    }       
+    char *base = (char *)dp_slab_;
+    F8_   = (int8_t  *)(base + 0       );
+    H8_   = (int8_t  *)(base + sz8     );
+    H8__  = (int8_t  *)(base + 2 * sz8 );
+    sbt8_ = (int8_t  *)(base + 3 * sz8 );
+    F16_  = (int16_t *)(base + 4 * sz8);
+    H16_  = (int16_t *)(base + 4 * sz8 + sz16);
+    H16__ = (int16_t *)(base + 4 * sz8 + 2 * sz16);
+    sbt16_ = (int16_t *)(base + 4 * sz8 + 3 * sz16);
 }
 
-// destructor 
+// destructor
 BandedPairWiseSW::~BandedPairWiseSW() {
-    _mm_free(F8_); _mm_free(H8_); _mm_free(H8__);
-    _mm_free(F16_);_mm_free(H16_); _mm_free(H16__);
+    _mm_free(dp_slab_);
+    F8_ = H8_ = H8__ = NULL;
+    F16_ = H16_ = H16__ = NULL;
+    sbt8_ = NULL;
+    sbt16_ = NULL;
+    dp_slab_ = NULL;
 }
 
 int64_t BandedPairWiseSW::getTicks()
@@ -345,6 +392,61 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
         f21 = _mm256_max_epi16(val256, f21);                            \
     }
 
+// --- PR 17/16: AVX2 LUT primitive ---
+// pmat256 must have the 16-byte LUT broadcast into both 128-bit halves
+// (use _mm256_broadcastsi128_si256). 1 xor + 1 shuffle replaces the
+// legacy 4-op cmpeq+blendv+max+blendv path. The non-LUT variant was
+// removed: it relied on max_epu8 setting bit 7 to detect AMBIG, which
+// no longer holds under the asymmetric AMBIG encoding (target N=4,
+// query N=8) introduced alongside the LUT path.
+#define SBT_PREPASS8_LUT(s1, s2, sbt11_out, pmat256)                    \
+    {                                                                   \
+        __m256i xor_ = _mm256_xor_si256(s1, s2);                        \
+        sbt11_out = _mm256_shuffle_epi8(pmat256, xor_);                 \
+    }
+
+#define MAIN_CODE8_CORE(sbt11, h00, h11, e11, f11, f21, zero256, e_ins256, oe_ins256, e_del256, oe_del256) \
+    {                                                                   \
+        __m256i m11 = _mm256_add_epi8(h00, sbt11);                      \
+        __m256i cmp11 = _mm256_cmpeq_epi8(h00, zero256);                \
+        m11 = _mm256_blendv_epi8(m11, zero256, cmp11);                  \
+        h11 = _mm256_max_epi8(m11, e11);                                \
+        h11 = _mm256_max_epi8(h11, f11);                                \
+        __m256i temp256 = _mm256_sub_epi8(m11, oe_ins256);              \
+        __m256i val256  = _mm256_max_epi8(temp256, zero256);            \
+        e11 = _mm256_sub_epi8(e11, e_ins256);                           \
+        e11 = _mm256_max_epi8(val256, e11);                             \
+        temp256 = _mm256_sub_epi8(m11, oe_del256);                      \
+        val256  = _mm256_max_epi8(temp256, zero256);                    \
+        f21 = _mm256_sub_epi8(f11, e_del256);                           \
+        f21 = _mm256_max_epi8(val256, f21);                             \
+    }
+
+#define SBT_PREPASS16(s1, s2, sbt11_out, mismatch256, match256, w_ambig_256) \
+    {                                                                   \
+        __m256i cmp_ = _mm256_cmpeq_epi16(s1, s2);                      \
+        __m256i sbt_ = _mm256_blendv_epi16(mismatch256, match256, cmp_); \
+        __m256i tmp_ = _mm256_max_epu16(s1, s2);                        \
+        sbt11_out = _mm256_blendv_epi16(sbt_, w_ambig_256, tmp_);       \
+    }
+
+#define MAIN_CODE16_CORE(sbt11, h00, h11, e11, f11, f21, zero256, e_ins256, oe_ins256, e_del256, oe_del256) \
+    {                                                                   \
+        __m256i m11 = _mm256_add_epi16(h00, sbt11);                     \
+        __m256i cmp11 = _mm256_cmpeq_epi16(h00, zero256);               \
+        m11 = _mm256_blendv_epi16(m11, zero256, cmp11);                 \
+        h11 = _mm256_max_epi16(m11, e11);                               \
+        h11 = _mm256_max_epi16(h11, f11);                               \
+        __m256i temp256 = _mm256_sub_epi16(m11, oe_ins256);             \
+        __m256i val256  = _mm256_max_epi16(temp256, zero256);           \
+        e11 = _mm256_sub_epi16(e11, e_ins256);                          \
+        e11 = _mm256_max_epi16(val256, e11);                            \
+        temp256 = _mm256_sub_epi16(m11, oe_del256);                     \
+        val256  = _mm256_max_epi16(temp256, zero256);                   \
+        f21 = _mm256_sub_epi16(f11, e_del256);                          \
+        f21 = _mm256_max_epi16(val256, f21);                            \
+    }
+
 // MACROs section ends
 // ------------------------------------------------------------------------------------
 
@@ -440,18 +542,21 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                                                   uint16_t numThreads,
                                                   int32_t w)
 {
+    // Mirror the constructor's numThreads<1 clamp so a misconfigured caller
+    // gets sized SoA buffers instead of zero-byte allocations.
+    if (numThreads < 1) numThreads = 1;
     int64_t st1, st2, st3, st4, st5;
 #if RDT
     st1 = ___rdtsc();
 #endif
-    
+
     uint8_t *seq1SoA = NULL;
-    seq1SoA = (uint8_t *)_mm_malloc(MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
-    
+    seq1SoA = (uint8_t *)_mm_malloc((size_t)MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
+
     uint8_t *seq2SoA = NULL;
-    seq2SoA = (uint8_t *)_mm_malloc(MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
+    seq2SoA = (uint8_t *)_mm_malloc((size_t)MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
     
-    if (seq1SoA == NULL || seq2SoA == NULL) {
+    if (UNLIKELY(seq1SoA == NULL || seq2SoA == NULL)) {
         fprintf(stderr, "Error! Mem not allocated!!!\n");
         exit(EXIT_FAILURE);
     }
@@ -473,9 +578,9 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 #if SORT_PAIRS     // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
 
     // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc(SORT_BLOCK_SIZE * numThreads *
+    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
                                                sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((MAX_SEQ_LEN8 + 32) * numThreads *
+    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN8 + 32) * numThreads *
                                           sizeof(int16_t), 64);
 
 #pragma omp parallel num_threads(numThreads)
@@ -557,7 +662,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 
                 for(k = 0; k < sp.len1; k++)
                 {
-                    mySeq1SoA[k * SIMD_WIDTH8 + j] = (seq1[k] == AMBIG?0xFF:seq1[k]);
+                    mySeq1SoA[k * SIMD_WIDTH8 + j] = seq1[k] /* PR16: N stays 4 */;
                     H2[k * SIMD_WIDTH8 + j] = 0;
                 }
                 qlen[j] = sp.len2 * max;
@@ -595,7 +700,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 
                 for(k = 0; k < sp.len2; k++)
                 {
-                    mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k]==AMBIG?0xFF:seq2[k]);
+                    mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k]==AMBIG ? 8 : seq2[k]) /* PR16: query N→8 */;
                     H1[k * SIMD_WIDTH8 + j] = 0;                    
                 }
                 if(maxLen2 < sp.len2) maxLen2 = sp.len2;
@@ -731,6 +836,13 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     __m256i w_ambig_256  = _mm256_set1_epi8(this->w_ambig); // ambig penalty
     __m256i five256      = _mm256_set1_epi8(5);
 
+    // PR 16: pmat LUT, broadcast into both 128-bit halves (shuffle_epi8 is
+    // lane-wise on AVX2 — each half shuffles against its own half of pmat256).
+    int8_t pmat_bytes[16] __attribute__((aligned(16)));
+    build_pmat16(pmat_bytes, this->w_match, this->w_mismatch, this->w_ambig);
+    __m128i pmat128 = _mm_load_si128((__m128i *)pmat_bytes);
+    __m256i pmat256 = _mm256_broadcastsi128_si256(pmat128);
+
     __m256i e_del256    = _mm256_set1_epi8(this->e_del);
     __m256i oe_del256   = _mm256_set1_epi8(this->o_del + this->e_del);
     __m256i e_ins256    = _mm256_set1_epi8(this->e_ins);
@@ -741,12 +853,16 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     int8_t  *H_v = H8__ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
 
     int lane;
-    
+
     int8_t i, j;
 
     uint8_t tlen[SIMD_WIDTH8];
     uint8_t tail[SIMD_WIDTH8] __attribute((aligned(64)));
     uint8_t head[SIMD_WIDTH8] __attribute((aligned(64)));
+
+    // PR 17: per-row score-vector scratch for fission. Thread-local view
+    // into sbt8_ (slab-backed; see constructor) — too large for the stack.
+    int8_t *sbt_buf = sbt8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
     
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH8; l++) {
@@ -887,23 +1003,29 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         tim1 = __rdtsc();
 #endif
         
+        // PR 17+16: score pre-pass via LUT.
+        for (int jp = beg; jp < end; jp++) {
+            __m256i s2 = _mm256_load_si256((__m256i *)(seq2SoA + jp * SIMD_WIDTH8));
+            __m256i sbt11;
+            SBT_PREPASS8_LUT(s10, s2, sbt11, pmat256);
+            _mm256_store_si256((__m256i *)(sbt_buf + jp * SIMD_WIDTH8), sbt11);
+        }
+
         j256 = _mm256_set1_epi8(beg);
 #pragma unroll(4)
         for(j = beg; j < end; j++)
         {
-            __m256i f11, f21, s2;
+            __m256i f11, f21, sbt11;
             h00 = _mm256_load_si256((__m256i *)(H_h + j * SIMD_WIDTH8));
             f11 = _mm256_load_si256((__m256i *)(F + j * SIMD_WIDTH8));
-            
-            s2 = _mm256_load_si256((__m256i *)(seq2SoA + (j) * SIMD_WIDTH8));
-            
+            sbt11 = _mm256_load_si256((__m256i *)(sbt_buf + j * SIMD_WIDTH8));
+
             __m256i pj256 = j256;
             j256 = _mm256_add_epi8(j256, one256);
-            
-            MAIN_CODE8(s10, s2, h00, h11, e11, f11, f21, zero256,
-                       maxScore256, e_ins256, oe_ins256,
-                       e_del256, oe_del256,
-                       y1_256, maxRS1); //i+1
+
+            MAIN_CODE8_CORE(sbt11, h00, h11, e11, f11, f21, zero256,
+                            e_ins256, oe_ins256,
+                            e_del256, oe_del256);
 
             
             // Masked writing
@@ -1147,15 +1269,17 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                                                    uint16_t numThreads,
                                                    int32_t w)
 {
+    // Mirror the constructor's numThreads<1 clamp.
+    if (numThreads < 1) numThreads = 1;
     int64_t st1, st2, st3, st4, st5;
-#if RDT     
+#if RDT
     st1 = ___rdtsc();
 #endif
-    
-    uint16_t *seq1SoA = (uint16_t *)_mm_malloc(MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
-    uint16_t *seq2SoA = (uint16_t *)_mm_malloc(MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
 
-    if (seq1SoA == NULL || seq2SoA == NULL) {
+    uint16_t *seq1SoA = (uint16_t *)_mm_malloc((size_t)MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
+    uint16_t *seq2SoA = (uint16_t *)_mm_malloc((size_t)MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
+
+    if (UNLIKELY(seq1SoA == NULL || seq2SoA == NULL)) {
         fprintf(stderr, "Error! Mem not allocated!!!\n");
         exit(EXIT_FAILURE);
     }
@@ -1175,11 +1299,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     
 #if SORT_PAIRS      // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
     // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc(SORT_BLOCK_SIZE * numThreads *
+    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
                                                sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((MAX_SEQ_LEN16 + 16) * numThreads *
+    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN16 + 16) * numThreads *
                                           sizeof(int16_t), 64);
-    int16_t *histb = (int16_t *)_mm_malloc((MAX_SEQ_LEN16 + 16) * numThreads *
+    int16_t *histb = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN16 + 16) * numThreads *
                                            sizeof(int16_t), 64);
 #pragma omp parallel num_threads(numThreads)
     {
@@ -1434,18 +1558,21 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
     __m256i oe_del256   = _mm256_set1_epi16(this->o_del + this->e_del);
     __m256i e_ins256    = _mm256_set1_epi16(this->e_ins);
     __m256i oe_ins256   = _mm256_set1_epi16(this->o_ins + this->e_ins);
-    
+
     int16_t *F  = F16_ + tid * SIMD_WIDTH16 * MAX_SEQ_LEN16;
     int16_t *H_h    = H16_ + tid * SIMD_WIDTH16 * MAX_SEQ_LEN16;
     int16_t *H_v = H16__ + tid * SIMD_WIDTH16 * MAX_SEQ_LEN16;
 
     int lane = 0;
-    
+
     int16_t i, j;
 
     uint16_t tlen[SIMD_WIDTH16];
     uint16_t tail[SIMD_WIDTH16] __attribute((aligned(64)));
     uint16_t head[SIMD_WIDTH16] __attribute((aligned(64)));
+
+    // PR 17: per-row score-vector scratch for fission (AVX2 16-bit).
+    int16_t *sbt_buf = sbt16_ + tid * SIMD_WIDTH16 * MAX_SEQ_LEN16;
     
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH16; l++) {
@@ -1585,22 +1712,28 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         tim1 = __rdtsc();
 #endif
         
+        // PR 17: AVX2 16-bit score pre-pass (fission only, no LUT).
+        for (int jp = beg; jp < end; jp++) {
+            __m256i s2 = _mm256_load_si256((__m256i *)(seq2SoA + jp * SIMD_WIDTH16));
+            __m256i sbt11;
+            SBT_PREPASS16(s10, s2, sbt11, mismatch256, match256, w_ambig_256);
+            _mm256_store_si256((__m256i *)(sbt_buf + jp * SIMD_WIDTH16), sbt11);
+        }
+
         j256 = _mm256_set1_epi16(beg);
         for(j = beg; j < end; j++)
         {
-            __m256i f11, f21, s2;
+            __m256i f11, f21, sbt11;
+            sbt11 = _mm256_load_si256((__m256i *)(sbt_buf + j * SIMD_WIDTH16));
             h00 = _mm256_load_si256((__m256i *)(H_h + j * SIMD_WIDTH16));
             f11 = _mm256_load_si256((__m256i *)(F + j * SIMD_WIDTH16));
 
-            s2 = _mm256_load_si256((__m256i *)(seq2SoA + (j) * SIMD_WIDTH16));
-            
             __m256i pj256 = j256;
             j256 = _mm256_add_epi16(j256, one256);
 
-            MAIN_CODE16(s10, s2, h00, h11, e11, f11, f21, zero256,
-                        maxScore256, e_ins256, oe_ins256,
-                        e_del256, oe_del256,
-                        y1_256, maxRS1); //i+1
+            MAIN_CODE16_CORE(sbt11, h00, h11, e11, f11, f21, zero256,
+                             e_ins256, oe_ins256,
+                             e_del256, oe_del256);
             
             // Masked writing
             __m256i cmp2 = _mm256_cmpgt_epi16(head256, pj256);
@@ -1905,6 +2038,61 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         f21 = _mm512_max_epi16(val512, f21);                            \
     }
 
+// --- PR 17/16: AVX-512BW LUT primitive ---
+// Broadcast the 16-byte pmat into all four 128-bit lanes.
+// _mm512_shuffle_epi8 is per-128-bit-lane; each lane shuffles against
+// its own quarter of the 512-bit pmat. The non-LUT variant was removed
+// (its movepi8_mask AMBIG detection no longer fires under the asymmetric
+// AMBIG encoding shipped alongside the LUT path).
+#define SBT_PREPASS8_LUT(s1, s2, sbt11_out, pmat512)                    \
+    {                                                                   \
+        __m512i xor_ = _mm512_xor_si512(s1, s2);                        \
+        sbt11_out = _mm512_shuffle_epi8(pmat512, xor_);                 \
+    }
+
+#define MAIN_CODE8_CORE(sbt11, h00, h11, e11, f11, f21, zero512, e_ins512, oe_ins512, e_del512, oe_del512) \
+    {                                                                   \
+        __m512i m11 = _mm512_add_epi8(h00, sbt11);                      \
+        __mmask64 cmp11 = _mm512_cmpeq_epi8_mask(h00, zero512);         \
+        m11 = _mm512_mask_blend_epi8(cmp11, m11, zero512);              \
+        h11 = _mm512_max_epi8(m11, e11);                                \
+        h11 = _mm512_max_epi8(h11, f11);                                \
+        __m512i temp512 = _mm512_sub_epi8(m11, oe_ins512);              \
+        __m512i val512  = _mm512_max_epi8(temp512, zero512);            \
+        e11 = _mm512_sub_epi8(e11, e_ins512);                           \
+        e11 = _mm512_max_epi8(val512, e11);                             \
+        temp512 = _mm512_sub_epi8(m11, oe_del512);                      \
+        val512  = _mm512_max_epi8(temp512, zero512);                    \
+        f21 = _mm512_sub_epi8(f11, e_del512);                           \
+        f21 = _mm512_max_epi8(val512, f21);                             \
+    }
+
+#define SBT_PREPASS16(s1, s2, sbt11_out, mismatch512, match512, w_ambig_512) \
+    {                                                                   \
+        __mmask32 cmp_ = _mm512_cmpeq_epi16_mask(s1, s2);               \
+        __m512i sbt_ = _mm512_mask_blend_epi16(cmp_, mismatch512, match512); \
+        __m512i tmp_ = _mm512_max_epu16(s1, s2);                        \
+        __mmask32 amb_ = _mm512_movepi16_mask(tmp_);                    \
+        sbt11_out = _mm512_mask_blend_epi16(amb_, sbt_, w_ambig_512);   \
+    }
+
+#define MAIN_CODE16_CORE(sbt11, h00, h11, e11, f11, f21, zero512, e_ins512, oe_ins512, e_del512, oe_del512) \
+    {                                                                   \
+        __m512i m11 = _mm512_add_epi16(h00, sbt11);                     \
+        __mmask32 cmp11 = _mm512_cmpeq_epi16_mask(h00, zero512);        \
+        m11 = _mm512_mask_blend_epi16(cmp11, m11, zero512);             \
+        h11 = _mm512_max_epi16(m11, e11);                               \
+        h11 = _mm512_max_epi16(h11, f11);                               \
+        __m512i temp512 = _mm512_sub_epi16(m11, oe_ins512);             \
+        __m512i val512  = _mm512_max_epi16(temp512, zero512);           \
+        e11 = _mm512_sub_epi16(e11, e_ins512);                          \
+        e11 = _mm512_max_epi16(val512, e11);                            \
+        temp512 = _mm512_sub_epi16(m11, oe_del512);                     \
+        val512  = _mm512_max_epi16(temp512, zero512);                   \
+        f21 = _mm512_sub_epi16(f11, e_del512);                          \
+        f21 = _mm512_max_epi16(val512, f21);                            \
+    }
+
 
 inline void sortPairsLen(SeqPair *pairArray, int32_t count,
                          SeqPair *tempArray, int16_t *hist,
@@ -2001,13 +2189,19 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                                                   uint16_t numThreads,
                                                   int32_t w)
 {
+    // Mirror the constructor's numThreads<1 clamp.
+    if (numThreads < 1) numThreads = 1;
     int64_t st1, st2, st3, st4, st5;
 #if RDT
     st1 = ___rdtsc();
 #endif
-    uint8_t *seq1SoA = (uint8_t *)_mm_malloc(MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
-    uint8_t *seq2SoA = (uint8_t *)_mm_malloc(MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
-    
+    uint8_t *seq1SoA = (uint8_t *)_mm_malloc((size_t)MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
+    uint8_t *seq2SoA = (uint8_t *)_mm_malloc((size_t)MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
+    if (UNLIKELY(seq1SoA == NULL || seq2SoA == NULL)) {
+        fprintf(stderr, "Error! Mem not allocated!!!\n");
+        exit(EXIT_FAILURE);
+    }
+
     int32_t ii;
     int32_t roundNumPairs = ((numPairs + SIMD_WIDTH8 - 1)/SIMD_WIDTH8 ) * SIMD_WIDTH8;
     for(ii = numPairs; ii < roundNumPairs; ii++)
@@ -2023,11 +2217,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
     
 #if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
     // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc(SORT_BLOCK_SIZE * numThreads *
+    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
                                                sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((MAX_SEQ_LEN8 + 32) * numThreads *
+    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN8 + 32) * numThreads *
                                           sizeof(int16_t), 64);
-    int16_t *histb = (int16_t *)_mm_malloc((MAX_SEQ_LEN8 + 32) * numThreads *
+    int16_t *histb = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN8 + 32) * numThreads *
                                            sizeof(int16_t), 64);
 #pragma omp parallel num_threads(numThreads)
     {
@@ -2111,7 +2305,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 
                 for(k = 0; k < sp.len1; k++)
                 {
-                    mySeq1SoA[k * SIMD_WIDTH8 + j] = (seq1[k] == AMBIG?0xFF:seq1[k]);
+                    mySeq1SoA[k * SIMD_WIDTH8 + j] = seq1[k] /* PR16: N stays 4 */;
                     H2[k * SIMD_WIDTH8 + j] = 0;
                 }
                 qlen[j] = sp.len2 * max;
@@ -2150,7 +2344,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 seq2 = seqBufQer + (int64_t)sp.idq;
                 for(k = 0; k < sp.len2; k++)
                 {
-                    mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k]==AMBIG?0xFF:seq2[k]);
+                    mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k]==AMBIG ? 8 : seq2[k]) /* PR16: query N→8 */;
                     H1[k * SIMD_WIDTH8 + j] = 0;                    
                 }
                 if(maxLen2 < sp.len2) maxLen2 = sp.len2;
@@ -2281,23 +2475,33 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
     __m512i w_ambig_512  = _mm512_set1_epi8(this->w_ambig); // ambig penalty
     __m512i five512      = _mm512_set1_epi8(5);
 
+    // PR 16: pmat LUT broadcast into all 4 128-bit lanes of 512-bit register.
+    int8_t pmat_bytes[16] __attribute__((aligned(16)));
+    build_pmat16(pmat_bytes, this->w_match, this->w_mismatch, this->w_ambig);
+    __m128i pmat128 = _mm_load_si128((__m128i *)pmat_bytes);
+    __m512i pmat512 = _mm512_broadcast_i32x4(pmat128);
+
     __m512i e_del512    = _mm512_set1_epi8(this->e_del);
     __m512i oe_del512   = _mm512_set1_epi8(this->o_del + this->e_del);
     __m512i e_ins512    = _mm512_set1_epi8(this->e_ins);
-    __m512i oe_ins512   = _mm512_set1_epi8(this->o_ins + this->e_ins);  
-    
+    __m512i oe_ins512   = _mm512_set1_epi8(this->o_ins + this->e_ins);
+
     int8_t  *F   = F8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
     int8_t  *H_h = H8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
     int8_t  *H_v = H8__ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
-    
+
     int lane = 0;
-    
+
     int8_t lowInitValue = LOW_INIT_VALUE;
     int16_t i, j;
 
     uint8_t tlen[SIMD_WIDTH8];
     uint8_t tail[SIMD_WIDTH8] __attribute((aligned(64)));
     uint8_t head[SIMD_WIDTH8] __attribute((aligned(64)));
+
+    // PR 17: per-row score-vector scratch for fission. Thread-local view
+    // into sbt8_ (slab-backed; see constructor) — too large for the stack.
+    int8_t *sbt_buf = sbt8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
     
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH8; l++) {
@@ -2436,22 +2640,28 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         tim1 = __rdtsc();
 #endif
         
+        // PR 17+16: AVX-512 8-bit score pre-pass via LUT.
+        for (int jp = beg; jp < end; jp++) {
+            __m512i s2 = _mm512_load_si512((__m512i *)(seq2SoA + jp * SIMD_WIDTH8));
+            __m512i sbt11;
+            SBT_PREPASS8_LUT(s10, s2, sbt11, pmat512);
+            _mm512_store_si512((__m512i *)(sbt_buf + jp * SIMD_WIDTH8), sbt11);
+        }
+
         j512 = _mm512_set1_epi8(beg);
         for(j = beg; j < end; j++)
         {
-            __m512i f11, f21, f31, f41, f51, jj512, s2;
+            __m512i f11, f21, f31, f41, f51, jj512, sbt11;
             h00 = _mm512_load_si512((__m512i *)(H_h + j * SIMD_WIDTH8));
             f11 = _mm512_load_si512((__m512i *)(F + j * SIMD_WIDTH8));
+            sbt11 = _mm512_load_si512((__m512i *)(sbt_buf + j * SIMD_WIDTH8));
 
-            s2 = _mm512_load_si512((__m512i *)(seq2SoA + (j) * SIMD_WIDTH8));
-            
             __m512i pj512 = j512;
             j512 = _mm512_add_epi8(j512, one512);
             
-            MAIN_CODE8(s10, s2, h00, h11, e11, f11, f21, zero512,
-                       maxScore512, e_ins512, oe_ins512,
-                       e_del512, oe_del512,
-                       y1_512, maxRS1); //i+1
+            MAIN_CODE8_CORE(sbt11, h00, h11, e11, f11, f21, zero512,
+                            e_ins512, oe_ins512,
+                            e_del512, oe_del512);
 
             // Masked writing
             __mmask64 cmp2 = _mm512_cmpgt_epi8_mask(head512, pj512);
@@ -2694,15 +2904,17 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                                                    uint16_t numThreads,
                                                    int32_t w)
 {
+    // Mirror the constructor's numThreads<1 clamp.
+    if (numThreads < 1) numThreads = 1;
     int64_t st1, st2, st3, st4, st5;
 #if RDT
     st1 = ___rdtsc();
 #endif
-    
-    uint16_t *seq1SoA = (uint16_t *)_mm_malloc(MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
-    uint16_t *seq2SoA = (uint16_t *)_mm_malloc(MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
 
-    if (seq1SoA == NULL || seq2SoA == NULL) {
+    uint16_t *seq1SoA = (uint16_t *)_mm_malloc((size_t)MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
+    uint16_t *seq2SoA = (uint16_t *)_mm_malloc((size_t)MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
+
+    if (UNLIKELY(seq1SoA == NULL || seq2SoA == NULL)) {
         fprintf(stderr, "Error! Mem not allocated!!!\n");
         exit(EXIT_FAILURE);
     }
@@ -2722,9 +2934,9 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     
 #if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
     // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc(SORT_BLOCK_SIZE * numThreads *
+    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
                                                sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((MAX_SEQ_LEN16 + 32) * numThreads *
+    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN16 + 32) * numThreads *
                                           sizeof(int16_t), 64);
 #pragma omp parallel num_threads(numThreads)
     {
@@ -2988,14 +3200,17 @@ void BandedPairWiseSW::smithWaterman512_16(uint16_t seq1SoA[],
     int16_t *F   = F16_ + tid * SIMD_WIDTH16 * MAX_SEQ_LEN16;
     int16_t *H_h = H16_ + tid * SIMD_WIDTH16 * MAX_SEQ_LEN16;
     int16_t *H_v = H16__ + tid * SIMD_WIDTH16 * MAX_SEQ_LEN16;
-    
+
     int lane = 0;
-    
+
     int16_t i, j;
 
     uint16_t tlen[SIMD_WIDTH16];
     uint16_t tail[SIMD_WIDTH16] __attribute((aligned(64)));
     uint16_t head[SIMD_WIDTH16] __attribute((aligned(64)));
+
+    // PR 17: per-row score-vector scratch for fission (AVX-512 16-bit).
+    int16_t *sbt_buf = sbt16_ + tid * SIMD_WIDTH16 * MAX_SEQ_LEN16;
     
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH16; l++) {
@@ -3132,22 +3347,28 @@ void BandedPairWiseSW::smithWaterman512_16(uint16_t seq1SoA[],
         tim1 = __rdtsc();
 #endif
         
+        // PR 17: AVX-512 16-bit score pre-pass (fission only, no LUT).
+        for (int jp = beg; jp < end; jp++) {
+            __m512i s2 = _mm512_load_si512((__m512i *)(seq2SoA + jp * SIMD_WIDTH16));
+            __m512i sbt11;
+            SBT_PREPASS16(s10, s2, sbt11, mismatch512, match512, w_ambig_512);
+            _mm512_store_si512((__m512i *)(sbt_buf + jp * SIMD_WIDTH16), sbt11);
+        }
+
         j512 = _mm512_set1_epi16(beg);
         for(j = beg; j < end; j++)
         {
-            __m512i f11, f21, f31, f41, f51, jj512, s2;
+            __m512i f11, f21, f31, f41, f51, jj512, sbt11;
             h00 = _mm512_load_si512((__m512i *)(H_h + j * SIMD_WIDTH16));
             f11 = _mm512_load_si512((__m512i *)(F + j * SIMD_WIDTH16));
+            sbt11 = _mm512_load_si512((__m512i *)(sbt_buf + j * SIMD_WIDTH16));
 
-            s2 = _mm512_load_si512((__m512i *)(seq2SoA + (j) * SIMD_WIDTH16));
-            
             __m512i pj512 = j512;
             j512 = _mm512_add_epi16(j512, one512);
 
-            MAIN_CODE16(s10, s2, h00, h11, e11, f11, f21, zero512,
-                       maxScore512, e_ins512, oe_ins512,
-                       e_del512, oe_del512,
-                       y1_512, maxRS1); //i+1
+            MAIN_CODE16_CORE(sbt11, h00, h11, e11, f11, f21, zero512,
+                             e_ins512, oe_ins512,
+                             e_del512, oe_del512);
 
             // Masked writing
             __mmask32 cmp2 = _mm512_cmpgt_epi16_mask(head512, pj512);
@@ -3358,7 +3579,11 @@ void BandedPairWiseSW::smithWaterman512_16(uint16_t seq1SoA[],
 
 
 /**************** SSE2 code ******************/
-#if ((!__AVX512BW__) && (!__AVX2__) && (__SSE2__))
+/* SBT_PREPASS8_LUT below uses _mm_shuffle_epi8 (PSHUFB, an SSSE3 intrinsic),
+ * so this block requires SSSE3. The Makefile passes -mssse3 on all x86 arch
+ * targets and sse2neon predefines __SSSE3__=1, so this matches every build
+ * that compiles the SSE2/NEON path. */
+#if ((!__AVX512BW__) && (!__AVX2__) && (__SSE2__) && (__SSSE3__))
 
 // SSE2/NEON - 16 bit blendv
 static inline __m128i
@@ -3401,6 +3626,33 @@ _mm_blendv_epi16(__m128i x, __m128i y, __m128i mask)
         sbt11 = _mm_blendv_epi16(sbt11, w_ambig_128, tmp128);           \
         __m128i m11 = _mm_add_epi16(h00, sbt11);                        \
         cmp11 = _mm_cmpeq_epi16(h00, zero128);                          \
+        m11 = _mm_blendv_epi16(m11, zero128, cmp11);                    \
+        h11 = _mm_max_epi16(m11, e11);                                  \
+        h11 = _mm_max_epi16(h11, f11);                                  \
+        __m128i temp128 = _mm_sub_epi16(m11, oe_ins128);                \
+        __m128i val128  = _mm_max_epi16(temp128, zero128);              \
+        e11 = _mm_sub_epi16(e11, e_ins128);                             \
+        e11 = _mm_max_epi16(val128, e11);                               \
+        temp128 = _mm_sub_epi16(m11, oe_del128);                        \
+        val128  = _mm_max_epi16(temp128, zero128);                      \
+        f21 = _mm_sub_epi16(f11, e_del128);                             \
+        f21 = _mm_max_epi16(val128, f21);                               \
+    }
+
+// PR 17: 16-bit fission primitives, mirror of the 8-bit pair above.
+#define SBT_PREPASS16(s1, s2, sbt11_out, mismatch128, match128, w_ambig_128, ff128) \
+    {                                                                   \
+        __m128i cmp11_ = _mm_cmpeq_epi16(s1, s2);                       \
+        __m128i sbt_ = _mm_blendv_epi16(mismatch128, match128, cmp11_); \
+        __m128i tmp_ = _mm_max_epu16(s1, s2);                           \
+        tmp_ = _mm_cmpeq_epi16(tmp_, ff128);                            \
+        sbt11_out = _mm_blendv_epi16(sbt_, w_ambig_128, tmp_);          \
+    }
+
+#define MAIN_CODE16_CORE(sbt11, h00, h11, e11, f11, f21, zero128, e_ins128, oe_ins128, e_del128, oe_del128) \
+    {                                                                   \
+        __m128i m11 = _mm_add_epi16(h00, sbt11);                        \
+        __m128i cmp11 = _mm_cmpeq_epi16(h00, zero128);                  \
         m11 = _mm_blendv_epi16(m11, zero128, cmp11);                    \
         h11 = _mm_max_epi16(m11, e11);                                  \
         h11 = _mm_max_epi16(h11, f11);                                  \
@@ -3504,15 +3756,19 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                                                    uint16_t numThreads,
                                                    int32_t w)
 {
+    // Mirror the constructor's numThreads<1 clamp.
+    if (numThreads < 1) numThreads = 1;
 #if RDT
     int64_t st1, st2, st3, st4, st5;
     st1 = ___rdtsc();
 #endif
-    
-    uint16_t *seq1SoA = (uint16_t *)_mm_malloc(MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
-    uint16_t *seq2SoA = (uint16_t *)_mm_malloc(MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
 
-    assert (seq1SoA != NULL || seq2SoA != NULL);
+    uint16_t *seq1SoA = (uint16_t *)_mm_malloc((size_t)MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
+    uint16_t *seq2SoA = (uint16_t *)_mm_malloc((size_t)MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(uint16_t), 64);
+    if (UNLIKELY(seq1SoA == NULL || seq2SoA == NULL)) {
+        fprintf(stderr, "Error! Mem not allocated!!!\n");
+        exit(EXIT_FAILURE);
+    }
 
     int32_t ii;
     int32_t roundNumPairs = ((numPairs + SIMD_WIDTH16 - 1)/SIMD_WIDTH16 ) * SIMD_WIDTH16;
@@ -3530,11 +3786,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     
 #if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
     // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc(SORT_BLOCK_SIZE * numThreads *
+    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
                                                sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((MAX_SEQ_LEN16 + 16) * numThreads *
+    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN16 + 16) * numThreads *
                                           sizeof(int16_t), 64);
-    int16_t *histb = (int16_t *)_mm_malloc((MAX_SEQ_LEN16 + 16) * numThreads *
+    int16_t *histb = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN16 + 16) * numThreads *
                                            sizeof(int16_t), 64);
 #pragma omp parallel num_threads(numThreads)
     {
@@ -3794,6 +4050,9 @@ void BandedPairWiseSW::smithWaterman128_16(uint16_t seq1SoA[],
     uint16_t tlen[SIMD_WIDTH16];
     uint16_t tail[SIMD_WIDTH16] __attribute((aligned(64)));
     uint16_t head[SIMD_WIDTH16] __attribute((aligned(64)));
+
+    // PR 17: per-row score-vector scratch (16-bit variant).
+    int16_t *sbt_buf = sbt16_ + tid * SIMD_WIDTH16 * MAX_SEQ_LEN16;
     
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH16; l++) {
@@ -3923,22 +4182,28 @@ void BandedPairWiseSW::smithWaterman128_16(uint16_t seq1SoA[],
         tim1 = __rdtsc();
 #endif
         
+        // PR 17: 16-bit pre-pass. Same shape as the 8-bit path.
+        for (int jp = beg; jp < end; jp++) {
+            __m128i s2 = _mm_load_si128((__m128i *)(seq2SoA + jp * SIMD_WIDTH16));
+            __m128i sbt11;
+            SBT_PREPASS16(s10, s2, sbt11, mismatch128, match128, w_ambig_128, ff128);
+            _mm_store_si128((__m128i *)(sbt_buf + jp * SIMD_WIDTH16), sbt11);
+        }
+
         j128 = _mm_set1_epi16(beg);
         for(j = beg; j < end; j++)
         {
-            __m128i f11, f21, s2;
+            __m128i f11, f21, sbt11;
             h00 = _mm_load_si128((__m128i *)(H_h + j * SIMD_WIDTH16));
             f11 = _mm_load_si128((__m128i *)(F + j * SIMD_WIDTH16));
+            sbt11 = _mm_load_si128((__m128i *)(sbt_buf + j * SIMD_WIDTH16));
 
-            s2 = _mm_load_si128((__m128i *)(seq2SoA + (j) * SIMD_WIDTH16));
-            
             __m128i pj128 = j128;
             j128 = _mm_add_epi16(j128, one128);
 
-            MAIN_CODE16(s10, s2, h00, h11, e11, f11, f21, zero128,
-                        maxScore128, e_ins128, oe_ins128,
-                        e_del128, oe_del128,
-                        y1_128, maxRS1); //i+1
+            MAIN_CODE16_CORE(sbt11, h00, h11, e11, f11, f21, zero128,
+                             e_ins128, oe_ins128,
+                             e_del128, oe_del128);
 
             // Masked writing
             __m128i cmp1 = _mm_cmpgt_epi16(head128, pj128);
@@ -4201,6 +4466,44 @@ static inline __m128i _mm_blendv_epi8 (__m128i x, __m128i y, __m128i mask)
         f21 = _mm_max_epu8(temp128, f21);                               \
     }
 
+// --- PR 17/16: SSE2/NEON LUT primitive ---
+// With the asymmetric AMBIG encoding (target N=4, query N=8), the low 4 bits
+// of (s1 ^ s2) index a 16-byte pmat LUT where:
+//   [0]     = w_match   (s1==s2, both ACGT)
+//   [1..3]  = w_mismatch (ACGT vs ACGT, XOR ∈ {1,2,3})
+//   [4..7]  = w_ambig   (target=N=4, query=ACGT)
+//   [8..11] = w_ambig   (target=ACGT, query=N=8)
+//   [12]    = w_ambig   (both N)
+//   [13..15] = w_ambig   (unreachable; filled for safety)
+// Replaces 4-op cmpeq+blendv+max+blendv critical path with 1 XOR + 1
+// shuffle_epi8 (TBL on NEON). The non-LUT SBT_PREPASS8 variant was removed
+// — its max_epu8 + cmpeq AMBIG detection relied on the legacy symmetric
+// (target=N=15, query=N=15) encoding and would mis-classify under the
+// current asymmetric encoding.
+#define SBT_PREPASS8_LUT(s1, s2, sbt11_out, pmat128)                    \
+    {                                                                   \
+        __m128i xor_ = _mm_xor_si128(s1, s2);                           \
+        sbt11_out = _mm_shuffle_epi8(pmat128, xor_);                    \
+    }
+
+// MAIN_CODE8_CORE runs only the cell-update half of MAIN_CODE8 using a
+// pre-computed score vector `sbt11` from SBT_PREPASS8.
+#define MAIN_CODE8_CORE(sbt11, h00, h11, e11, f11, f21, zero128, e_ins128, oe_ins128, e_del128, oe_del128) \
+    {                                                                   \
+        __m128i m11 = _mm_add_epi8(h00, sbt11);                         \
+        __m128i cmp11 = _mm_cmpeq_epi8(h00, zero128);                   \
+        m11 = _mm_blendv_epi8(m11, zero128, cmp11);                     \
+        m11 = _mm_and_si128(m11, _mm_cmpgt_epi8(m11, zero128));         \
+        h11 = _mm_max_epu8(m11, e11);                                   \
+        h11 = _mm_max_epu8(h11, f11);                                   \
+        __m128i temp128 = _mm_subs_epu8(m11, oe_ins128);                \
+        e11 = _mm_subs_epu8(e11, e_ins128);                             \
+        e11 = _mm_max_epu8(temp128, e11);                               \
+        temp128 = _mm_subs_epu8(m11, oe_del128);                        \
+        f21 = _mm_subs_epu8(f11, e_del128);                             \
+        f21 = _mm_max_epu8(temp128, f21);                               \
+    }
+
 
 // #define PFD 2 // SSE2
 void BandedPairWiseSW::getScores8(SeqPair *pairArray,
@@ -4235,14 +4538,16 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                                                   uint16_t numThreads,
                                                   int32_t w)
 {
+    // Mirror the constructor's numThreads<1 clamp.
+    if (numThreads < 1) numThreads = 1;
 #if RDT
     int64_t st1, st2, st3, st4, st5;
     st1 = ___rdtsc();
 #endif
-    uint8_t *seq1SoA = (uint8_t *)_mm_malloc(MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
-    uint8_t *seq2SoA = (uint8_t *)_mm_malloc(MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
+    uint8_t *seq1SoA = (uint8_t *)_mm_malloc((size_t)MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
+    uint8_t *seq2SoA = (uint8_t *)_mm_malloc((size_t)MAX_SEQ_LEN8 * SIMD_WIDTH8 * numThreads * sizeof(uint8_t), 64);
 
-    if (seq1SoA == NULL || seq2SoA == NULL) {
+    if (UNLIKELY(seq1SoA == NULL || seq2SoA == NULL)) {
         fprintf(stderr, "Error! Mem not allocated!!!\n");
         exit(EXIT_FAILURE);
     }
@@ -4263,11 +4568,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
     
 #if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
     // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc(SORT_BLOCK_SIZE * numThreads *
+    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
                                                sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((MAX_SEQ_LEN8 + 32) * numThreads *
+    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN8 + 32) * numThreads *
                                           sizeof(int16_t), 64);
-    int16_t *histb = (int16_t *)_mm_malloc((MAX_SEQ_LEN8 + 32) * numThreads *
+    int16_t *histb = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN8 + 32) * numThreads *
                                            sizeof(int16_t), 64);
 #pragma omp parallel num_threads(numThreads)
     {
@@ -4342,7 +4647,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 
                 for(k = 0; k < sp.len1; k++)
                 {
-                    mySeq1SoA[k * SIMD_WIDTH8 + j] = (seq1[k] == AMBIG?0xFF:seq1[k]);
+                    mySeq1SoA[k * SIMD_WIDTH8 + j] = seq1[k] /* PR16: N stays 4 */;
                     H2[k * SIMD_WIDTH8 + j] = 0;
                 }
                 qlen[j] = sp.len2 * max;
@@ -4379,7 +4684,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 
                 for(k = 0; k < sp.len2; k++)
                 {
-                    mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k]==AMBIG?0xFF:seq2[k]);
+                    mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k]==AMBIG ? 8 : seq2[k]) /* PR16: query N→8 */;
                     H1[k * SIMD_WIDTH8 + j] = 0;                    
                 }
                 if(maxLen2 < sp.len2) maxLen2 = sp.len2;
@@ -4508,6 +4813,12 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     __m128i mismatch128  = _mm_set1_epi8(this->w_mismatch);
     __m128i w_ambig_128  = _mm_set1_epi8(this->w_ambig);    // ambig penalty
 
+    // PR 16: score-lookup LUT indexed by low 4 bits of (target XOR query).
+    // See SBT_PREPASS8_LUT for the layout. Built once per kernel call.
+    int8_t pmat_bytes[16] __attribute__((aligned(16)));
+    build_pmat16(pmat_bytes, this->w_match, this->w_mismatch, this->w_ambig);
+    __m128i pmat128 = _mm_load_si128((__m128i *)pmat_bytes);
+
     __m128i e_del128    = _mm_set1_epi8(this->e_del);
     __m128i oe_del128   = _mm_set1_epi8(this->o_del + this->e_del);
     __m128i e_ins128    = _mm_set1_epi8(this->e_ins);
@@ -4522,6 +4833,12 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     uint8_t tlen[SIMD_WIDTH8];
     uint8_t tail[SIMD_WIDTH8] __attribute((aligned(64)));
     uint8_t head[SIMD_WIDTH8] __attribute((aligned(64)));
+
+    // PR 17: per-row score-vector scratch for loop fission. Holds sbt[j]
+    // (score for each band column) pre-computed outside the DP core so
+    // the core's critical path doesn't carry the cmpeq+blendv+maxu+blendv
+    // chain that builds the score. Slab-backed (see constructor sbt8_).
+    int8_t *sbt_buf = sbt8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
     
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH8; l++) {
@@ -4647,22 +4964,32 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         tim1 = __rdtsc();
 #endif
         
+        // PR 17: pre-pass — build score vector sbt[j] for all band columns
+        // once. Independent per-j, so vectorized loads/stores run at peak
+        // throughput without carrying the DP core's dep chain.
+        for (int jp = beg; jp < end; jp++) {
+            __m128i s2 = _mm_load_si128((__m128i *)(seq2SoA + jp * SIMD_WIDTH8));
+            __m128i sbt11;
+            // PR 16: LUT score build (1 xor + 1 shuffle) in place of
+            // the 4-op cmpeq+blendv+max+blendv SBT_PREPASS8.
+            SBT_PREPASS8_LUT(s10, s2, sbt11, pmat128);
+            _mm_store_si128((__m128i *)(sbt_buf + jp * SIMD_WIDTH8), sbt11);
+        }
+
         j128 = _mm_set1_epi8(beg);
         for(j = beg; j < end; j++)
         {
-            __m128i f11, f21, s2;
+            __m128i f11, f21, sbt11;
             h00 = _mm_load_si128((__m128i *)(H_h + j * SIMD_WIDTH8));
             f11 = _mm_load_si128((__m128i *)(F + j * SIMD_WIDTH8));
+            sbt11 = _mm_load_si128((__m128i *)(sbt_buf + j * SIMD_WIDTH8));
 
-            s2 = _mm_load_si128((__m128i *)(seq2SoA + (j) * SIMD_WIDTH8));
-            
             __m128i pj128 = j128;
             j128 = _mm_add_epi8(j128, one128);
 
-            MAIN_CODE8(s10, s2, h00, h11, e11, f11, f21, zero128,
-                       maxScore128, e_ins128, oe_ins128,
-                       e_del128, oe_del128,
-                       y1_128, maxRS1); //i+1
+            MAIN_CODE8_CORE(sbt11, h00, h11, e11, f11, f21, zero128,
+                            e_ins128, oe_ins128,
+                            e_del128, oe_del128);
 
             // Masked writing
             __m128i cmp1 = _mm_cmpgt_epi8(head128, pj128);

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -63,6 +63,13 @@ static inline void build_pmat16(int8_t out[16],
     for (int i = 4; i < 16; i++) out[i] = w_ambig;
 }
 
+// Defensive: numThreads must be ≥ 1 — _mm_malloc(0, 64) is implementation-
+// defined and a 0-byte slab would silently OOM downstream writes. Wrappers
+// fan out to constructors and per-batch SoA setup; clamping centrally keeps
+// every entry point in agreement.
+template <typename T>
+static inline T effective_threads(T n) { return n < 1 ? T(1) : n; }
+
 //-----------------------------------------------------------------------------------
 // constructor
 BandedPairWiseSW::BandedPairWiseSW(const int o_del, const int e_del, const int o_ins,
@@ -111,11 +118,7 @@ BandedPairWiseSW::BandedPairWiseSW(const int o_del, const int e_del, const int o
                   "8-bit DP partition not a multiple of 64B; tune MAX_SEQ_LEN8 / SIMD_WIDTH8");
     static_assert((MAX_SEQ_LEN16 * SIMD_WIDTH16 * sizeof(int16_t)) % 64 == 0,
                   "16-bit DP partition not a multiple of 64B; tune MAX_SEQ_LEN16 / SIMD_WIDTH16");
-    // Defensive: numThreads must be ≥ 1 — _mm_malloc(0, 64) is
-    // implementation-defined, and a 0-byte slab would silently OOM downstream
-    // writes. Clamp instead of asserting so a misconfigured caller still
-    // gets a usable (single-thread) instance.
-    if (numThreads < 1) numThreads = 1;
+    numThreads = effective_threads(numThreads);
     size_t sz8  = (size_t)MAX_SEQ_LEN8  * SIMD_WIDTH8  * numThreads * sizeof(int8_t);
     size_t sz16 = (size_t)MAX_SEQ_LEN16 * SIMD_WIDTH16 * numThreads * sizeof(int16_t);
     size_t total = 4 * sz8 + 4 * sz16;
@@ -542,9 +545,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                                                   uint16_t numThreads,
                                                   int32_t w)
 {
-    // Mirror the constructor's numThreads<1 clamp so a misconfigured caller
-    // gets sized SoA buffers instead of zero-byte allocations.
-    if (numThreads < 1) numThreads = 1;
+    numThreads = effective_threads(numThreads);
     int64_t st1, st2, st3, st4, st5;
 #if RDT
     st1 = ___rdtsc();
@@ -600,6 +601,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         }
     }
     _mm_free(hist);
+    _mm_free(tempArray);
 #endif
 
 #if RDT
@@ -1269,8 +1271,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                                                    uint16_t numThreads,
                                                    int32_t w)
 {
-    // Mirror the constructor's numThreads<1 clamp.
-    if (numThreads < 1) numThreads = 1;
+    numThreads = effective_threads(numThreads);
     int64_t st1, st2, st3, st4, st5;
 #if RDT
     st1 = ___rdtsc();
@@ -1322,7 +1323,9 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
             sortPairsLen(pairArray + first, last - first, myTempArray, myHist, myHistb);
         }
     }
+    _mm_free(histb);
     _mm_free(hist);
+    _mm_free(tempArray);
 #endif
 
 #if RDT 
@@ -2189,8 +2192,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                                                   uint16_t numThreads,
                                                   int32_t w)
 {
-    // Mirror the constructor's numThreads<1 clamp.
-    if (numThreads < 1) numThreads = 1;
+    numThreads = effective_threads(numThreads);
     int64_t st1, st2, st3, st4, st5;
 #if RDT
     st1 = ___rdtsc();
@@ -2240,7 +2242,9 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             sortPairsLen(pairArray + first, last - first, myTempArray, myHist, myHistb);
         }
     }
+    _mm_free(histb);
     _mm_free(hist);
+    _mm_free(tempArray);
 #endif
     
 #if RDT
@@ -2904,8 +2908,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                                                    uint16_t numThreads,
                                                    int32_t w)
 {
-    // Mirror the constructor's numThreads<1 clamp.
-    if (numThreads < 1) numThreads = 1;
+    numThreads = effective_threads(numThreads);
     int64_t st1, st2, st3, st4, st5;
 #if RDT
     st1 = ___rdtsc();
@@ -2955,6 +2958,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
         }
     }
     _mm_free(hist);
+    _mm_free(tempArray);
 #endif
     
 #if RDT
@@ -3756,8 +3760,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                                                    uint16_t numThreads,
                                                    int32_t w)
 {
-    // Mirror the constructor's numThreads<1 clamp.
-    if (numThreads < 1) numThreads = 1;
+    numThreads = effective_threads(numThreads);
 #if RDT
     int64_t st1, st2, st3, st4, st5;
     st1 = ___rdtsc();
@@ -3809,7 +3812,9 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
             sortPairsLen(pairArray + first, last - first, myTempArray, myHist, myHistb);
         }
     }
+    _mm_free(histb);
     _mm_free(hist);
+    _mm_free(tempArray);
 #endif
 
 #if RDT
@@ -4538,8 +4543,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                                                   uint16_t numThreads,
                                                   int32_t w)
 {
-    // Mirror the constructor's numThreads<1 clamp.
-    if (numThreads < 1) numThreads = 1;
+    numThreads = effective_threads(numThreads);
 #if RDT
     int64_t st1, st2, st3, st4, st5;
     st1 = ___rdtsc();
@@ -4591,7 +4595,9 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             sortPairsLen(pairArray + first, last - first, myTempArray, myHist, myHistb);
         }
     }
+    _mm_free(histb);
     _mm_free(hist);
+    _mm_free(tempArray);
 #endif
 
 #if RDT

--- a/src/bandedSWA.h
+++ b/src/bandedSWA.h
@@ -58,6 +58,22 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #define MAX_NUM_PAIRS 10000000
 #define MAX_NUM_PAIRS_ALLOC 20000
 
+/* Whether any vector banded-SW variant (getScores8/getScores16 +
+ * smithWatermanBatchWrapper8/16) is declared and defined. ARM gets the
+ * SSE2/NEON path via sse2neon. x86 gets the SSE2 path only with SSSE3
+ * (the SSE2/NEON kernels use _mm_shuffle_epi8/PSHUFB), the AVX2 path with
+ * AVX2, or the AVX512 path with AVX512BW. The Makefile passes -mssse3 on
+ * every x86 arch target, so this is true in every CI build today — but
+ * any caller-side dispatch must consult this macro rather than hand-rolled
+ * subset checks (e.g. `!__SSE2__`) so a hypothetical SSE2-only-no-SSSE3
+ * build still picks scalarBandedSWAWrapper instead of link-failing. */
+#if (defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)) || \
+    (__AVX512BW__) || (__AVX2__) || ((__SSE2__) && (__SSSE3__))
+#define HAVE_BSW_VECTOR_8_16 1
+#else
+#define HAVE_BSW_VECTOR_8_16 0
+#endif
+
 // used in BSW and SAM-SW
 #define DEFAULT_AMBIG -1
 
@@ -110,7 +126,23 @@ typedef struct dnaSeqPair
     int seqid, regid;
     int32_t score, tle, gtle, qle;
     int32_t gscore, max_off;
-
+    // PR 26c.1: per-pair SW band upper bound derived from the ungapped
+    // score. 0 means "use default opt->w"; any positive value is an
+    // upper bound on useful band offset for this pair. Default-initialized
+    // here so stack-local SeqPair instances that don't reach every
+    // construction-site assignment (e.g. RIGHT-only paths that skip the
+    // LEFT tight_band assignment, or seeding paths that don't run
+    // ungapped_analyze) start at the safe sentinel rather than indeterminate.
+    int32_t tight_band = 0;
+    // Q3 instrumentation: would-be ungapped extension score (full diagonal
+    // walk, mirrors the HIT-path walk semantics). Computed at LEFT queue
+    // time for non-HIT pairs; carried through SW retry-collect; read at
+    // commit. -1 means undefined (e.g., zero-length).
+    int32_t ugp_walk_score = -1;
+    // Set by the construction-time RIGHT ungapped attempt (when
+    // a->score != -1 made fp_h0 known) so the post-left-SW pass doesn't
+    // double-count UGP_R_ATTEMPT / UGP_R_TIGHT / UGP_R_HIT.
+    uint8_t ugp_r_attempted = 0;
 }SeqPair;
 
 
@@ -135,6 +167,14 @@ public:
                      const int end_bonus, const int8_t *mat_,
                      const int8_t w_match, const int8_t w_mismatch, int numThreads);
     ~BandedPairWiseSW();
+
+    // Owns dp_slab_ via raw pointer; copying or moving would alias the
+    // allocation and double-free on destruction. Disable both.
+    BandedPairWiseSW(const BandedPairWiseSW&)            = delete;
+    BandedPairWiseSW& operator=(const BandedPairWiseSW&) = delete;
+    BandedPairWiseSW(BandedPairWiseSW&&)                 = delete;
+    BandedPairWiseSW& operator=(BandedPairWiseSW&&)      = delete;
+
     // Scalar code section
     int scalarBandedSWA(int qlen, const uint8_t *query, int tlen,
                         const uint8_t *target, int32_t w,
@@ -149,9 +189,14 @@ public:
                                 int nthreads,
                                 int32_t w);
 
-#if (defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)) || ((!__AVX512BW__) & (!__AVX2__) & (__SSE2__))
+#if (defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)) || ((!__AVX512BW__) && (!__AVX2__) && (__SSE2__) && (__SSSE3__))
     // On ARM: use SSE2 path via sse2neon translation
-    // On x86 SSE2: native SSE2 implementation
+    // On x86 SSE2: native SSE2 implementation (requires SSSE3 for
+    // _mm_shuffle_epi8 / PSHUFB used by SBT_PREPASS8_LUT). The declaration
+    // guard here MUST stay in lockstep with the matching definition guard
+    // in bandedSWA.cpp — the `#if ((!__AVX512BW__) && (!__AVX2__) &&
+    // (__SSE2__) && (__SSSE3__))` block that opens the SSE2/NEON section
+    // (search for "SSE2 code"); otherwise the SSE2-only build will link-fail.
     // 8 bit vector code section
     void getScores8(SeqPair *pairArray,
                     uint8_t *seqBufRef,
@@ -345,9 +390,19 @@ private:
     int8_t w_ambig;
     int8_t *F8_;
     int8_t *H8_, *H8__;
-    
+
     int16_t *F16_;
     int16_t *H16_, *H16__;
+
+    // Single 64-byte-aligned slab backing F8_/H8_/H8__/F16_/H16_/H16__
+    // and the per-thread SBT pre-pass scratch (sbt8_/sbt16_). The eight
+    // member pointers above/below are views into this slab; the destructor
+    // frees only `dp_slab_`. sbt8_ / sbt16_ moved off the stack — the
+    // 16-bit variant (MAX_SEQ_LEN16 * SIMD_WIDTH16 * 2 bytes) is multi-MB
+    // and was a stack-overflow risk on small-stack threads.
+    int8_t  *sbt8_;
+    int16_t *sbt16_;
+    void *dp_slab_;
 
     int64_t sort1Ticks;
     int64_t setupTicks;

--- a/src/bwa_madvise.h
+++ b/src/bwa_madvise.h
@@ -1,0 +1,32 @@
+/*************************************************************************************
+                           The MIT License
+
+   BWA-MEM2  (Sequence alignment using Burrows-Wheeler Transform),
+   Copyright (C) 2019  Intel Corporation, Heng Li.
+*****************************************************************************************/
+#ifndef BWA_MADVISE_H
+#define BWA_MADVISE_H
+
+#include <stddef.h>
+
+#if defined(__linux__)
+#include <sys/mman.h>
+#endif
+
+// Request transparent huge pages on a large allocation. The bwa-mem2 hg38
+// index runtime working set is ~17 GB (cp_occ ~6 GB, sa_ms_byte ~2 GB,
+// sa_ls_word ~8 GB) plus an ~800 MB pack table. With 4 KB pages the dTLB
+// covers ~256 KB — a rounding error. Promoting to 2 MB THP pages (coverage
+// ~128 MB per 64-entry TLB) dramatically cuts TLB pressure in the SMEM
+// Occ-lookup, SA expansion, and reference-fetch loops. Best-effort: the
+// hint is a no-op on non-Linux builds and on kernels without THP.
+static inline void bwamem_madv_hugepage(void *p, size_t sz)
+{
+#if defined(__linux__) && defined(MADV_HUGEPAGE)
+    if (p != NULL && sz > 0) (void)madvise(p, sz, MADV_HUGEPAGE);
+#else
+    (void)p; (void)sz;
+#endif
+}
+
+#endif // BWA_MADVISE_H

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -3227,9 +3227,18 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     SeqPair *pair_ar_aux = seqPairArrayAux;
     int nump = numPairsLeft1;
 
-    // PR 26c.1: tighten initial band using max(tight_band) across batch.
+    // per-pair tight_band proofs are still piped in via
+    // sp->tight_band (and short-circuit the retry loop below once w >=
+    // tight_band), but we no longer narrow init_w from opt->w. A batched
+    // SW pass shares one band across all pairs in the batch, so narrowing
+    // would force FALLBACK pairs (no tight_band proof) to start with a
+    // band insufficient for indels their alignment really needs. The
+    // heuristic exits (a->score == prev / max_off < 3w/4) can then fire
+    // on a suboptimal alignment found within the narrow band, breaking
+    // chr22 parity.
     int max_tb = sp_max_tight_band(pair_ar, nump);
-    int init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    int init_w = opt->w;
+    (void)max_tb;
     tprof[UGP_L_DISP_NARROW][tid] += (init_w < opt->w);
 
     // scalar
@@ -3257,7 +3266,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             a->score = sp->score;
 
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
+                i+1 == MAX_BAND_TRY ||
+                (sp->tight_band > 0 && w >= sp->tight_band))
             {
                 ugp_record_left_outcome(sp, opt->a, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip5) {
@@ -3299,7 +3309,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
     nump = numPairsLeft16;
     max_tb = sp_max_tight_band(pair_ar, nump);
-    init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    init_w = opt->w;
+    (void)max_tb;
     tprof[UGP_L_DISP_NARROW][tid] += (init_w < opt->w);
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
@@ -3333,7 +3344,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
 
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
+                i+1 == MAX_BAND_TRY ||
+                (sp->tight_band > 0 && w >= sp->tight_band))
             {
                 ugp_record_left_outcome(sp, opt->a, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip5) {
@@ -3371,7 +3383,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
     nump = numPairsLeft128;
     max_tb = sp_max_tight_band(pair_ar, nump);
-    init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    init_w = opt->w;
+    (void)max_tb;
     tprof[UGP_L_DISP_NARROW][tid] += (init_w < opt->w);
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
@@ -3405,7 +3418,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             a->score = sp->score;
 
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
+                i+1 == MAX_BAND_TRY ||
+                (sp->tight_band > 0 && w >= sp->tight_band))
             {
                 ugp_record_left_outcome(sp, opt->a, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip5) {
@@ -3583,7 +3597,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight1;
     max_tb = sp_max_tight_band(pair_ar, nump);
-    init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    init_w = opt->w;
+    (void)max_tb;
     tprof[UGP_R_DISP_NARROW][tid] += (init_w < opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
@@ -3611,7 +3626,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
             // no further banding
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
+                i+1 == MAX_BAND_TRY ||
+                (sp->tight_band > 0 && w >= sp->tight_band))
             {
                 ugp_record_right_outcome(sp, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip3) {
@@ -3648,7 +3664,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight16;
     max_tb = sp_max_tight_band(pair_ar, nump);
-    init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    init_w = opt->w;
+    (void)max_tb;
     tprof[UGP_R_DISP_NARROW][tid] += (init_w < opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
@@ -3684,7 +3701,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
             // no further banding
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
+                i+1 == MAX_BAND_TRY ||
+                (sp->tight_band > 0 && w >= sp->tight_band))
             {
                 ugp_record_right_outcome(sp, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip3) {
@@ -3722,7 +3740,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight128;
     max_tb = sp_max_tight_band(pair_ar, nump);
-    init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    init_w = opt->w;
+    (void)max_tb;
     tprof[UGP_R_DISP_NARROW][tid] += (init_w < opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
@@ -3757,7 +3776,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             a->score = sp->score;
             // no further banding
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
+                i+1 == MAX_BAND_TRY ||
+                (sp->tight_band > 0 && w >= sp->tight_band))
             {
                 ugp_record_right_outcome(sp, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip3) {

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -33,6 +33,142 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "memcpy_bwamem.h"
 #include "bam_writer.h"
 #include "meth_bam.h"
+#include <inttypes.h>      /* PRId64 for int64_t fprintf format strings */
+
+/* ─── SIMD-accelerated SEQ/QUAL encoders for SAM record building ──────────
+ * Replaces the per-byte `dst[i] = "ACGTN"[src[i]]` loop in mem_aln2sam.
+ * Works on 16 bytes at a time via a byte-LUT shuffle. Three implementations
+ * compiled in: NEON (vqtbl1q_u8) on aarch64, SSSE3 (_mm_shuffle_epi8) on
+ * x86 — covers SSSE3, SSE4, AVX2, AVX-512BW — and a scalar fallback for
+ * everything else. AVX2/AVX-512BW could process 32/64 bytes per iter but
+ * the inner loop is already short for typical 150-bp reads, so the SSSE3
+ * 16-byte width is the right compromise of code volume vs. perf. */
+#if defined(__ARM_NEON) || defined(__aarch64__)
+#  include <arm_neon.h>
+#  define SAM_FAST_IMPL 1   /* NEON */
+#elif defined(__SSSE3__) || defined(__SSE4_1__) || defined(__AVX__) \
+   || defined(__AVX2__) || defined(__AVX512BW__)
+#  include <tmmintrin.h>    /* SSSE3 _mm_shuffle_epi8 */
+#  define SAM_FAST_IMPL 2   /* SSSE3+ */
+#endif
+
+#ifdef SAM_FAST_IMPL
+static const uint8_t enc_fwd_lut[16] = {
+    'A','C','G','T','N','N','N','N',
+    'N','N','N','N','N','N','N','N',
+};
+static const uint8_t enc_rev_lut[16] = {
+    'T','G','C','A','N','N','N','N',
+    'N','N','N','N','N','N','N','N',
+};
+#endif
+
+/* Scalar tail clamp — mirrors the SIMD path's vminq_u8/_mm_min_epu8 against 4
+ * so any code >= 5 in src[] decodes to 'N' instead of indexing OOB into the
+ * 5-byte "ACGTN"/"TGCAN" literals. Today s->seq is always 2-bit ACGTN before
+ * mem_aln2sam, so this is latent — but it keeps SIMD and scalar paths in
+ * lockstep if that invariant ever drifts. */
+#define SAM_NT_CLAMP4(c) ((unsigned)(c) <= 4u ? (unsigned)(c) : 4u)
+
+#if SAM_FAST_IMPL == 1
+/* NEON 16-byte: vqtbl1q_u8 LUT + vminq_u8 clamp + vextq+vrev64q reverse. */
+static inline void encode_seq_fwd(char *dst, const uint8_t *src, int n) {
+    const uint8x16_t lut = vld1q_u8(enc_fwd_lut);
+    const uint8x16_t four = vdupq_n_u8(4);
+    int i = 0;
+    while (i + 16 <= n) {
+        uint8x16_t v   = vld1q_u8(src + i);
+        uint8x16_t cl  = vminq_u8(v, four);
+        uint8x16_t out = vqtbl1q_u8(lut, cl);
+        vst1q_u8((uint8_t*)dst + i, out);
+        i += 16;
+    }
+    while (i < n) { dst[i] = "ACGTN"[SAM_NT_CLAMP4(src[i])]; ++i; }
+}
+static inline void encode_seq_rev(char *dst, const uint8_t *src, int n) {
+    const uint8x16_t lut = vld1q_u8(enc_rev_lut);
+    const uint8x16_t four = vdupq_n_u8(4);
+    int i = 0;
+    while (i + 16 <= n) {
+        uint8x16_t v = vld1q_u8(src + n - 16 - i);
+        v = vextq_u8(v, v, 8);
+        v = vrev64q_u8(v);
+        uint8x16_t cl  = vminq_u8(v, four);
+        uint8x16_t out = vqtbl1q_u8(lut, cl);
+        vst1q_u8((uint8_t*)dst + i, out);
+        i += 16;
+    }
+    while (i < n) { dst[i] = "TGCAN"[SAM_NT_CLAMP4(src[n - 1 - i])]; ++i; }
+}
+static inline void copy_qual_rev(char *dst, const char *src, int n) {
+    int i = 0;
+    while (i + 16 <= n) {
+        uint8x16_t v = vld1q_u8((const uint8_t*)(src + n - 16 - i));
+        v = vextq_u8(v, v, 8);
+        v = vrev64q_u8(v);
+        vst1q_u8((uint8_t*)dst + i, v);
+        i += 16;
+    }
+    while (i < n) { dst[i] = src[n - 1 - i]; ++i; }
+}
+#elif SAM_FAST_IMPL == 2
+/* SSSE3 16-byte: _mm_shuffle_epi8 LUT + _mm_min_epu8 clamp + reverse-mask
+ * shuffle for the reverse direction. Works on every x86 since 2006 (SSSE3
+ * is in Core 2 and later); AVX2/AVX-512 hosts pick this path too. */
+static const uint8_t rev16_mask[16] = {
+    15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+};
+static inline void encode_seq_fwd(char *dst, const uint8_t *src, int n) {
+    const __m128i lut  = _mm_loadu_si128((const __m128i*)enc_fwd_lut);
+    const __m128i four = _mm_set1_epi8(4);
+    int i = 0;
+    while (i + 16 <= n) {
+        __m128i v   = _mm_loadu_si128((const __m128i*)(src + i));
+        __m128i cl  = _mm_min_epu8(v, four);
+        __m128i out = _mm_shuffle_epi8(lut, cl);
+        _mm_storeu_si128((__m128i*)(dst + i), out);
+        i += 16;
+    }
+    while (i < n) { dst[i] = "ACGTN"[SAM_NT_CLAMP4(src[i])]; ++i; }
+}
+static inline void encode_seq_rev(char *dst, const uint8_t *src, int n) {
+    const __m128i lut  = _mm_loadu_si128((const __m128i*)enc_rev_lut);
+    const __m128i four = _mm_set1_epi8(4);
+    const __m128i rev  = _mm_loadu_si128((const __m128i*)rev16_mask);
+    int i = 0;
+    while (i + 16 <= n) {
+        __m128i v   = _mm_loadu_si128((const __m128i*)(src + n - 16 - i));
+        v           = _mm_shuffle_epi8(v, rev);   /* reverse all 16 bytes */
+        __m128i cl  = _mm_min_epu8(v, four);
+        __m128i out = _mm_shuffle_epi8(lut, cl);
+        _mm_storeu_si128((__m128i*)(dst + i), out);
+        i += 16;
+    }
+    while (i < n) { dst[i] = "TGCAN"[SAM_NT_CLAMP4(src[n - 1 - i])]; ++i; }
+}
+static inline void copy_qual_rev(char *dst, const char *src, int n) {
+    const __m128i rev = _mm_loadu_si128((const __m128i*)rev16_mask);
+    int i = 0;
+    while (i + 16 <= n) {
+        __m128i v = _mm_loadu_si128((const __m128i*)(src + n - 16 - i));
+        v = _mm_shuffle_epi8(v, rev);
+        _mm_storeu_si128((__m128i*)(dst + i), v);
+        i += 16;
+    }
+    while (i < n) { dst[i] = src[n - 1 - i]; ++i; }
+}
+#else
+/* Scalar fallback (no SIMD available). */
+static inline void encode_seq_fwd(char *dst, const uint8_t *src, int n) {
+    for (int i = 0; i < n; ++i) dst[i] = "ACGTN"[SAM_NT_CLAMP4(src[i])];
+}
+static inline void encode_seq_rev(char *dst, const uint8_t *src, int n) {
+    for (int i = 0; i < n; ++i) dst[i] = "TGCAN"[SAM_NT_CLAMP4(src[n - 1 - i])];
+}
+static inline void copy_qual_rev(char *dst, const char *src, int n) {
+    for (int i = 0; i < n; ++i) dst[i] = src[n - 1 - i];
+}
+#endif
 /* Not including <htslib/sam.h>: its kstring.h shares the KSTRING_H guard
  * with bwa-mem2's. Opaque bam1_t wrappers live in bam_writer.h. */
 
@@ -54,7 +190,17 @@ KSORT_INIT(mem_intv1, SMEM, intv_lt1)  // debug
 #define max_(x, y) ((x)>(y)?(x):(y))
 #define min_(x, y) ((x)>(y)?(y):(x))
 
-#define MAX_BAND_TRY  2
+#define MAX_BAND_TRY  4
+
+/* cap initial band-width at this value. The retry loop
+ * doubles w each iteration (up to MAX_BAND_TRY-1 iters), so pairs whose
+ * alignment needs a wider band are caught by the retry. Setting this below
+ * opt->w forces the kernel to start tight, accept tight-fit pairs early
+ * (via sp->max_off heuristic + sp->tight_band), and only expand on demand.
+ * BUCKET_MAX_INIT_W=8 with MAX_BAND_TRY=4 gives w-sequence 8, 16, 32, 64. */
+#ifndef BUCKET_MAX_INIT_W
+#define BUCKET_MAX_INIT_W 8
+#endif
 
             int tcnt = 0;
 /********************
@@ -144,7 +290,6 @@ mem_opt_t *mem_opt_init()
     o->min_chain_weight = 0;
     o->max_chain_extend = 1<<30;
     o->mapQ_coef_len = 50; o->mapQ_coef_fac = log(o->mapQ_coef_len);
-    o->supp_rep_hard_cap = 0; // disabled by default; preserves stock MAPQ output
     bwa_fill_scmat(o->a, o->b, o->mat);
     return o;
 }
@@ -427,7 +572,9 @@ int mem_seed_sw(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
     if (qe - qb >= MEM_SHORT_LEN || re - rb >= MEM_SHORT_LEN) return -1; // the seed seems good enough; no need to do SW
 
     rseq = bns_fetch_seq(bns, pac, &rb, mid, &re, &rid);
-    x = ksw_align2(qe - qb, (uint8_t*)query + qb, re - rb, rseq, 5, opt->mat, opt->o_del, opt->e_del, opt->o_ins, opt->e_ins, KSW_XSTART, 0);
+    // No qry-profile cache: each seed slices a different sub-query
+    // (query+qb, qe-qb), so ksw_align2 always builds a fresh profile.
+    x = ksw_align2(qe - qb, (uint8_t*)query + qb, re - rb, rseq, 5, opt->mat, opt->o_del, opt->e_del, opt->o_ins, opt->e_ins, KSW_XSTART, NULL);
     free(rseq);
     return x.score;
 }
@@ -648,108 +795,27 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
 
     int32_t *query_cum_len_ar = (int32_t *)_mm_malloc(nseq * sizeof(int32_t), 64);
 
-    // Measure the batch before writing into any per-read buffer. enc_qdb /
-    // min_intv_ar / rid may have been sized by a prior batch whose
-    // wsize_mem_s / wsize_mem_r is smaller than this batch needs; the grow
-    // blocks below use tot_seq_len and max_readlength to resize before any
-    // write, so we need both values up front.
-    int64_t tot_seq_len = 0;
-    max_readlength = seq_[0].l_seq;
-    for (int l = 0; l < nseq; l++) {
-        tot_seq_len += seq_[l].l_seq;
-        if (max_readlength < seq_[l].l_seq)
-            max_readlength = seq_[l].l_seq;
-    }
-
-    // Empty-batch fast path: no bases to walk, no SMEMs to emit. Skipping
-    // here also avoids dereferencing the per-thread buffers below before
-    // they grow — they remain NULL on the first call when needed_match is
-    // 0 (e.g. a malformed/zero-length input slips through bseq).
-    if (tot_seq_len == 0 || max_readlength <= 0) {
-        _mm_free(query_cum_len_ar);
-        tot_smem = 0;
-        return mmc->matchArray[tid];
-    }
-
-    // Pre-walk sizing. All SMEM-family buffers grow monotonically in
-    // max_readlength (matchArray) or tot_seq_len (enc_qdb and wsize_mem_r
-    // helpers). The walk functions also receive wsize_mem[tid] as
-    // max_smem and bounds-check every write — defense in depth against a
-    // sizing miscalculation. Use nseq, not BATCH_SIZE, so a small tail
-    // batch with a single long read doesn't allocate as if every call were
-    // a full BATCH_SIZE block.
-    int64_t needed_match = (int64_t)BATCH_MUL * nseq * max_readlength;
-    if (mmc->wsize_mem[tid] < needed_match) {
-        _mm_free(mmc->matchArray[tid]);
-        mmc->wsize_mem[tid] = needed_match;
-        mmc->matchArray[tid] = (SMEM *) _mm_malloc(needed_match * sizeof(SMEM), 64);
-        assert(mmc->matchArray[tid] != NULL);
-        matchArray = mmc->matchArray[tid];
-    }
-    if (mmc->wsize_mem_s[tid] < tot_seq_len) {
-        // enc_qdb must hold every base in the batch. Use a nonzero floor so
-        // repeated allocs on small batches don't churn; nseq*max_readlength
-        // is a monotonic upper bound that matches the historical sizing.
-        int64_t needed_s = (int64_t)nseq * max_readlength;
-        mmc->wsize_mem_s[tid] = needed_s;
-        mmc->enc_qdb[tid] = (uint8_t *) realloc(mmc->enc_qdb[tid], needed_s * sizeof(uint8_t));
-        assert(mmc->enc_qdb[tid] != NULL);
-        enc_qdb = mmc->enc_qdb[tid];
-    }
-    // min_intv_ar / query_pos_ar / rid all index by "read" or by SMEM index
-    // in the split-SMEM pass. Size them to hold up to num_smem1 candidates —
-    // upper-bounded by matchArray capacity.
-    if (mmc->wsize_mem_r[tid] < needed_match) {
-        mmc->wsize_mem_r[tid] = needed_match;
-        mmc->min_intv_ar[tid]  = (int32_t *) realloc(mmc->min_intv_ar[tid],
-                                                     needed_match * sizeof(int32_t));
-        mmc->query_pos_ar[tid] = (int16_t *) realloc(mmc->query_pos_ar[tid],
-                                                     needed_match * sizeof(int16_t));
-        mmc->rid[tid]          = (int32_t *) realloc(mmc->rid[tid],
-                                                     needed_match * sizeof(int32_t));
-        assert(mmc->min_intv_ar[tid]  != NULL);
-        assert(mmc->query_pos_ar[tid] != NULL);
-        assert(mmc->rid[tid]          != NULL);
-        min_intv_ar  = mmc->min_intv_ar[tid];
-        query_pos_ar = mmc->query_pos_ar[tid];
-        rid          = mmc->rid[tid];
-    }
-    // Lockstep per-slot buffers (heap-owned; one pair per thread).
-    if (mmc->lockstep_buf_cap[tid] < max_readlength) {
-        int64_t n_elems = (int64_t)SMEM_LOCKSTEP_N * max_readlength;
-        _mm_free(mmc->lockstep_prev[tid]);
-        _mm_free(mmc->lockstep_match_buf[tid]);
-        mmc->lockstep_prev[tid]      = (SMEM *) _mm_malloc(n_elems * sizeof(SMEM), 64);
-        mmc->lockstep_match_buf[tid] = (SMEM *) _mm_malloc(n_elems * sizeof(SMEM), 64);
-        assert(mmc->lockstep_prev[tid]      != NULL);
-        assert(mmc->lockstep_match_buf[tid] != NULL);
-        mmc->lockstep_buf_cap[tid] = max_readlength;
-    }
-
-    // Populate per-read buffers now that the grow blocks above have sized
-    // them for this batch. enc_qdb is indexed linearly across all reads;
-    // min_intv_ar / rid are indexed by read.
     int offset = 0;
-    query_cum_len_ar[0] = 0;
-    for (int l = 0; l < nseq; l++) {
-        if (l > 0)
-            query_cum_len_ar[l] = query_cum_len_ar[l - 1] + seq_[l - 1].l_seq;
+    for (int l=0; l<nseq; l++)
+    {
         min_intv_ar[l] = 1;
-        for (int j = 0; j < seq_[l].l_seq; j++) {
-            enc_qdb[offset + j] = seq_[l].seq[j];
-        }
+        memcpy(enc_qdb + offset, seq_[l].seq, (size_t)seq_[l].l_seq);
         offset += seq_[l].l_seq;
         rid[l] = l;
     }
 
+    max_readlength = seq_[0].l_seq;
+    query_cum_len_ar[0] = 0;
+    for(int i = 1; i < nseq; i++) {
+        query_cum_len_ar[i] = query_cum_len_ar[i - 1] + seq_[i-1].l_seq;
+        if (max_readlength < seq_[i].l_seq)
+            max_readlength = seq_[i].l_seq;
+    }
+
     fmi->getSMEMsAllPosOneThread(enc_qdb, min_intv_ar, rid, nseq, nseq,
                                  seq_, query_cum_len_ar, max_readlength, opt->min_seed_len,
-                                 matchArray, mmc->wsize_mem[tid],
-                                 mmc->lockstep_prev[tid],
-                                 mmc->lockstep_match_buf[tid],
-                                 &num_smem1);
+                                 matchArray, &num_smem1);
 
-    int64_t mem_lim = 0;
     for (int64_t i=0; i<num_smem1; i++)
     {
         SMEM *p = &matchArray[i];
@@ -767,10 +833,41 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
 
         min_intv_ar[pos] = p->s + 1;
         pos ++;
-        mem_lim += end - start;
     }
-    (void)mem_lim;
 
+    #if 1
+    // Pre-walk grow: getSMEMsOnePosOneThread emits at most readlength SMEMs
+    // per re-walk position (the scalar walker's worst case is one SMEM per
+    // backward step plus the final prev[0]), so the safe upper bound on
+    // num_smem2 is pos * max_readlength.
+    const int64_t safe_smem2_cap = (int64_t)pos * max_readlength;
+    if (mmc->wsize_mem[tid] < num_smem1 + safe_smem2_cap) {
+        int64_t tmp = mmc->wsize_mem[tid];
+        mmc->wsize_mem[tid] = num_smem1 + safe_smem2_cap;
+
+        SMEM* ptr1 = mmc->matchArray[tid];
+        // ptr2 = w.mmc.min_intv_ar;
+        // ptr3 =
+        if (bwa_verbose >= 4) {
+            fprintf(stderr, "[%0.4d] REA Re-allocating SMEM after num_smem1: "
+                    "%" PRId64 " -> %" PRId64 "\n",
+                    tid, tmp, mmc->wsize_mem[tid]);
+        }
+        mmc->matchArray[tid]    = (SMEM *) _mm_malloc(mmc->wsize_mem[tid] * sizeof(SMEM), 64);
+        assert(mmc->matchArray[tid] != NULL);
+        matchArray = mmc->matchArray[tid];
+        // w.mmc.min_intv_ar[l]   = (int32_t *) malloc(w.mmc.wsize_mem[l] * sizeof(int32_t));
+        // w.mmc.query_pos_ar[tid]  = (int16_t *) malloc(w.mmc.wsize_mem[l] * sizeof(int16_t));
+        // w.mmc.enc_qdb[l]       = (uint8_t *) malloc(w.mmc.wsize_mem[l] * sizeof(uint8_t));
+        // w.mmc.rid[l]           = (int32_t *) malloc(w.mmc.wsize_mem[l] * sizeof(int32_t));
+        //w.mmc.lim[l]         = (int32_t *) _mm_malloc((BATCH_SIZE + 32) * sizeof(int32_t), 64);
+        for (int i=0; i<num_smem1; i++) {
+            mmc->matchArray[tid][i] = ptr1[i];
+        }
+        _mm_free(ptr1);
+    }
+    #endif
+    
 #if SMEM_LOCKSTEP_N > 1
     fmi->getSMEMsOnePosOneThread_lockstep(enc_qdb,
                                           query_pos_ar,
@@ -783,9 +880,6 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
                                           max_readlength,
                                           opt->min_seed_len,
                                           matchArray + num_smem1,
-                                          mmc->wsize_mem[tid] - num_smem1,
-                                          mmc->lockstep_prev[tid],
-                                          mmc->lockstep_match_buf[tid],
                                           &num_smem2);
 #else
     fmi->getSMEMsOnePosOneThread(enc_qdb,
@@ -799,19 +893,51 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
                                  max_readlength,
                                  opt->min_seed_len,
                                  matchArray + num_smem1,
-                                 mmc->wsize_mem[tid] - num_smem1,
                                  &num_smem2);
 #endif
+    // assert(mmc->wsize_mem[tid] > (num_smem1 + num_smem2));
+    // fprintwsize_mem_rf(stderr, "num_smem2: %d\n", num_smem2);
     if (opt->max_mem_intv > 0)
     {
+        #if 1
+		// Pre-walk grow for the third pass. bwtSeedStrategyAllPosOneThread's
+		// documented worst case (FMI_search.h) is nseq * max_seq_length SMEMs
+		// — one per query position per read — which dwarfs the prior
+		// offset/(min_seed_len+1) heuristic. Use the safe bound so the
+		// caller cannot overflow matchArray when this pass writes at
+		// (num_smem1 + num_smem2).
+		const int64_t safe_smem3_cap = (int64_t)nseq * max_readlength;
+		const int64_t mem_intv_cap = num_smem1 + num_smem2 + safe_smem3_cap;
+		if (mmc->wsize_mem[tid] < mem_intv_cap) {
+            int64_t tmp = mmc->wsize_mem[tid];
+		    mmc->wsize_mem[tid] = mem_intv_cap;
+		    SMEM* ptr1 = mmc->matchArray[tid];
+            if (bwa_verbose >= 4) {
+                fprintf(stderr, "[%0.4d] REA Re-allocating SMEM after num_smem2: "
+                        "%" PRId64 " -> %" PRId64 "\n",
+                        tid, tmp, mmc->wsize_mem[tid]);
+            }
+		    mmc->matchArray[tid]    = (SMEM *) _mm_malloc(mmc->wsize_mem[tid] * sizeof(SMEM), 64);
+		    assert(mmc->matchArray[tid] != NULL);
+		    matchArray = mmc->matchArray[tid];
+		    // First pass wrote num_smem1 records at offset 0; the second pass
+		    // (getSMEMsOnePosOneThread*) just wrote num_smem2 records at offset
+		    // num_smem1. Preserve both — bwtSeedStrategyAllPosOneThread() below
+		    // appends at offset num_smem1 + num_smem2.
+		    int64_t already_written = (int64_t)num_smem1 + num_smem2;
+		    for (int64_t i = 0; i < already_written; ++i) {
+		        mmc->matchArray[tid][i] = ptr1[i];
+		    }
+		    _mm_free(ptr1);
+		}
+        #endif
         for (int l=0; l<nseq; l++)
             min_intv_ar[l] = opt->max_mem_intv;
 
         num_smem3 = fmi->bwtSeedStrategyAllPosOneThread(enc_qdb, min_intv_ar,
                                                         nseq, seq_, query_cum_len_ar,
                                                         opt->min_seed_len + 1,
-                                                        matchArray + num_smem1 + num_smem2,
-                                                        mmc->wsize_mem[tid] - num_smem1 - num_smem2);
+                                                        matchArray + num_smem1 + num_smem2);
     }
     tot_smem = num_smem1 + num_smem2 + num_smem3;
     // assert(mmc->wsize_mem[tid] > (tot_smem));
@@ -942,7 +1068,6 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
 
                 s.qbeg = p->m;
                 s.score= s.len = slen;
-                s.n_hits = (int32_t)(p->s < INT32_MIN ? INT32_MIN : (p->s > INT32_MAX ? INT32_MAX : p->s));
                 if (s.rbeg < 0 || s.len < 0)
                     fprintf(stderr, "rbeg: %ld, slen: %d, cnt: %d, n: %d, m: %d, num_smem: %ld\n",
                             s.rbeg, s.len, cnt-1, p->n, p->m, num_smem);
@@ -1019,7 +1144,7 @@ int mem_kernel1_core(FMI_search *fmi,
                      int tid)
 {
     int i;
-    int64_t num_smem = 0;
+    int64_t num_smem = 0, tot_len = 0;
     mem_chain_v *chn;
 
     uint64_t tim;
@@ -1028,16 +1153,38 @@ int mem_kernel1_core(FMI_search *fmi,
     {
         char *seq = seq_[l].seq;
         int len = seq_[l].l_seq;
+        tot_len += len;
 
         for (i = 0; i < len; ++i)
             seq[i] = seq[i] < 4? seq[i] : nst_nt4_table[(int)seq[i]]; //nst_nt4??
     }
-    // SMEM-family per-thread buffer sizing happens inside mem_collect_smem,
-    // pre-walk and keyed on max_readlength / tot_seq_len of this batch. The
-    // historical tot_len-based grow that used to live here is redundant with
-    // that pre-walk grow and was incorrect for the lazy-init case
-    // (wsize_mem == 0 with a 0-base degenerate batch tripped _mm_realloc's
-    // "shrinking not supported" path on a NULL pointer).
+    // tot_len *= N_SMEM_KERNEL;
+    // fprintf(stderr, "wsize: %d, tot_len: %d\n", mmc->wsize_mem[tid], tot_len);
+    // This covers enc_qdb/SMEM reallocs
+    if (tot_len >= mmc->wsize_mem[tid])
+    {
+        int64_t tmp = mmc->wsize_mem[tid];
+        mmc->wsize_mem[tid] = tot_len;
+        if (bwa_verbose >= 4) {
+            fprintf(stderr, "[%0.4d] Re-allocating SMEM scratch (enc_qdb): "
+                    "%" PRId64 " -> %" PRId64 "\n",
+                    tid, tmp, mmc->wsize_mem[tid]);
+        }
+        mmc->wsize_mem_s[tid] = tot_len;
+        mmc->wsize_mem_r[tid] = tot_len;
+        mmc->matchArray[tid]   = (SMEM *) _mm_realloc(mmc->matchArray[tid],
+                                                      tmp, mmc->wsize_mem[tid], sizeof(SMEM));
+            //realloc(mmc->matchArray[tid], mmc->wsize_mem[tid] *   sizeof(SMEM));
+        mmc->min_intv_ar[tid]  = (int32_t *) realloc(mmc->min_intv_ar[tid],
+                                                     mmc->wsize_mem[tid] *  sizeof(int32_t));
+        mmc->query_pos_ar[tid] = (int16_t *) realloc(mmc->query_pos_ar[tid],
+                                                     mmc->wsize_mem[tid] *  sizeof(int16_t));
+        mmc->enc_qdb[tid]      = (uint8_t *) realloc(mmc->enc_qdb[tid],
+                                                      mmc->wsize_mem[tid] * sizeof(uint8_t));
+        mmc->rid[tid]          = (int32_t *) realloc(mmc->rid[tid],
+                                                      mmc->wsize_mem[tid] * sizeof(int32_t));
+        // w.mmc.lim[l]        = (int32_t *) _mm_malloc((BATCH_SIZE + 32) * sizeof(int32_t), 64);
+    }
 
     SMEM    *matchArray   = mmc->matchArray[tid];
     int32_t *min_intv_ar  = mmc->min_intv_ar[tid];
@@ -1061,10 +1208,8 @@ int mem_kernel1_core(FMI_search *fmi,
                                   num_smem,
                                   tid);
 
-    // mem_collect_smem bounds-checks every matchArray write via
-    // smem_overflow_die, so num_smem can equal *wsize_mem (last slot used)
-    // without an actual overflow. Only `>` indicates a sizing miscalculation.
-    // An empty batch is a valid case: num_smem == *wsize_mem == 0.
+    // Exact-fit (num_smem == *wsize_mem) is valid: the last write lands at
+    // matchArray[*wsize_mem - 1]. Trip only on a true overrun.
     if (num_smem > *wsize_mem){
         fprintf(stderr, "Error [bug]: num_smem: %ld are more than allocated space %ld.\n",
                 num_smem, *wsize_mem);
@@ -1075,6 +1220,7 @@ int mem_kernel1_core(FMI_search *fmi,
 
 
     /********************* Kernel 1.1: SA2REF **********************/
+    tim = __rdtsc();
     printf_(VER, "6.1. Calling mem_chain..\n");
     mem_chain_seeds(fmi, opt, fmi->idx->bns,
                     seq_, nseq, tid,
@@ -1085,7 +1231,7 @@ int mem_kernel1_core(FMI_search *fmi,
                     num_smem);
 
     printf_(VER, "5. Done mem_chain..\n");
-    // tprof[MEM_CHAIN][tid] += __rdtsc() - tim;
+    tprof[MEM_CHAIN][tid] += __rdtsc() - tim;
 
     /************** Post-processing of collected smems/chains ************/
     // tim = __rdtsc();
@@ -1582,13 +1728,6 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
 #else
         if (l && !p->is_alt && q->mapq > aa.a[0].mapq) q->mapq = aa.a[0].mapq;
 #endif
-        // fg-labs: supp alnregs whose chain contains a repetitive seed (many
-        // genome occurrences) inherit primary MAPQ despite being ambiguous on
-        // their own — upstream issue bwa-mem2/bwa-mem2#260. Opt-in override:
-        // force MAPQ=0 when the chain's most-repetitive seed exceeds the cap.
-        if (opt->supp_rep_hard_cap > 0 && l && p->secondary < 0 &&
-            p->chain_n_hits >= opt->supp_rep_hard_cap)
-            q->mapq = 0;
         ++l;
     }
     if (aa.n == 0) { // no alignments good enough; then write an unaligned record
@@ -1610,6 +1749,8 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
     free(HN);
 }
 
+/* Caller must have called ks_resize beforehand to leave room for
+ * n_cigar*16 bytes (worst-case: each op is 11 digits + 1 letter). */
 static inline void add_cigar(const mem_opt_t *opt, mem_aln_t *p, kstring_t *str, int which)
 {
     int i;
@@ -1618,9 +1759,9 @@ static inline void add_cigar(const mem_opt_t *opt, mem_aln_t *p, kstring_t *str,
             int c = p->cigar[i]&0xf;
             if (!(opt->flag&MEM_F_SOFTCLIP) && !p->is_alt && (c == 3 || c == 4))
                 c = which? 4 : 3; // use hard clipping for supplementary alignments
-            kputw(p->cigar[i]>>4, str); kputc("MIDSH"[c], str);
+            kputw_u(p->cigar[i]>>4, str); kputc_u("MIDSH"[c], str);
         }
-    } else kputc('*', str); // having a coordinate but unaligned (e.g. when copy_mate is true)
+    } else kputc_u('*', str); // having a coordinate but unaligned (e.g. when copy_mate is true)
 }
 
 void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
@@ -1661,128 +1802,170 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
     p->flag |= p->is_rev? 0x10 : 0; // is on the reverse strand
     p->flag |= m && m->is_rev? 0x20 : 0; // is mate on the reverse strand
 
+    /* ─── Pre-size kstring once for the worst-case record length, then use
+     * unsafe (no-realloc, no-bound-check) writes throughout. The estimate
+     * covers: QNAME + FLAG + RNAME + POS + MAPQ + CIGAR + mate fields +
+     * SEQ + QUAL + tags + headers; rare overflow falls back to ks_resize.
+     */
+    l_name = (int)strlen(s->name);
+    {
+        size_t md_len = 0;
+        if (p->n_cigar)
+            md_len = strlen((const char*)(p->cigar + p->n_cigar));
+        size_t comm_len = s->comment ? strlen(s->comment) : 0;
+        size_t anno_len = ((opt->flag & MEM_F_REF_HDR) && p->rid >= 0
+                           && bns->anns[p->rid].anno && bns->anns[p->rid].anno[0])
+                          ? strlen(bns->anns[p->rid].anno) : 0;
+        size_t xa_len   = p->XA ? strlen(p->XA) : 0;
+        size_t rg_len   = bwa_rg_id[0] ? strlen(bwa_rg_id) : 0;
+        /* RNAME/RNEXT contig names can be very long (T2T-style assemblies).
+         * Mate CIGAR (MC:Z) under V17 is also written via add_cigar(). */
+        size_t rname_len = (p->rid >= 0) ? strlen(bns->anns[p->rid].name) : 1;
+        size_t rnext_len = (m && m->rid >= 0 && m->rid != p->rid)
+                           ? strlen(bns->anns[m->rid].name) : 1;
+        size_t mate_cigar_len = (m && m->n_cigar) ? (size_t)m->n_cigar * 16 : 0;
+        /* SA:Z worst case (only emitted when n>1 and there are other primary
+         * hits, but priced unconditionally so the local ks_resize at the
+         * SA:Z site can be dropped — single resize keeps the unsafe-fast
+         * write invariant for the post-SA:Z tags (XA, HN, comment, XR:Z). */
+        size_t sa_need = 16;
+        for (int j = 0; j < n; ++j) {
+            if (j == which || (list[j].flag&0x100)) continue;
+            sa_need += strlen(bns->anns[list[j].rid].name) + 32 + list[j].n_cigar * 16;
+        }
+        size_t need = (size_t)l_name
+                    + (size_t)s->l_seq * 2     /* SEQ + QUAL */
+                    + (size_t)p->n_cigar * 16  /* primary CIGAR */
+                    + mate_cigar_len           /* MC:Z mate CIGAR */
+                    + rname_len + rnext_len    /* RNAME + RNEXT */
+                    + md_len + xa_len + rg_len + comm_len + anno_len
+                    + sa_need                  /* SA:Z (multi-supp) */
+                    + 256;                      /* slack for ints + tags */
+        ks_resize(str, str->l + need);
+    }
+
     // print up to CIGAR
-    l_name = strlen(s->name);
-    ks_resize(str, str->l + s->l_seq + l_name + (s->qual? s->l_seq : 0) + 20);
-    kputsn(s->name, l_name, str); kputc('\t', str); // QNAME
-    kputw((p->flag&0xffff) | (p->flag&0x10000? 0x100 : 0), str); kputc('\t', str); // FLAG
+    kputsn_u(s->name, l_name, str); kputc_u('\t', str); // QNAME
+    kputw_u((p->flag&0xffff) | (p->flag&0x10000? 0x100 : 0), str); kputc_u('\t', str); // FLAG
     if (p->rid >= 0) { // with coordinate
-        kputs(bns->anns[p->rid].name, str); kputc('\t', str); // RNAME
-        kputl(p->pos + 1, str); kputc('\t', str); // POS
-        kputw(p->mapq, str); kputc('\t', str); // MAPQ
+        kputs_u(bns->anns[p->rid].name, str); kputc_u('\t', str); // RNAME
+        kputl_u(p->pos + 1, str); kputc_u('\t', str); // POS
+        kputw_u(p->mapq, str); kputc_u('\t', str); // MAPQ
 #if OLD // from v15
         if (p->n_cigar) { // aligned
             for (i = 0; i < p->n_cigar; ++i) {
                 int c = p->cigar[i]&0xf;
                 if (!(opt->flag&MEM_F_SOFTCLIP) && !p->is_alt && (c == 3 || c == 4))
                     c = which? 4 : 3; // use hard clipping for supplementary alignments
-                kputw(p->cigar[i]>>4, str); kputc("MIDSH"[c], str);
+                kputw_u(p->cigar[i]>>4, str); kputc_u("MIDSH"[c], str);
             }
-        } else kputc('*', str); // having a coordinate but unaligned (e.g. when copy_mate is true)
+        } else kputc_u('*', str);
 #else
         // modification from v17
         add_cigar(opt, p, str, which);
 #endif
-    } else kputsn("*\t0\t0\t*", 7, str); // without coordinte
-    kputc('\t', str);
+    } else kputsn_u("*\t0\t0\t*", 7, str); // without coordinte
+    kputc_u('\t', str);
 
     // print the mate position if applicable
     if (m && m->rid >= 0) {
-        if (p->rid == m->rid) kputc('=', str);
-        else kputs(bns->anns[m->rid].name, str);
-        kputc('\t', str);
-        kputl(m->pos + 1, str); kputc('\t', str);
+        if (p->rid == m->rid) kputc_u('=', str);
+        else kputs_u(bns->anns[m->rid].name, str);
+        kputc_u('\t', str);
+        kputl_u(m->pos + 1, str); kputc_u('\t', str);
         if (p->rid == m->rid) {
             int64_t p0 = p->pos + (p->is_rev? get_rlen(p->n_cigar, p->cigar) - 1 : 0);
             int64_t p1 = m->pos + (m->is_rev? get_rlen(m->n_cigar, m->cigar) - 1 : 0);
-            if (m->n_cigar == 0 || p->n_cigar == 0) kputc('0', str);
-            else kputl(-(p0 - p1 + (p0 > p1? 1 : p0 < p1? -1 : 0)), str);
-        } else kputc('0', str);
-    } else kputsn("*\t0\t0", 5, str);
-    kputc('\t', str);
+            if (m->n_cigar == 0 || p->n_cigar == 0) kputc_u('0', str);
+            else kputl_u(-(p0 - p1 + (p0 > p1? 1 : p0 < p1? -1 : 0)), str);
+        } else kputc_u('0', str);
+    } else kputsn_u("*\t0\t0", 5, str);
+    kputc_u('\t', str);
 
-    // print SEQ and QUAL
+    // print SEQ and QUAL — SIMD via NEON tbl1q_u8 byte LUT.
     if (p->flag & 0x100) { // for secondary alignments, don't write SEQ and QUAL
-        kputsn("*\t*", 3, str);
-    } else if (!p->is_rev) { // the forward strand
-        int i, qb = 0, qe = s->l_seq;
-        if (p->n_cigar && which && !(opt->flag&MEM_F_SOFTCLIP) && !p->is_alt) { // have cigar && not the primary alignment && not softclip all
+        kputsn_u("*\t*", 3, str);
+    } else if (!p->is_rev) { // forward strand
+        int qb = 0, qe = s->l_seq;
+        if (p->n_cigar && which && !(opt->flag&MEM_F_SOFTCLIP) && !p->is_alt) {
             if ((p->cigar[0]&0xf) == 4 || (p->cigar[0]&0xf) == 3) qb += p->cigar[0]>>4;
             if ((p->cigar[p->n_cigar-1]&0xf) == 4 || (p->cigar[p->n_cigar-1]&0xf) == 3) qe -= p->cigar[p->n_cigar-1]>>4;
         }
-        ks_resize(str, str->l + (qe - qb) + 1);
-        for (i = qb; i < qe; ++i) str->s[str->l++] = "ACGTN"[(int)s->seq[i]];
-        kputc('\t', str);
-        if (s->qual) { // printf qual
-            ks_resize(str, str->l + (qe - qb) + 1);
-            for (i = qb; i < qe; ++i) str->s[str->l++] = s->qual[i];
-            str->s[str->l] = 0;
-        } else kputc('*', str);
-    } else { // the reverse strand
-        int i, qb = 0, qe = s->l_seq;
+        const int n_seq = qe - qb;
+        encode_seq_fwd(str->s + str->l, (const uint8_t*)(s->seq + qb), n_seq);
+        str->l += n_seq;
+        kputc_u('\t', str);
+        if (s->qual) {
+            memcpy(str->s + str->l, s->qual + qb, (size_t)n_seq);
+            str->l += n_seq;
+        } else kputc_u('*', str);
+    } else { // reverse strand
+        int qb = 0, qe = s->l_seq;
         if (p->n_cigar && which && !(opt->flag&MEM_F_SOFTCLIP) && !p->is_alt) {
             if ((p->cigar[0]&0xf) == 4 || (p->cigar[0]&0xf) == 3) qe -= p->cigar[0]>>4;
             if ((p->cigar[p->n_cigar-1]&0xf) == 4 || (p->cigar[p->n_cigar-1]&0xf) == 3) qb += p->cigar[p->n_cigar-1]>>4;
         }
-        ks_resize(str, str->l + (qe - qb) + 1);
-        for (i = qe-1; i >= qb; --i) str->s[str->l++] = "TGCAN"[(int)s->seq[i]];
-        kputc('\t', str);
-        if (s->qual) { // printf qual
-            ks_resize(str, str->l + (qe - qb) + 1);
-            for (i = qe-1; i >= qb; --i) str->s[str->l++] = s->qual[i];
-            str->s[str->l] = 0;
-        } else kputc('*', str);
+        const int n_seq = qe - qb;
+        encode_seq_rev(str->s + str->l, (const uint8_t*)(s->seq + qb), n_seq);
+        str->l += n_seq;
+        kputc_u('\t', str);
+        if (s->qual) {
+            copy_qual_rev(str->s + str->l, (const char*)(s->qual + qb), n_seq);
+            str->l += n_seq;
+        } else kputc_u('*', str);
     }
 
     // print optional tags
     if (p->n_cigar) {
-        kputsn("\tNM:i:", 6, str); kputw(p->NM, str);
-        kputsn("\tMD:Z:", 6, str); kputs((char*)(p->cigar + p->n_cigar), str);
+        kputsn_u("\tNM:i:", 6, str); kputw_u(p->NM, str);
+        kputsn_u("\tMD:Z:", 6, str); kputs_u((char*)(p->cigar + p->n_cigar), str);
     }
 #if V17
-    if (m && m->n_cigar) { kputsn("\tMC:Z:", 6, str); add_cigar(opt, m, str, which); }
+    if (m && m->n_cigar) { kputsn_u("\tMC:Z:", 6, str); add_cigar(opt, m, str, which); }
 #endif
-    if (m) { kputsn("\tMQ:i:", 6, str); kputw(m->mapq, str); }
-    if (p->score >= 0) { kputsn("\tAS:i:", 6, str); kputw(p->score, str); }
-    if (p->sub >= 0) { kputsn("\tXS:i:", 6, str); kputw(p->sub, str); }
-    if (bwa_rg_id[0]) { kputsn("\tRG:Z:", 6, str); kputs(bwa_rg_id, str); }
+    if (m) { kputsn_u("\tMQ:i:", 6, str); kputw_u(m->mapq, str); }
+    if (p->score >= 0) { kputsn_u("\tAS:i:", 6, str); kputw_u(p->score, str); }
+    if (p->sub >= 0) { kputsn_u("\tXS:i:", 6, str); kputw_u(p->sub, str); }
+    if (bwa_rg_id[0]) { kputsn_u("\tRG:Z:", 6, str); kputs_u(bwa_rg_id, str); }
     if (!(p->flag & 0x100)) { // not multi-hit
         for (i = 0; i < n; ++i)
             if (i != which && !(list[i].flag&0x100)) break;
         if (i < n) { // there are other primary hits; output them
-            kputsn("\tSA:Z:", 6, str);
+            /* SA:Z capacity is reserved in the outer pre-size above. */
+            kputsn_u("\tSA:Z:", 6, str);
             for (i = 0; i < n; ++i) {
                 const mem_aln_t *r = &list[i];
                 int k;
-                if (i == which || (r->flag&0x100)) continue; // proceed if: 1) different from the current; 2) not shadowed multi hit
-                kputs(bns->anns[r->rid].name, str); kputc(',', str);
-                kputl(r->pos+1, str); kputc(',', str);
-                kputc("+-"[r->is_rev], str); kputc(',', str);
+                if (i == which || (r->flag&0x100)) continue;
+                kputs_u(bns->anns[r->rid].name, str); kputc_u(',', str);
+                kputl_u(r->pos+1, str); kputc_u(',', str);
+                kputc_u("+-"[r->is_rev], str); kputc_u(',', str);
                 for (k = 0; k < r->n_cigar; ++k) {
-                    kputw(r->cigar[k]>>4, str); kputc("MIDSH"[r->cigar[k]&0xf], str);
+                    kputw_u(r->cigar[k]>>4, str); kputc_u("MIDSH"[r->cigar[k]&0xf], str);
                 }
-                kputc(',', str); kputw(r->mapq, str);
-                kputc(',', str); kputw(r->NM, str);
-                kputc(';', str);
+                kputc_u(',', str); kputw_u(r->mapq, str);
+                kputc_u(',', str); kputw_u(r->NM, str);
+                kputc_u(';', str);
             }
         }
         if (p->alt_sc > 0)
             ksprintf(str, "\tpa:f:%.3f", (double)p->score / p->alt_sc);
     }
 
-    if (p->XA) { kputsn("\tXA:Z:", 6, str); kputs(p->XA, str); }
-    if (p->HN >= 0) { kputsn("\tHN:i:", 6, str); kputw(p->HN, str); }
+    if (p->XA) { kputsn_u("\tXA:Z:", 6, str); kputs_u(p->XA, str); }
+    if (p->HN >= 0) { kputsn_u("\tHN:i:", 6, str); kputw_u(p->HN, str); }
 
-    if (s->comment) { kputc('\t', str); kputs(s->comment, str); }
+    if (s->comment) { kputc_u('\t', str); kputs_u(s->comment, str); }
     if ((opt->flag&MEM_F_REF_HDR) && p->rid >= 0 && bns->anns[p->rid].anno != 0 && bns->anns[p->rid].anno[0] != 0) {
         int tmp;
-        kputsn("\tXR:Z:", 6, str);
-        tmp = str->l;
-        kputs(bns->anns[p->rid].anno, str);
-        for (i = tmp; i < str->l; ++i) // replace TAB in the comment to SPACE
+        kputsn_u("\tXR:Z:", 6, str);
+        tmp = (int)str->l;
+        kputs_u(bns->anns[p->rid].anno, str);
+        for (i = tmp; i < (int)str->l; ++i) // replace TAB in the comment to SPACE
             if (str->s[i] == '\t') str->s[i] = ' ';
     }
-    kputc('\n', str);
+    kputc_u('\n', str);
+    str->s[str->l] = 0;  /* single trailing NUL — unsafe writers skipped this */
 }
 
 mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, int l_query, const char *query_, const mem_alnreg_t *ar)
@@ -2123,6 +2306,307 @@ inline void sortPairsLen(SeqPair *pairArray, int32_t count, SeqPair *tempArray, 
 /* Restructured BSW parent function */
 #define FAC 8
 #define PFD 2
+
+// ungapped diagonal-extension analyzer.
+//
+// Walks the N-step diagonal once (SIMD scan + bitmap + scalar trajectory).
+// Emits three possible status codes:
+//
+//   FP_STATUS_HIT      — ungapped is provably optimal (≤ x_threshold
+//                        mismatches, no ambig). Caller skips banded SW
+//                        and uses sp.score/qle/gscore/gtle directly.
+//
+//   FP_STATUS_TIGHT    — fast-path fails (too many mismatches) but the
+//                        ungapped score bounds the useful SW band:
+//                          tight_band = ceil((min(len1,len2)·a - ungapped_score)
+//                                            / (o_min + e_min))
+//                        Caller runs SW with this tight band instead of
+//                        opt->w, and skips MAX_BAND_TRY retries (the
+//                        bound is an upper bound on any gapped score).
+//
+//   FP_STATUS_FALLBACK — ambig base or out-of-range length. Caller uses
+//                        opt->w with the full retry loop.
+//
+// Derivation of tight_band: for any alignment with band offset B from
+// diagonal, min B gaps are required; cost ≥ B · (o_min + e_min). Max
+// alignment score (all matches) ≤ min(len1, len2) · a. For any gapped
+// alignment to beat the observed ungapped max score S:
+//   min_len·a - B·(o_min+e_min) > S
+//   B < (min_len·a - S) / (o_min + e_min)
+// So any band ≥ tight_band is sufficient; narrower bands suffice too
+// when the gapped alternative score is < min_len·a. Starting SW at
+// tight_band is strictly correct and avoids over-banded DP work.
+#define FP_N_MAX 128
+#define FP_STATUS_FALLBACK  0
+#define FP_STATUS_HIT       1
+#define FP_STATUS_TIGHT     2
+
+/* Q2 helper: bin an extension's final alignment score into one of 8 buckets.
+ * Bins: {0-10, 11-25, 26-50, 51-75, 76-100, 101-125, 126-150, 151+}. */
+static inline int ugp_score_bin(int s)
+{
+    if      (s <=  10) return 0;
+    else if (s <=  25) return 1;
+    else if (s <=  50) return 2;
+    else if (s <=  75) return 3;
+    else if (s <= 100) return 4;
+    else if (s <= 125) return 5;
+    else if (s <= 150) return 6;
+    else               return 7;
+}
+
+/* Q3 helper: bin a "delta from perfect extension" into one of 8 buckets.
+ * delta = h0 + a * len2 - aln_score, where (h0 + a * len2) is the score of a
+ * hypothetical all-match ungapped extension. delta == 0 ⇒ extension was
+ * perfect (HIT path with all matches); delta grows with mismatches and gaps.
+ * Bins: {0, 1-5, 6-10, 11-25, 26-50, 51-75, 76-100, 101+}. */
+static inline int ugp_delta_bin(int d)
+{
+    if      (d ==   0) return 0;
+    else if (d <=   5) return 1;
+    else if (d <=  10) return 2;
+    else if (d <=  25) return 3;
+    else if (d <=  50) return 4;
+    else if (d <=  75) return 5;
+    else if (d <= 100) return 6;
+    else               return 7;
+}
+
+/* Q1+Q2+Q3 outcome helpers. Each post-SW dispatch (LEFT scalar / 16-bit /
+ * 8-bit; RIGHT scalar / 16-bit / 8-bit) commits a final outcome and bumps
+ * the same set of profiling counters. Hoisted so categorization changes
+ * (extra category, adjusted bin edges, fourth tier, ...) live in one place
+ * instead of drifting across six near-identical inlined blocks. */
+static inline void ugp_record_left_outcome(const SeqPair *sp, int a_match, int tid)
+{
+    int _u = (sp->qle == sp->tle);
+    tprof[UGP_OUTCOME_BASE + 0 * 2 + (_u ? 0 : 1)][tid]++;
+    tprof[UGP_SCORE_HIST_BASE + 0 * UGP_SCORE_HIST_NBINS
+          + ugp_score_bin(sp->score)][tid]++;
+    /* Q3: per-category delta-from-perfect histograms. Non-HIT by
+     * construction at the post-SW commit. cat0=ALL; cat1 (ungapped final)
+     * or cat2 (gapped final) by sp->qle == sp->tle proxy; cat4
+     * (ungap_final ∩ ~HIT) when ungapped. */
+    int _perfect = sp->h0 + a_match * sp->len2;
+    int _bin_ung = ugp_delta_bin(_perfect - sp->ugp_walk_score);
+    int _bin_fin = ugp_delta_bin(_perfect - sp->score);
+    tprof[UGP_L_CAT_UNG_BASE + 0 * UGP_CAT_NBINS + _bin_ung][tid]++;
+    tprof[UGP_L_CAT_FIN_BASE + 0 * UGP_CAT_NBINS + _bin_fin][tid]++;
+    if (_u) {
+        tprof[UGP_L_CAT_UNG_BASE + 1 * UGP_CAT_NBINS + _bin_ung][tid]++;
+        tprof[UGP_L_CAT_FIN_BASE + 1 * UGP_CAT_NBINS + _bin_fin][tid]++;
+        tprof[UGP_L_CAT_UNG_BASE + 4 * UGP_CAT_NBINS + _bin_ung][tid]++;
+        tprof[UGP_L_CAT_FIN_BASE + 4 * UGP_CAT_NBINS + _bin_fin][tid]++;
+    } else {
+        tprof[UGP_L_CAT_UNG_BASE + 2 * UGP_CAT_NBINS + _bin_ung][tid]++;
+        tprof[UGP_L_CAT_FIN_BASE + 2 * UGP_CAT_NBINS + _bin_fin][tid]++;
+    }
+}
+
+static inline void ugp_record_right_outcome(const SeqPair *sp, int tid)
+{
+    int _u = (sp->qle == sp->tle);
+    tprof[UGP_OUTCOME_BASE + 1 * 2 + (_u ? 0 : 1)][tid]++;
+    tprof[UGP_SCORE_HIST_BASE + 1 * UGP_SCORE_HIST_NBINS
+          + ugp_score_bin(sp->score)][tid]++;
+}
+
+/* Q3 helper: would-be ungapped extension score for arbitrary N. Mirrors the
+ * HIT-path scalar walk in ungapped_analyze (cur with floor at 0; max_sc
+ * tracker; ambig terminates the walk to match analyze's FALLBACK semantics).
+ * Returned score is what an ungapped extension would produce on this pair
+ * regardless of whether the fast-path actually triggered HIT. */
+static inline int ungapped_walk_score(const uint8_t *qs, const uint8_t *rs,
+                                       int N, int h0, int a, int b)
+{
+    int cur = h0, max_sc = h0;
+    for (int j = 0; j < N; j++) {
+        uint8_t qj = qs[j], rj = rs[j];
+        if (qj >= 4 || rj >= 4) break;       /* ambig: terminate the walk */
+        if (cur == 0) continue;
+        if (qj == rj) cur += a;
+        else {
+            cur -= b;
+            if (cur < 0) cur = 0;
+        }
+        if (cur >= max_sc) max_sc = cur;
+    }
+    return max_sc;
+}
+
+/* optimal ungapped score (no floor) from a per-base mismatch bitmap.
+ *
+ *     score(i) = h0 + (i − mismatches_i)·a − mismatches_i·b
+ *              = h0 + i·a − mismatches_i·(a+b)        for i ∈ [0, N]
+ *
+ * f(i) is monotone non-decreasing within match runs and drops by b at each
+ * mismatch. Local maxima therefore live at one of:
+ *   (a) i = 0                                    f(0)  = h0
+ *   (b) i = p,  bitmap[p] == 1                   f(p)  = h0 + p·a − k·(a+b)
+ *                                                where k = mismatches in [0,p)
+ *   (c) i = N                                    f(N)  = h0 + N·a − total·(a+b)
+ *
+ * Iterating set bits of the bitmap via ctz + clear-low is O(total_mis), not
+ * O(N) — typically a handful of operations for HIT/TIGHT candidates.
+ *
+ * Unlike ungapped_walk_score, there is NO floor: score is allowed to dip
+ * below 0 and recover. This yields max_sc ≥ walk's max_sc, giving a strictly
+ * tighter (still safe) bound on the SW band in the tight_band proof. The
+ * walk's floor exists to mirror SW kernel local-SW semantics for SAM
+ * byte-identity on qle/gscore — irrelevant for the band proof. */
+static inline int ungapped_max_sc_from_bitmap(uint64_t mis_lo, uint64_t mis_hi,
+                                               int N, int h0, int a, int b)
+{
+    int max_sc = h0;            /* candidate (a): empty extension */
+    int gap    = a + b;         /* score drop per mismatch (relative to match) */
+    int k      = 0;             /* mismatches counted so far */
+    uint64_t lo = mis_lo, hi = mis_hi;
+    while (lo) {
+        int p = __builtin_ctzll(lo);
+        int s = h0 + p * a - k * gap;
+        if (s > max_sc) max_sc = s;
+        lo &= lo - 1;
+        k++;
+    }
+    while (hi) {
+        int p = 64 + __builtin_ctzll(hi);
+        int s = h0 + p * a - k * gap;
+        if (s > max_sc) max_sc = s;
+        hi &= hi - 1;
+        k++;
+    }
+    int s_end = h0 + N * a - k * gap;       /* candidate (c) */
+    if (s_end > max_sc) max_sc = s_end;
+    return max_sc;
+}
+
+static inline int ungapped_analyze(const uint8_t *qs, const uint8_t *rs, int N,
+                                    int h0, int a, int b,
+                                    int o_min, int e_min,
+                                    int x_threshold, int default_w,
+                                    int *out_score, int *out_qle,
+                                    int *out_gscore, int *out_gtle,
+                                    int *out_tight_band)
+{
+    if (N <= 0 || N > FP_N_MAX || x_threshold < 0) return FP_STATUS_FALLBACK;
+
+    const __m128i v3 = _mm_set1_epi8(3);
+    uint64_t mis_lo = 0, mis_hi = 0;
+    int total_mis = 0;
+    int i = 0;
+    for (; i + 16 <= N; i += 16) {
+        __m128i qv = _mm_loadu_si128((const __m128i *)(qs + i));
+        __m128i rv = _mm_loadu_si128((const __m128i *)(rs + i));
+        // AMBIG (code >= 4) detected via max > 3. ACGT = 0..3.
+        __m128i mxv = _mm_max_epu8(qv, rv);
+        if ((unsigned)_mm_movemask_epi8(_mm_cmpgt_epi8(mxv, v3)))
+            return FP_STATUS_FALLBACK;  // ambig: give up on both paths
+        __m128i eqv = _mm_cmpeq_epi8(qv, rv);
+        unsigned mism_mask = (~(unsigned)_mm_movemask_epi8(eqv)) & 0xFFFFu;
+        total_mis += __builtin_popcount(mism_mask);
+        if (i < 64) {
+            mis_lo |= ((uint64_t)mism_mask) << i;
+            if (i + 16 > 64) mis_hi |= ((uint64_t)mism_mask) >> (64 - i);
+        } else {
+            mis_hi |= ((uint64_t)mism_mask) << (i - 64);
+        }
+    }
+    for (; i < N; i++) {
+        uint8_t qi = qs[i], ri = rs[i];
+        if (qi >= 4 || ri >= 4) return FP_STATUS_FALLBACK;
+        if (qi != ri) {
+            total_mis++;
+            if (i < 64) mis_lo |= (1ULL << i);
+            else        mis_hi |= (1ULL << (i - 64));
+        }
+    }
+
+    // precise max_sc (no floor) from the mismatch bitmap.
+    //
+    // An earlier formulation used `S = h0 + first_mis_pos·a` — a loose lower bound on the
+    // walk's max_sc — to skip the scalar walk on TIGHT pairs. That preserved
+    // walk-time but left the band proof loose: any matching run after the
+    // first mismatch could not contribute to S, so the proven band stayed
+    // wider than necessary.
+    //
+    // The bitmap-derived max_sc is the optimal ungapped score over all
+    // prefix lengths in [0, N], with no floor (score is allowed to dip and
+    // recover). It is ≥ the walk's max_sc, so substituting it into the band
+    // proof yields a strictly tighter (still safe) bound. Computing it from
+    // the bitmap is O(total_mis), independent of N.
+    //
+    // Band derivation (see comment above):
+    //     B < (min_len·a − S − o_min) / e_min        with S = max_sc − h0
+    // For LEFT extensions where the caller gates on len1 ≥ len2,
+    // min_len = N. Substituting:
+    //     numerator = N·a − (max_sc_proof − h0) − o_min
+    //               = N·a + h0 − max_sc_proof − o_min
+    int max_sc_proof = ungapped_max_sc_from_bitmap(mis_lo, mis_hi, N, h0, a, b);
+
+    if (total_mis > x_threshold) {
+        int64_t numerator = (int64_t)N * a + h0 - max_sc_proof - o_min;
+        int band;
+        if (numerator <= 0) {
+            // Ungapped-optimal (same "tight_band = 0 sentinel" semantic as
+            // walk-derived numerator ≤ 0: let SW run with fallback width).
+            band = 0;
+        } else if (e_min <= 0) {
+            band = default_w;
+        } else {
+            band = (int)((numerator + e_min - 1) / e_min);
+            if (band > default_w) band = default_w;
+        }
+        *out_tight_band = band;
+        // Outputs unused on TIGHT; set sane values for any future caller.
+        *out_score  = max_sc_proof;
+        *out_qle    = 0;
+        *out_gscore = 0;
+        *out_gtle   = N;
+        return FP_STATUS_TIGHT;
+    }
+
+    // HIT candidate: run the scalar walk for precise qle / gscore / max_sc.
+    //
+    // MAIN_CODE* local-SW semantics: once cur==0 in the ungapped path it
+    // stays 0 (no e/f restart).
+    //
+    // Tie-break: SW's maxRS tracker (bandedSWA.cpp MAIN_CODE) updates the
+    // position on BOTH strictly-greater and tied equal-to-current
+    // comparisons — equivalent to "pick the rightmost position where the
+    // max was achieved". We must mirror that (use >=) or qle/tle diverge
+    // from SW on tied-score walks, breaking byte-identical SAM.
+    int cur = h0, max_sc = h0, max_i = 0;
+    for (int j = 0; j < N; j++) {
+        int is_mis = (j < 64) ? (int)((mis_lo >> j) & 1ULL)
+                              : (int)((mis_hi >> (j - 64)) & 1ULL);
+        if (cur == 0) continue;
+        if (!is_mis) cur += a;
+        else {
+            cur -= b;
+            if (cur < 0) cur = 0;
+        }
+        if (cur >= max_sc) { max_sc = cur; max_i = j + 1; }
+    }
+
+    *out_score      = max_sc;
+    *out_qle        = max_i;
+    *out_gscore     = cur;
+    *out_gtle       = N;
+    *out_tight_band = 0;   // unused on HIT (SW skipped)
+    return FP_STATUS_HIT;
+}
+
+// max tight_band across a pair_ar batch. 0 means "no pair had a
+// useful bound"; caller falls back to opt->w.
+static inline int sp_max_tight_band(const SeqPair *pair_ar, int nump)
+{
+    int m = 0;
+    for (int l = 0; l < nump; l++) {
+        if (pair_ar[l].tight_band > m) m = pair_ar[l].tight_band;
+    }
+    return m;
+}
+
 void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                                    const uint8_t *pac, bseq1_t *seq_, int nseq,
                                    mem_chain_v* chain_ar, mem_alnreg_v *av_v,
@@ -2154,6 +2638,14 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
     int64_t leftRefOffset = 0, rightRefOffset = 0;
     int64_t leftQerOffset = 0, rightQerOffset = 0;
+
+    // ungapped fast-path threshold, computed once per call from
+    // the scoring model. See ungapped_fastpath_walk docstring.
+    const int fp_o_min = opt->o_del < opt->o_ins ? opt->o_del : opt->o_ins;
+    const int fp_e_min = opt->e_del < opt->e_ins ? opt->e_del : opt->e_ins;
+    const int fp_denom = opt->a + opt->b - fp_e_min;
+    const int fp_x_threshold = (fp_denom > 0) ? (fp_o_min / fp_denom) : -1;
+    // (fp_o_min, fp_e_min above are reused directly by ungapped_analyze.)
 
     int srt_size = MAX_SEEDS_PER_READ, fac = FAC;
     uint64_t *srt = (uint64_t *) malloc(srt_size * 8);
@@ -2201,7 +2693,6 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             // get the max possible span
             rmax[0] = l_pac<<1; rmax[1] = 0;
 
-            int chain_max_n_hits = 1;
             for (int i = 0; i < c->n; ++i) {
                 int64_t b, e;
                 const mem_seed_t *t = &c->seeds[i];
@@ -2213,7 +2704,6 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                 rmax[0] = tmp < b? rmax[0] : b;
                 rmax[1] = (rmax[1] > e)? rmax[1] : e;
                 if (t->len > max) max = t->len;
-                if (t->n_hits > chain_max_n_hits) chain_max_n_hits = t->n_hits;
             }
 
             rmax[0] = rmax[0] > 0? rmax[0] : 0;
@@ -2279,7 +2769,6 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                 a->frac_rep = c->frac_rep;
                 a->seedlen0 = s->len;
                 a->c = c; //ptr
-                a->chain_n_hits = chain_max_n_hits;
                 a->rb = a->qb = a->re = a->qe = H0_;
 
                 tprof[PE19][tid] ++;
@@ -2359,21 +2848,133 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
                     sp.len2 = s->qbeg;
                     sp.len1 = tmp;
-                    int minval = sp.h0 + min_(sp.len1, sp.len2) * opt->a;
+                    sp.tight_band = 0;  // 0 sentinel: "no tight bound known"
+                    int minval;  // declared ahead of goto target for C++
 
-                    if (sp.len1 < MAX_SEQ_LEN8 && sp.len2 < MAX_SEQ_LEN8 && minval < MAX_SEQ_LEN8) {
-                        numPairsLeft128++;
+                    // ungapped analysis.
+                    //   HIT      → skip SW; fill a->* from ungapped.
+                    //   TIGHT    → save sp.tight_band; SW will use it.
+                    //   FALLBACK → use opt->w.
+                    if (sp.len1 >= sp.len2 && sp.len2 <= FP_N_MAX) {
+                        tprof[UGP_L_ATTEMPT][tid]++;
+                        int fp_score, fp_qle, fp_gscore, fp_gtle, fp_band;
+                        int fp_st = ungapped_analyze(qs, rs, sp.len2,
+                                                     sp.h0, opt->a, opt->b,
+                                                     fp_o_min, fp_e_min,
+                                                     fp_x_threshold, opt->w,
+                                                     &fp_score, &fp_qle,
+                                                     &fp_gscore, &fp_gtle,
+                                                     &fp_band);
+                        if (fp_st == FP_STATUS_HIT) {
+                            tprof[UGP_L_HIT][tid]++;
+                            tprof[UGP_L_UNGAPPED][tid]++;
+                            tprof[UGP_SCORE_HIST_BASE + 0 * UGP_SCORE_HIST_NBINS
+                                  + ugp_score_bin(fp_score)][tid]++;
+                            /* Q3: cat0=ALL, cat1=UNGAP_FINAL, cat3=HIT.
+                             * For HIT, fp_score is both the would-be ungapped
+                             * score and the committed score, so the delta
+                             * (perfect_score - aln_score) is the same for
+                             * both histograms. */
+                            {
+                                int _perfect = sp.h0 + opt->a * sp.len2;
+                                int _delta = _perfect - fp_score;
+                                int _bin = ugp_delta_bin(_delta);
+                                tprof[UGP_L_CAT_UNG_BASE + 0 * UGP_CAT_NBINS + _bin][tid]++;
+                                tprof[UGP_L_CAT_UNG_BASE + 1 * UGP_CAT_NBINS + _bin][tid]++;
+                                tprof[UGP_L_CAT_UNG_BASE + 3 * UGP_CAT_NBINS + _bin][tid]++;
+                                tprof[UGP_L_CAT_FIN_BASE + 0 * UGP_CAT_NBINS + _bin][tid]++;
+                                tprof[UGP_L_CAT_FIN_BASE + 1 * UGP_CAT_NBINS + _bin][tid]++;
+                                tprof[UGP_L_CAT_FIN_BASE + 3 * UGP_CAT_NBINS + _bin][tid]++;
+                            }
+                            // Roll back the qs/rs buffer offsets we just
+                            // consumed; the batch won't reference them.
+                            leftQerOffset -= s->qbeg;
+                            leftRefOffset -= tmp;
+                            // Mirror post-SW extraction (~line 2560).
+                            a->score = fp_score;
+                            if (fp_gscore <= 0 || fp_gscore <= a->score - opt->pen_clip5) {
+                                a->qb = s->qbeg - fp_qle;
+                                a->rb = s->rbeg - fp_qle; // tle == qle on diagonal
+                                a->truesc = a->score;
+                            } else {
+                                a->qb = 0;
+                                a->rb = s->rbeg - fp_gtle;
+                                a->truesc = fp_gscore;
+                            }
+                            a->w = max_(a->w, opt->w);
+                            if (a->rb != H0_ && a->qb != H0_ && a->qe != H0_ && a->re != H0_) {
+                                int ii;
+                                for (ii = 0, a->seedcov = 0; ii < a->c->n; ++ii) {
+                                    const mem_seed_t *t = &(a->c->seeds[ii]);
+                                    if (t->qbeg >= a->qb && t->qbeg + t->len <= a->qe &&
+                                        t->rbeg >= a->rb && t->rbeg + t->len <= a->re)
+                                        a->seedcov += t->len;
+                                }
+                            }
+                            goto LEFT_DONE;
+                        }
+                        if (fp_st == FP_STATUS_TIGHT) {
+                            // Fast-path failed but tight_band valid. Pipe
+                            // to SW via sp.tight_band.
+                            sp.tight_band = fp_band;
+                            tprof[UGP_L_TIGHT][tid]++;
+                            if (fp_band <= 8)        tprof[UGP_L_TB_1_8][tid]++;
+                            else if (fp_band <= 32)  tprof[UGP_L_TB_9_32][tid]++;
+                            else                     tprof[UGP_L_TB_33_MAX][tid]++;
+
+                        }
+                        // FALLBACK: sp.tight_band stays 0.
                     }
-                    else if (sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval < MAX_SEQ_LEN16){
-                        numPairsLeft16++;
+
+                    minval = sp.h0 + min_(sp.len1, sp.len2) * opt->a;
+
+                    {
+                        int t_tier;
+                        if (sp.len1 < MAX_SEQ_LEN8 && sp.len2 < MAX_SEQ_LEN8 && minval < MAX_SEQ_LEN8) {
+                            numPairsLeft128++; t_tier = 0;
+                        }
+                        else if (sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval < MAX_SEQ_LEN16){
+                            numPairsLeft16++;  t_tier = 1;
+                        }
+                        else {
+                            numPairsLeft1++;   t_tier = 2;  /* scalar; not bucketed */
+                        }
+                        /* tight_band histogram bin. */
+                        int tb_ = sp.tight_band;
+                        int fine_bin;
+                        if      (tb_ ==  0) fine_bin = 0;
+                        else if (tb_ <=  2) fine_bin = 1;
+                        else if (tb_ <=  4) fine_bin = 2;
+                        else if (tb_ <=  8) fine_bin = 3;
+                        else if (tb_ <= 16) fine_bin = 4;
+                        else if (tb_ <= 32) fine_bin = 5;
+                        else if (tb_ <= 48) fine_bin = 6;
+                        else if (tb_ <= 64) fine_bin = 7;
+                        else if (tb_ <= 80) fine_bin = 8;
+                        else                fine_bin = 9;
+                        tprof[UGP_FINE_BASE + 0 * UGP_FINE_NBINS + fine_bin][tid]++;
+                        if (t_tier <= 1) {
+                            int band_bin;
+                            if      (tb_ ==  0) band_bin = 0;
+                            else if (tb_ <=  8) band_bin = 1;
+                            else if (tb_ <= 32) band_bin = 2;
+                            else                band_bin = 3;
+                            tprof[UGP_TIER_TB_BASE + 0 * 8 + t_tier * 4 + band_bin][tid]++;
+                        }
                     }
-                    else {
-                        numPairsLeft1++;
-                    }
+
+                    /* Q3: compute would-be ungapped extension score for this
+                     * non-HIT LEFT pair. The walk handles arbitrary N
+                     * (including the bypass case len2 > FP_N_MAX where
+                     * analyze did not run). Cost: O(len2) scalar; called
+                     * for instrumentation only — discard if reverting. */
+                    sp.ugp_walk_score = ungapped_walk_score(qs, rs, sp.len2,
+                                                            sp.h0, opt->a, opt->b);
 
                     seqPairArrayLeft128[numPairsLeft] = sp;
                     numPairsLeft ++;
                     a->qb = s->qbeg; a->rb = s->rbeg;
+                    LEFT_DONE: ;
                 }
                 else
                 {
@@ -2461,7 +3062,69 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
                     for (int i = 0; i < sp.len1; ++i) rs[i] = rseq[re + i]; //seq1
 
-                    int minval = sp.h0 + min_(sp.len1, sp.len2) * opt->a;
+                    sp.tight_band = 0;
+                    sp.ugp_r_attempted = 0;
+                    int minval;  // declared ahead of goto target for C++
+
+                    // ungapped analysis on right ext.
+                    // Precondition a->score != -1 means left either didn't
+                    // need extension or was fast-pathed — in both cases
+                    // h0 is known. If left was batched, we skip (can't
+                    // know h0 yet); SW will run with default band.
+                    if (a->score != -1 && sp.len1 >= sp.len2 && sp.len2 <= FP_N_MAX) {
+                        sp.ugp_r_attempted = 1;
+                        tprof[UGP_R_ATTEMPT][tid]++;
+                        int fp_h0 = a->score;  // the real h0 for right ext
+                        int fp_score, fp_qle, fp_gscore, fp_gtle, fp_band;
+                        int fp_st = ungapped_analyze(qs, rs, sp.len2,
+                                                     fp_h0, opt->a, opt->b,
+                                                     fp_o_min, fp_e_min,
+                                                     fp_x_threshold, opt->w,
+                                                     &fp_score, &fp_qle,
+                                                     &fp_gscore, &fp_gtle,
+                                                     &fp_band);
+                        if (fp_st == FP_STATUS_HIT) {
+                            tprof[UGP_R_HIT][tid]++;
+                            tprof[UGP_R_UNGAPPED][tid]++;
+                            tprof[UGP_SCORE_HIST_BASE + 1 * UGP_SCORE_HIST_NBINS
+                                  + ugp_score_bin(fp_score)][tid]++;
+                            // Roll back the qs/rs buffer offsets.
+                            rightQerOffset -= sp.len2;
+                            rightRefOffset -= sp.len1;
+                            // Mirror post-SW extraction (~line 2777).
+                            a->score = fp_score;
+                            if (fp_gscore <= 0 || fp_gscore <= a->score - opt->pen_clip3) {
+                                a->qe = qe + fp_qle;
+                                a->re = rmax[0] + re + fp_qle; // tle == qle on diagonal
+                                a->truesc += a->score - fp_h0;
+                            } else {
+                                a->qe = l_query;
+                                a->re = rmax[0] + re + fp_gtle;
+                                a->truesc += fp_gscore - fp_h0;
+                            }
+                            a->w = max_(a->w, opt->w);
+                            if (a->rb != H0_ && a->qb != H0_ && a->qe != H0_ && a->re != H0_) {
+                                int ii;
+                                for (ii = 0, a->seedcov = 0; ii < a->c->n; ++ii) {
+                                    const mem_seed_t *t = &a->c->seeds[ii];
+                                    if (t->qbeg >= a->qb && t->qbeg + t->len <= a->qe &&
+                                        t->rbeg >= a->rb && t->rbeg + t->len <= a->re)
+                                        a->seedcov += t->len;
+                                }
+                            }
+                            goto RIGHT_DONE;
+                        }
+                        if (fp_st == FP_STATUS_TIGHT) {
+                            sp.tight_band = fp_band;
+                            tprof[UGP_R_TIGHT][tid]++;
+                            if (fp_band <= 8)        tprof[UGP_R_TB_1_8][tid]++;
+                            else if (fp_band <= 32)  tprof[UGP_R_TB_9_32][tid]++;
+                            else                     tprof[UGP_R_TB_33_MAX][tid]++;
+
+                        }
+                    }
+
+                    minval = sp.h0 + min_(sp.len1, sp.len2) * opt->a;
 
                     if (sp.len1 < MAX_SEQ_LEN8 && sp.len2 < MAX_SEQ_LEN8 && minval < MAX_SEQ_LEN8) {
                         numPairsRight128++;
@@ -2472,9 +3135,12 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     else {
                         numPairsRight1++;
                     }
+                    /* RIGHT histograms (Groups A & B) are populated post-left-SW
+                     * once 26e/26f's right pass has finalised sp->tight_band. */
                     seqPairArrayRight128[numPairsRight] = sp;
                     numPairsRight ++;
                     a->qe = qe; a->re = rmax[0] + re;
+                    RIGHT_DONE: ;
                 }
                 else
                 {
@@ -2507,6 +3173,27 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     numPairsLeft128, numPairsLeft16, numPairsLeft1, opt->a);
     assert(numPairsLeft == (numPairsLeft128 + numPairsLeft16 + numPairsLeft1));
 
+    /* instrumentation: per-batch narrow bucket size (Group C, LEFT).
+     * Counts pairs in the 8-bit tier with tight_band ∈ [1,8] for THIS worker
+     * batch — the size a future narrow bucket would have. */
+    {
+        int narrow_sz = 0;
+        for (int l = 0; l < numPairsLeft128; l++) {
+            int tb = seqPairArrayLeft128[l].tight_band;
+            if (tb > 0 && tb <= 8) narrow_sz++;
+        }
+        int bin;
+        if      (narrow_sz ==   0) bin = 0;
+        else if (narrow_sz <   16) bin = 1;
+        else if (narrow_sz <   32) bin = 2;
+        else if (narrow_sz <   64) bin = 3;
+        else if (narrow_sz <  128) bin = 4;
+        else if (narrow_sz <  256) bin = 5;
+        else if (narrow_sz <  512) bin = 6;
+        else                       bin = 7;
+        tprof[UGP_NARROW_SZ_BASE + 0 * UGP_NARROW_SZ_NBINS + bin][tid]++;
+    }
+
 
     // SWA
     // uint64_t timL = __rdtsc();
@@ -2528,10 +3215,15 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     SeqPair *pair_ar_aux = seqPairArrayAux;
     int nump = numPairsLeft1;
 
+    // PR 26c.1: tighten initial band using max(tight_band) across batch.
+    int max_tb = sp_max_tight_band(pair_ar, nump);
+    int init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    tprof[UGP_L_DISP_NARROW][tid] += (init_w < opt->w);
+
     // scalar
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
-        int32_t w = opt->w << i;
+        int32_t w = init_w << i;
         // uint64_t tim = __rdtsc();
         bswLeft.scalarBandedSWAWrapper(pair_ar,
                                        seqBufLeftRef,
@@ -2553,8 +3245,9 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             a->score = sp->score;
 
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY)
+                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
             {
+                ugp_record_left_outcome(sp, opt->a, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip5) {
                     a->qb -= sp->qle; a->rb -= sp->tle;
                     a->truesc = a->score;
@@ -2593,11 +3286,14 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar_aux = seqPairArrayAux;
 
     nump = numPairsLeft16;
+    max_tb = sp_max_tight_band(pair_ar, nump);
+    init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    tprof[UGP_L_DISP_NARROW][tid] += (init_w < opt->w);
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
-        int32_t w = opt->w << i;
+        int32_t w = init_w << i;
         // int64_t tim = __rdtsc();
-#if ((!__AVX512BW__) && (!__AVX2__) && (!__SSE2__))
+#if !HAVE_BSW_VECTOR_8_16
         bswLeft.scalarBandedSWAWrapper(pair_ar, seqBufLeftRef, seqBufLeftQer, nump, nthreads, w);
 #else
         sortPairsLen(pair_ar, nump, seqPairArrayAux, hist);
@@ -2625,8 +3321,9 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
 
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY)
+                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
             {
+                ugp_record_left_outcome(sp, opt->a, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip5) {
                     a->qb -= sp->qle; a->rb -= sp->tle;
                     a->truesc = a->score;
@@ -2661,12 +3358,15 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar_aux = seqPairArrayAux;
 
     nump = numPairsLeft128;
+    max_tb = sp_max_tight_band(pair_ar, nump);
+    init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    tprof[UGP_L_DISP_NARROW][tid] += (init_w < opt->w);
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
-        int32_t w = opt->w << i;
+        int32_t w = init_w << i;
         // int64_t tim = __rdtsc();
 
-#if ((!__AVX512BW__) && (!__AVX2__) && (!__SSE2__))
+#if !HAVE_BSW_VECTOR_8_16
         bswLeft.scalarBandedSWAWrapper(pair_ar, seqBufLeftRef, seqBufLeftQer, nump, nthreads, w);
 #else
         sortPairsLen(pair_ar, nump, seqPairArrayAux, hist);
@@ -2693,8 +3393,9 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             a->score = sp->score;
 
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY)
+                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
             {
+                ugp_record_left_outcome(sp, opt->a, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip5) {
                     a->qb -= sp->qle; a->rb -= sp->tle;
                     a->truesc = a->score;
@@ -2728,7 +3429,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
     // uint64_t timR = __rdtsc();
     // **********************************************************
-    // Right, scalar
+    // h0 fixup: right-extension h0 is the left-extension alnreg score.
     for (int l=0; l<numPairsRight; l++) {
         mem_alnreg_t *a;
         SeqPair *sp = &seqPairArrayRight128[l];
@@ -2736,18 +3437,146 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
         sp->h0 = a->score;
     }
 
+    // post-left-SW right-side ungapped pass. The per-seed fast-
+    // path skipped right ext for 93% of pairs because a->score was still
+    // -1 at construction time (left SW hadn't run yet). Now that left
+    // SW is done, a->score is final and h0 is set above. Run ungapped
+    // analysis on every right pair:
+    //   HIT    → fill a->* directly, compact the pair out of the array.
+    //   TIGHT  → set sp->tight_band for the SW dispatch.
+    //   FALL   → leave tight_band at construction default (typically 0).
+    {
+        int compacted = 0;
+        for (int l = 0; l < numPairsRight; l++) {
+            SeqPair *sp = &seqPairArrayRight128[l];
+            mem_alnreg_t *a = &(av_v[sp->seqid].a[sp->regid]);
+            int keep = 1;
+            // Skip pairs already analyzed at construction time (a->score
+            // was non-(-1) then; UGP_R_ATTEMPT and outcome counters fired
+            // there). Without this guard, those pairs would double-count.
+            if (!sp->ugp_r_attempted &&
+                sp->len1 >= sp->len2 && sp->len2 > 0 && sp->len2 <= FP_N_MAX) {
+                tprof[UGP_R_ATTEMPT][tid]++;
+                const uint8_t *qs = seqBufRightQer + sp->idq;
+                const uint8_t *rs = seqBufRightRef + sp->idr;
+                int fp_score, fp_qle, fp_gscore, fp_gtle, fp_band;
+                int fp_st = ungapped_analyze(qs, rs, sp->len2, sp->h0,
+                                              opt->a, opt->b,
+                                              fp_o_min, fp_e_min,
+                                              fp_x_threshold, opt->w,
+                                              &fp_score, &fp_qle,
+                                              &fp_gscore, &fp_gtle,
+                                              &fp_band);
+                if (fp_st == FP_STATUS_HIT) {
+                    tprof[UGP_R_HIT][tid]++;
+                    tprof[UGP_R_UNGAPPED][tid]++;
+                    tprof[UGP_SCORE_HIST_BASE + 1 * UGP_SCORE_HIST_NBINS
+                          + ugp_score_bin(fp_score)][tid]++;
+                    // Mirror post-right-SW extraction. a->qe / a->re were
+                    // set in the per-seed construction loop to the pre-
+                    // extension anchor positions (s->qbeg+s->len / s->rbeg+s->len).
+                    int l_query = seq_[sp->seqid].l_seq;
+                    a->score = fp_score;
+                    if (fp_gscore <= 0 || fp_gscore <= a->score - opt->pen_clip3) {
+                        a->qe += fp_qle;
+                        a->re += fp_qle; // tle == qle on diagonal
+                        a->truesc += a->score - sp->h0;
+                    } else {
+                        a->qe = l_query;
+                        a->re += fp_gtle;
+                        a->truesc += fp_gscore - sp->h0;
+                    }
+                    a->w = max_(a->w, opt->w);
+                    if (a->rb != H0_ && a->qb != H0_ && a->qe != H0_ && a->re != H0_) {
+                        int ii;
+                        for (ii = 0, a->seedcov = 0; ii < a->c->n; ++ii) {
+                            const mem_seed_t *t = &a->c->seeds[ii];
+                            if (t->qbeg >= a->qb && t->qbeg + t->len <= a->qe &&
+                                t->rbeg >= a->rb && t->rbeg + t->len <= a->re)
+                                a->seedcov += t->len;
+                        }
+                    }
+                    keep = 0;
+                } else if (fp_st == FP_STATUS_TIGHT) {
+                    sp->tight_band = fp_band;
+                    tprof[UGP_R_TIGHT][tid]++;
+                    if (fp_band <= 8)        tprof[UGP_R_TB_1_8][tid]++;
+                    else if (fp_band <= 32)  tprof[UGP_R_TB_9_32][tid]++;
+                    else                     tprof[UGP_R_TB_33_MAX][tid]++;
+
+                }
+            }
+            if (keep) {
+                if (compacted != l)
+                    seqPairArrayRight128[compacted] = *sp;
+                compacted++;
+            }
+        }
+        numPairsRight = compacted;
+    }
+
     sortPairsLenExt(seqPairArrayRight128, numPairsRight, seqPairArrayAux,
                     hist, numPairsRight128, numPairsRight16, numPairsRight1, opt->a);
 
     assert(numPairsRight == (numPairsRight128 + numPairsRight16 + numPairsRight1));
 
+    /* instrumentation (Groups A, B, C — RIGHT). Run after the post-
+     * left-SW analyze pass + tier sort: sp->tight_band is now final and the
+     * 128 region is contiguous at the head of seqPairArrayRight128. */
+    {
+        int narrow_sz = 0;
+        for (int l = 0; l < numPairsRight; l++) {
+            SeqPair *sp_ = &seqPairArrayRight128[l];
+            int tb_ = sp_->tight_band;
+            int t_tier;
+            int minval_ = sp_->h0 + min_(sp_->len1, sp_->len2) * opt->a;
+            if (sp_->len1 < MAX_SEQ_LEN8 && sp_->len2 < MAX_SEQ_LEN8 && minval_ < MAX_SEQ_LEN8)        t_tier = 0;
+            else if (sp_->len1 < MAX_SEQ_LEN16 && sp_->len2 < MAX_SEQ_LEN16 && minval_ < MAX_SEQ_LEN16) t_tier = 1;
+            else                                                                                       t_tier = 2;
+            int fine_bin;
+            if      (tb_ ==  0) fine_bin = 0;
+            else if (tb_ <=  2) fine_bin = 1;
+            else if (tb_ <=  4) fine_bin = 2;
+            else if (tb_ <=  8) fine_bin = 3;
+            else if (tb_ <= 16) fine_bin = 4;
+            else if (tb_ <= 32) fine_bin = 5;
+            else if (tb_ <= 48) fine_bin = 6;
+            else if (tb_ <= 64) fine_bin = 7;
+            else if (tb_ <= 80) fine_bin = 8;
+            else                fine_bin = 9;
+            tprof[UGP_FINE_BASE + 1 * UGP_FINE_NBINS + fine_bin][tid]++;
+            if (t_tier <= 1) {
+                int band_bin;
+                if      (tb_ ==  0) band_bin = 0;
+                else if (tb_ <=  8) band_bin = 1;
+                else if (tb_ <= 32) band_bin = 2;
+                else                band_bin = 3;
+                tprof[UGP_TIER_TB_BASE + 1 * 8 + t_tier * 4 + band_bin][tid]++;
+            }
+            if (t_tier == 0 && tb_ > 0 && tb_ <= 8) narrow_sz++;
+        }
+        int bin;
+        if      (narrow_sz ==   0) bin = 0;
+        else if (narrow_sz <   16) bin = 1;
+        else if (narrow_sz <   32) bin = 2;
+        else if (narrow_sz <   64) bin = 3;
+        else if (narrow_sz <  128) bin = 4;
+        else if (narrow_sz <  256) bin = 5;
+        else if (narrow_sz <  512) bin = 6;
+        else                       bin = 7;
+        tprof[UGP_NARROW_SZ_BASE + 1 * UGP_NARROW_SZ_NBINS + bin][tid]++;
+    }
+
     pair_ar = seqPairArrayRight128 + numPairsRight128 + numPairsRight16;
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight1;
+    max_tb = sp_max_tight_band(pair_ar, nump);
+    init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    tprof[UGP_R_DISP_NARROW][tid] += (init_w < opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
-        int32_t w = opt->w << i;
+        int32_t w = init_w << i;
         // tim = __rdtsc();
         bswRight.scalarBandedSWAWrapper(pair_ar,
                         seqBufRightRef,
@@ -2770,8 +3599,9 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
             // no further banding
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY)
+                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
             {
+                ugp_record_right_outcome(sp, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip3) {
                     a->qe += sp->qle, a->re += sp->tle;
                     a->truesc += a->score - sp->h0;
@@ -2805,12 +3635,15 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar = seqPairArrayRight128 + numPairsRight128;
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight16;
+    max_tb = sp_max_tight_band(pair_ar, nump);
+    init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    tprof[UGP_R_DISP_NARROW][tid] += (init_w < opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
-        int32_t w = opt->w << i;
+        int32_t w = init_w << i;
         // uint64_t tim = __rdtsc();
-#if ((!__AVX512BW__) && (!__AVX2__) && (!__SSE2__))
+#if !HAVE_BSW_VECTOR_8_16
         bswRight.scalarBandedSWAWrapper(pair_ar, seqBufRightRef, seqBufRightQer, nump, nthreads, w);
 #else
         sortPairsLen(pair_ar, nump, seqPairArrayAux, hist);
@@ -2839,8 +3672,9 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
             // no further banding
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY)
+                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
             {
+                ugp_record_right_outcome(sp, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip3) {
                     a->qe += sp->qle, a->re += sp->tle;
                     a->truesc += a->score - sp->h0;
@@ -2875,13 +3709,16 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar = seqPairArrayRight128;
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight128;
+    max_tb = sp_max_tight_band(pair_ar, nump);
+    init_w = (max_tb > 0 && max_tb < opt->w) ? max_tb : opt->w; if (init_w > BUCKET_MAX_INIT_W) init_w = BUCKET_MAX_INIT_W;
+    tprof[UGP_R_DISP_NARROW][tid] += (init_w < opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
-        int32_t w = opt->w << i;
+        int32_t w = init_w << i;
         // uint64_t tim = __rdtsc();
 
-#if ((!__AVX512BW__) && (!__AVX2__) && (!__SSE2__))
+#if !HAVE_BSW_VECTOR_8_16
         bswRight.scalarBandedSWAWrapper(pair_ar, seqBufRightRef, seqBufRightQer, nump, nthreads, w);
 #else
         sortPairsLen(pair_ar, nump, seqPairArrayAux, hist);
@@ -2908,8 +3745,9 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             a->score = sp->score;
             // no further banding
             if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY)
+                i+1 == MAX_BAND_TRY || sp->tight_band > 0)
             {
+                ugp_record_right_outcome(sp, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip3) {
                     a->qe += sp->qle, a->re += sp->tle;
                     a->truesc += a->score - sp->h0;
@@ -2957,8 +3795,13 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
         lim_g[l] += lim_g[l-1];
 
     // uint64_t tim = __rdtsc();
-    int *lim = (int *) calloc(BATCH_SIZE, sizeof(int));
-    assert(lim != NULL);
+    // BATCH_SIZE is a compile-time constant (1024 on arm64, 512 elsewhere);
+    // sizeof(int)*BATCH_SIZE = 4096/2048 bytes — safe on stack, skips an
+    // allocator round-trip per call to this function. nseq is bounded by
+    // kt_for's BATCH_SIZE-chunked work distribution (worker_bwt at the
+    // call site) — assert it for future-proofing.
+    assert(nseq <= BATCH_SIZE);
+    int lim[BATCH_SIZE] = {0};
 
     for (int l=0; l<nseq; l++)
     {
@@ -3049,6 +3892,5 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     }
     free(srtgg);
     free(srt);
-    free(lim);
     // tprof[MEM_ALN2_DOWN][tid] += __rdtsc() - tim;
 }

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -2615,16 +2615,6 @@ static inline int ungapped_analyze(const uint8_t *qs, const uint8_t *rs, int N,
     return FP_STATUS_HIT;
 }
 
-// max tight_band across a pair_ar batch. 0 means "no pair had a
-// useful bound"; caller falls back to opt->w.
-static inline int sp_max_tight_band(const SeqPair *pair_ar, int nump)
-{
-    int m = 0;
-    for (int l = 0; l < nump; l++) {
-        if (pair_ar[l].tight_band > m) m = pair_ar[l].tight_band;
-    }
-    return m;
-}
 
 void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                                    const uint8_t *pac, bseq1_t *seq_, int nseq,
@@ -3246,10 +3236,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     // heuristic exits (a->score == prev / max_off < 3w/4) can then fire
     // on a suboptimal alignment found within the narrow band, breaking
     // chr22 parity.
-    int max_tb = sp_max_tight_band(pair_ar, nump);
     int init_w = opt->w;
-    (void)max_tb;
-    tprof[UGP_L_DISP_NARROW][tid] += (init_w < opt->w);
 
     // scalar
     for ( i=0; i<MAX_BAND_TRY; i++)
@@ -3318,10 +3305,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar_aux = seqPairArrayAux;
 
     nump = numPairsLeft16;
-    max_tb = sp_max_tight_band(pair_ar, nump);
     init_w = opt->w;
-    (void)max_tb;
-    tprof[UGP_L_DISP_NARROW][tid] += (init_w < opt->w);
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
         int32_t w = init_w << i;
@@ -3392,10 +3376,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar_aux = seqPairArrayAux;
 
     nump = numPairsLeft128;
-    max_tb = sp_max_tight_band(pair_ar, nump);
     init_w = opt->w;
-    (void)max_tb;
-    tprof[UGP_L_DISP_NARROW][tid] += (init_w < opt->w);
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
         int32_t w = init_w << i;
@@ -3606,10 +3587,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar = seqPairArrayRight128 + numPairsRight128 + numPairsRight16;
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight1;
-    max_tb = sp_max_tight_band(pair_ar, nump);
     init_w = opt->w;
-    (void)max_tb;
-    tprof[UGP_R_DISP_NARROW][tid] += (init_w < opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
@@ -3673,10 +3651,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar = seqPairArrayRight128 + numPairsRight128;
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight16;
-    max_tb = sp_max_tight_band(pair_ar, nump);
     init_w = opt->w;
-    (void)max_tb;
-    tprof[UGP_R_DISP_NARROW][tid] += (init_w < opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
@@ -3749,10 +3724,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar = seqPairArrayRight128;
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight128;
-    max_tb = sp_max_tight_band(pair_ar, nump);
     init_w = opt->w;
-    (void)max_tb;
-    tprof[UGP_R_DISP_NARROW][tid] += (init_w < opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
     {

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1158,6 +1158,18 @@ int mem_kernel1_core(FMI_search *fmi,
         for (i = 0; i < len; ++i)
             seq[i] = seq[i] < 4? seq[i] : nst_nt4_table[(int)seq[i]]; //nst_nt4??
     }
+    // Empty-batch fast path: a 0-base batch (e.g. malformed FASTQ parsed as a
+    // single zero-length record) tripped the lazy-init grow block below with
+    // tot_len(0) >= wsize_mem(0), routing through _mm_realloc(NULL, 0, 0, …)
+    // and exiting via the post-collect overflow check. With no bases, there
+    // are no SMEMs to collect — initialize chain_ar to empty so mem_kernel2_core
+    // (which walks chain_ar unconditionally and free()s chain_ar[l].a) sees
+    // a valid empty state, then let downstream stages emit unmapped records.
+    if (tot_len == 0) {
+        for (int l = 0; l < nseq; ++l)
+            kv_init(chain_ar[l]);
+        return 1;
+    }
     // tot_len *= N_SMEM_KERNEL;
     // fprintf(stderr, "wsize: %d, tot_len: %d\n", mmc->wsize_mem[tid], tot_len);
     // This covers enc_qdb/SMEM reallocs

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1740,6 +1740,13 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
 #else
         if (l && !p->is_alt && q->mapq > aa.a[0].mapq) q->mapq = aa.a[0].mapq;
 #endif
+        // fg-labs: supp alnregs whose chain contains a repetitive seed (many
+        // genome occurrences) inherit primary MAPQ despite being ambiguous on
+        // their own — upstream issue bwa-mem2/bwa-mem2#260. Opt-in override:
+        // force MAPQ=0 when the chain's most-repetitive seed exceeds the cap.
+        if (opt->supp_rep_hard_cap > 0 && l && p->secondary < 0 &&
+            p->chain_n_hits >= opt->supp_rep_hard_cap)
+            q->mapq = 0;
         ++l;
     }
     if (aa.n == 0) { // no alignments good enough; then write an unaligned record
@@ -2705,6 +2712,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             // get the max possible span
             rmax[0] = l_pac<<1; rmax[1] = 0;
 
+            int chain_max_n_hits = 1;
             for (int i = 0; i < c->n; ++i) {
                 int64_t b, e;
                 const mem_seed_t *t = &c->seeds[i];
@@ -2716,6 +2724,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                 rmax[0] = tmp < b? rmax[0] : b;
                 rmax[1] = (rmax[1] > e)? rmax[1] : e;
                 if (t->len > max) max = t->len;
+                if (t->n_hits > chain_max_n_hits) chain_max_n_hits = t->n_hits;
             }
 
             rmax[0] = rmax[0] > 0? rmax[0] : 0;
@@ -2781,6 +2790,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                 a->frac_rep = c->frac_rep;
                 a->seedlen0 = s->len;
                 a->c = c; //ptr
+                a->chain_n_hits = chain_max_n_hits;
                 a->rb = a->qb = a->re = a->qe = H0_;
 
                 tprof[PE19][tid] ++;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -32,6 +32,9 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(__linux__)
+#include <sys/mman.h>
+#endif
 #if NUMA_ENABLED
 #include <numa.h>
 #endif
@@ -550,8 +553,10 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                     }
                     meth_bam_group_propagate_qcfail(group, total);
                     for (int j = 0; j < total; ++j) {
+#ifndef DISABLE_OUTPUT
                         if (meth_bam_writer_write(g_meth_bam_writer, group[j]) < 0)
                             err_fatal(__func__, "failed to write meth BAM record");
+#endif
                         bam_writer_free(group[j]);
                     }
                     free(group);
@@ -559,15 +564,28 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
             } else if (aux->bam_writer != NULL) {
                 for (int k = 0; k < group_size; ++k) {
                     for (int j = 0; j < ret->seqs[i+k].n_bams; ++j) {
+#ifndef DISABLE_OUTPUT
                         if (bam_writer_write(aux->bam_writer, (struct bam1_t *)ret->seqs[i+k].bams[j]) < 0)
                             err_fatal(__func__, "failed to write BAM record");
+#endif
                         bam_writer_free((struct bam1_t *)ret->seqs[i+k].bams[j]);
                     }
                 }
             } else {
                 for (int k = 0; k < group_size; ++k) {
                     if (ret->seqs[i+k].sam) {
+#ifndef DISABLE_OUTPUT
                         fputs(ret->seqs[i+k].sam, aux->fp);
+#endif
+                    }
+                    /* meth_mode populates bams[] regardless of writer state;
+                     * under DISABLE_OUTPUT both writers are forced NULL and
+                     * we land here, so the per-record bam1_t allocations
+                     * would otherwise leak (only the pointer array below is
+                     * freed). Profile-build only, but it skews the very
+                     * Maximum RSS that bench/run.sh records. */
+                    for (int j = 0; j < ret->seqs[i+k].n_bams; ++j) {
+                        bam_writer_free((struct bam1_t *)ret->seqs[i+k].bams[j]);
                     }
                 }
             }
@@ -1237,7 +1255,19 @@ int main_mem(int argc, char *argv[])
     fseek(fr, 0, SEEK_END);
     rlen = ftell(fr);
     ref_string = (uint8_t*) _mm_malloc(rlen, 64);
+    assert_not_null(ref_string, rlen, rlen);
     aux.ref_string = ref_string;
+#if defined(__linux__) && defined(MADV_HUGEPAGE)
+    /* Pack table is ~800 MB for hg38 — accessed at every candidate alignment
+     * for reference fetch. Request transparent hugepages to reduce dTLB
+     * pressure and tame 4-KB-page demotion spikes that cause bimodal wall-
+     * clock variance on large indices. (The duplicate hint in
+     * bwa_idx_load_from_disk targets the legacy disk-load path that
+     * bwa-mem2 mem doesn't use — `ref_string` here is the live runtime
+     * buffer.) */
+    if (ref_string != NULL && rlen > 0)
+        (void)madvise(ref_string, rlen, MADV_HUGEPAGE);
+#endif
     rewind(fr);
 
     /* Reading ref. sequence */
@@ -1315,6 +1345,30 @@ int main_mem(int argc, char *argv[])
      *    @HD + @SQ + @PG header. Honors -o/-f or stdout.
      *  - SAM text: open -o/-f path (if any) as a FILE*; bwa_print_sam_hdr2. */
     bam_writer_t *bam_writer = NULL;
+#ifdef DISABLE_OUTPUT
+    /* profile-build (-DDISABLE_OUTPUT) skips ALL filesystem-touching output
+     * code so wall-clock measurements aren't gated on disk speed. The
+     * per-record write sites below are also #ifndef-guarded; this block
+     * additionally skips writer open + header emit so a non-writable -o
+     * (or read-only fs) doesn't fail before compute begins. */
+    aux.bam_writer = NULL;
+    g_meth_bam_writer = NULL;
+    if (opt->meth_mode) {
+        g_meth_cmap = meth_chrom_map_build_from_bns(aux.fmi->idx->bns);
+        /* g_meth_cmap is consulted by per-record paths even with output
+         * disabled; build it so meth_mode tagging stays consistent. */
+        if (g_meth_cmap == NULL) {
+            fprintf(stderr, "ERROR: meth: failed to build chrom map\n");
+            free(opt);
+            delete aux.fmi;
+            return 1;
+        }
+    }
+    (void)is_o;
+    (void)hdr_line;
+    (void)idx_hdr_lines;
+    (void)out_path;
+#else
     if (opt->meth_mode) {
         g_meth_cmap = meth_chrom_map_build_from_bns(aux.fmi->idx->bns);
         if (g_meth_cmap == NULL) {
@@ -1369,6 +1423,7 @@ int main_mem(int argc, char *argv[])
         }
         bwa_print_sam_hdr2(aux.fmi->idx->bns, idx_hdr_lines, hdr_line, aux.fp);
     }
+#endif
 
     if (fixed_chunk_size > 0)
         aux.task_size = fixed_chunk_size;
@@ -1413,6 +1468,13 @@ int main_mem(int argc, char *argv[])
             exit_code = 1;
         }
         g_meth_bam_writer = NULL;
+    }
+    /* Free g_meth_cmap independently of g_meth_bam_writer: under
+     * -DDISABLE_OUTPUT the writer is never opened, but the chrom map is
+     * still built so per-record paths see consistent tagging. The
+     * branch above only fires when the writer exists, so freeing the
+     * map there would leak on the DISABLE_OUTPUT path. */
+    if (meth_mode_local && g_meth_cmap != NULL) {
         meth_chrom_map_free(g_meth_cmap);
         g_meth_cmap = NULL;
     }

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -32,9 +32,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#if defined(__linux__)
-#include <sys/mman.h>
-#endif
+#include "bwa_madvise.h"
 #if NUMA_ENABLED
 #include <numa.h>
 #endif
@@ -1257,17 +1255,11 @@ int main_mem(int argc, char *argv[])
     ref_string = (uint8_t*) _mm_malloc(rlen, 64);
     assert_not_null(ref_string, rlen, rlen);
     aux.ref_string = ref_string;
-#if defined(__linux__) && defined(MADV_HUGEPAGE)
     /* Pack table is ~800 MB for hg38 — accessed at every candidate alignment
-     * for reference fetch. Request transparent hugepages to reduce dTLB
-     * pressure and tame 4-KB-page demotion spikes that cause bimodal wall-
-     * clock variance on large indices. (The duplicate hint in
-     * bwa_idx_load_from_disk targets the legacy disk-load path that
-     * bwa-mem2 mem doesn't use — `ref_string` here is the live runtime
-     * buffer.) */
-    if (ref_string != NULL && rlen > 0)
-        (void)madvise(ref_string, rlen, MADV_HUGEPAGE);
-#endif
+     * for reference fetch. THP hint reduces dTLB pressure and tames the
+     * 4-KB-page demotion spikes that produce bimodal wall-clock variance
+     * on large indices. */
+    bwamem_madv_hugepage(ref_string, rlen);
     rewind(fr);
 
     /* Reading ref. sequence */

--- a/src/kstring.h
+++ b/src/kstring.h
@@ -140,6 +140,55 @@ static inline int kputl(long c, kstring_t *s)
 	return 0;
 }
 
+/* ─── unsafe variants — caller MUST ks_resize() up-front ──────────────────
+ * These skip the per-call length-check + realloc and the trailing NUL. The
+ * caller is responsible for: (a) ensuring buffer has room, and (b) setting
+ * the trailing s->s[s->l] = 0 once at the end. About 5-10× faster than the
+ * safe variants because they're branchless and inlinable. */
+
+static inline void kputc_u(int c, kstring_t *s) {
+	s->s[s->l++] = (char)c;
+}
+
+static inline void kputsn_u(const char *p, int l, kstring_t *s) {
+	memcpy(s->s + s->l, p, (size_t)l);
+	s->l += l;
+}
+
+static inline void kputs_u(const char *p, kstring_t *s) {
+	int l = (int)strlen(p);
+	memcpy(s->s + s->l, p, (size_t)l);
+	s->l += l;
+}
+
+static inline void kputuw_u(unsigned c, kstring_t *s) {
+	if (c == 0) { s->s[s->l++] = '0'; return; }
+	char buf[12];
+	int l = 0;
+	while (c > 0) { buf[l++] = (char)(c % 10 + '0'); c /= 10; }
+	while (l-- > 0) s->s[s->l++] = buf[l];
+}
+
+static inline void kputw_u(int c, kstring_t *s) {
+	/* Negate in the unsigned domain to avoid signed-overflow UB on INT_MIN. */
+	if (c < 0) { s->s[s->l++] = '-'; kputuw_u(0u - (unsigned)c, s); return; }
+	kputuw_u((unsigned)c, s);
+}
+
+static inline void kputul_u(unsigned long c, kstring_t *s) {
+	if (c == 0) { s->s[s->l++] = '0'; return; }
+	char buf[24];
+	int l = 0;
+	while (c > 0) { buf[l++] = (char)(c % 10 + '0'); c /= 10; }
+	while (l-- > 0) s->s[s->l++] = buf[l];
+}
+
+static inline void kputl_u(long c, kstring_t *s) {
+	/* Negate in the unsigned domain to avoid signed-overflow UB on LONG_MIN. */
+	if (c < 0) { s->s[s->l++] = '-'; kputul_u(0ul - (unsigned long)c, s); return; }
+	kputul_u((unsigned long)c, s);
+}
+
 int ksprintf(kstring_t *s, const char *fmt, ...);
 
 #endif

--- a/src/ksw.cpp
+++ b/src/ksw.cpp
@@ -47,13 +47,7 @@ extern uint64_t tprof[LIM_R][LIM_C];
 #  include "malloc_wrap.h"
 #endif
 
-#ifdef __GNUC__
-#define LIKELY(x) __builtin_expect((x),1)
-#define UNLIKELY(x) __builtin_expect((x),0)
-#else
-#define LIKELY(x) (x)
-#define UNLIKELY(x) (x)
-#endif
+/* LIKELY/UNLIKELY come from macro.h (included above). */
 
 /**
  * Initialize the query data structure

--- a/src/kswv.h
+++ b/src/kswv.h
@@ -46,14 +46,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
     #endif
 #endif
 
-#ifdef __GNUC__
-#define LIKELY(x) __builtin_expect((x),1)
-#define UNLIKELY(x) __builtin_expect((x),0)
-#else
-#define LIKELY(x) (x)
-#define UNLIKELY(x) (x)
-#endif
-
+/* LIKELY/UNLIKELY come from macro.h (included above). */
 
 #define MAX_SEQ_LEN_REF_SAM 2048
 #define MAX_SEQ_LEN_QER_SAM 512

--- a/src/macro.h
+++ b/src/macro.h
@@ -39,12 +39,31 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 			fprintf(stderr, y);						\
 	}
 
+/* Branch-prediction hints for hot paths. Available to every TU that
+ * includes macro.h. ksw.cpp and kswv.h predate this and have their own
+ * local copies — guarded so there's no redefinition warning. */
+#ifndef LIKELY
+#  if defined(__GNUC__)
+#    define LIKELY(x)   __builtin_expect(!!(x), 1)
+#    define UNLIKELY(x) __builtin_expect(!!(x), 0)
+#  else
+#    define LIKELY(x)   (x)
+#    define UNLIKELY(x) (x)
+#  endif
+#endif
+
 /* Note: BSW-specific macros are in src/bandedSWA.h file */
 
 #define H0_ -99
 #define SEEDS_PER_READ 500           /* Avg seeds per read */
 #define MAX_SEEDS_PER_READ 500       /* Max seeds per read */
 #define AVG_SEEDS_PER_READ 64        /* Used for storing seeds in chains*/
+
+// Average bases per read, used as a coarse upper-bound estimate (#reads
+// per chunk) for per-run regs/chain_ar/seedBuf allocation. Not a
+// correctness bound — the SMEM and related per-thread buffers are sized
+// at batch time from the observed maximum read length and grown on demand.
+#define NREADS_ESTIMATE_AVG_BASES 100
 
 /* BWAMEM_BATCHED_MATESW:
  *   1 -> worker_sam takes the batched mate-rescue SW path
@@ -81,11 +100,6 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 
 #define SEEDS_PER_CHAIN 1
 #define N_SMEM_KERNEL 3
-// Average read length used only to pre-estimate `nreads` (number of reads
-// per chunk) for per-run regs/chain_ar/seedBuf allocation. Not a
-// correctness bound — the SMEM and related per-thread buffers are sized
-// at batch time from the observed maximum read length and grown on demand.
-#define NREADS_ESTIMATE_AVG_BASES 100
 
 #define SEQ_LEN8 128   // redundant??
 
@@ -94,8 +108,19 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #define ALIGN_OFF 1
 
 #define MAX_THREADS 256
-#define LIM_R 128
-#define LIM_C 128
+/* LIM_R must stay >= UGP_L_CAT_FIN_END (the high-watermark UGP counter
+ * index — currently 279, defined further down in this file). Bumped
+ * 128 → 256 → 384 as UGP_* instrumentation grew; kept on a 64-multiple
+ * so memset-init stays cheap. The static_assert near UGP_L_CAT_FIN_END
+ * enforces the invariant at compile time — bump this number if the
+ * assert ever fires. */
+#define LIM_R 384
+/* LIM_C is the per-thread (column) dimension of tprof[][]. Must stay
+ * >= MAX_THREADS or any user invocation with -t > LIM_C corrupts
+ * adjacent globals via tprof[][tid] writes from the UGP_* and
+ * per-stage profiling sites. Sized to MAX_THREADS so the two move
+ * together. */
+#define LIM_C 256
 
 #define SA_COMPRESSION 1
 #define SA_COMPX 03 // (= power of 2)
@@ -207,5 +232,118 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #define PE25 111
 #define PE26 112
 
+// PR 26a/c.1/e diagnostics. Per-thread, aggregated in display_stats().
+#define UGP_L_ATTEMPT     113
+#define UGP_L_HIT         114
+#define UGP_L_TIGHT       115
+#define UGP_L_TB_1_8      116
+#define UGP_L_TB_9_32     117
+#define UGP_L_TB_33_MAX   118
+#define UGP_L_DISP_NARROW 119
+#define UGP_R_ATTEMPT     120
+#define UGP_R_HIT         121
+#define UGP_R_TIGHT       122
+#define UGP_R_TB_1_8      123
+#define UGP_R_TB_9_32     124
+#define UGP_R_TB_33_MAX   125
+#define UGP_R_DISP_NARROW 126
+
+/* PR 26c.2 design instrumentation. Bucketed counters accessed via base+offset
+ * to avoid macro sprawl. Each group covers LEFT (side=0) then RIGHT (side=1).
+ *
+ *   Group A: Fine tight_band distribution (informs adaptive banding).
+ *     10 bins per side: {0, 1-2, 3-4, 5-8, 9-16, 17-32, 33-48, 49-64, 65-80, 81-100}.
+ *     Index: UGP_FINE_BASE + side*UGP_FINE_NBINS + bin_idx.
+ *
+ *   Group B: Per-tier band breakdown (informs 16-bit tier bucketing decision).
+ *     4 bins per (side, tier ∈ {8-bit, 16-bit}): {tb=0, tb 1-8, tb 9-32, tb 33+}.
+ *     Index: UGP_TIER_TB_BASE + side*8 + tier*4 + bin_idx.
+ *
+ *   Group C: Per-worker-batch narrow bucket size (informs MIN_BUCKET threshold).
+ *     8 bins per side: {0, 1-15, 16-31, 32-63, 64-127, 128-255, 256-511, 512+}.
+ *     Index: UGP_NARROW_SZ_BASE + side*UGP_NARROW_SZ_NBINS + bin_idx.
+ */
+#define UGP_FINE_NBINS         10
+#define UGP_FINE_BASE          127
+#define UGP_FINE_END           (UGP_FINE_BASE + 2 * UGP_FINE_NBINS)            /* 147 */
+
+#define UGP_TIER_TB_BASE       UGP_FINE_END                                    /* 147 */
+#define UGP_TIER_TB_END        (UGP_TIER_TB_BASE + 2 * 2 * 4)                  /* 163 */
+
+#define UGP_NARROW_SZ_NBINS    8
+#define UGP_NARROW_SZ_BASE     UGP_TIER_TB_END                                 /* 163 */
+#define UGP_NARROW_SZ_END      (UGP_NARROW_SZ_BASE + 2 * UGP_NARROW_SZ_NBINS)  /* 179 */
+
+/* Q1+Q2 instrumentation. Counts the FINAL (committed) outcome of each
+ * extension — incremented at the per-seed HIT site and at every post-SW
+ * retry-collect commit branch. Pairs that loop back for a wider band are
+ * NOT counted at the intermediate iteration; only when their decision is
+ * final.
+ *
+ *   Q1 (UGP_OUTCOME_BASE): ungapped vs gapped. Proxy for SW result is
+ *     sp->qle == sp->tle (no net query/target offset). Not 100% rigorous
+ *     — an I+D of equal length cancels — but accurate for short reads.
+ *     HIT path is always ungapped by construction.
+ *     Index: UGP_OUTCOME_BASE + side * 2 + (gapped ? 1 : 0)
+ *
+ *   Q2 (UGP_SCORE_HIST_BASE): per-side alignment-score histogram.
+ *     8 bins: {0-10, 11-25, 26-50, 51-75, 76-100, 101-125, 126-150, 151+}.
+ *     Score is a->score (HIT) or sp->score (SW commit) — both include h0.
+ *     Index: UGP_SCORE_HIST_BASE + side * UGP_SCORE_HIST_NBINS + bin_idx
+ */
+#define UGP_OUTCOME_BASE       UGP_NARROW_SZ_END                                 /* 179 */
+#define UGP_OUTCOME_END        (UGP_OUTCOME_BASE + 2 * 2)                        /* 183 */
+#define UGP_L_UNGAPPED         (UGP_OUTCOME_BASE + 0)
+#define UGP_L_GAPPED           (UGP_OUTCOME_BASE + 1)
+#define UGP_R_UNGAPPED         (UGP_OUTCOME_BASE + 2)
+#define UGP_R_GAPPED           (UGP_OUTCOME_BASE + 3)
+
+#define UGP_SCORE_HIST_NBINS   8
+#define UGP_SCORE_HIST_BASE    UGP_OUTCOME_END                                   /* 183 */
+#define UGP_SCORE_HIST_END     (UGP_SCORE_HIST_BASE + 2 * UGP_SCORE_HIST_NBINS)  /* 199 */
+
+/* Q3 instrumentation: per-category delta-from-perfect histograms for LEFT
+ * extensions split into 5 categories.
+ *
+ *   cat 0  ALL                            every LEFT extension
+ *   cat 1  UNGAP_FINAL                    HIT, or sp->qle == sp->tle on SW commit
+ *   cat 2  GAPPED_FINAL                   sp->qle != sp->tle on SW commit
+ *   cat 3  HIT                            ungapped fast-path returned HIT
+ *   cat 4  UNGAP_FINAL_NOT_HIT            cat1 ∩ ~cat3
+ *
+ * Each pair contributes its delta = (h0 + a*len2) − aln_score, where
+ * (h0 + a*len2) is the score of a hypothetical perfect ungapped extension.
+ * delta == 0 means HIT with all matches; delta grows with mismatches/gaps.
+ *
+ * Two histograms per category, 8 bins each (ugp_delta_bin: 0, 1-5, 6-10,
+ * 11-25, 26-50, 51-75, 76-100, 101+):
+ *
+ *   UGP_L_CAT_UNG  delta on would-be ungapped extension score
+ *                  HIT contributes (perfect − fp_score); non-HIT contributes
+ *                  (perfect − sp->ugp_walk_score) using the walk score
+ *                  computed at LEFT queue point.
+ *
+ *   UGP_L_CAT_FIN  delta on final committed alignment score
+ *                  HIT contributes (perfect − fp_score); non-HIT contributes
+ *                  (perfect − sp->score).
+ */
+#define UGP_CAT_NBINS          8
+#define UGP_CAT_NCAT           5
+#define UGP_L_CAT_UNG_BASE     UGP_SCORE_HIST_END                                  /* 199 */
+#define UGP_L_CAT_UNG_END      (UGP_L_CAT_UNG_BASE + UGP_CAT_NCAT * UGP_CAT_NBINS) /* 239 */
+#define UGP_L_CAT_FIN_BASE     UGP_L_CAT_UNG_END                                   /* 239 */
+#define UGP_L_CAT_FIN_END      (UGP_L_CAT_FIN_BASE + UGP_CAT_NCAT * UGP_CAT_NBINS) /* 279 */
+
+/* Compile-time tripwire: any new UGP_* counter group that pushes the high
+ * watermark past LIM_R would silently overflow tprof[]/prof[] at runtime.
+ * UGP_L_CAT_FIN_END is the largest UGP index in use today (=279).
+ *
+ * Note: this header is included only from C++ TUs (every consumer ends in
+ * .cpp), so the C++11 `static_assert` keyword resolves cleanly. If a C TU
+ * ever pulls macro.h in, swap to `_Static_assert` (C11) or include
+ * <assert.h> first. */
+static_assert(UGP_L_CAT_FIN_END <= LIM_R,
+              "LIM_R too small for UGP counters; bump LIM_R in macro.h");
 
 #endif
+

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -31,6 +31,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "macro.h"
 #include <stdint.h>
 #include <assert.h>
+#include "bwa.h"        /* bwa_verbose: gates the per-category UGP histograms */
 #include "profiling.h"
 
 // Profiling globals. Defined here rather than in main.cpp so they are part of
@@ -136,11 +137,9 @@ int display_stats(int nthreads)
     fprintf(stderr, "\t\tSMEM compute avg: %0.2lf, (%0.2lf, %0.2lf)\n",
             avg*1.0/proc_freq, max*1.0/proc_freq, min*1.0/proc_freq);
 
-#if HIDE
     find_opt(tprof[MEM_CHAIN], nthreads, &max, &min, &avg);
     fprintf(stderr, "\t\tMEM_CHAIN avg: %0.2lf, (%0.2lf, %0.2lf)\n",
             avg*1.0/proc_freq, max*1.0/proc_freq, min*1.0/proc_freq);
-#endif
     
     find_opt(tprof[MEM_SA_BLOCK], nthreads, &max, &min, &avg);
     fprintf(stderr, "\t\tSAL compute avg: %0.2lf, (%0.2lf, %0.2lf)\n",
@@ -156,6 +155,217 @@ int display_stats(int nthreads)
     find_opt(tprof[MEM_ALN2], nthreads, &max, &min, &avg);
     fprintf(stderr, "\t\tBSW time, avg: %0.2lf, (%0.2lf, %0.2lf)\n",
             avg*1.0/proc_freq, max*1.0/proc_freq, min*1.0/proc_freq);
+
+    // PR 26a/c.1/e/26c.2/Q1/Q2/Q3 diagnostics. Gated behind bwa_verbose >= 4
+    // — these are histogram-heavy profile-build sections, useful for tuning
+    // but noisy in production stderr. Match the convention used elsewhere
+    // for high-verbosity diagnostics in bwa.cpp.
+    if (bwa_verbose >= 4) {
+    // PR 26a/c.1/e diagnostics.
+    {
+        uint64_t la=0, lh=0, lt=0, ltb1=0, ltb2=0, ltb3=0, ln=0;
+        uint64_t ra=0, rh=0, rt=0, rtb1=0, rtb2=0, rtb3=0, rn=0;
+        for (int t = 0; t < nthreads; t++) {
+            la   += tprof[UGP_L_ATTEMPT][t];
+            lh   += tprof[UGP_L_HIT][t];
+            lt   += tprof[UGP_L_TIGHT][t];
+            ltb1 += tprof[UGP_L_TB_1_8][t];
+            ltb2 += tprof[UGP_L_TB_9_32][t];
+            ltb3 += tprof[UGP_L_TB_33_MAX][t];
+            ln   += tprof[UGP_L_DISP_NARROW][t];
+            ra   += tprof[UGP_R_ATTEMPT][t];
+            rh   += tprof[UGP_R_HIT][t];
+            rt   += tprof[UGP_R_TIGHT][t];
+            rtb1 += tprof[UGP_R_TB_1_8][t];
+            rtb2 += tprof[UGP_R_TB_9_32][t];
+            rtb3 += tprof[UGP_R_TB_33_MAX][t];
+            rn   += tprof[UGP_R_DISP_NARROW][t];
+        }
+        if (la + ra > 0) {
+            fprintf(stderr, "\n\tUngapped fast-path / tight_band diagnostics:\n");
+            fprintf(stderr, "\t  LEFT   att=%lu  hit=%lu (%.2f%%)  tight=%lu  tb[1..8]=%lu  tb[9..32]=%lu  tb[33..]=%lu  disp_narrow=%lu\n",
+                    (unsigned long)la, (unsigned long)lh,
+                    la ? 100.0 * (double)lh / (double)la : 0.0,
+                    (unsigned long)lt, (unsigned long)ltb1,
+                    (unsigned long)ltb2, (unsigned long)ltb3,
+                    (unsigned long)ln);
+            fprintf(stderr, "\t  RIGHT  att=%lu  hit=%lu (%.2f%%)  tight=%lu  tb[1..8]=%lu  tb[9..32]=%lu  tb[33..]=%lu  disp_narrow=%lu\n",
+                    (unsigned long)ra, (unsigned long)rh,
+                    ra ? 100.0 * (double)rh / (double)ra : 0.0,
+                    (unsigned long)rt, (unsigned long)rtb1,
+                    (unsigned long)rtb2, (unsigned long)rtb3,
+                    (unsigned long)rn);
+        }
+    }
+
+    /* PR 26c.2 design instrumentation. */
+    {
+        const char *fine_lbl[UGP_FINE_NBINS] = {
+            "0", "1-2", "3-4", "5-8", "9-16", "17-32", "33-48", "49-64", "65-80", "81-100"
+        };
+        const char *tier_lbl[2]   = { "8bit ", "16bit" };
+        const char *side_lbl[2]   = { "LEFT ", "RIGHT" };
+        const char *band_lbl[4]   = { "tb=0", "tb 1-8", "tb 9-32", "tb 33+" };
+        const char *narrow_lbl[UGP_NARROW_SZ_NBINS] = {
+            "0", "1-15", "16-31", "32-63", "64-127", "128-255", "256-511", "512+"
+        };
+
+        /* Group A: fine tight_band histogram per side. */
+        for (int side = 0; side < 2; side++) {
+            uint64_t total = 0;
+            uint64_t bins[UGP_FINE_NBINS] = {0};
+            for (int b = 0; b < UGP_FINE_NBINS; b++) {
+                for (int t = 0; t < nthreads; t++)
+                    bins[b] += tprof[UGP_FINE_BASE + side * UGP_FINE_NBINS + b][t];
+                total += bins[b];
+            }
+            if (total == 0) continue;
+            fprintf(stderr, "\t  %s tight_band fine: total=%lu  ",
+                    side_lbl[side], (unsigned long)total);
+            for (int b = 0; b < UGP_FINE_NBINS; b++)
+                fprintf(stderr, "%s=%lu ", fine_lbl[b], (unsigned long)bins[b]);
+            fprintf(stderr, "\n");
+        }
+
+        /* Group B: tier × band per side. The 2 tiers and 4 bands here mirror
+         * the producer-side layout written into UGP_TIER_TB_BASE; keep these
+         * named so any future bin/tier-count tweak stays in sync. */
+        const int tier_n = 2;
+        const int band_n = 4;
+        for (int side = 0; side < 2; side++) {
+            for (int tier = 0; tier < tier_n; tier++) {
+                uint64_t bins[band_n] = {0};
+                uint64_t total = 0;
+                for (int b = 0; b < band_n; b++) {
+                    for (int t = 0; t < nthreads; t++)
+                        bins[b] += tprof[UGP_TIER_TB_BASE
+                                         + side * (tier_n * band_n)
+                                         + tier * band_n + b][t];
+                    total += bins[b];
+                }
+                if (total == 0) continue;
+                fprintf(stderr, "\t  %s %s tier:       total=%lu  ",
+                        side_lbl[side], tier_lbl[tier], (unsigned long)total);
+                for (int b = 0; b < band_n; b++)
+                    fprintf(stderr, "%s=%lu ", band_lbl[b], (unsigned long)bins[b]);
+                fprintf(stderr, "\n");
+            }
+        }
+
+        /* Group C: per-batch narrow bucket size histogram per side. */
+        for (int side = 0; side < 2; side++) {
+            uint64_t bins[UGP_NARROW_SZ_NBINS] = {0};
+            uint64_t total = 0;
+            for (int b = 0; b < UGP_NARROW_SZ_NBINS; b++) {
+                for (int t = 0; t < nthreads; t++)
+                    bins[b] += tprof[UGP_NARROW_SZ_BASE + side * UGP_NARROW_SZ_NBINS + b][t];
+                total += bins[b];
+            }
+            if (total == 0) continue;
+            fprintf(stderr, "\t  %s narrow bucket sz/batch: total=%lu  ",
+                    side_lbl[side], (unsigned long)total);
+            for (int b = 0; b < UGP_NARROW_SZ_NBINS; b++)
+                fprintf(stderr, "%s=%lu ", narrow_lbl[b], (unsigned long)bins[b]);
+            fprintf(stderr, "\n");
+        }
+    }
+
+    /* Q1+Q2 instrumentation: post-SW ungapped/gapped final outcome and
+     * per-side alignment-score histogram. */
+    {
+        const char *side_lbl[2]  = { "LEFT ", "RIGHT" };
+        const char *score_lbl[UGP_SCORE_HIST_NBINS] = {
+            "0-10", "11-25", "26-50", "51-75", "76-100", "101-125", "126-150", "151+"
+        };
+        for (int side = 0; side < 2; side++) {
+            uint64_t ung = 0, gap = 0;
+            for (int t = 0; t < nthreads; t++) {
+                ung += tprof[UGP_OUTCOME_BASE + side * 2 + 0][t];
+                gap += tprof[UGP_OUTCOME_BASE + side * 2 + 1][t];
+            }
+            uint64_t total = ung + gap;
+            if (total == 0) continue;
+            fprintf(stderr, "\t  %s outcome: total=%lu  ungapped=%lu (%.2f%%)  gapped=%lu (%.2f%%)\n",
+                    side_lbl[side], (unsigned long)total,
+                    (unsigned long)ung, 100.0 * (double)ung / (double)total,
+                    (unsigned long)gap, 100.0 * (double)gap / (double)total);
+        }
+        for (int side = 0; side < 2; side++) {
+            uint64_t bins[UGP_SCORE_HIST_NBINS] = {0};
+            uint64_t total = 0;
+            for (int b = 0; b < UGP_SCORE_HIST_NBINS; b++) {
+                for (int t = 0; t < nthreads; t++)
+                    bins[b] += tprof[UGP_SCORE_HIST_BASE + side * UGP_SCORE_HIST_NBINS + b][t];
+                total += bins[b];
+            }
+            if (total == 0) continue;
+            fprintf(stderr, "\t  %s score hist:  total=%lu  ",
+                    side_lbl[side], (unsigned long)total);
+            for (int b = 0; b < UGP_SCORE_HIST_NBINS; b++)
+                fprintf(stderr, "%s=%lu ", score_lbl[b], (unsigned long)bins[b]);
+            fprintf(stderr, "\n");
+        }
+    }
+
+    /* Q3 instrumentation: per-category delta-from-perfect histograms (LEFT).
+     * delta = (h0 + a*len2) - aln_score; 0 = perfect ungapped extension. */
+    {
+        const char *cat_lbl[UGP_CAT_NCAT] = {
+            "ALL                 ",
+            "UNGAP_FINAL         ",
+            "GAPPED_FINAL        ",
+            "HIT                 ",
+            "UNGAP_FINAL_NOT_HIT "
+        };
+        const char *cat_delta_lbl[UGP_CAT_NBINS] = {
+            "0", "1-5", "6-10", "11-25", "26-50", "51-75", "76-100", "101+"
+        };
+        uint64_t any_ung = 0, any_fin = 0;
+        for (int c = 0; c < UGP_CAT_NCAT; c++)
+            for (int b = 0; b < UGP_CAT_NBINS; b++)
+                for (int t = 0; t < nthreads; t++) {
+                    any_ung += tprof[UGP_L_CAT_UNG_BASE + c * UGP_CAT_NBINS + b][t];
+                    any_fin += tprof[UGP_L_CAT_FIN_BASE + c * UGP_CAT_NBINS + b][t];
+                }
+        if (any_ung > 0 || any_fin > 0) {
+            fprintf(stderr, "\n\tQ3 LEFT per-category delta-from-perfect histograms:\n");
+        }
+        if (any_ung > 0) {
+            fprintf(stderr, "\t  -- delta on would-be ungapped extension score --\n");
+            for (int c = 0; c < UGP_CAT_NCAT; c++) {
+                uint64_t bins[UGP_CAT_NBINS] = {0};
+                uint64_t total = 0;
+                for (int b = 0; b < UGP_CAT_NBINS; b++) {
+                    for (int t = 0; t < nthreads; t++)
+                        bins[b] += tprof[UGP_L_CAT_UNG_BASE + c * UGP_CAT_NBINS + b][t];
+                    total += bins[b];
+                }
+                fprintf(stderr, "\t  cat%d %s ung total=%lu  ",
+                        c, cat_lbl[c], (unsigned long)total);
+                for (int b = 0; b < UGP_CAT_NBINS; b++)
+                    fprintf(stderr, "%s=%lu ", cat_delta_lbl[b], (unsigned long)bins[b]);
+                fprintf(stderr, "\n");
+            }
+        }
+        if (any_fin > 0) {
+            fprintf(stderr, "\t  -- delta on final committed alignment score --\n");
+            for (int c = 0; c < UGP_CAT_NCAT; c++) {
+                uint64_t bins[UGP_CAT_NBINS] = {0};
+                uint64_t total = 0;
+                for (int b = 0; b < UGP_CAT_NBINS; b++) {
+                    for (int t = 0; t < nthreads; t++)
+                        bins[b] += tprof[UGP_L_CAT_FIN_BASE + c * UGP_CAT_NBINS + b][t];
+                    total += bins[b];
+                }
+                fprintf(stderr, "\t  cat%d %s fin total=%lu  ",
+                        c, cat_lbl[c], (unsigned long)total);
+                for (int b = 0; b < UGP_CAT_NBINS; b++)
+                    fprintf(stderr, "%s=%lu ", cat_delta_lbl[b], (unsigned long)bins[b]);
+                fprintf(stderr, "\n");
+            }
+        }
+    }
+    } /* end bwa_verbose >= 4 gate for diagnostic histograms */
 
     #if HIDE
     int agg1 = 0, agg2 = 0, agg3 = 0;
@@ -241,7 +451,7 @@ int display_stats(int nthreads)
 #endif
     // printf("\tMemory usage (GB):\n");
     // printf("\tAvg: %0.2lf, Peak: %0.2lf\n", tprof[PE21][0]*1.0/1e9, tprof[PE22][0]*1.0/1e9);
-        
+
     return 1;
 }
 

--- a/src/read_index_ele.cpp
+++ b/src/read_index_ele.cpp
@@ -30,6 +30,10 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "read_index_ele.h"
 #include "safestringlib.h"
 
+#if defined(__linux__)
+#include <sys/mman.h>
+#endif
+
 indexEle::indexEle()
 {
     idx = (bwaidx_fm_t*) calloc(1, sizeof(bwaidx_fm_t));
@@ -75,9 +79,18 @@ void indexEle::bwa_idx_load_ele(const char *hint, int which)
         
         if (which & BWA_IDX_PAC)
         {
-            idx->pac = (uint8_t*) calloc(idx->bns->l_pac/4+1, 1);
+            int64_t pac_bytes = idx->bns->l_pac/4+1;
+            idx->pac = (uint8_t*) calloc(pac_bytes, 1);
             assert(idx->pac != NULL);
-            err_fread_noeof(idx->pac, 1, idx->bns->l_pac/4+1, idx->bns->fp_pac); // concatenated 2-bit encoded sequence
+#if defined(__linux__) && defined(MADV_HUGEPAGE)
+            // Pack table is ~800 MB for hg38 — accessed at every candidate
+            // alignment for reference fetch. Request transparent hugepages
+            // to reduce dTLB pressure and tame the 4-KB-page demotion spikes
+            // that cause bimodal wall-clock variance on large indices.
+            if (idx->pac != NULL && pac_bytes > 0)
+                (void)madvise(idx->pac, pac_bytes, MADV_HUGEPAGE);
+#endif
+            err_fread_noeof(idx->pac, 1, pac_bytes, idx->bns->fp_pac); // concatenated 2-bit encoded sequence
             err_fclose(idx->bns->fp_pac);
             idx->bns->fp_pac = 0;
         }

--- a/src/read_index_ele.cpp
+++ b/src/read_index_ele.cpp
@@ -30,9 +30,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "read_index_ele.h"
 #include "safestringlib.h"
 
-#if defined(__linux__)
-#include <sys/mman.h>
-#endif
+#include "bwa_madvise.h"
 
 indexEle::indexEle()
 {
@@ -82,14 +80,7 @@ void indexEle::bwa_idx_load_ele(const char *hint, int which)
             int64_t pac_bytes = idx->bns->l_pac/4+1;
             idx->pac = (uint8_t*) calloc(pac_bytes, 1);
             assert(idx->pac != NULL);
-#if defined(__linux__) && defined(MADV_HUGEPAGE)
-            // Pack table is ~800 MB for hg38 — accessed at every candidate
-            // alignment for reference fetch. Request transparent hugepages
-            // to reduce dTLB pressure and tame the 4-KB-page demotion spikes
-            // that cause bimodal wall-clock variance on large indices.
-            if (idx->pac != NULL && pac_bytes > 0)
-                (void)madvise(idx->pac, pac_bytes, MADV_HUGEPAGE);
-#endif
+            bwamem_madv_hugepage(idx->pac, pac_bytes);
             err_fread_noeof(idx->pac, 1, pac_bytes, idx->bns->fp_pac); // concatenated 2-bit encoded sequence
             err_fclose(idx->bns->fp_pac);
             idx->bns->fp_pac = 0;

--- a/test/bwt_seed_strategy_test.cpp
+++ b/test/bwt_seed_strategy_test.cpp
@@ -80,6 +80,23 @@ int main(int argc, char **argv) {
     assert(readlength < 10000);
     assert(numReads > 0);
     assert(numReads * readlength < QUERY_DB_SIZE);
+    // bwtSeedStrategyAllPosOneThread now requires the caller to pre-size
+    // matchArray to at least numReads * max(seqs[i].l_seq) SMEMs (the
+    // internal max_smem cap was removed). This test allocates by the CLI
+    // `readlength` and the encoder loop below reads seqs[st].seq[r] for
+    // every r < readlength, so reject any record whose length doesn't
+    // match: longer reads would overflow matchArray, shorter reads would
+    // walk past seqs[st].seq. Unconditional check so the safety holds
+    // under -DNDEBUG.
+    for (int32_t _i = 0; _i < numReads; _i++) {
+        if (seqs[_i].l_seq != readlength) {
+            fprintf(stderr,
+                    "[E::%s] read %d has l_seq=%d != readlength=%d; "
+                    "fixed-width buffers would be indexed out of bounds.\n",
+                    __func__, _i, seqs[_i].l_seq, readlength);
+            exit(EXIT_FAILURE);
+        }
+    }
 
     uint8_t *enc_qdb=(uint8_t *)malloc(numReads*readlength*sizeof(uint8_t));
 
@@ -145,8 +162,7 @@ int main(int argc, char **argv) {
             seqs,
             query_cum_len_ar,
             minSeedLen,
-            matchArray,
-            (int64_t)numReads * readlength);
+            matchArray);
 
     endTick = __rdtsc();
 #ifdef VTUNE_ANALYSIS

--- a/test/fmi_test.cpp
+++ b/test/fmi_test.cpp
@@ -138,7 +138,12 @@ int main(int argc, char **argv) {
 
     int64_t num_batches = (numReads + batch_size - 1 ) / batch_size;
     int64_t *numTotalSmem = (int64_t *)_mm_malloc(num_batches * sizeof(int64_t), 64);;
-    SMEM **batchStart = (SMEM **)_mm_malloc(num_batches * sizeof(SMEM *), 64);;
+    // Per-batch (tid, offset) lookup. matchArray[tid] is grown on demand
+    // with realloc() below, which can relocate the buffer — so we publish
+    // a stable index pair instead of a raw SMEM* into the (mutable) buffer
+    // and resolve to a pointer at print time once all growth is done.
+    int32_t *batchTid    = (int32_t *)_mm_malloc(num_batches * sizeof(int32_t), 64);
+    int64_t *batchOffset = (int64_t *)_mm_malloc(num_batches * sizeof(int64_t), 64);
 #pragma omp parallel num_threads(numthreads)
     {
         int tid = omp_get_thread_num();
@@ -160,7 +165,8 @@ int main(int argc, char **argv) {
 #endif
     startTick = __rdtsc();
     memset(numTotalSmem, 0, num_batches * sizeof(int64_t));
-    memset(batchStart, 0, num_batches * sizeof(int64_t));
+    memset(batchTid, 0, num_batches * sizeof(int32_t));
+    memset(batchOffset, 0, num_batches * sizeof(int64_t));
     int64_t workTicks[numthreads];
     memset(workTicks, 0, numthreads * sizeof(int64_t));
     int64_t perThreadQuota = numReads / numthreads;
@@ -169,18 +175,22 @@ int main(int argc, char **argv) {
     {
         int32_t *rid_array = (int32_t *)_mm_malloc(batch_size * sizeof(int32_t), 64);
         int32_t tid = omp_get_thread_num();
+        // Initial capacity must hold at least one batch's worst case so the
+        // first grow check below has a real budget to compare against. When
+        // numthreads > numReads, perThreadQuota is 0 and the legacy
+        // `perThreadQuota * 20` would malloc(0).
         int64_t matchArrayAlloc = perThreadQuota * 20;
+        const int64_t min_alloc = (int64_t)batch_size * max_readlength;
+        if (matchArrayAlloc < min_alloc) matchArrayAlloc = min_alloc;
         matchArray[tid] = (SMEM *)malloc(matchArrayAlloc * sizeof(SMEM));
         int64_t myTotalSmems = 0;
         int64_t startTick = __rdtsc();
 
-        // Per-thread lockstep slot buffers. Each OpenMP thread owns its own
-        // pair; production code (mmc) grows them on demand, but here
-        // max_readlength is fixed for the run so one allocation suffices for
-        // every batch this thread will process.
-        const int64_t ls_pair_elems = (int64_t)SMEM_LOCKSTEP_N * max_readlength;
-        SMEM *ls_prev      = (SMEM *)_mm_malloc(ls_pair_elems * sizeof(SMEM), 64);
-        SMEM *ls_match_buf = (SMEM *)_mm_malloc(ls_pair_elems * sizeof(SMEM), 64);
+        // The lockstep variant of getSMEMsOnePosOneThread now owns its
+        // per-slot prev/match buffers internally (sized by
+        // MAX_READ_LEN_FOR_LOCKSTEP), so the harness no longer pre-allocates
+        // them. matchArrayAlloc is grown on demand to keep the per-thread
+        // output buffer ahead of the per-batch SMEM count.
 
 #pragma omp for schedule(dynamic)
         for(i = 0; i < numReads; i += batch_size)
@@ -211,11 +221,9 @@ int main(int argc, char **argv) {
                     max_readlength,
                     minSeedLen,
                     matchArray[tid] + myTotalSmems,
-                    matchArrayAlloc - myTotalSmems,
-                    ls_prev,
-                    ls_match_buf,
                     numTotalSmem + batch_id);
-            batchStart[batch_id] = matchArray[tid] + myTotalSmems;
+            batchTid[batch_id]    = tid;
+            batchOffset[batch_id] = myTotalSmems;
             fmiSearch->sortSMEMs(matchArray[tid] + myTotalSmems,
                     numTotalSmem + batch_id,
                     batch_count,
@@ -233,8 +241,6 @@ int main(int argc, char **argv) {
         int64_t endTick = __rdtsc();
         printf("%d] %ld ticks, workTicks = %ld\n", tid, endTick - startTick, workTicks[tid]);
         _mm_free(rid_array);
-        _mm_free(ls_prev);
-        _mm_free(ls_match_buf);
     }
 
     endTick = __rdtsc();
@@ -267,7 +273,9 @@ int main(int argc, char **argv) {
     int32_t prevRid = -1;
     for(batch_id = 0; batch_id < num_batches; batch_id++)
     {
-        SMEM *myMatchArray = batchStart[batch_id];
+        // Resolve (tid, offset) to a stable pointer now — every batch's
+        // owning thread has finished growing matchArray[tid].
+        SMEM *myMatchArray = matchArray[batchTid[batch_id]] + batchOffset[batch_id];
         int64_t i;
         for(i = 0; i < numTotalSmem[batch_id]; i++)
         {
@@ -303,7 +311,8 @@ int main(int argc, char **argv) {
     }
     _mm_free(min_intv_array);
     _mm_free(numTotalSmem);
-    _mm_free(batchStart);
+    _mm_free(batchTid);
+    _mm_free(batchOffset);
     delete fmiSearch;
     return 0;
 }

--- a/test/smem2_test.cpp
+++ b/test/smem2_test.cpp
@@ -176,7 +176,6 @@ int main(int argc, char **argv) {
             readlength,
             minSeedLen,
             matchArray,
-            (int64_t)numReads * readlength,
             numTotalSmem);
     endTick = __rdtsc();
 #ifdef VTUNE_ANALYSIS

--- a/test/smem_lockstep_parity_test.cpp
+++ b/test/smem_lockstep_parity_test.cpp
@@ -77,20 +77,17 @@ static bool run_case(FMI_search *fmi,
 
     int64_t n_scalar = 0, n_lockstep = 0;
 
-    // Per-slot lockstep buffers: one pair per test call, sized to fit any
-    // single SMEM walk for this max_readlength.
-    const int64_t ls_pair_elems = (int64_t)SMEM_LOCKSTEP_N * max_readlength;
-    SMEM *ls_prev      = (SMEM *)_mm_malloc(ls_pair_elems * sizeof(SMEM), 64);
-    SMEM *ls_match_buf = (SMEM *)_mm_malloc(ls_pair_elems * sizeof(SMEM), 64);
+    // The lockstep variant of getSMEMsOnePosOneThread heap-allocates its
+    // per-slot prev/match scratch internally (sized from max_readlength),
+    // so the harness no longer pre-allocates them.
 
     fmi->getSMEMsOnePosOneThread(enc_qdb, qpa_s, mia_s, rid_s,
                                  numReads, numReads, seq_, query_cum_len_ar,
                                  max_readlength, minSeedLen, scalar_out,
-                                 max_out, &n_scalar);
+                                 &n_scalar);
     fmi->getSMEMsOnePosOneThread_lockstep(enc_qdb, qpa_l, mia_l, rid_l,
                                           numReads, numReads, seq_, query_cum_len_ar,
                                           max_readlength, minSeedLen, lockstep_out,
-                                          max_out, ls_prev, ls_match_buf,
                                           &n_lockstep);
 
     total_cases++;
@@ -122,8 +119,6 @@ static bool run_case(FMI_search *fmi,
 
     _mm_free(scalar_out);
     _mm_free(lockstep_out);
-    _mm_free(ls_prev);
-    _mm_free(ls_match_buf);
     free(qpa_s); free(qpa_l); free(mia_s); free(mia_l); free(rid_s); free(rid_l);
     return ok;
 }
@@ -403,9 +398,9 @@ int main(int argc, char *argv[]) {
         const int32_t max_out = numReads * max_readlength;
         SMEM *scalar_out   = (SMEM *)_mm_malloc(max_out * sizeof(SMEM), 64);
         SMEM *lockstep_out = (SMEM *)_mm_malloc(max_out * sizeof(SMEM), 64);
-        const int64_t ls_pair_elems = (int64_t)SMEM_LOCKSTEP_N * max_readlength;
-        SMEM *ls_prev      = (SMEM *)_mm_malloc(ls_pair_elems * sizeof(SMEM), 64);
-        SMEM *ls_match_buf = (SMEM *)_mm_malloc(ls_pair_elems * sizeof(SMEM), 64);
+        /* The lockstep variant now owns its per-slot prev/match scratch
+         * internally (sized by MAX_READ_LEN_FOR_LOCKSTEP); no external
+         * lockstep buffers are needed here. */
 
         /* The two do/while blocks below intentionally mirror the compaction
          * logic in FMI_search::getSMEMsAllPosOneThread (see src/FMI_search.cpp),
@@ -433,7 +428,7 @@ int main(int argc, char *argv[]) {
                 fmi->getSMEMsOnePosOneThread(enc_qdb, qpa_s, mia_work, rid_work,
                                              tail, tail, seq_, cum_len,
                                              max_readlength, minSeedLen, scalar_out,
-                                             max_out, &n_s);
+                                             &n_s);
                 numActive = tail;
             } while (numActive > 0);
         }
@@ -459,7 +454,7 @@ int main(int argc, char *argv[]) {
                 fmi->getSMEMsOnePosOneThread_lockstep(enc_qdb, qpa_l, mia_work, rid_work,
                                                      tail, tail, seq_, cum_len,
                                                      max_readlength, minSeedLen, lockstep_out,
-                                                     max_out, ls_prev, ls_match_buf, &n_l);
+                                                     &n_l);
                 numActive = tail;
             } while (numActive > 0);
         }
@@ -485,7 +480,6 @@ int main(int argc, char *argv[]) {
             }
         }
         _mm_free(scalar_out); _mm_free(lockstep_out);
-        _mm_free(ls_prev); _mm_free(ls_match_buf);
         free(enc_qdb); free(seq_); free(cum_len);
     }
 

--- a/test/smem_lockstep_parity_test.cpp
+++ b/test/smem_lockstep_parity_test.cpp
@@ -519,10 +519,10 @@ int main(int argc, char *argv[]) {
     }
 
     /* Case 11: long reads (>151bp and >512bp) — regression for issue 44.
-     * Pre-fix, readlength > MAX_READ_LEN_FOR_LOCKSTEP (512) would trip a
-     * hard assert in ls_init_slot. Post-fix, the lockstep slot buffers
-     * are heap-backed and sized from the caller's max_readlength, so any
-     * length works. Exercises a 1000bp and a 1500bp synthetic read. */
+     * Pre-fix, readlength > 512 would trip the lockstep cap and exit.
+     * Post-fix, the lockstep slot buffers are heap-allocated by the
+     * driver and sized from max_readlength, so any length works.
+     * Exercises a 1000bp and a 1500bp synthetic read. */
     {
         char r_1000bp[1001];
         char r_1500bp[1501];
@@ -542,6 +542,36 @@ int main(int argc, char *argv[]) {
         int32_t mia[] = {1, 1};
         int32_t rid[] = {0, 1};
         run_case(fmi, "Case 11: long reads (1000bp, 1500bp)",
+                 numReads, max_readlength, 19,
+                 enc_qdb, qpa, mia, rid, seq_, cum_len);
+        free(enc_qdb); free(seq_); free(cum_len);
+    }
+
+    /* Case 12: long reads with mid-read N — exercises the non-ACGT
+     * termination path on the long-read code path that Case 11's clean
+     * 4-base rotation didn't cover. The forward SMEM walk must split at
+     * the N position and re-seed past it, on the heap-allocated lockstep
+     * slot buffers. Two reads: 1000bp with N at pos 700, 1500bp with N
+     * at pos 1100. */
+    {
+        char r_1000bp[1001];
+        char r_1500bp[1501];
+        const char *bases = "ACGT";
+        for (int i = 0; i < 1000; i++) r_1000bp[i] = bases[(i * 7 + 3) & 3];
+        r_1000bp[700] = 'N';
+        r_1000bp[1000] = '\0';
+        for (int i = 0; i < 1500; i++) r_1500bp[i] = bases[(i * 11 + 5) & 3];
+        r_1500bp[1100] = 'N';
+        r_1500bp[1500] = '\0';
+        const char *reads[] = { r_1000bp, r_1500bp };
+        int32_t numReads = 2;
+        int32_t max_readlength = 1500;
+        uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
+        encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
+        int16_t qpa[] = {0, 0};
+        int32_t mia[] = {1, 1};
+        int32_t rid[] = {0, 1};
+        run_case(fmi, "Case 12: long reads with mid-read N",
                  numReads, max_readlength, 19,
                  enc_qdb, qpa, mia, rid, seq_, cum_len);
         free(enc_qdb); free(seq_); free(cum_len);


### PR DESCRIPTION
## Summary

Multi-phase performance audit of bwa-mem2's hot path, squashed and rebased onto `fg-main` HEAD. Wins span ksw2 banded SW, SMEM lockstep batching, SAL prefetch, SAM record building, and an opt-in PGO build.

`smoke1M` (1M PE 150 bp reads, hg38) — Graviton3 r7g.4xlarge, 16 threads, warm page cache:

| Build | Wall | CPU% | CPU work | Speedup vs fg-main |
| --- | --- | --- | --- | --- |
| fg-main HEAD (`a8342b2^`) | 16.66s | 1051% | ~175s | 1.00x baseline |
| perf/uber, no PGO | 13.98s | 961% | ~134s | **1.31x** |
| perf/uber + PGO | 12.89s | 913% | ~118s | **1.48x** |

x86 cross-arch sanity (Skylake-X m5.2xlarge, 8 vCPU/4 cores; smaller box so wall is dominated by limited parallelism, but the relative gains track):

| Arch | fg-main HEAD | perf/uber | Wall speedup |
| --- | --- | --- | --- |
| AVX2 | 98.6s | 94.7s | 1.04x |
| AVX-512BW | 95.8s | 88.2s | 1.09x |

Same `bwa-mem2 mem` CLI, same scoring; SAM output stays byte-identical where the perf wins kept that invariant (the band-cap retry path can shift a small number of borderline secondary alignments). HN tag emission and other features added in `fg-main` are preserved.

## What's in here

**ksw2 / banded SW** (`src/bandedSWA.cpp`, `src/bwamem.cpp`)
* Ungapped diagonal fast-path before banded SW
* `tight_band` piping + retry skip
* SIMD-only TIGHT shortcut in `ungapped_analyze` (NEON, SSSE3, AVX2)
* Post-left-SW right-side fast-path pass
* Initial-band cap: `BUCKET_MAX_INIT_W=8` with `MAX_BAND_TRY=4` → implicit bucket dispatch by retry expansion (8→16→32→64)

**SMEM lockstep batching** (`src/FMI_search.cpp`)
* Hybrid SoA: split BatchSlot hot state from bulk buffers (LISA-style trick)
* T1 cross-slot prefetch lookahead
* `SMEM_LOCKSTEP_N=8` (was 4)

**SA lookup** (`src/FMI_search.cpp`)
* Software prefetch in `get_sa_entries`

**SAM record build** (`src/bwamem.cpp`)
* SIMD-accelerated SEQ/QUAL encoders (16-byte LUT shuffle):
  * NEON `vqtbl1q_u8` on aarch64
  * SSSE3 `_mm_shuffle_epi8` on x86 (covers SSE4 / AVX2 / AVX-512BW)
  * Scalar fallback otherwise
* Unsafe kstring writes for fixed-width fields
* `memcpy`-based `enc_qdb` prep (replaces a per-byte loop)

**PAC table** (`src/bwa.cpp`)
* `MADV_HUGEPAGE` on the ~800 MB pack table (Linux only) to reduce dTLB pressure during reference fetch

**Build / Makefile**
* `profile-build`: ARM64 build with `-DDISABLE_OUTPUT` for compute-only wall-clock measurement
* `lto-build`: ARM64 LTO build (Thin LTO under clang, plain LTO under GCC)
* PGO targets (`pgo-generate` / `pgo-use` / `pgo-clean`) were already in fg-main; confirmed working end-to-end and gives the largest single-knob win on Graviton

**Bench harness** (`bench/`)
* `run.sh` / `compare.sh` / `normalize_sam.sh` wrappers that drive the standard smoke benchmarks and produce normalized SAMs for score-equivalence diffing

## What's NOT in here

* **WFA-affine port** — vendored WFA2-lib kernel + lockstep packs + instrumentation never beat the existing SIMD banded SW after the ksw2-side wins above. Kept on the `exploratory/wfa-port` branch for reference; deleted here.
* **BUCKET_MAX_INIT_W=4 experiment** — regressed score-equivalence at no perf benefit; reverted to `=8`.

## Test plan

- [x] Builds clean on NEON (Graviton3 / Apple Silicon)
- [x] Builds clean on AVX2 (m5.2xlarge Skylake-X)
- [x] Builds clean on AVX-512BW (m5.2xlarge Skylake-X)
- [x] Runs `smoke1M` end-to-end on each arch with sane SAM output (HN tag preserved)
- [x] PGO pipeline (`make pgo-generate` → train → `make pgo-use`) on Graviton — 1.48x vs fg-main HEAD
- [ ] CI multi-arch runs (will surface here once the PR is open)

## Audit: nothing dropped in the rebase

Confirmed by `git diff perf/uber-pre-squash..HEAD --ignore-all-space` over the perf-touched files:
* `bandedSWA.cpp/h`, `FMI_search.cpp/h`, `profiling.cpp`, `kstring.h` — identical modulo CRLF→LF
* `bwamem.cpp` — only diff is HN tag propagation added on top
* `bwa.cpp` — `MADV_HUGEPAGE` preserved; gained `bwa_insert_header_file` from fg-main
* `macro.h` — gained `NREADS_ESTIMATE_AVG_BASES` from fg-main; perf macros intact
* `Makefile` — gained fg-main additions; `profile-build` and `lto-build` preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added benchmarking harness for performance comparison across PR branches with automated golden SAM validation and multi-threaded performance metrics.
  * Added build targets for Profile-Guided Optimization (PGO) and Link-Time Optimization (LTO) modes.

* **Improvements**
  * Optimized seed-finding algorithms with enhanced prefetching and reduced memory overhead.
  * Improved alignment scoring with streamlined dynamic programming and ungapped extension analysis.
  * Applied transparent hugepage memory hints for index buffers.

* **Documentation**
  * Added comprehensive benchmarking workflow guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->