### PR TITLE
feat(makefile): parameterize PGO targets by arch + profile dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ myall:arm64
 endif
 endif
 
-CXXFLAGS+=	-g -O3 -std=gnu++14 -fpermissive $(ARCH_FLAGS) $(ASAN_FLAGS) #-Wall ##-xSSE2
+CXXFLAGS+=	-g -O3 -std=gnu++14 -fpermissive $(ARCH_FLAGS) $(ASAN_FLAGS) $(EXTRA_CXXFLAGS) #-Wall ##-xSSE2
 
 # Control build flag for the batched mate-rescue SW port on ARM.
 # When set (e.g. `make arm64 DISABLE_BATCHED_MATESW=1`), the source gate for
@@ -333,28 +333,59 @@ $(MIMALLOC_LIB):
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
 clean:
-	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_selftest kswv_nrow_zero_test bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
+	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_selftest kswv_nrow_zero_test bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64 bwa-mem2.pgo bwa-mem2.pgo-instr bwa-mem2.pgo.* bwa-mem2.pgo-instr.*
 	cd ext/safestringlib/ && $(MAKE) clean
 	-[ -f ext/htslib/config.mk ] && cd ext/htslib && $(MAKE) distclean
 	rm -rf $(MIMALLOC_BUILD)
 
-# Profile-Guided Optimization (PGO) targets for Apple Silicon
-# Usage: make pgo-generate && <run training workload> && make pgo-use
-PGO_PROFILE_DIR=pgo_profiles
+# Profile-Guided Optimization (PGO) targets.
+#
+# Usage (host-default arch, single shared profile dir — preserves prior
+# arm64 behavior on Apple Silicon / aarch64 hosts):
+#   make pgo-generate && <run training workload> && make pgo-use
+#
+# Multi-arch / multi-regime usage (override at command line):
+#   make pgo-generate PGO_ARCH=avx2 PGO_PROFILE_DIR=/path/to/regimeA
+#   <run training>
+#   make pgo-use PGO_ARCH=avx2 PGO_PROFILE_DIR=/path/to/regimeA
+#
+# PGO_ARCH accepts the same values as the top-level `arch=` knob: arm64,
+# sse41, sse42, avx, avx2, avx512, avx512bw, native, or any custom flag
+# string. Defaults match the host: arm64 on Apple Silicon / aarch64,
+# native otherwise. Output binaries are arch-suffixed when PGO_ARCH is
+# non-default, so multiple per-arch builds coexist:
+#   PGO_ARCH=arm64  -> bwa-mem2.pgo-instr,    bwa-mem2.pgo
+#   PGO_ARCH=avx2   -> bwa-mem2.pgo-instr.avx2, bwa-mem2.pgo.avx2
+ifneq ($(IS_ARM),)
+    PGO_ARCH ?= arm64
+else
+    PGO_ARCH ?= native
+endif
+PGO_PROFILE_DIR ?= pgo_profiles
+
+# Output names: keep the bare names when PGO_ARCH is the default arm64
+# (backward-compat); arch-suffix otherwise so per-arch outputs don't collide.
+ifeq ($(PGO_ARCH),arm64)
+    PGO_INSTR_EXE = bwa-mem2.pgo-instr
+    PGO_FINAL_EXE = bwa-mem2.pgo
+else
+    PGO_INSTR_EXE = bwa-mem2.pgo-instr.$(PGO_ARCH)
+    PGO_FINAL_EXE = bwa-mem2.pgo.$(PGO_ARCH)
+endif
 
 pgo-generate:
 	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
-	$(MAKE) arch=arm64 EXE=bwa-mem2.pgo-instr CXXFLAGS="$(CXXFLAGS) -g -O3 -fpermissive $(ARCH_FLAGS) -fprofile-generate=$(PGO_PROFILE_DIR)" CXX=$(CXX) all
-	@echo "PGO instrumented binary built. Run training workload with bwa-mem2.pgo-instr"
-	@echo "Then run: make pgo-use"
+	$(MAKE) arch=$(PGO_ARCH) EXE=$(PGO_INSTR_EXE) EXTRA_CXXFLAGS="-fprofile-generate=$(PGO_PROFILE_DIR)" CXX=$(CXX) all
+	@echo "PGO instrumented binary built: $(PGO_INSTR_EXE) (arch=$(PGO_ARCH), profile dir=$(PGO_PROFILE_DIR))"
+	@echo "Run training workload with $(PGO_INSTR_EXE), then: make pgo-use PGO_ARCH=$(PGO_ARCH) PGO_PROFILE_DIR=$(PGO_PROFILE_DIR)"
 
 pgo-use:
 	rm -f src/*.o $(BWA_LIB); cd ext/safestringlib/ && $(MAKE) clean;
-	$(MAKE) arch=arm64 EXE=bwa-mem2.pgo CXXFLAGS="$(CXXFLAGS) -g -O3 -fpermissive $(ARCH_FLAGS) -fprofile-use=$(PGO_PROFILE_DIR) -fprofile-correction" CXX=$(CXX) all
-	@echo "PGO optimized binary built: bwa-mem2.pgo"
+	$(MAKE) arch=$(PGO_ARCH) EXE=$(PGO_FINAL_EXE) EXTRA_CXXFLAGS="-fprofile-use=$(PGO_PROFILE_DIR) -fprofile-correction" CXX=$(CXX) all
+	@echo "PGO optimized binary built: $(PGO_FINAL_EXE) (arch=$(PGO_ARCH))"
 
 pgo-clean:
-	rm -rf $(PGO_PROFILE_DIR) bwa-mem2.pgo-instr bwa-mem2.pgo
+	rm -rf $(PGO_PROFILE_DIR) bwa-mem2.pgo-instr bwa-mem2.pgo bwa-mem2.pgo-instr.* bwa-mem2.pgo.*
 
 # Print the effective mimalloc setting. Used by CI and humans.
 print-mimalloc-config:


### PR DESCRIPTION
## Summary

Generalize the existing `pgo-generate` / `pgo-use` Makefile targets so they accept a build arch and a profile directory at the command line, instead of hardcoding `arch=arm64` and a single shared `pgo_profiles/`.

## Changes

- Add `PGO_ARCH` (default: `arm64`). Passes through to the recursive `make` invocation as `arch=$(PGO_ARCH)`. Accepts the same values the rest of the Makefile already understands: `arm64`, `sse41`, `sse42`, `avx`, `avx2`, `avx512`, `avx512bw`, `native`, or any custom flag string.
- Make `PGO_PROFILE_DIR` overridable from the command line (was a hard `=`, now `?=`). Lets each (regime × arch) capture into its own dir.
- Per-arch output binary names: when ``PGO_ARCH != arm64``, outputs are ``bwa-mem2.pgo-instr.\$(PGO_ARCH)`` and ``bwa-mem2.pgo.\$(PGO_ARCH)`` so multiple per-arch builds coexist. Default arm64 keeps the bare names.
- Update the section comment from \"for Apple Silicon\" to reflect multi-arch usage.
- Widen ``clean`` and ``pgo-clean`` to remove arch-suffixed PGO binaries.

## Backward compatibility

Existing ``make pgo-generate && make pgo-use`` on Apple Silicon is unchanged. Defaults preserve ``arch=arm64``, ``PGO_PROFILE_DIR=pgo_profiles``, and bare ``bwa-mem2.pgo-instr`` / ``bwa-mem2.pgo`` output names.

## Motivation

Enables per-arch + per-regime PGO experiments. A downstream benchmarking workflow needs ``(arch × regime × training-source)`` profile capture, which requires both knobs.

## Test plan

Verified locally on macOS arm64:

- [x] ``make pgo-generate`` (no args) -> arch=arm64, builds ``bwa-mem2.pgo-instr`` with ``-fprofile-generate=pgo_profiles``. Identical to prior behavior.
- [x] ``make pgo-generate PGO_PROFILE_DIR=/tmp/regimeA`` -> propagates the custom directory into ``-fprofile-generate=``.
- [x] ``make -n pgo-generate PGO_ARCH=avx2 PGO_PROFILE_DIR=/tmp/regimeA`` -> recursive make sees ``arch=avx2`` and ``EXE=bwa-mem2.pgo-instr.avx2``, with ``-fprofile-generate=/tmp/regimeA``.
- [x] ``make pgo-clean`` removes both bare and arch-suffixed PGO binaries.
- [ ] CI build of an x86 PGO_ARCH=avx2 / PGO_ARCH=avx512bw target (requires x86 host).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build system now accepts externally supplied compilation flags so custom flags propagate into builds.
  * Profile-Guided Optimization (PGO) flow generalized to support per-architecture builds via configurable arch and profile-directory variables.
  * PGO generation/use steps honor the selected architecture and flags.
  * Cleanup targets and user messages updated to remove PGO artifacts for default and per-architecture outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->