### PR TITLE
feat(cli): wire up --help across commands

### DIFF
--- a/src/bwtindex.cpp
+++ b/src/bwtindex.cpp
@@ -172,6 +172,22 @@ static int64_t parse_memory_spec(const char *s)
     return v;
 }
 
+static void index_usage(void)
+{
+	fprintf(stderr, "Usage: bwa-mem2 index [-p prefix] [-t N] [--max-memory SIZE] [--tmp-dir PATH] [--meth] <in.fasta>\n");
+	fprintf(stderr, "\n"
+	        "  -p STR             output prefix (default: <in.fasta>)\n"
+	        "  -t INT             worker threads [auto: detected cores, cgroup-aware]\n"
+	        "  --max-memory SIZE  peak memory budget; SIZE accepts a G/M/K suffix\n"
+	        "                     (case-insensitive) or bare bytes\n"
+	        "                     [auto: min(50%% of RAM, 32G), cgroup-aware]\n"
+	        "  --tmp-dir PATH     scratch directory [$TMPDIR]\n"
+	        "  --meth             build a bwameth-style doubled c2t reference + FMI.\n"
+	        "                     Writes <in.fasta>.bwameth.c2t and the FMI alongside it.\n"
+	        "                     Use with `bwa-mem2 mem --meth <in.fasta> R1.fq [R2.fq]`.\n"
+	        "  -h, --help         print this help message and exit\n");
+}
+
 int bwa_index(int argc, char *argv[]) // the "index" command
 {
 	int c;
@@ -184,9 +200,10 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 		{"max-memory", required_argument, 0, 1001},
 		{"tmp-dir",    required_argument, 0, 1002},
 		{"threads",    required_argument, 0, 't'},
+		{"help",       no_argument,       0, 'h'},
 		{0, 0, 0, 0}
 	};
-	while ((c = getopt_long(argc, argv, "p:t:", long_opts, NULL)) >= 0) {
+	while ((c = getopt_long(argc, argv, "p:t:h", long_opts, NULL)) >= 0) {
 		if (c == 'p') prefix = optarg;
 		else if (c == 't') {
 			// Mirror parse_memory_spec's strict strtol parsing: atoi
@@ -211,21 +228,16 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 			user_max_memory = mem;
 		} else if (c == 1002) {
 			setenv("BWA_INDEX_TMPDIR", optarg, 1);
+		} else if (c == 'h') {
+			index_usage();
+			return 0;
 		} else {
 			return 1;
 		}
 	}
 
 	if (optind + 1 > argc) {
-		fprintf(stderr, "Usage: bwa-mem2 index [-p prefix] [-t N] [--max-memory G] [--tmp-dir PATH] [--meth] <in.fasta>\n");
-		fprintf(stderr, "\n"
-		        "  -p STR          output prefix (default: <in.fasta>)\n"
-		        "  -t INT          worker threads [auto: detected cores, cgroup-aware]\n"
-		        "  --max-memory G  peak memory budget [auto: min(50%% of RAM, 32G), cgroup-aware]\n"
-		        "  --tmp-dir PATH  scratch directory [$TMPDIR]\n"
-		        "  --meth          build a bwameth-style doubled c2t reference + FMI.\n"
-		        "                  Writes <in.fasta>.bwameth.c2t and the FMI alongside it.\n"
-		        "                  Use with `bwa-mem2 mem --meth <in.fasta> R1.fq [R2.fq]`.\n");
+		index_usage();
 		return 1;
 	}
 

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -877,6 +877,8 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                 with >=INT genome occurrences (i.e. the supp region is repetitive on its\n");
     fprintf(stderr, "                 own). 0 disables (default). Typical values 5-20; lower = more aggressive.\n");
     fprintf(stderr, "                 Primary MAPQ is unaffected.\n");
+    fprintf(stderr, "Help:\n");
+    fprintf(stderr, "   --help        print this help message and exit\n");
     fprintf(stderr, "Note: Please read the man page for detailed description of the command line and options.\n");
 }
 
@@ -921,6 +923,7 @@ int main_mem(int argc, char *argv[])
         OPT_METH_SET_AS_FAILED,
         OPT_METH_NO_CHIMERA,
         OPT_SUPP_REP_HARD_CAP,
+        OPT_HELP,
     };
     static struct option long_opts[] = {
         {"bam",                      optional_argument, 0, OPT_BAM},
@@ -928,6 +931,7 @@ int main_mem(int argc, char *argv[])
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
         {"do-not-penalize-chimeras", no_argument,       0, OPT_METH_NO_CHIMERA},
         {"supp-rep-hard-cap",        required_argument, 0, OPT_SUPP_REP_HARD_CAP},
+        {"help",                     no_argument,       0, OPT_HELP},
         {0, 0, 0, 0}
     };
     while ((c = getopt_long(argc, argv, "51qpaMCSPVYjuk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:o:f:z:",
@@ -1080,6 +1084,14 @@ int main_mem(int argc, char *argv[])
                 return 1;
             }
             opt->supp_rep_hard_cap = (int)v;
+        }
+        else if (c == OPT_HELP) {
+            usage(opt);
+            free(opt);
+            free(hdr_line);
+            free(rg_line);
+            if (out_opened) fclose(aux.fp);
+            return 0;
         }
         else if (c == 'I')
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@ int usage()
     fprintf(stderr, "  index         create index (add --meth to build a bwameth-style doubled c2t reference)\n");
     fprintf(stderr, "  mem           alignment (add --meth for bisulfite-seq: inline c2t + BAM output)\n");
     fprintf(stderr, "  version       print version number\n");
+    fprintf(stderr, "Run `bwa-mem2 <command> --help` for command-specific options.\n");
     return 1;
 }
 
@@ -78,6 +79,11 @@ int main(int argc, char* argv[])
     int ret = -1;
     if (argc < 2) return usage();
 
+    if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0) {
+        usage();
+        return 0;
+    }
+
     if (strcmp(argv[1], "index") == 0)
     {
          uint64_t tim = __rdtsc();
@@ -87,6 +93,43 @@ int main(int argc, char* argv[])
     }
     else if (strcmp(argv[1], "mem") == 0)
     {
+        // Short-circuit `mem --help` so we skip the AVX/SA banner and the
+        // post-run profiling trailer (printed below when ret==0). Skip
+        // tokens that are the value of an option that takes an argument
+        // -- otherwise `mem -R --help ...`, `mem -o --help ...`, or
+        // `mem --set-as-failed --help ...` would treat the option's
+        // value as a help request and suppress the banner. Keep the
+        // short-option string and long-option list in sync with the
+        // optstring and long_opts table in fastmap.cpp::main_mem.
+        static const char *const MEM_SHORT_OPTS_WITH_ARG =
+            "kcvsrtRABOEUwLdTQDmINWxGhyKXHofz";
+        static const char *const MEM_LONG_OPTS_WITH_ARG[] = {
+            "--set-as-failed", "--supp-rep-hard-cap", NULL,
+        };
+        for (int i = 2; i < argc; ++i) {
+            const char *t = argv[i];
+            if (strcmp(t, "--") == 0) break;
+            if (strcmp(t, "--help") == 0) return main_mem(argc-1, argv+1);
+            // Long option (no `=`): next argv token is its value.
+            int matched_long = 0;
+            for (int j = 0; MEM_LONG_OPTS_WITH_ARG[j]; ++j) {
+                if (strcmp(t, MEM_LONG_OPTS_WITH_ARG[j]) == 0) {
+                    matched_long = 1; break;
+                }
+            }
+            if (matched_long) { ++i; continue; }
+            // Short-option bundle `-abc[value]`: walk chars; the first
+            // arg-taking option consumes the rest of the bundle (if any)
+            // or the next argv token (if the bundle ends at it).
+            if (t[0] != '-' || t[1] == '\0' || t[1] == '-') continue;
+            for (const char *p = t + 1; *p; ++p) {
+                if (strchr(MEM_SHORT_OPTS_WITH_ARG, *p)) {
+                    if (*(p + 1) == '\0') ++i;
+                    break;
+                }
+            }
+        }
+
         tprof[MEM][0] = __rdtsc();
         kstring_t pg = {0,0,0};
         extern char *bwa_pg;

--- a/test/help_prescan_test.sh
+++ b/test/help_prescan_test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# test/help_prescan_test.sh
+#
+# `bwa-mem2 mem` pre-scans argv for `--help` so the AVX/SA banner and the
+# post-run profiling trailer are skipped on a real help request. The scan
+# must NOT match `--help` when it appears as the value of an option that
+# takes an argument (e.g. `-R --help`, `-o --help`,
+# `--set-as-failed --help`). Without the fix, those legitimate runs
+# wrongly short-circuit to `main_mem` and suppress the banner.
+#
+# Usage: test/help_prescan_test.sh <bwa-mem2-binary> <fixtures-dir>
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <bwa-mem2-binary> <fixtures-dir>" >&2
+    exit 2
+fi
+
+# Resolve to absolute paths so the `cd "$tmpdir"` block in test 2 still
+# finds the binary, reference, and reads regardless of how the script
+# was invoked.
+abspath() { (cd "$(dirname "$1")" && printf '%s/%s\n' "$(pwd)" "$(basename "$1")"); }
+bin="$(abspath "$1")"
+fixtures="$(abspath "$2")"
+ref="$fixtures/phix.fa"
+reads="$fixtures/reads.fa"
+
+[[ -x "$bin" ]]   || { echo "FAIL: bwa-mem2 binary not executable at $bin" >&2; exit 1; }
+[[ -s "$ref" ]]   || { echo "FAIL: phix.fa missing at $ref" >&2; exit 1; }
+[[ -s "$reads" ]] || { echo "FAIL: reads.fa missing at $reads" >&2; exit 1; }
+
+# Build the phiX FMI index if not already present.
+if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.0123" || ! -s "$ref.amb" \
+      || ! -s "$ref.ann"       || ! -s "$ref.pac" ]]; then
+    "$bin" index "$ref" >/dev/null 2>&1 \
+        || { echo "FAIL: bwa-mem2 index on phix.fa failed" >&2; exit 1; }
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# --- 1. Real `mem --help` short-circuits: option list, no banner, exit 0. ---
+set +e
+"$bin" mem --help > "$tmpdir/help.out" 2> "$tmpdir/help.err"
+rc=$?
+set -e
+[[ $rc -eq 0 ]] \
+    || { echo "FAIL: mem --help exited with $rc, expected 0" >&2
+         echo "---- stderr ----" >&2; cat "$tmpdir/help.err" >&2; exit 1; }
+grep -q 'Algorithm options' "$tmpdir/help.err" \
+    || { echo "FAIL: mem --help did not print the usage option list" >&2
+         echo "---- stderr ----" >&2; cat "$tmpdir/help.err" >&2; exit 1; }
+if grep -q 'Executing in' "$tmpdir/help.err"; then
+    echo "FAIL: mem --help printed the AVX/SA banner; pre-scan should suppress it" >&2
+    exit 1
+fi
+
+# --- 2. `mem -o --help <ref> <reads>` is a legitimate run whose -o value -----
+# is the literal string `--help`. The banner must be printed, the run must
+# exit 0, and SAM must be written to a file literally named `--help`. Run
+# from the tmp dir so the output file lands there even though `--help`
+# looks like an option.
+set +e
+( cd "$tmpdir" && "$bin" mem -o "--help" "$ref" "$reads" > run.out 2> run.err )
+rc=$?
+set -e
+[[ $rc -eq 0 ]] \
+    || { echo "FAIL: 'mem -o --help' exited $rc, expected 0" >&2
+         echo "---- stderr ----" >&2; cat "$tmpdir/run.err" >&2; exit 1; }
+[[ -s "$tmpdir/--help" ]] \
+    || { echo "FAIL: mem -o --help did not write SAM to file '--help'" >&2
+         echo "---- stderr ----" >&2; cat "$tmpdir/run.err" >&2; exit 1; }
+grep -q 'Executing in' "$tmpdir/run.err" \
+    || { echo "FAIL: banner missing from 'mem -o --help' invocation; pre-scan wrongly matched the option's value" >&2
+         echo "---- stderr ----" >&2; cat "$tmpdir/run.err" >&2; exit 1; }
+
+# --- 3. `mem -R --help <ref> <reads>` -- here -R rejects `--help` as an -----
+# invalid @RG, but the banner must still be printed first and the run must
+# exit non-zero (so the test can't pass if `--help` were ever wrongly
+# consumed and the run completed successfully).
+set +e
+"$bin" mem -R "--help" "$ref" "$reads" > "$tmpdir/rg.out" 2> "$tmpdir/rg.err"
+rc=$?
+set -e
+[[ $rc -ne 0 ]] \
+    || { echo "FAIL: 'mem -R --help' exited 0; expected non-zero (invalid @RG)" >&2
+         echo "---- stderr ----" >&2; cat "$tmpdir/rg.err" >&2; exit 1; }
+grep -q 'Executing in' "$tmpdir/rg.err" \
+    || { echo "FAIL: banner missing from 'mem -R --help' invocation; pre-scan wrongly matched the option's value" >&2
+         echo "---- stderr ----" >&2; cat "$tmpdir/rg.err" >&2; exit 1; }
+
+# --- 4. `mem --set-as-failed --help <ref> <reads>` -- long option with a ----
+# required argument; the banner must still be printed and the run must
+# exit non-zero.
+set +e
+"$bin" mem --set-as-failed "--help" "$ref" "$reads" \
+    > "$tmpdir/saf.out" 2> "$tmpdir/saf.err"
+rc=$?
+set -e
+[[ $rc -ne 0 ]] \
+    || { echo "FAIL: 'mem --set-as-failed --help' exited 0; expected non-zero (--help is not a valid 'f'|'r' value)" >&2
+         echo "---- stderr ----" >&2; cat "$tmpdir/saf.err" >&2; exit 1; }
+grep -q 'Executing in' "$tmpdir/saf.err" \
+    || { echo "FAIL: banner missing from 'mem --set-as-failed --help' invocation; pre-scan wrongly matched the option's value" >&2
+         echo "---- stderr ----" >&2; cat "$tmpdir/saf.err" >&2; exit 1; }
+
+echo "PASS: mem --help short-circuits; mem <opt-with-arg> --help does not"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -85,6 +85,12 @@ ok "xeonbsw ($LINES pair scores emitted)"
 "$HERE/pg_cl_escape_test.sh" "$BWAMEM2" "$FIXTURES" || fail "pg_cl_escape_test failed"
 ok "pg_cl_escape_test"
 
+# --- help_prescan_test ----------------------------------------------------
+# `mem --help` pre-scan must not match `--help` when it is the value of
+# an option that takes an argument (-R, -o, --set-as-failed, ...).
+"$HERE/help_prescan_test.sh" "$BWAMEM2" "$FIXTURES" || fail "help_prescan_test failed"
+ok "help_prescan_test"
+
 # --- smem_lockstep_parity_test --------------------------------------------
 OUT="$(cd "$HERE" && ./smem_lockstep_parity_test "$FIXTURES/phix.fa" 2>&1)"
 CASES_PASSED="$(echo "$OUT" | sed -nE 's/^([0-9]+) \/ ([0-9]+) cases passed$/\1/p')"


### PR DESCRIPTION
## Summary

- `bwa-mem2 -h` / `bwa-mem2 --help` and `bwa-mem2 index -h` / `--help` now print usage and exit 0 instead of falling through to `unknown command` / `unknown option` errors.
- `bwa-mem2 mem --help` works the same way; the AVX/SA-compression banner and the post-run profiling trailer are skipped when `--help` is given so the output is a clean help dump.
- `mem -h INT[,INT]` (XA-hits threshold) is preserved unchanged — that short option is inherited from upstream `bwa`/`bwa-mem2` and silently breaking it would corrupt existing pipelines. `--help` is the only new spelling for `mem`.

## Behavior matrix

| Invocation | Before | After |
|---|---|---|
| `bwa-mem2` (no args) | usage, exit 1 | unchanged |
| `bwa-mem2 -h` | `ERROR: unknown command '-h'` | top-level usage, exit 0 |
| `bwa-mem2 --help` | `ERROR: unknown command '--help'` | top-level usage, exit 0 |
| `bwa-mem2 mem` (no args) | banner + usage | unchanged |
| `bwa-mem2 mem -h` | `option requires an argument -- h` | unchanged (XA-hits threshold) |
| `bwa-mem2 mem -h N` / `-h N,M` | XA-hits set | unchanged |
| `bwa-mem2 mem --help` | `illegal option -- -` | usage, no banner, no trailer, exit 0 |
| `bwa-mem2 index` (no args) | usage, exit 1 | unchanged |
| `bwa-mem2 index -h` / `--help` | getopt error | usage, exit 0 |

## Implementation notes

- `main.cpp`: top-level dispatch intercepts `-h` / `--help` before the subcommand branch. The `mem` branch additionally scans `argv` for `--help` (stopping at `--`) and short-circuits straight to `main_mem` so the AVX/SA banner, `@PG` line, and profiling trailer are skipped.
- `bwtindex.cpp`: extracted the inlined usage block into `index_usage()`; added `h` to the optstring and `{"help", no_argument, 0, 'h'}` to the long-option table.
- `fastmap.cpp`: added `OPT_HELP` sentinel and the matching `{"help", no_argument, 0, OPT_HELP}` long-option entry; the handler frees `opt`, closes any output file, and returns 0. The visible usage block now lists `--help` at the bottom.

## Test plan

- [x] `make` builds clean (Apple Silicon arm64 single-binary path)
- [x] `make test` (kswv selftest + nrow-zero) passes
- [x] `bash test/run_unit_tests.sh` — all unit + smoke tests pass (incl. `bwa-mem2 mem` end-to-end smoke runs)
- [x] Manual matrix walk-through: all 9 invocations above behave as expected
- [ ] CI on Linux/AVX2 / AVX-512 / SSE4.2 paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified -h/--help handling at top level and for subcommands; pre-scan ensures `--help` is treated as an option when appropriate and exits without running commands.

* **Bug Fixes**
  * Missing positional arguments now show the unified usage/help text consistently.

* **Tests**
  * Added an automated prescan test for various `--help` scenarios and integrated it into the unit-test run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->