### PR TITLE
feat(shm): port `bwa shm` from bwa-mem v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,8 @@ OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/memcpy_bwamem.o src/kthread.
 			src/FMI_search.o src/read_index_ele.o src/bwamem_pair.o src/kswv.o src/bwa.o \
 			src/bwamem_extra.o src/kopen.o src/bam_writer.o src/meth_bam.o \
 			src/packed_text.o src/fm_index_writer.o src/index_prelude.o \
-			src/system.o src/libsais_build.o
+			src/system.o src/libsais_build.o \
+			src/bwa_shm.o
 BWA_LIB=    libbwa.a
 SAFE_STR_LIB=    ext/safestringlib/libsafestring.a
 HTS_LIB=    ext/htslib/libhts.a
@@ -267,7 +268,7 @@ ifneq ($(strip $(DISABLE_BATCHED_MATESW)),)
     CPPFLAGS += -DDISABLE_BATCHED_MATESW=$(DISABLE_BATCHED_MATESW)
 endif
 
-.PHONY:all clean depend multi print-mimalloc-config kswv_nrow_zero_test test FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean
+.PHONY:all clean depend multi print-mimalloc-config kswv_nrow_zero_test shm_section_find_test shm_pack_round_trip_test test FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean
 .SUFFIXES:.cpp .o
 
 .cpp.o:
@@ -336,14 +337,28 @@ test-binaries: $(BWA_LIB)
 	    COVERAGE=$(COVERAGE) \
 	    ARCH_FLAGS_FROM_PARENT='$(ARCH_FLAGS)'
 
+shm_section_find_test: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_section_find_test.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/shm_section_find_test.o $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) -o $@
+
+shm_pack_round_trip_test: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_pack_round_trip_test.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/shm_pack_round_trip_test.o $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) -o $@
+
+test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
+
 # Run the in-tree tests via the unit-test harness in test/, plus the
-# standalone kswv_nrow_zero_test regression.
-test: test-binaries kswv_nrow_zero_test
+# standalone regressions (kswv_nrow_zero_test + shm_section_find_test).
+# shm_pack_round_trip_test runs via test/shm_pack_round_trip_test.sh which
+# builds the phiX index first; invoked from test/run_unit_tests.sh.
+test: test-binaries kswv_nrow_zero_test shm_section_find_test
 	./test/bwa_mem2_tests_unit
 	./test/bwa_mem2_tests_integration
 	./kswv_nrow_zero_test
+	./shm_section_find_test
 
 test/kswv_nrow_zero_test.o: test/kswv_nrow_zero_test.cpp
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
+
+test/shm_section_find_test.o: test/shm_section_find_test.cpp
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 $(BWA_LIB):$(OBJS)
@@ -410,7 +425,7 @@ $(MIMALLOC_LIB):
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
 clean: pgo-clean profile-clean lto-clean
-	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
+	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test shm_section_find_test shm_pack_round_trip_test bwa-mem2.sse41 bwa-mem2.sse42 bwa-mem2.avx bwa-mem2.avx2 bwa-mem2.avx512bw bwa-mem2.arm64
 	rm -f $(LIBSAIS_OBJS)
 	rm -f src/*.gcno src/*.gcda
 	$(MAKE) -C test clean

--- a/README.md
+++ b/README.md
@@ -112,6 +112,55 @@ Where
 Where <prefix> is the prefix specified when creating the index or the path to the reference fasta file in case no prefix was provided.
 ```
 
+## Shared-memory index (`shm`)
+
+The bwa-mem2 FM-index is large (~28 GB for hg38), and `bwa-mem2 mem`
+re-reads it from disk on every invocation. For workloads that align
+many small samples back-to-back on the same machine, or for benchmark
+runs that want to measure mapping in isolation from index-load cost,
+the index can be staged once into POSIX shared memory:
+
+```sh
+# Stage the index. After this, subsequent `mem` runs auto-attach.
+./bwa-mem2 shm <prefix>
+
+# List staged indices.
+./bwa-mem2 shm -l
+
+# Drop everything (does not unstage selectively — matches bwa v1).
+./bwa-mem2 shm -d
+```
+
+`bwa-mem2 mem <prefix> ...` automatically attaches when a matching
+segment is staged; no extra flag is needed. Subsequent `mem`
+invocations on the same host see the FMI, BNS, PAC, and the `.0123`
+reference string aliased into the shared mapping rather than re-read
+from disk.
+
+**Footgun: there is no staleness check.** If you re-run `bwa-mem2
+index <prefix>`, the on-disk files will not match the staged segment,
+but `mem` will still attach to the stale segment and silently
+mis-align. Always `bwa-mem2 shm -d` before re-indexing.
+
+**Basename collisions.** Per-index segment names are derived from the
+filename component of the prefix, so `/data/a/hg38` and `/data/b/hg38`
+both map to `/bwaidx-hg38` and collide. Stage one at a time, or use
+distinct prefix basenames.
+
+**macOS.** Apple's POSIX shared-memory implementation imposes its own
+per-segment size cap that is not directly the same as the SysV
+`kern.sysv.shmmax` knob. Small reference indices (a few hundred MB)
+work out of the box; larger indices may simply fail to stage with no
+straightforward operator-facing tunable. For production references
+(e.g. hg38), prefer Linux, where `/dev/shm` is a tmpfs that defaults
+to ~50% of RAM on bare metal and rarely needs tuning.
+
+**Containers.** In Docker and Kubernetes, `/dev/shm` is often much
+smaller than the host default (commonly 64 MiB) and will fail to fit
+a real reference index. Raise it explicitly: `docker run --shm-size=32g
+...`, or in Kubernetes mount an `emptyDir` with `medium: Memory` and
+a generous `sizeLimit` at `/dev/shm`.
+
 ## Performance
 
 Datasets:  

--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -32,7 +32,9 @@ Authors: Sanchit Misra <sanchit.misra@intel.com>; Vasimuddin Md <vasimuddin.md@i
 #include <stdlib.h>
 #include <inttypes.h>
 #include <climits>
+#include <sys/mman.h>     /* munmap */
 #include "bwa_madvise.h"
+#include "bwa_shm.h"
 #include "FMI_search.h"
 #include "memcpy_bwamem.h"
 #include "profiling.h"
@@ -43,26 +45,123 @@ Authors: Sanchit Misra <sanchit.misra@intel.com>; Vasimuddin Md <vasimuddin.md@i
 FMI_search::FMI_search(const char *fname)
 {
     fprintf(stderr, "* Entering FMI_search\n");
-    //strcpy(file_name, fname);
     strcpy_s(file_name, PATH_MAX, fname);
     reference_seq_len = 0;
     sentinel_index = 0;
     sa_ls_word = NULL;
     sa_ms_byte = NULL;
     cp_occ = NULL;
-    one_hot_mask_array = NULL;
+    shm_base = NULL;
+    shm_len = 0;
+
+    /* one_hot_mask_array is constant across the FMI's lifetime and is
+     * identical on disk and shm paths; initialize it once at construction. */
+    int64_t one_hot_bytes = 64 * (int64_t)sizeof(uint64_t);
+    one_hot_mask_array = (uint64_t *)_mm_malloc(one_hot_bytes, 64);
+    assert_not_null(one_hot_mask_array, one_hot_bytes, one_hot_bytes);
+    one_hot_mask_array[0] = 0;
+    uint64_t base = 0x8000000000000000L;
+    one_hot_mask_array[1] = base;
+    for (int64_t i = 2; i < 64; ++i) {
+        one_hot_mask_array[i] = (one_hot_mask_array[i - 1] >> 1) | base;
+    }
 }
 
 FMI_search::~FMI_search()
 {
-    if(sa_ms_byte)
-        _mm_free(sa_ms_byte);
-    if(sa_ls_word)
-        _mm_free(sa_ls_word);
-    if(cp_occ)
-        _mm_free(cp_occ);
-    if(one_hot_mask_array)
-        _mm_free(one_hot_mask_array);
+    /* When attached from shm, cp_occ/sa_*_byte/sa_*_word alias mmap'd pages
+     * owned by the shm segment, so we don't _mm_free them. We do munmap the
+     * mapping itself — leaving it would leak VA in long-lived processes that
+     * construct and destroy FMI_search repeatedly. */
+    if (shm_base != NULL) {
+        munmap(shm_base, shm_len);
+        shm_base = NULL;
+        shm_len  = 0;
+    } else {
+        if (sa_ms_byte) _mm_free(sa_ms_byte);
+        if (sa_ls_word) _mm_free(sa_ls_word);
+        if (cp_occ)     _mm_free(cp_occ);
+    }
+    if (one_hot_mask_array) _mm_free(one_hot_mask_array);
+}
+
+int64_t FMI_search::cp_occ_size_bytes() const {
+    return ((reference_seq_len >> CP_SHIFT) + 1) * (int64_t)sizeof(CP_OCC);
+}
+
+int64_t FMI_search::sa_sample_count() const {
+    return (reference_seq_len >> SA_COMPX) + 1;
+}
+
+void FMI_search::load_index_from_shm(uint8_t *base, size_t len)
+{
+    if (base == NULL) {
+        fprintf(stderr, "ERROR! load_index_from_shm called with NULL base\n");
+        exit(EXIT_FAILURE);
+    }
+    uint64_t off = 0, sz = 0;
+
+    if (bwa_shm_section_find(base, BWA_SHM_SEC_FMI_SCALARS, &off, &sz) != 0
+        || sz != BWA_SHM_FMI_SCALARS_BYTES) {
+        fprintf(stderr, "ERROR! shm segment missing or malformed FMI_SCALARS\n");
+        exit(EXIT_FAILURE);
+    }
+    memcpy(&reference_seq_len, base + off,                                    sizeof(int64_t));
+    memcpy(count,              base + off + sizeof(int64_t),                  sizeof(int64_t) * 5);
+    memcpy(&sentinel_index,    base + off + sizeof(int64_t) * 6,              sizeof(int64_t));
+
+    /* Validate scalars before we use reference_seq_len in cp_occ_size_bytes()
+     * and the SA size accessors. Bounds match the disk path's asserts in
+     * load_index() and the writer-side checks in bwa_shm_compute(). A corrupt
+     * segment would otherwise drive negative or overflowing section sizes. */
+    if (reference_seq_len <= 0 || reference_seq_len > 0x7fffffffffLL) {
+        fprintf(stderr,
+            "ERROR! shm FMI_SCALARS: reference_seq_len=%lld out of bounds\n",
+            (long long)reference_seq_len);
+        exit(EXIT_FAILURE);
+    }
+    /* count[] is +1-adjusted by bwa_shm_compute; range [1, ref_seq_len+1]. */
+    for (int i = 0; i < 5; ++i) {
+        if (count[i] < 0 || count[i] > reference_seq_len + 1) {
+            fprintf(stderr,
+                "ERROR! shm FMI_SCALARS: count[%d]=%lld out of bounds (ref_seq_len=%lld)\n",
+                i, (long long)count[i], (long long)reference_seq_len);
+            exit(EXIT_FAILURE);
+        }
+    }
+    if (sentinel_index < 0 || sentinel_index >= reference_seq_len) {
+        fprintf(stderr,
+            "ERROR! shm FMI_SCALARS: sentinel_index=%lld out of bounds (ref_seq_len=%lld)\n",
+            (long long)sentinel_index, (long long)reference_seq_len);
+        exit(EXIT_FAILURE);
+    }
+
+    if (bwa_shm_section_find(base, BWA_SHM_SEC_FMI_CP_OCC, &off, &sz) != 0
+        || (int64_t)sz != cp_occ_size_bytes()) {
+        fprintf(stderr, "ERROR! shm segment missing or sized FMI_CP_OCC\n");
+        exit(EXIT_FAILURE);
+    }
+    cp_occ = (CP_OCC *)(base + off);
+
+    if (bwa_shm_section_find(base, BWA_SHM_SEC_FMI_SA_MS, &off, &sz) != 0
+        || (int64_t)sz != sa_ms_byte_size_bytes()) {
+        fprintf(stderr, "ERROR! shm segment missing or sized FMI_SA_MS\n");
+        exit(EXIT_FAILURE);
+    }
+    sa_ms_byte = (int8_t *)(base + off);
+
+    if (bwa_shm_section_find(base, BWA_SHM_SEC_FMI_SA_LS, &off, &sz) != 0
+        || (int64_t)sz != sa_ls_word_size_bytes()) {
+        fprintf(stderr, "ERROR! shm segment missing or sized FMI_SA_LS\n");
+        exit(EXIT_FAILURE);
+    }
+    sa_ls_word = (uint32_t *)(base + off);
+
+    shm_base = base;
+    shm_len  = len;
+
+    fprintf(stderr, "* FMI attached from shm: ref_seq_len=%ld sentinel_index=%ld\n",
+            (long)reference_seq_len, (long)sentinel_index);
 }
 
 int FMI_search::build_index() {
@@ -120,20 +219,25 @@ int FMI_search::build_index() {
 
 void FMI_search::load_index()
 {
+    /* Try the staged shm segment first. On hit, both the FMI internals
+     * (cp_occ / sa_*) and the BNS+PAC are attached as views into the
+     * mapping; the segment lifetime belongs to the shm-loading process. */
+    {
+        size_t   shm_attach_len = 0;
+        uint8_t *shm_base_local = bwa_shm_attach(file_name, &shm_attach_len);
+        if (shm_base_local != NULL) {
+            load_index_from_shm(shm_base_local, shm_attach_len);
+            bwa_idx_load_ele_from_shm(shm_base_local, shm_attach_len);
+            fprintf(stderr, "* FMI+BNS+PAC attached from shm; "
+                    "skipping disk load.\n");
+            return;
+        }
+    }
+
     // Running total of index bytes allocated so far in this function.
     // Passed to assert_not_null so a failed allocation reports both the
     // attempted size and how much we'd already committed before failing.
     int64_t index_alloc = 0;
-
-    one_hot_mask_array = (uint64_t *)_mm_malloc(64 * sizeof(uint64_t), 64);
-    one_hot_mask_array[0] = 0;
-    uint64_t base = 0x8000000000000000L;
-    one_hot_mask_array[1] = base;
-    int64_t i = 0;
-    for(i = 2; i < 64; i++)
-    {
-        one_hot_mask_array[i] = (one_hot_mask_array[i - 1] >> 1) | base;
-    }
 
     char *ref_file_name = file_name;
     //beCalls = 0;

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -100,9 +100,32 @@ class FMI_search: public indexEle
     FMI_search(const char *fname);
     ~FMI_search();
     //int64_t beCalls;
-    
+
+    /* Read-only size accessors. Used by load_index_from_shm for section
+     * validation, and by the round-trip test for byte-equality checks. */
+    int64_t cp_occ_size_bytes()      const;
+    int64_t sa_sample_count()        const;
+    int64_t sa_ms_byte_size_bytes()  const { return sa_sample_count() * (int64_t)sizeof(int8_t); }
+    int64_t sa_ls_word_size_bytes() const { return sa_sample_count() * (int64_t)sizeof(uint32_t); }
+
+    /* Read-only data accessors. Used by the round-trip test to byte-compare
+     * the packed segment payload against the in-memory loader's buffers. */
+    const void     *cp_occ_data()     const { return cp_occ; }
+    const int8_t   *sa_ms_byte_data() const { return sa_ms_byte; }
+    const uint32_t *sa_ls_word_data() const { return sa_ls_word; }
+    const int64_t  *count_data()      const { return count; }
+
+    /* Return the shm segment base if load_index attached from shm, else NULL.
+     * fastmap reuses this so it doesn't have to re-attach for the ref string. */
+    uint8_t *shm_attached_base()     const { return shm_base; }
+
     int build_index();
     void load_index();
+
+    /* Attach to a packed bwa-mem2 index segment from bwa_shm_attach. Sets
+     * scalars and the cp_occ / sa_ms_byte / sa_ls_word pointers; the
+     * destructor munmaps `base` and leaves the aliased buffers untouched. */
+    void load_index_from_shm(uint8_t *base, size_t len);
 
     /* matchArray sizing contract (applies to all four SMEM-emitting methods
      * below). The previous internal `max_smem` capacity guard was removed;
@@ -224,6 +247,14 @@ private:
         CP_OCC *cp_occ;
 
         uint64_t *one_hot_mask_array;
+
+        /* If non-NULL, cp_occ / sa_ms_byte / sa_ls_word point into a shared
+         * memory mapping owned by the shm segment rather than being
+         * _mm_malloc'd. shm_len is the byte length of the mapping so the
+         * destructor can munmap it; the destructor also skips _mm_free on
+         * shm-backed buffers. */
+        uint8_t *shm_base;
+        size_t   shm_len;
 
         SMEM backwardExt(SMEM smem, uint8_t a);
 

--- a/src/bwa_shm.cpp
+++ b/src/bwa_shm.cpp
@@ -1,0 +1,842 @@
+/*************************************************************************************
+                           The MIT License
+
+   BWA-MEM2  (Sequence alignment using Burrows-Wheeler Transform),
+   Copyright (C) 2026  Fulcrum Genomics, contributors of bwa-mem2.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*****************************************************************************************/
+
+#include "bwa_shm.h"
+#include "bwa.h"           /* BWA_CTL_SIZE — see static_assert below */
+#include "FMI_search.h"    /* CP_FILENAME_SUFFIX, CP_OCC, CP_SHIFT */
+#include "macro.h"         /* SA_COMPX */
+#include "bntseq.h"        /* bntseq_t, bns_restore, bns_destroy */
+#include "utils.h"         /* err_fread_noeof, err_fclose, xopen */
+#include "safestringlib.h" /* strcpy_s, strcat_s */
+
+#include <stdio.h>
+#include <cstdlib>
+#include <cstring>
+#include <sys/mman.h>      /* shm_open, mmap, munmap */
+#include <sys/stat.h>      /* mode constants, stat */
+#include <fcntl.h>         /* O_* */
+#include <unistd.h>        /* close, ftruncate */
+#include <errno.h>
+#include <limits.h>        /* PATH_MAX */
+
+/* /bwactl layout: 16-bit n_entries, 16-bit next_write_offset, then packed
+ * (int64_t l_mem, char[] basename) entries. The header is 4 bytes total
+ * (two uint16_t fields). next_write_offset starts at 4 on a fresh segment. */
+#define BWA_SHM_CTL_HEADER_BYTES 4
+
+/* .bwt.2bit.64 prefix: int64_t reference_seq_len, int64_t count[5]. */
+#define BWA_BWT_2BIT_HEADER_BYTES (sizeof(int64_t) * 6)
+
+/* Sanity bound on reference_seq_len read from disk. The bwa-mem2 FM-index
+ * has long enforced reference_seq_len <= 0x7fffffffff (about 549 Gbp); see
+ * FMI_search::load_index. Anything beyond this is a malformed file. */
+#define BWA_SHM_MAX_REF_SEQ_LEN 0x7fffffffffLL
+
+/* Sanity bound on the total packed segment size we'll create. 1 TiB is far
+ * larger than any realistic reference genome's index and well below what
+ * 64-bit arithmetic can express, so overflow checks against this max are
+ * effectively impossible to trip in practice but cheap to enforce. */
+#define BWA_SHM_MAX_TOTAL_SIZE (1ull << 40)
+
+/* The two constants must agree. bwa.h::BWA_CTL_SIZE is a v1-era stub that
+ * we'll remove in a separate cleanup commit; until then, this assert
+ * prevents silent drift if either definition is edited. */
+static_assert(BWA_SHM_CTL_SIZE == BWA_CTL_SIZE,
+              "BWA_SHM_CTL_SIZE must equal bwa.h::BWA_CTL_SIZE");
+
+/* Return a pointer to the filename component of `hint` — everything after
+ * the last '/'. If `hint` has no '/', returns `hint`. */
+static const char *prefix_basename(const char *hint)
+{
+    if (hint == NULL || hint[0] == '\0') return hint;
+    const char *p = hint + std::strlen(hint) - 1;
+    while (p >= hint && *p != '/') --p;
+    return p + 1;
+}
+
+/* Build "<a><b>" into `out` (PATH_MAX-bounded) using safestringlib helpers,
+ * matching the path-building convention used elsewhere in the codebase
+ * (see bntseq.cpp, FMI_search.cpp, fastmap.cpp). */
+static void path_concat2(char out[PATH_MAX], const char *a, const char *b)
+{
+    strcpy_s(out, PATH_MAX, a);
+    strcat_s(out, PATH_MAX, b);
+}
+
+/* Open `/bwactl` read-write, creating it if necessary and zero-initializing
+ * a fresh segment with next-write offset = BWA_SHM_CTL_HEADER_BYTES.
+ *
+ * On success returns the mmap'd address (a `BWA_SHM_CTL_SIZE`-byte writable
+ * mapping) and `*fd_out` holds the still-open file descriptor — caller
+ * closes it after the mapping is no longer needed (typical pattern: close
+ * immediately, since the mapping survives close).
+ *
+ * NOTE: there is no advisory lock around the registry. POSIX shm fds on
+ * macOS reject flock(2) with EOPNOTSUPP, so a portable lock would require
+ * a side-channel lockfile. We accept the v1 race window here: two
+ * concurrent `bwa-mem2 shm <prefix>` invocations may both pass the
+ * pre-stage `bwa_shm_test` and append duplicate entries (or have one
+ * `O_EXCL`-create the segment and the other discover it via EEXIST). The
+ * EEXIST branch in `bwa_shm_stage` treats that as already-staged. */
+static void *ctl_open_rw(int *fd_out)
+{
+    int created = 0;
+    int fd = shm_open(BWA_SHM_CTL_NAME, O_RDWR, 0);
+    if (fd < 0) {
+        if (errno != ENOENT) return NULL;
+        fd = shm_open(BWA_SHM_CTL_NAME, O_CREAT | O_RDWR | O_EXCL, 0644);
+        if (fd < 0) {
+            fd = shm_open(BWA_SHM_CTL_NAME, O_RDWR, 0);
+            if (fd < 0) return NULL;
+        } else {
+            created = 1;
+        }
+    }
+    if (ftruncate(fd, BWA_SHM_CTL_SIZE) < 0) { close(fd); return NULL; }
+    void *m = mmap(NULL, BWA_SHM_CTL_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (m == MAP_FAILED) { close(fd); return NULL; }
+    if (created) {
+        std::memset(m, 0, BWA_SHM_CTL_SIZE);
+        uint16_t next_write = BWA_SHM_CTL_HEADER_BYTES;
+        std::memcpy((uint8_t *)m + 2, &next_write, sizeof(uint16_t));
+    }
+    *fd_out = fd;
+    return m;
+}
+
+static void ctl_close(void *m, int fd)
+{
+    if (m != NULL) munmap(m, BWA_SHM_CTL_SIZE);
+    if (fd >= 0)   close(fd);
+}
+
+/* Walk the registry, calling `cb(l_mem, name, ctx)` for each entry. cb may
+ * return 0 to continue or non-zero to stop. Returns the cb's last return
+ * value (or 0 if the registry is absent or empty), -1 on open/mmap error. */
+typedef int (*bwa_shm_ctl_cb_t)(int64_t l_mem, const char *name, void *ctx);
+
+static int ctl_walk(bwa_shm_ctl_cb_t cb, void *ctx)
+{
+    int fd = shm_open(BWA_SHM_CTL_NAME, O_RDONLY, 0);
+    if (fd < 0) return errno == ENOENT ? 0 : -1;
+    /* A previous failed stage can leave a zero-sized registry; on macOS an
+     * unlinked-but-still-referenced segment also lingers at size 0. mmap
+     * rejects 0-byte mappings with EINVAL. ctl_open_rw always ftruncates
+     * the segment to the full BWA_SHM_CTL_SIZE on creation, so anything
+     * smaller is junk left behind by an aborted stage — treat as empty. */
+    struct stat st;
+    if (fstat(fd, &st) < 0 || (size_t)st.st_size < BWA_SHM_CTL_SIZE) {
+        close(fd);
+        return 0;
+    }
+    void *m = mmap(NULL, BWA_SHM_CTL_SIZE, PROT_READ, MAP_SHARED, fd, 0);
+    close(fd);
+    if (m == MAP_FAILED) return -1;
+
+    const uint8_t *base = (const uint8_t *)m;
+    uint16_t n_entries = 0;
+    std::memcpy(&n_entries, base, sizeof(uint16_t));
+    const uint8_t *p   = base + BWA_SHM_CTL_HEADER_BYTES;
+    const uint8_t *end = base + BWA_SHM_CTL_SIZE;
+    int rc = 0;
+    for (uint16_t i = 0; i < n_entries; ++i) {
+        if (p + sizeof(int64_t) >= end) break;
+        int64_t l_mem = 0;
+        std::memcpy(&l_mem, p, sizeof(int64_t));
+        const char *name = (const char *)(p + sizeof(int64_t));
+        size_t name_max  = (size_t)(end - (const uint8_t *)name);
+        size_t namelen   = strnlen(name, name_max);
+        if (namelen == name_max) break;
+        rc = cb(l_mem, name, ctx);
+        if (rc != 0) break;
+        p = (const uint8_t *)name + namelen + 1;
+    }
+
+    munmap(m, BWA_SHM_CTL_SIZE);
+    return rc;
+}
+
+extern "C" {
+
+int bwa_shm_compute(const char *prefix, bwa_shm_layout_t *layout)
+{
+    if (prefix == NULL || layout == NULL) return -1;
+
+    memset(layout, 0, sizeof(*layout));
+    size_t plen = strlen(prefix);
+    if (plen + 1 > sizeof(layout->prefix)) {
+        fprintf(stderr, "[E::%s] prefix too long\n", __func__);
+        return -1;
+    }
+    memcpy(layout->prefix, prefix, plen + 1);
+
+    /* 1. Load BNS (.ann + .amb + name/anno strings; opens .pac fp which we
+     *    don't need here). */
+    bntseq_t *bns = bns_restore(prefix);
+    if (bns == NULL) {
+        fprintf(stderr, "[E::%s] bns_restore(%s) failed\n", __func__, prefix);
+        return -1;
+    }
+    /* Close the .pac stream that bns_restore left open; pack_into re-opens
+     * it via xopen on the .pac path. Zero the field so bns_destroy doesn't
+     * double-close. */
+    if (bns->fp_pac != NULL) {
+        err_fclose(bns->fp_pac);
+        bns->fp_pac = NULL;
+    }
+    layout->bns = bns;
+
+    if (bns->n_seqs < 0 || bns->n_holes < 0 || bns->l_pac <= 0) {
+        fprintf(stderr,
+            "[E::%s] malformed BNS in %s (n_seqs=%d n_holes=%d l_pac=%lld)\n",
+            __func__, prefix, bns->n_seqs, bns->n_holes, (long long)bns->l_pac);
+        bwa_shm_layout_free(layout);
+        return -1;
+    }
+
+    /* 2. Peek FMI scalars + sentinel_index out of <prefix>.bwt.2bit.64. */
+    char cp_path[PATH_MAX];
+    path_concat2(cp_path, prefix, CP_FILENAME_SUFFIX);
+    FILE *cp = xopen(cp_path, "rb");
+    err_fread_noeof(&layout->reference_seq_len, sizeof(int64_t), 1, cp);
+    err_fread_noeof(layout->count, sizeof(int64_t), 5, cp);
+
+    if (layout->reference_seq_len <= 0 ||
+        layout->reference_seq_len > BWA_SHM_MAX_REF_SEQ_LEN) {
+        fprintf(stderr,
+            "[E::%s] %s: reference_seq_len=%lld out of bounds (1..%lld)\n",
+            __func__, cp_path, (long long)layout->reference_seq_len,
+            (long long)BWA_SHM_MAX_REF_SEQ_LEN);
+        err_fclose(cp);
+        bwa_shm_layout_free(layout);
+        return -1;
+    }
+    /* count[i] read from disk is the cumulative occurrence; +1 mirrors the
+     * adjustment in FMI_search::load_index. Each value must be in
+     * [0, reference_seq_len] after adjustment. */
+    for (int i = 0; i < 5; ++i) {
+        if (layout->count[i] < 0 || layout->count[i] > layout->reference_seq_len) {
+            fprintf(stderr,
+                "[E::%s] %s: count[%d]=%lld out of bounds (0..%lld)\n",
+                __func__, cp_path, i, (long long)layout->count[i],
+                (long long)layout->reference_seq_len);
+            err_fclose(cp);
+            bwa_shm_layout_free(layout);
+            return -1;
+        }
+        layout->count[i] += 1;
+    }
+
+    int64_t cp_occ_count = (layout->reference_seq_len >> CP_SHIFT) + 1;
+    int64_t sa_count     = (layout->reference_seq_len >> SA_COMPX) + 1;
+    int64_t cp_occ_bytes = cp_occ_count * (int64_t)sizeof(CP_OCC);
+    int64_t sa_ms_bytes  = sa_count     * (int64_t)sizeof(int8_t);
+    int64_t sa_ls_bytes  = sa_count     * (int64_t)sizeof(uint32_t);
+
+    int64_t sentinel_off = (int64_t)BWA_BWT_2BIT_HEADER_BYTES
+                         + cp_occ_bytes + sa_ms_bytes + sa_ls_bytes;
+    if (fseek(cp, (long)sentinel_off, SEEK_SET) != 0) {
+        fprintf(stderr, "[E::%s] fseek(%lld) failed in %s\n",
+                __func__, (long long)sentinel_off, cp_path);
+        err_fclose(cp);
+        bwa_shm_layout_free(layout);
+        return -1;
+    }
+    err_fread_noeof(&layout->sentinel_index, sizeof(int64_t), 1, cp);
+    err_fclose(cp);
+
+    if (layout->sentinel_index < 0 ||
+        layout->sentinel_index >= layout->reference_seq_len) {
+        fprintf(stderr,
+            "[E::%s] %s: sentinel_index=%lld out of bounds (0..%lld)\n",
+            __func__, cp_path, (long long)layout->sentinel_index,
+            (long long)layout->reference_seq_len);
+        bwa_shm_layout_free(layout);
+        return -1;
+    }
+
+    /* 3. Stat <prefix>.0123 for its size. */
+    char zer_path[PATH_MAX];
+    path_concat2(zer_path, prefix, ".0123");
+    struct stat zst;
+    if (stat(zer_path, &zst) != 0) {
+        fprintf(stderr, "[E::%s] stat(%s) failed: %s\n",
+                __func__, zer_path, strerror(errno));
+        bwa_shm_layout_free(layout);
+        return -1;
+    }
+    if (zst.st_size <= 0) {
+        fprintf(stderr, "[E::%s] %s is empty\n", __func__, zer_path);
+        bwa_shm_layout_free(layout);
+        return -1;
+    }
+    layout->ref_string_len = (int64_t)zst.st_size;
+
+    /* 4. BNS_NAMES section size: walk anns[]. */
+    int64_t bns_names_bytes = 0;
+    for (int i = 0; i < bns->n_seqs; ++i) {
+        bns_names_bytes += (int64_t)strlen(bns->anns[i].name) + 1
+                         + (int64_t)strlen(bns->anns[i].anno) + 1;
+    }
+
+    /* 5. Compute section sizes (matching the historical layout). */
+    int64_t fmi_scalars_bytes = (int64_t)BWA_SHM_FMI_SCALARS_BYTES;
+    int64_t bns_struct_bytes  = (int64_t)sizeof(bntseq_t);
+    int64_t bns_ambs_bytes    = (int64_t)bns->n_holes * (int64_t)sizeof(bntamb1_t);
+    int64_t bns_anns_bytes    = (int64_t)bns->n_seqs  * (int64_t)sizeof(bntann1_t);
+    int64_t pac_bytes         = bns->l_pac / 4 + 1;
+
+    /* 6. Lay out sections at 64-byte aligned offsets. */
+    static const uint32_t N_SECTIONS = 10;
+    uint64_t cursor = sizeof(bwa_shm_header_t)
+                    + (uint64_t)N_SECTIONS * sizeof(bwa_shm_section_t);
+    cursor = (cursor + 63ull) & ~63ull;
+
+    bwa_shm_section_t *sec = layout->sections;
+    auto place = [&](uint32_t kind, int64_t size, uint32_t i) {
+        sec[i].kind   = kind;
+        sec[i].offset = cursor;
+        sec[i].size   = (uint64_t)size;
+        cursor = (cursor + (uint64_t)size + 63ull) & ~63ull;
+    };
+
+    place(BWA_SHM_SEC_FMI_SCALARS, fmi_scalars_bytes, 0);
+    place(BWA_SHM_SEC_FMI_CP_OCC,  cp_occ_bytes,      1);
+    place(BWA_SHM_SEC_FMI_SA_MS,   sa_ms_bytes,       2);
+    place(BWA_SHM_SEC_FMI_SA_LS,   sa_ls_bytes,       3);
+    place(BWA_SHM_SEC_BNS_STRUCT,  bns_struct_bytes,  4);
+    place(BWA_SHM_SEC_BNS_AMBS,    bns_ambs_bytes,    5);
+    place(BWA_SHM_SEC_BNS_ANNS,    bns_anns_bytes,    6);
+    place(BWA_SHM_SEC_BNS_NAMES,   bns_names_bytes,   7);
+    place(BWA_SHM_SEC_PAC,         pac_bytes,         8);
+    place(BWA_SHM_SEC_REF_STRING,  layout->ref_string_len, 9);
+
+    if (cursor > BWA_SHM_MAX_TOTAL_SIZE) {
+        fprintf(stderr,
+            "[E::%s] computed segment size %llu exceeds max %llu\n",
+            __func__, (unsigned long long)cursor,
+            (unsigned long long)BWA_SHM_MAX_TOTAL_SIZE);
+        bwa_shm_layout_free(layout);
+        return -1;
+    }
+
+    layout->n_sections = N_SECTIONS;
+    layout->total_size = cursor;
+    return 0;
+}
+
+int bwa_shm_pack_into(const bwa_shm_layout_t *layout, uint8_t *dest)
+{
+    if (layout == NULL || dest == NULL || layout->bns == NULL) return -1;
+    const bntseq_t *bns = (const bntseq_t *)layout->bns;
+    const bwa_shm_section_t *sec = layout->sections;
+
+    /* 1. Header. */
+    bwa_shm_header_t hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.magic       = BWA_SHM_MAGIC;
+    hdr.version     = BWA_SHM_VERSION;
+    hdr.n_sections  = layout->n_sections;
+    hdr.total_size  = layout->total_size;
+    memcpy(dest, &hdr, sizeof(hdr));
+
+    /* 2. Section table. */
+    memcpy(dest + sizeof(bwa_shm_header_t),
+           layout->sections,
+           (size_t)layout->n_sections * sizeof(bwa_shm_section_t));
+
+    /* 3. FMI_SCALARS (assembled on stack). */
+    {
+        uint8_t scratch[BWA_SHM_FMI_SCALARS_BYTES];
+        memcpy(scratch,        &layout->reference_seq_len, sizeof(int64_t));
+        memcpy(scratch + 8,    layout->count,              sizeof(int64_t) * 5);
+        memcpy(scratch + 48,   &layout->sentinel_index,    sizeof(int64_t));
+        memcpy(dest + sec[0].offset, scratch, sizeof(scratch));
+    }
+
+    /* 4. CP_OCC + SA_MS + SA_LS: one fp, three contiguous freads. */
+    char cp_path[PATH_MAX];
+    path_concat2(cp_path, layout->prefix, CP_FILENAME_SUFFIX);
+    FILE *cp = xopen(cp_path, "rb");
+    if (fseek(cp, (long)BWA_BWT_2BIT_HEADER_BYTES, SEEK_SET) != 0) {
+        fprintf(stderr, "[E::%s] fseek on %s failed\n", __func__, cp_path);
+        err_fclose(cp);
+        return -1;
+    }
+    err_fread_noeof(dest + sec[1].offset, 1, (size_t)sec[1].size, cp);
+    err_fread_noeof(dest + sec[2].offset, 1, (size_t)sec[2].size, cp);
+    err_fread_noeof(dest + sec[3].offset, 1, (size_t)sec[3].size, cp);
+    err_fclose(cp);
+
+    /* 5. BNS_STRUCT, BNS_AMBS, BNS_ANNS — all small. */
+    memcpy(dest + sec[4].offset, bns,       (size_t)sec[4].size);
+    memcpy(dest + sec[5].offset, bns->ambs, (size_t)sec[5].size);
+    memcpy(dest + sec[6].offset, bns->anns, (size_t)sec[6].size);
+
+    /* 6. BNS_NAMES: concatenate name\0 anno\0 for each seq. The bns_anns
+     *    payload's name/anno pointers are not patched here — the unpacker
+     *    points them into BNS_NAMES at attach time once the segment base
+     *    address is known. */
+    {
+        uint8_t *dst = dest + sec[7].offset;
+        for (int i = 0; i < bns->n_seqs; ++i) {
+            size_t n = strlen(bns->anns[i].name) + 1;
+            memcpy(dst, bns->anns[i].name, n); dst += n;
+            size_t a = strlen(bns->anns[i].anno) + 1;
+            memcpy(dst, bns->anns[i].anno, a); dst += a;
+        }
+    }
+
+    /* 7. PAC: stream <prefix>.pac. */
+    {
+        char pac_path[PATH_MAX];
+        path_concat2(pac_path, layout->prefix, ".pac");
+        FILE *fp = xopen(pac_path, "rb");
+        err_fread_noeof(dest + sec[8].offset, 1, (size_t)sec[8].size, fp);
+        err_fclose(fp);
+    }
+
+    /* 8. REF_STRING: stream <prefix>.0123. */
+    {
+        char zer_path[PATH_MAX];
+        path_concat2(zer_path, layout->prefix, ".0123");
+        FILE *fp = xopen(zer_path, "rb");
+        err_fread_noeof(dest + sec[9].offset, 1, (size_t)sec[9].size, fp);
+        err_fclose(fp);
+    }
+
+    return 0;
+}
+
+void bwa_shm_layout_free(bwa_shm_layout_t *layout)
+{
+    if (layout == NULL) return;
+    if (layout->bns != NULL) {
+        bns_destroy((bntseq_t *)layout->bns);
+        layout->bns = NULL;
+    }
+}
+
+int bwa_shm_pack_from_disk(const char *prefix, uint8_t **buf_out, uint64_t *len_out)
+{
+    *buf_out = NULL;
+    *len_out = 0;
+
+    bwa_shm_layout_t layout;
+    if (bwa_shm_compute(prefix, &layout) != 0) return -1;
+
+    uint8_t *buf = (uint8_t *)malloc(layout.total_size);
+    if (buf == NULL) {
+        bwa_shm_layout_free(&layout);
+        return -1;
+    }
+    if (bwa_shm_pack_into(&layout, buf) != 0) {
+        free(buf);
+        bwa_shm_layout_free(&layout);
+        return -1;
+    }
+
+    *buf_out = buf;
+    *len_out = layout.total_size;
+    bwa_shm_layout_free(&layout);
+    return 0;
+}
+
+static int test_cb(int64_t /*l_mem*/, const char *name, void *ctx)
+{
+    return std::strcmp(name, (const char *)ctx) == 0 ? 1 : 0;
+}
+
+int bwa_shm_test(const char *prefix)
+{
+    if (prefix == NULL || prefix[0] == '\0') return -1;
+    return ctl_walk(test_cb, (void *)prefix_basename(prefix));
+}
+
+static int list_cb(int64_t l_mem, const char *name, void * /*ctx*/)
+{
+    std::printf("%s\t%lld\n", name, (long long)l_mem);
+    return 0;
+}
+
+int bwa_shm_list(void)
+{
+    int rc = ctl_walk(list_cb, NULL);
+    return rc < 0 ? rc : 0;
+}
+
+static int destroy_cb(int64_t /*l_mem*/, const char *name, void * /*ctx*/)
+{
+    char idx_path[PATH_MAX];
+    path_concat2(idx_path, BWA_SHM_IDX_PREFIX, name);
+    shm_unlink(idx_path);   /* ignore errors (entry may already be gone) */
+    return 0;
+}
+
+int bwa_shm_destroy(void)
+{
+    int rc = ctl_walk(destroy_cb, NULL);
+    if (rc < 0) return rc;
+    shm_unlink(BWA_SHM_CTL_NAME);
+    return 0;
+}
+
+int bwa_shm_stage(const char *prefix)
+{
+    if (prefix == NULL || prefix[0] == '\0') {
+        std::fprintf(stderr, "[E::%s] empty prefix\n", __func__);
+        return -1;
+    }
+    int already = bwa_shm_test(prefix);
+    if (already < 0) {
+        std::fprintf(stderr, "[E::%s] failed to probe registry\n", __func__);
+        return -1;
+    }
+    if (already == 1) {
+        std::fprintf(stderr, "[M::%s] index '%s' is already in shm\n",
+                     __func__, prefix);
+        return 0;
+    }
+
+    const char *name = prefix_basename(prefix);
+    if (name[0] == '\0') {
+        std::fprintf(stderr, "[E::%s] prefix has no basename component\n", __func__);
+        return -1;
+    }
+
+    /* 1. Compute the layout (loads BNS; peeks scalars from the FMI file). */
+    bwa_shm_layout_t layout;
+    if (bwa_shm_compute(prefix, &layout) != 0) {
+        std::fprintf(stderr, "[E::%s] failed to compute layout for '%s'\n",
+                     __func__, prefix);
+        return -1;
+    }
+
+    /* 2. Open the control segment R/W. There is no advisory lock — see the
+     *    note on ctl_open_rw for why. We re-check the registry below to
+     *    catch the case where another stager appended this prefix between
+     *    our pre-stage bwa_shm_test and now. */
+    int   ctl_fd  = -1;
+    void *ctl_map = ctl_open_rw(&ctl_fd);
+    if (ctl_map == NULL) {
+        std::fprintf(stderr, "[E::%s] failed to open control segment %s: %s\n",
+                     __func__, BWA_SHM_CTL_NAME, std::strerror(errno));
+        bwa_shm_layout_free(&layout);
+        return -1;
+    }
+
+    /* 3. Re-scan the live registry for this basename. */
+    uint16_t n_entries = 0, next_write = 0;
+    std::memcpy(&n_entries,  (uint8_t *)ctl_map,     sizeof(uint16_t));
+    std::memcpy(&next_write, (uint8_t *)ctl_map + 2, sizeof(uint16_t));
+    {
+        const uint8_t *p   = (const uint8_t *)ctl_map + BWA_SHM_CTL_HEADER_BYTES;
+        const uint8_t *end = (const uint8_t *)ctl_map + BWA_SHM_CTL_SIZE;
+        for (uint16_t i = 0; i < n_entries; ++i) {
+            if (p + sizeof(int64_t) >= end) break;
+            const char *entry_name = (const char *)(p + sizeof(int64_t));
+            size_t name_max = (size_t)(end - (const uint8_t *)entry_name);
+            size_t namelen  = strnlen(entry_name, name_max);
+            if (namelen == name_max) break;
+            if (std::strcmp(entry_name, name) == 0) {
+                std::fprintf(stderr,
+                    "[M::%s] index '%s' was staged by another process\n",
+                    __func__, prefix);
+                ctl_close(ctl_map, ctl_fd);
+                bwa_shm_layout_free(&layout);
+                return 0;
+            }
+            p = (const uint8_t *)entry_name + namelen + 1;
+        }
+    }
+
+    /* 4. Bound-check the new entry. next_write is a uint16_t and
+     *    BWA_SHM_CTL_SIZE is 0x10000 (65536), which uint16_t cannot represent.
+     *    Reject the exact-fill case so the post-write cast back to uint16_t
+     *    cannot wrap to 0 and have the next stage overwrite the header. */
+    size_t name_bytes  = std::strlen(name) + 1;
+    size_t entry_bytes = sizeof(int64_t) + name_bytes;
+    if ((size_t)next_write + entry_bytes >= BWA_SHM_CTL_SIZE) {
+        std::fprintf(stderr,
+                     "[E::%s] control segment full (cannot stage '%s')\n",
+                     __func__, name);
+        ctl_close(ctl_map, ctl_fd);
+        bwa_shm_layout_free(&layout);
+        return -1;
+    }
+
+    /* 5. Create the per-index segment. EEXIST means another stager raced us
+     *    to a segment with the same basename — treat that as already-staged
+     *    rather than unlinking and re-creating, which would invalidate any
+     *    process currently attached to it. */
+    char idx_path[PATH_MAX];
+    path_concat2(idx_path, BWA_SHM_IDX_PREFIX, name);
+    int idx_fd = shm_open(idx_path, O_CREAT | O_RDWR | O_EXCL, 0644);
+    if (idx_fd < 0 && errno == EEXIST) {
+        std::fprintf(stderr,
+            "[M::%s] segment %s already exists; treating as already staged\n",
+            __func__, idx_path);
+        ctl_close(ctl_map, ctl_fd);
+        bwa_shm_layout_free(&layout);
+        return 0;
+    }
+    if (idx_fd < 0) {
+        std::fprintf(stderr, "[E::%s] shm_open(%s) failed: %s\n",
+                     __func__, idx_path, std::strerror(errno));
+        ctl_close(ctl_map, ctl_fd);
+        bwa_shm_layout_free(&layout);
+        return -1;
+    }
+    if (ftruncate(idx_fd, (off_t)layout.total_size) < 0) {
+        std::fprintf(stderr, "[E::%s] ftruncate(%s, %llu) failed: %s\n",
+                     __func__, idx_path,
+                     (unsigned long long)layout.total_size, std::strerror(errno));
+        close(idx_fd);
+        shm_unlink(idx_path);
+        ctl_close(ctl_map, ctl_fd);
+        bwa_shm_layout_free(&layout);
+        return -1;
+    }
+    void *idx_map = mmap(NULL, (size_t)layout.total_size,
+                         PROT_READ | PROT_WRITE, MAP_SHARED, idx_fd, 0);
+    if (idx_map == MAP_FAILED) {
+        std::fprintf(stderr, "[E::%s] mmap(%s) failed: %s\n",
+                     __func__, idx_path, std::strerror(errno));
+        close(idx_fd);
+        shm_unlink(idx_path);
+        ctl_close(ctl_map, ctl_fd);
+        bwa_shm_layout_free(&layout);
+        return -1;
+    }
+
+    /* 6. Stream-pack directly into the mmap'd region. No heap intermediate. */
+    if (bwa_shm_pack_into(&layout, (uint8_t *)idx_map) != 0) {
+        std::fprintf(stderr, "[E::%s] pack_into failed for %s\n", __func__, prefix);
+        munmap(idx_map, (size_t)layout.total_size);
+        close(idx_fd);
+        shm_unlink(idx_path);
+        ctl_close(ctl_map, ctl_fd);
+        bwa_shm_layout_free(&layout);
+        return -1;
+    }
+    munmap(idx_map, (size_t)layout.total_size);
+    close(idx_fd);
+
+    /* 7. Append the entry to the control segment. */
+    uint8_t *entry = (uint8_t *)ctl_map + next_write;
+    int64_t l_mem = (int64_t)layout.total_size;
+    std::memcpy(entry,                       &l_mem, sizeof(int64_t));
+    std::memcpy(entry + sizeof(int64_t),     name,   name_bytes);
+    n_entries  = (uint16_t)(n_entries + 1);
+    next_write = (uint16_t)(next_write + entry_bytes);
+    std::memcpy((uint8_t *)ctl_map,     &n_entries,  sizeof(uint16_t));
+    std::memcpy((uint8_t *)ctl_map + 2, &next_write, sizeof(uint16_t));
+
+    ctl_close(ctl_map, ctl_fd);
+
+    std::fprintf(stderr, "[M::%s] staged '%s' (%llu bytes) as %s\n",
+                 __func__, name,
+                 (unsigned long long)layout.total_size, idx_path);
+    bwa_shm_layout_free(&layout);
+    return 0;
+}
+
+uint8_t *bwa_shm_attach(const char *prefix, size_t *len_out)
+{
+    if (len_out != NULL) *len_out = 0;
+    if (prefix == NULL || prefix[0] == '\0') return NULL;
+
+    /* Cheap pre-check: skip the open if there's no registry entry. */
+    if (bwa_shm_test(prefix) != 1) return NULL;
+
+    const char *name = prefix_basename(prefix);
+    char idx_path[PATH_MAX];
+    path_concat2(idx_path, BWA_SHM_IDX_PREFIX, name);
+
+    int fd = shm_open(idx_path, O_RDONLY, 0);
+    if (fd < 0) {
+        std::fprintf(stderr, "[E::%s] shm_open(%s) failed: %s\n",
+                     __func__, idx_path, std::strerror(errno));
+        return NULL;
+    }
+
+    struct stat st;
+    if (fstat(fd, &st) < 0) {
+        std::fprintf(stderr, "[E::%s] fstat(%s) failed: %s\n",
+                     __func__, idx_path, std::strerror(errno));
+        close(fd);
+        return NULL;
+    }
+    if (st.st_size < (off_t)sizeof(bwa_shm_header_t)) {
+        std::fprintf(stderr, "[E::%s] segment %s too small (%lld bytes)\n",
+                     __func__, idx_path, (long long)st.st_size);
+        close(fd);
+        return NULL;
+    }
+    size_t len = (size_t)st.st_size;
+
+    void *m = mmap(NULL, len, PROT_READ, MAP_SHARED, fd, 0);
+    close(fd);
+    if (m == MAP_FAILED) {
+        std::fprintf(stderr, "[E::%s] mmap(%s, %llu) failed: %s\n",
+                     __func__, idx_path, (unsigned long long)len, std::strerror(errno));
+        return NULL;
+    }
+
+    /* Validate the on-segment header. */
+    bwa_shm_header_t hdr;
+    std::memcpy(&hdr, m, sizeof(hdr));
+    if (hdr.magic != BWA_SHM_MAGIC) {
+        std::fprintf(stderr, "[E::%s] bad magic in %s\n", __func__, idx_path);
+        munmap(m, len);
+        return NULL;
+    }
+    if (hdr.version != BWA_SHM_VERSION) {
+        std::fprintf(stderr, "[E::%s] unsupported segment version %u in %s (expected %u)\n",
+                     __func__, hdr.version, idx_path, BWA_SHM_VERSION);
+        munmap(m, len);
+        return NULL;
+    }
+    /* total_size is the exact data written; st_size may be page-rounded up.
+     * Require total_size <= segment size to tolerate ftruncate's rounding. */
+    if (hdr.total_size > (uint64_t)len) {
+        std::fprintf(stderr, "[E::%s] header total_size=%llu exceeds segment size %llu in %s\n",
+                     __func__, (unsigned long long)hdr.total_size,
+                     (unsigned long long)len, idx_path);
+        munmap(m, len);
+        return NULL;
+    }
+
+    if (len_out != NULL) *len_out = (size_t)hdr.total_size;
+    return (uint8_t *)m;
+}
+
+int bwa_shm_section_find(const uint8_t *base, uint32_t kind,
+                         uint64_t *offset_out, uint64_t *size_out)
+{
+    if (base == NULL) return -1;
+    const bwa_shm_header_t *hdr = (const bwa_shm_header_t *)base;
+    if (hdr->magic   != BWA_SHM_MAGIC)   return -1;
+    if (hdr->version != BWA_SHM_VERSION) return -1;
+
+    /* Bound-check the section table itself before walking it. A corrupt
+     * n_sections could otherwise drive us past the mapped region. */
+    if (hdr->total_size < sizeof(bwa_shm_header_t)) return -1;
+    const uint64_t table_bytes =
+        (uint64_t)hdr->n_sections * (uint64_t)sizeof(bwa_shm_section_t);
+    if (table_bytes > hdr->total_size - sizeof(bwa_shm_header_t)) return -1;
+
+    const bwa_shm_section_t *table =
+        (const bwa_shm_section_t *)(base + sizeof(bwa_shm_header_t));
+    for (uint32_t i = 0; i < hdr->n_sections; ++i) {
+        if (table[i].kind == kind) {
+            /* Reject sections whose extent escapes the segment. */
+            if (table[i].size > hdr->total_size ||
+                table[i].offset > hdr->total_size - table[i].size) {
+                return -1;
+            }
+            if (offset_out != NULL) *offset_out = table[i].offset;
+            if (size_out   != NULL) *size_out   = table[i].size;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static void print_shm_usage(void)
+{
+    std::fprintf(stderr,
+        "\nUsage: bwa-mem2 shm [-d|-l|--help] [idxbase]\n\n"
+        "Options:\n"
+        "  -d        destroy all indices in shared memory (matches bwa v1 behavior)\n"
+        "  -l        list names of indices in shared memory\n"
+        "  -h --help print this help and exit\n\n"
+        "Stage with no flags: `bwa-mem2 shm <idxbase>` loads the index into\n"
+        "POSIX shared memory; subsequent `bwa-mem2 mem <idxbase> ...` runs\n"
+        "auto-attach instead of re-reading from disk.\n\n"
+        "Footgun: if you re-build the index, run `bwa-mem2 shm -d` first.\n"
+        "There is no staleness check -- a stale segment will silently mis-align.\n\n"
+        "macOS: POSIX shm has implementation-defined per-segment caps; large\n"
+        "       indices may simply fail to stage. Prefer Linux for production.\n"
+        "Linux: /dev/shm defaults to ~50%% of RAM on bare metal; in containers\n"
+        "       it is often much smaller and may need raising via --shm-size\n"
+        "       (Docker) or an emptyDir tmpfs (Kubernetes).\n\n");
+}
+
+int main_shm(int argc, char *argv[])
+{
+    int c, to_list = 0, to_drop = 0, ret = 0;
+
+    /* Pre-scan for --help / -h. getopt's "ld" optstring would treat them as
+     * unknown options and print a generic error, but the top-level usage
+     * (src/main.cpp) advertises `bwa-mem2 <command> --help`, so we honor it. */
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0) {
+            print_shm_usage();
+            return 0;
+        }
+    }
+
+    /* getopt's global state may carry over from prior subcommand parsing.
+     * Reset for a clean reparse. POSIX requires optind=1; macOS/BSD also
+     * needs optreset=1 to clear the static `place` pointer inside getopt. */
+    optind = 1;
+    opterr = 1;
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+    extern int optreset;
+    optreset = 1;
+#endif
+    while ((c = getopt(argc, argv, "ld")) >= 0) {
+        if      (c == 'l') to_list = 1;
+        else if (c == 'd') to_drop = 1;
+        else               return 1;   /* getopt printed the error */
+    }
+    if (optind == argc && !to_list && !to_drop) {
+        print_shm_usage();
+        return 1;
+    }
+    if (optind < argc && (to_list || to_drop)) {
+        std::fprintf(stderr,
+            "[E::%s] -l or -d cannot be combined with idxbase\n", __func__);
+        return 1;
+    }
+
+    /* Stage. */
+    if (optind < argc) {
+        if (bwa_shm_stage(argv[optind]) < 0) {
+            std::fprintf(stderr,
+                "[E::%s] failed to stage '%s' in shared memory\n",
+                __func__, argv[optind]);
+            ret = 1;
+        }
+    }
+    if (to_list)  ret |= (bwa_shm_list()    < 0) ? 1 : 0;
+    if (to_drop)  ret |= (bwa_shm_destroy() < 0) ? 1 : 0;
+    return ret;
+}
+
+} /* extern "C" */

--- a/src/bwa_shm.h
+++ b/src/bwa_shm.h
@@ -1,0 +1,133 @@
+/*************************************************************************************
+                           The MIT License
+
+   BWA-MEM2  (Sequence alignment using Burrows-Wheeler Transform),
+   Copyright (C) 2019  Intel Corporation, Heng Li.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+
+Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@intel.com>;
+         Heng Li <hli@jimmy.harvard.edu>
+*****************************************************************************************/
+
+#ifndef BWA_SHM_H_
+#define BWA_SHM_H_
+
+#include <stdint.h>
+#include <stddef.h>
+#include <limits.h>   /* PATH_MAX */
+
+/* "BWAMEM2\0" interpreted as a little-endian uint64_t:
+ *   'B'=0x42 'W'=0x57 'A'=0x41 'M'=0x4D 'E'=0x45 'M'=0x4D '2'=0x32 '\0'=0x00
+ * little-endian => bytes 0x42 0x57 0x41 0x4D 0x45 0x4D 0x32 0x00 read as u64. */
+#define BWA_SHM_MAGIC          0x00324D454D415742ull
+#define BWA_SHM_VERSION        1u
+#define BWA_SHM_CTL_NAME       "/bwactl"
+#define BWA_SHM_IDX_PREFIX     "/bwaidx-"
+#define BWA_SHM_CTL_SIZE       0x10000   /* 64 KiB. Must equal bwa.h::BWA_CTL_SIZE
+                                          * (the legacy v1 stub); a static_assert in
+                                          * bwa_shm.cpp will enforce equality once
+                                          * that translation unit is added. */
+
+/* FMI_SCALARS section: int64_t reference_seq_len, count[5], sentinel_index. */
+#define BWA_SHM_FMI_SCALARS_BYTES (sizeof(int64_t) * 7)
+
+/* Section kinds — see implementation plan for what each holds. */
+#define BWA_SHM_SEC_FMI_SCALARS  1u
+#define BWA_SHM_SEC_FMI_CP_OCC   2u
+#define BWA_SHM_SEC_FMI_SA_MS    3u
+#define BWA_SHM_SEC_FMI_SA_LS    4u
+#define BWA_SHM_SEC_BNS_STRUCT   5u
+#define BWA_SHM_SEC_BNS_AMBS     6u
+#define BWA_SHM_SEC_BNS_ANNS     7u
+#define BWA_SHM_SEC_BNS_NAMES    8u
+#define BWA_SHM_SEC_PAC          9u
+#define BWA_SHM_SEC_REF_STRING   10u
+
+typedef struct {
+	uint64_t magic;          /* BWA_SHM_MAGIC */
+	uint32_t version;        /* BWA_SHM_VERSION */
+	uint32_t n_sections;
+	uint64_t total_size;     /* bytes including this header */
+	uint64_t reserved[5];    /* zero-fill for forward-compat */
+} bwa_shm_header_t;           /* 64 bytes; first object in every segment */
+
+typedef struct {
+	uint32_t kind;           /* one of BWA_SHM_SEC_* */
+	uint32_t flags;          /* zero-fill for now */
+	uint64_t offset;         /* bytes from segment start to payload */
+	uint64_t size;           /* payload bytes (does not count alignment padding) */
+	uint64_t reserved;       /* zero-fill for forward-compat */
+} bwa_shm_section_t;          /* 32 bytes */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	int       bwa_shm_test(const char *prefix);                      /* 1 if staged, 0 if not, -1 on error */
+	int       bwa_shm_stage(const char *prefix);                     /* loads from disk, packs, stages */
+	int       bwa_shm_destroy(void);                                 /* drops all (matches v1 -d) */
+	int       bwa_shm_list(void);                                    /* prints staged indices to stdout */
+	int       main_shm(int argc, char *argv[]);                      /* CLI entry — see src/main.cpp dispatch */
+
+	/* Attach helpers used by FMI_search / indexEle / fastmap. */
+	uint8_t  *bwa_shm_attach(const char *prefix, size_t *len_out);   /* NULL if not staged */
+	int       bwa_shm_section_find(const uint8_t *base, uint32_t kind,
+	                               uint64_t *offset_out, uint64_t *size_out);
+
+	/* Layout of a packed bwa-mem2 index segment. Computed by bwa_shm_compute
+	 * from a prefix on disk; consumed by bwa_shm_pack_into and bwa_shm_stage.
+	 * Owns a heap-loaded bntseq_t held across compute->pack_into so we don't
+	 * read .ann/.amb twice. Free with bwa_shm_layout_free. */
+	typedef struct {
+		char     prefix[PATH_MAX];       /* matches the disk loader's PATH_MAX buffers */
+		void    *bns;                    /* bntseq_t *; void* to keep bntseq.h optional here */
+		int64_t  reference_seq_len;
+		int64_t  count[5];               /* +1-adjusted, ready to write */
+		int64_t  sentinel_index;
+		int64_t  ref_string_len;         /* file size of <prefix>.0123 */
+		uint64_t total_size;
+		uint32_t n_sections;
+		bwa_shm_section_t sections[16];  /* 10 used today; spare for forward-compat */
+	} bwa_shm_layout_t;
+
+	/* Compute layout and load BNS. Returns 0 on success, -1 on error. */
+	int  bwa_shm_compute(const char *prefix, bwa_shm_layout_t *layout);
+
+	/* Pack the index described by `layout` into `dest`, which must be at least
+	 * layout->total_size bytes. Streams cp_occ / sa_* / pac / ref_string from
+	 * disk straight into dest (no intermediate heap copy). Returns 0/-1. */
+	int  bwa_shm_pack_into(const bwa_shm_layout_t *layout, uint8_t *dest);
+
+	/* Release the layout's loaded BNS. Safe to call after compute fails. */
+	void bwa_shm_layout_free(bwa_shm_layout_t *layout);
+
+	/* Internal: load index components from disk and pack them into a single
+	 * self-describing buffer. Used by bwa_shm_stage (Phase 2) and exercised
+	 * by tests. On success, *buf_out is malloc'd and *len_out is its size;
+	 * caller frees with free(). Returns 0 on success, -1 on error. */
+	int bwa_shm_pack_from_disk(const char *prefix, uint8_t **buf_out, uint64_t *len_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BWA_SHM_H_ */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -42,6 +42,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "FMI_search.h"
 #include "bam_writer.h"
 #include "meth_bam.h"
+#include "bwa_shm.h"
 
 #if AFF && (__linux__)
 #include <sys/sysinfo.h>
@@ -898,6 +899,68 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "Note: Please read the man page for detailed description of the command line and options.\n");
 }
 
+/* Resolve `<prefix>.0123` to a `uint8_t *` view of the ref string. If
+ * `shm_base` is non-NULL, the FMI loader already attached this segment;
+ * resolve REF_STRING via that single mapping. Otherwise fall back to the
+ * disk slurp. The two paths must agree: if FMI came from disk, ref string
+ * must come from disk too, so we never call `bwa_shm_attach` here. */
+static uint8_t *load_ref_string(const char *prefix, uint8_t *shm_base,
+                                int64_t *rlen_out, int *is_shm_out)
+{
+    *is_shm_out = 0;
+    *rlen_out   = 0;
+
+    if (shm_base != NULL) {
+        uint64_t off = 0, sz = 0;
+        if (bwa_shm_section_find(shm_base, BWA_SHM_SEC_REF_STRING, &off, &sz) != 0) {
+            fprintf(stderr,
+                "ERROR: shm segment for '%s' is missing REF_STRING; aborting.\n"
+                "       The segment was staged by an older bwa-mem2; drop and re-stage.\n",
+                prefix);
+            exit(EXIT_FAILURE);
+        }
+        *is_shm_out = 1;
+        *rlen_out   = (int64_t)sz;
+        fprintf(stderr, "* Reference genome attached from shm: %lld bytes\n",
+                (long long)sz);
+        return shm_base + off;
+    }
+
+    /* Disk path. */
+    char binary_seq_file[PATH_MAX];
+    strcpy_s(binary_seq_file, PATH_MAX, prefix);
+    strcat_s(binary_seq_file, PATH_MAX, ".0123");
+
+    fprintf(stderr, "* Binary seq file = %s\n", binary_seq_file);
+    FILE *fr = fopen(binary_seq_file, "r");
+    if (fr == NULL) {
+        fprintf(stderr, "Error: can't open %s input file\n", binary_seq_file);
+        return NULL;
+    }
+    int64_t rlen = 0;
+    if (fseek(fr, 0, SEEK_END) != 0) {
+        fprintf(stderr, "Error: fseek failed on %s\n", binary_seq_file);
+        fclose(fr);
+        return NULL;
+    }
+    rlen = ftell(fr);
+    if (rlen <= 0) {
+        fprintf(stderr, "Error: %s is empty or unseekable (ftell=%lld)\n",
+                binary_seq_file, (long long)rlen);
+        fclose(fr);
+        return NULL;
+    }
+    uint8_t *buf = (uint8_t*) _mm_malloc(rlen, 64);
+    assert_not_null(buf, rlen, rlen);
+    bwamem_madv_hugepage(buf, rlen);
+    rewind(fr);
+    err_fread_noeof(buf, 1, rlen, fr);
+    fclose(fr);
+
+    *rlen_out = rlen;
+    return buf;
+}
+
 int main_mem(int argc, char *argv[])
 {
     int          i, c, ignore_alt = 0, no_mt_io = 0;
@@ -1242,46 +1305,23 @@ int main_mem(int argc, char *argv[])
     fprintf(stderr, "* Ref file: %s\n", ref_prefix);
     aux.fmi = new FMI_search(ref_prefix);
     aux.fmi->load_index();
+    aux.shm_base = aux.fmi->shm_attached_base();
     tprof[FMI][0] += __rdtsc() - tim;
 
-    // reading ref string from the file
+    // reading ref string (from shm if FMI attached, else from .0123 file)
     tim = __rdtsc();
     fprintf(stderr, "* Reading reference genome..\n");
-
-    char binary_seq_file[PATH_MAX];
-    strcpy_s(binary_seq_file, PATH_MAX, ref_prefix);
-    strcat_s(binary_seq_file, PATH_MAX, ".0123");
-    //sprintf(binary_seq_file, "%s.0123", argv[optind]);
-
-    fprintf(stderr, "* Binary seq file = %s\n", binary_seq_file);
-    FILE *fr = fopen(binary_seq_file, "r");
-
-    if (fr == NULL) {
-        fprintf(stderr, "Error: can't open %s input file\n", binary_seq_file);
+    int64_t rlen = 0;
+    int     ref_is_shm = 0;
+    ref_string = load_ref_string(ref_prefix, aux.shm_base, &rlen, &ref_is_shm);
+    if (ref_string == NULL) {
         exit(EXIT_FAILURE);
     }
-
-    int64_t rlen = 0;
-    fseek(fr, 0, SEEK_END);
-    rlen = ftell(fr);
-    ref_string = (uint8_t*) _mm_malloc(rlen, 64);
-    assert_not_null(ref_string, rlen, rlen);
-    aux.ref_string = ref_string;
-    /* Pack table is ~800 MB for hg38 — accessed at every candidate alignment
-     * for reference fetch. THP hint reduces dTLB pressure and tames the
-     * 4-KB-page demotion spikes that produce bimodal wall-clock variance
-     * on large indices. */
-    bwamem_madv_hugepage(ref_string, rlen);
-    rewind(fr);
-
-    /* Reading ref. sequence */
-    err_fread_noeof(ref_string, 1, rlen, fr);
-
-    uint64_t timer  = __rdtsc();
+    aux.ref_string         = ref_string;
+    aux.ref_string_is_shm  = ref_is_shm;
+    uint64_t timer = __rdtsc();
     tprof[REF_IO][0] += timer - tim;
-
-    fclose(fr);
-    fprintf(stderr, "* Reference genome size: %ld bp\n", rlen);
+    fprintf(stderr, "* Reference genome size: %ld bp\n", (long)rlen);
     fprintf(stderr, "* Done reading reference genome !!\n\n");
 
     if (ignore_alt)
@@ -1449,7 +1489,11 @@ int main_mem(int argc, char *argv[])
 
     // free memory
     int32_t nt = aux.opt->n_threads;
-    _mm_free(ref_string);
+    if (!aux.ref_string_is_shm) {
+        _mm_free(ref_string);
+    }
+    /* When ref_string aliases shm, the segment is owned by the loader
+     * process; the kernel reclaims the mapping at process exit. */
     free(hdr_line);
     free(idx_hdr_lines);
     free(opt);

--- a/src/fastmap.h
+++ b/src/fastmap.h
@@ -67,7 +67,9 @@ typedef struct {
 	int64_t actual_chunk_size;
 	FILE *fp;
 	uint8_t *ref_string;
+	int      ref_string_is_shm;   /* 1 if ref_string aliases shm pages; do not _mm_free. */
 	FMI_search *fmi;
+	uint8_t *shm_base;            /* if non-NULL, the active /bwaidx-<base> mapping */
 	struct bam_writer_s *bam_writer;  /* non-NULL when opt->bam_mode is set */
 } ktp_aux_t;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@ Contacts: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@
 // ----------------------------------
 #include "main.h"
 #include "version.h"
+#include "bwa_shm.h"
 
 #ifdef USE_MIMALLOC
 #include <mimalloc.h>
@@ -48,6 +49,7 @@ int usage()
     fprintf(stderr, "Commands:\n");
     fprintf(stderr, "  index         create index (add --meth to build a bwameth-style doubled c2t reference)\n");
     fprintf(stderr, "  mem           alignment (add --meth for bisulfite-seq: inline c2t + BAM output)\n");
+    fprintf(stderr, "  shm           load/list/drop the index in POSIX shared memory\n");
     fprintf(stderr, "  version       print version number\n");
     fprintf(stderr, "Run `bwa-mem2 <command> --help` for command-specific options.\n");
     return 1;
@@ -173,6 +175,10 @@ int main(int argc, char* argv[])
         }
 #endif
         return 0;
+    }
+    else if (strcmp(argv[1], "shm") == 0)
+    {
+        return main_shm(argc - 1, argv + 1);
     }
     else {
         fprintf(stderr, "ERROR: unknown command '%s'\n", argv[1]);

--- a/src/read_index_ele.cpp
+++ b/src/read_index_ele.cpp
@@ -31,6 +31,9 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "safestringlib.h"
 
 #include "bwa_madvise.h"
+#include "bwa_shm.h"
+
+#include <cstring>     /* memcpy */
 
 indexEle::indexEle()
 {
@@ -87,6 +90,149 @@ void indexEle::bwa_idx_load_ele(const char *hint, int which)
         }
     }
     free(prefix);
+}
+
+void indexEle::bwa_idx_load_ele_from_shm(uint8_t *base, size_t len)
+{
+    if (base == NULL) {
+        fprintf(stderr, "ERROR! bwa_idx_load_ele_from_shm called with NULL base\n");
+        exit(EXIT_FAILURE);
+    }
+
+    uint64_t off_bns = 0, sz_bns = 0;
+    uint64_t off_ambs = 0, sz_ambs = 0;
+    uint64_t off_anns = 0, sz_anns = 0;
+    uint64_t off_names = 0, sz_names = 0;
+    uint64_t off_pac = 0, sz_pac = 0;
+
+    if (bwa_shm_section_find(base, BWA_SHM_SEC_BNS_STRUCT, &off_bns,  &sz_bns)  != 0
+        || bwa_shm_section_find(base, BWA_SHM_SEC_BNS_AMBS,  &off_ambs, &sz_ambs) != 0
+        || bwa_shm_section_find(base, BWA_SHM_SEC_BNS_ANNS,  &off_anns, &sz_anns) != 0
+        || bwa_shm_section_find(base, BWA_SHM_SEC_BNS_NAMES, &off_names, &sz_names) != 0
+        || bwa_shm_section_find(base, BWA_SHM_SEC_PAC,       &off_pac,  &sz_pac)  != 0)
+    {
+        fprintf(stderr, "ERROR! shm segment missing one or more BNS/PAC sections\n");
+        exit(EXIT_FAILURE);
+    }
+
+    if (sz_bns != sizeof(bntseq_t)) {
+        fprintf(stderr, "ERROR! BNS_STRUCT size %llu != sizeof(bntseq_t) %llu\n",
+                (unsigned long long)sz_bns, (unsigned long long)sizeof(bntseq_t));
+        exit(EXIT_FAILURE);
+    }
+
+    /* Heap-copy bns so the mapper can mutate fp_pac and friends without
+     * writing into the shared segment. */
+    idx->bns = (bntseq_t *) malloc(sizeof(bntseq_t));
+    if (idx->bns == NULL) {
+        fprintf(stderr, "ERROR! malloc(bntseq_t) failed in %s\n", __func__);
+        exit(EXIT_FAILURE);
+    }
+    memcpy(idx->bns, base + off_bns, sizeof(bntseq_t));
+    /* fp_pac is closed by the disk loader after slurping into idx->pac;
+     * the segment was packed after that close, but zeroing here is cheap
+     * insurance against a future writer that forgets. */
+    idx->bns->fp_pac = NULL;
+
+    /* Validate the trusted-by-default scalar fields immediately after the
+     * memcpy from the segment. A corrupt or maliciously crafted segment
+     * could otherwise drive negative/overflowing size computations below.
+     * Bounds match the writer-side checks in bwa_shm_compute. */
+    if (idx->bns->n_seqs < 0 || idx->bns->n_holes < 0 || idx->bns->l_pac <= 0) {
+        fprintf(stderr,
+            "ERROR! shm BNS_STRUCT scalars out of bounds "
+            "(n_seqs=%d n_holes=%d l_pac=%lld)\n",
+            idx->bns->n_seqs, idx->bns->n_holes, (long long)idx->bns->l_pac);
+        exit(EXIT_FAILURE);
+    }
+
+    if ((int64_t)sz_ambs != (int64_t)idx->bns->n_holes * (int64_t)sizeof(bntamb1_t)) {
+        fprintf(stderr, "ERROR! BNS_AMBS size %llu != n_holes %d * sizeof(bntamb1_t) %llu\n",
+                (unsigned long long)sz_ambs, idx->bns->n_holes,
+                (unsigned long long)sizeof(bntamb1_t));
+        exit(EXIT_FAILURE);
+    }
+    if ((int64_t)sz_anns != (int64_t)idx->bns->n_seqs * (int64_t)sizeof(bntann1_t)) {
+        fprintf(stderr, "ERROR! BNS_ANNS size %llu != n_seqs %d * sizeof(bntann1_t) %llu\n",
+                (unsigned long long)sz_anns, idx->bns->n_seqs,
+                (unsigned long long)sizeof(bntann1_t));
+        exit(EXIT_FAILURE);
+    }
+
+    /* ambs is aliased into shm — read-only is fine. */
+    idx->bns->ambs = (bntamb1_t *)(base + off_ambs);
+
+    /* anns is heap-copied so the mapper can mutate is_alt etc. Each anns[i]
+     * has a name and anno pointer that we patch to point into the on-segment
+     * BNS_NAMES section (the original pointers came from the loader process
+     * heap and are stale). */
+    idx->bns->anns = (bntann1_t *) malloc((size_t)sz_anns);
+    if (idx->bns->anns == NULL) {
+        fprintf(stderr, "ERROR! malloc(%llu bytes for anns[]) failed in %s\n",
+                (unsigned long long)sz_anns, __func__);
+        exit(EXIT_FAILURE);
+    }
+    memcpy(idx->bns->anns, base + off_anns, (size_t)sz_anns);
+
+    /* Walk BNS_NAMES once, patching anns[i].name/anno pointers. memchr
+     * bounds each strlen so a malformed/truncated segment can't read past
+     * the section. Walk must consume the section exactly. */
+    {
+        const char *cursor = (const char *)(base + off_names);
+        const char *end    = cursor + sz_names;
+        for (int i = 0; i < idx->bns->n_seqs; ++i) {
+            const char *name_end =
+                (const char *)memchr(cursor, '\0', (size_t)(end - cursor));
+            if (name_end == NULL) {
+                fprintf(stderr,
+                    "ERROR! shm segment BNS_NAMES: unterminated name for seq %d\n", i);
+                exit(EXIT_FAILURE);
+            }
+            idx->bns->anns[i].name = (char *)cursor;
+            cursor = name_end + 1;
+
+            const char *anno_end =
+                (const char *)memchr(cursor, '\0', (size_t)(end - cursor));
+            if (anno_end == NULL) {
+                fprintf(stderr,
+                    "ERROR! shm segment BNS_NAMES: unterminated anno for seq %d\n", i);
+                exit(EXIT_FAILURE);
+            }
+            idx->bns->anns[i].anno = (char *)cursor;
+            cursor = anno_end + 1;
+        }
+        if (cursor != end) {
+            fprintf(stderr,
+                "ERROR! shm segment BNS_NAMES walk consumed %lld of %llu bytes\n",
+                (long long)(cursor - (const char *)(base + off_names)),
+                (unsigned long long)sz_names);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    /* pac aliased into shm. The on-disk loader allocates a dedicated buffer;
+     * here we just point at the segment. The size sanity check ensures the
+     * segment matches what bns->l_pac demands. */
+    int64_t expected_pac = idx->bns->l_pac / 4 + 1;
+    if ((int64_t)sz_pac != expected_pac) {
+        fprintf(stderr, "ERROR! BNS_PAC size %llu != l_pac/4+1 %lld\n",
+                (unsigned long long)sz_pac, (long long)expected_pac);
+        exit(EXIT_FAILURE);
+    }
+    idx->pac = (uint8_t *)(base + off_pac);
+
+    /* The destructor's existing is_shm gate skips free(idx->mem). We set
+     * idx->mem = base / idx->l_mem = len so the gate works as designed.
+     * Note: idx->bns->ambs and idx->pac point inside [base, base+len); they
+     * must NOT be freed individually. Likewise the patched anns[i].name /
+     * anns[i].anno pointers. The destructor only frees idx->bns and
+     * idx->bns->anns (both heap-copies above), gated by is_shm correctly. */
+    idx->is_shm = 1;
+    idx->mem    = base;
+    idx->l_mem  = (int64_t)len;
+
+    fprintf(stderr, "* BNS+PAC attached from shm: n_seqs=%d n_holes=%d l_pac=%ld\n",
+            idx->bns->n_seqs, idx->bns->n_holes, (long)idx->bns->l_pac);
 }
 
 #include <sys/file.h>

--- a/src/read_index_ele.h
+++ b/src/read_index_ele.h
@@ -60,6 +60,17 @@ public:
 	indexEle();
 	~indexEle();
 	void bwa_idx_load_ele(const char *hint, int which);
-	char *bwa_idx_infer_prefix(const char *hint);	
+	char *bwa_idx_infer_prefix(const char *hint);
+
+	/* Attach BNS + PAC from a packed bwa-mem2 index segment produced by
+	 * bwa_shm_pack_from_disk. `base`/`len` describe the segment (typically
+	 * from bwa_shm_attach). The bntseq_t struct and anns[] array are
+	 * heap-copied (mapper mutates them); ambs[], name/anno strings, and
+	 * pac are aliased into the segment. Sets idx->is_shm=1 and idx->mem,
+	 * idx->l_mem so the existing destructor gate skips the wrong frees.
+	 * The segment's lifetime belongs to the loader process; shm pages are
+	 * never freed by this object.
+	 */
+	void bwa_idx_load_ele_from_shm(uint8_t *base, size_t len);
 };
 #endif

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -17,6 +17,9 @@ ok()   { echo "OK:   $*"; }
 # Build the five unit binaries.
 (cd "$HERE" && make) || fail "test/ make failed"
 
+# Build any test binaries that live outside test/Makefile.
+( cd "$ROOT" && make -j4 shm_section_find_test shm_pack_round_trip_test ) >/dev/null
+
 # synthetic_1mb.fa is checked in alongside its committed baselines so the
 # byte-diff test stays reproducible across Python versions and platforms.
 # A previous version of this script regenerated the FASTA via random.choice;
@@ -201,5 +204,18 @@ ok "libsais_hg38_slice_diff_test"
 # --- libsais --max-memory peak-RSS budget test -----------------------------
 (cd "$HERE" && ./libsais_memory_budget_test.sh) || fail "libsais_memory_budget_test"
 ok "libsais_memory_budget_test"
+
+# --- shm_section_find_test (unit: section-find helper) -----------------------
+echo "==> shm_section_find_test"
+( cd "$ROOT" && ./shm_section_find_test )
+echo "OK:   shm_section_find_test"
+
+# --- shm pack round-trip (unit: pack/unpack a phiX segment) ------------------
+(cd "$HERE" && ./shm_pack_round_trip_test.sh) || fail "shm_pack_round_trip_test"
+ok "shm_pack_round_trip_test"
+
+# --- shm end-to-end round-trip (byte-identical SAM with and without shm) -----
+(cd "$HERE" && ./shm_round_trip_test.sh) || fail "shm_round_trip_test"
+ok "shm_round_trip_test"
 
 echo "ALL UNIT TESTS PASSED"

--- a/test/shm_pack_round_trip_test.cpp
+++ b/test/shm_pack_round_trip_test.cpp
@@ -1,0 +1,184 @@
+/* Round-trip check: pack the phix index into a self-describing buffer via
+ * bwa_shm_pack_from_disk, then verify each section's bytes match what the
+ * normal disk loader produces. Run via test/shm_pack_round_trip_test.sh,
+ * which builds the phix index first.
+ *
+ * Usage: shm_pack_round_trip_test <prefix>
+ *   <prefix> is the path passed to `bwa-mem2 index`, e.g. test/fixtures/phix.fa
+ */
+
+#include "bwa_shm.h"
+#include "FMI_search.h"
+#include "bntseq.h"
+#include "utils.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "CHECK failed at %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        std::fflush(stderr); \
+        std::abort(); \
+    } \
+} while (0)
+
+#define CHECK_EQ(a, b) do { \
+    auto _a = (a); auto _b = (b); \
+    if (_a != _b) { \
+        std::fprintf(stderr, "CHECK_EQ failed at %s:%d: %s (=%lld) != %s (=%lld)\n", \
+                     __FILE__, __LINE__, #a, (long long)_a, #b, (long long)_b); \
+        std::fflush(stderr); \
+        std::abort(); \
+    } \
+} while (0)
+
+static uint8_t *slurp(const char *path, int64_t *len_out) {
+    FILE *fp = std::fopen(path, "rb");
+    CHECK(fp != NULL);
+    std::fseek(fp, 0, SEEK_END);
+    int64_t n = std::ftell(fp);
+    std::rewind(fp);
+    uint8_t *buf = (uint8_t *)std::malloc((size_t)n);
+    CHECK(buf != NULL);
+    err_fread_noeof(buf, 1, (size_t)n, fp);
+    std::fclose(fp);
+    *len_out = n;
+    return buf;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        std::fprintf(stderr, "Usage: %s <prefix>\n", argv[0]);
+        return 2;
+    }
+    const char *prefix = argv[1];
+
+    /* 1. Pack from disk. */
+    uint8_t *buf = NULL;
+    uint64_t buf_len = 0;
+    CHECK_EQ(bwa_shm_pack_from_disk(prefix, &buf, &buf_len), 0);
+    CHECK(buf != NULL);
+    CHECK(buf_len > sizeof(bwa_shm_header_t));
+
+    /* 2. Header sanity. */
+    bwa_shm_header_t hdr;
+    std::memcpy(&hdr, buf, sizeof(hdr));
+    CHECK_EQ(hdr.magic,      BWA_SHM_MAGIC);
+    CHECK_EQ(hdr.version,    BWA_SHM_VERSION);
+    CHECK_EQ(hdr.n_sections, 10u);
+    CHECK_EQ(hdr.total_size, buf_len);
+
+    /* 3. Independently load the same index from disk for comparison. */
+    FMI_search ref(prefix);
+    ref.load_index();
+
+    char zer_path[4096];
+    std::snprintf(zer_path, sizeof(zer_path), "%s.0123", prefix);
+    int64_t ref_string_len = 0;
+    uint8_t *ref_string = slurp(zer_path, &ref_string_len);
+
+    /* 4. Walk sections and compare. */
+    auto section = [&](uint32_t kind, uint64_t *off, uint64_t *sz) {
+        CHECK_EQ(bwa_shm_section_find(buf, kind, off, sz), 0);
+    };
+
+    uint64_t off = 0, sz = 0;
+
+    /* FMI scalars: 8 (refseq_len) + 40 (count[5]) + 8 (sentinel_index) = 56. */
+    section(BWA_SHM_SEC_FMI_SCALARS, &off, &sz);
+    CHECK_EQ(sz, 56ull);
+    int64_t got_refseq = 0, got_count[5] = {0}, got_sentinel = 0;
+    std::memcpy(&got_refseq,   buf + off,            sizeof(int64_t));
+    std::memcpy(got_count,     buf + off + 8,        sizeof(int64_t) * 5);
+    std::memcpy(&got_sentinel, buf + off + 8 + 40,   sizeof(int64_t));
+    CHECK_EQ(got_refseq,   ref.reference_seq_len);
+    CHECK_EQ(got_sentinel, ref.sentinel_index);
+    for (int i = 0; i < 5; ++i) CHECK_EQ(got_count[i], ref.count_data()[i]);
+
+    /* CP_OCC. */
+    section(BWA_SHM_SEC_FMI_CP_OCC, &off, &sz);
+    CHECK_EQ((int64_t)sz, ref.cp_occ_size_bytes());
+    CHECK_EQ(std::memcmp(buf + off, ref.cp_occ_data(), (size_t)sz), 0);
+
+    /* SA_MS. */
+    section(BWA_SHM_SEC_FMI_SA_MS, &off, &sz);
+    CHECK_EQ((int64_t)sz, ref.sa_ms_byte_size_bytes());
+    CHECK_EQ(std::memcmp(buf + off, ref.sa_ms_byte_data(), (size_t)sz), 0);
+
+    /* SA_LS. */
+    section(BWA_SHM_SEC_FMI_SA_LS, &off, &sz);
+    CHECK_EQ((int64_t)sz, ref.sa_ls_word_size_bytes());
+    CHECK_EQ(std::memcmp(buf + off, ref.sa_ls_word_data(), (size_t)sz), 0);
+
+    /* BNS struct. The packed copy contains the SAME bntseq_t bytes as the
+     * loaded version, including its (now-zero) fp_pac/fp_dict and its
+     * pointer fields. We don't compare the bytes byte-for-byte because the
+     * pointer fields will differ (the loader points anns/ambs into freshly-
+     * malloc'd memory, while the packed copy serializes them as offsets in
+     * the segment, but the bns struct itself was memcpy'd before that
+     * patching). Just check size and a couple of stable scalars. */
+    section(BWA_SHM_SEC_BNS_STRUCT, &off, &sz);
+    CHECK_EQ(sz, sizeof(bntseq_t));
+    bntseq_t got_bns;
+    std::memcpy(&got_bns, buf + off, sizeof(got_bns));
+    CHECK_EQ(got_bns.l_pac,    ref.idx->bns->l_pac);
+    CHECK_EQ(got_bns.n_seqs,   ref.idx->bns->n_seqs);
+    CHECK_EQ(got_bns.n_holes,  ref.idx->bns->n_holes);
+    CHECK_EQ(got_bns.seed,     ref.idx->bns->seed);
+
+    /* AMBS — direct byte compare. */
+    section(BWA_SHM_SEC_BNS_AMBS, &off, &sz);
+    CHECK_EQ((int64_t)sz, (int64_t)ref.idx->bns->n_holes * (int64_t)sizeof(bntamb1_t));
+    CHECK_EQ(std::memcmp(buf + off, ref.idx->bns->ambs, (size_t)sz), 0);
+
+    /* ANNS — byte compare of the struct array. The pointers inside (name/anno)
+     * will differ because the loader's anns point at heap strings while the
+     * packed anns are direct memcpy of the loader's anns (still pointing at
+     * loader heap). Compare scalar fields only. */
+    section(BWA_SHM_SEC_BNS_ANNS, &off, &sz);
+    CHECK_EQ((int64_t)sz, (int64_t)ref.idx->bns->n_seqs * (int64_t)sizeof(bntann1_t));
+    const bntann1_t *got_anns = (const bntann1_t *)(buf + off);
+    for (int i = 0; i < ref.idx->bns->n_seqs; ++i) {
+        CHECK_EQ(got_anns[i].offset,   ref.idx->bns->anns[i].offset);
+        CHECK_EQ(got_anns[i].len,      ref.idx->bns->anns[i].len);
+        CHECK_EQ(got_anns[i].n_ambs,   ref.idx->bns->anns[i].n_ambs);
+        CHECK_EQ(got_anns[i].gi,       ref.idx->bns->anns[i].gi);
+        CHECK_EQ(got_anns[i].is_alt,   ref.idx->bns->anns[i].is_alt);
+    }
+
+    /* NAMES — concatenated name\0 anno\0 strings. */
+    section(BWA_SHM_SEC_BNS_NAMES, &off, &sz);
+    {
+        const char *p = (const char *)(buf + off);
+        const char *end = p + sz;
+        for (int i = 0; i < ref.idx->bns->n_seqs; ++i) {
+            CHECK(p < end);
+            CHECK_EQ(std::strcmp(p, ref.idx->bns->anns[i].name), 0);
+            p += std::strlen(p) + 1;
+            CHECK(p < end);
+            CHECK_EQ(std::strcmp(p, ref.idx->bns->anns[i].anno), 0);
+            p += std::strlen(p) + 1;
+        }
+        CHECK(p == end);
+    }
+
+    /* PAC. */
+    section(BWA_SHM_SEC_PAC, &off, &sz);
+    CHECK_EQ((int64_t)sz, (int64_t)(ref.idx->bns->l_pac / 4 + 1));
+    CHECK_EQ(std::memcmp(buf + off, ref.idx->pac, (size_t)sz), 0);
+
+    /* REF_STRING (.0123). */
+    section(BWA_SHM_SEC_REF_STRING, &off, &sz);
+    CHECK_EQ((int64_t)sz, ref_string_len);
+    CHECK_EQ(std::memcmp(buf + off, ref_string, (size_t)sz), 0);
+
+    /* Cleanup. */
+    std::free(ref_string);
+    std::free(buf);
+
+    std::printf("shm_pack_round_trip_test: OK\n");
+    return 0;
+}

--- a/test/shm_pack_round_trip_test.sh
+++ b/test/shm_pack_round_trip_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BIN=${BIN:-./bwa-mem2}
+INNER=${INNER:-./shm_pack_round_trip_test}
+PREFIX=test/fixtures/phix.fa
+
+if [[ ! -x "$BIN" ]]; then
+    echo "FAIL: $BIN not built. Run 'make -j4' first." >&2
+    exit 2
+fi
+if [[ ! -x "$INNER" ]]; then
+    echo "FAIL: $INNER not built. Run 'make -j4 shm_pack_round_trip_test' first." >&2
+    exit 2
+fi
+
+# Build the phix index if any of the index files are missing.
+need_index=0
+for ext in .0123 .amb .ann .bwt.2bit.64 .pac; do
+    if [[ ! -s "${PREFIX}${ext}" ]]; then
+        need_index=1; break
+    fi
+done
+if [[ "$need_index" -eq 1 ]]; then
+    echo "[setup] Building phix index..."
+    "$BIN" index "$PREFIX" >/dev/null 2>&1
+fi
+
+echo "[run] $INNER $PREFIX"
+"$INNER" "$PREFIX"

--- a/test/shm_round_trip_test.sh
+++ b/test/shm_round_trip_test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# End-to-end byte-identical regression: bwa-mem2 mem with a staged shm
+# segment vs. a disk-load run on the same phix index. Pass criterion is
+# (a) staged run shows the attach log line, (b) disk run does not, and
+# (c) `diff` between the two SAM outputs produces no output.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BIN=${BIN:-./bwa-mem2}
+PREFIX=test/fixtures/phix.fa
+READS=test/fixtures/reads.fa
+
+if [[ ! -x "$BIN" ]]; then
+    echo "FAIL: $BIN not built. Run 'make -j4' first." >&2
+    exit 2
+fi
+
+# Clean up any stale registry from a prior run (and on exit).
+"$BIN" shm -d >/dev/null 2>&1 || true
+trap '"$BIN" shm -d >/dev/null 2>&1 || true' EXIT
+
+# Build the phix index if any of the index files are missing.
+need_index=0
+for ext in .0123 .amb .ann .bwt.2bit.64 .pac; do
+    if [[ ! -s "${PREFIX}${ext}" ]]; then
+        need_index=1; break
+    fi
+done
+if [[ "$need_index" -eq 1 ]]; then
+    echo "[setup] Building phix index..."
+    "$BIN" index "$PREFIX" >/dev/null 2>&1
+fi
+
+if [[ ! -f "$READS" ]]; then
+    echo "FAIL: reads fixture missing: $READS" >&2
+    exit 2
+fi
+
+DISK_SAM=$(mktemp -t shm_disk.XXXXXX).sam
+SHM_SAM=$(mktemp -t shm_attached.XXXXXX).sam
+DISK_ERR=$(mktemp -t shm_disk.XXXXXX).err
+SHM_ERR=$(mktemp -t shm_attached.XXXXXX).err
+trap 'rm -f "$DISK_SAM" "$SHM_SAM" "$DISK_ERR" "$SHM_ERR"; "$BIN" shm -d >/dev/null 2>&1 || true' EXIT
+
+echo "[run] disk baseline"
+"$BIN" mem "$PREFIX" "$READS" > "$DISK_SAM" 2> "$DISK_ERR"
+
+echo "[run] stage and re-align"
+"$BIN" shm "$PREFIX"
+"$BIN" mem "$PREFIX" "$READS" > "$SHM_SAM" 2> "$SHM_ERR"
+
+# (a) Attach log line present in shm run.
+if ! grep -q "attached from shm" "$SHM_ERR"; then
+    echo "FAIL: shm run did not show 'attached from shm' in stderr" >&2
+    echo "----- shm stderr (last 40 lines) -----" >&2
+    tail -40 "$SHM_ERR" >&2
+    exit 1
+fi
+
+# (b) Attach log line absent in disk run.
+if grep -q "attached from shm" "$DISK_ERR"; then
+    echo "FAIL: disk run unexpectedly showed 'attached from shm' in stderr" >&2
+    echo "----- disk stderr (last 40 lines) -----" >&2
+    tail -40 "$DISK_ERR" >&2
+    exit 1
+fi
+
+# (c) Byte-identical SAM.
+if ! diff -q "$DISK_SAM" "$SHM_SAM" >/dev/null; then
+    echo "FAIL: SAM differs between disk and shm runs" >&2
+    diff -u "$DISK_SAM" "$SHM_SAM" | head -40 >&2
+    exit 1
+fi
+
+# (d) After dropping the segment, mem reverts to the disk path.
+"$BIN" shm -d
+DROP_ERR=$(mktemp -t shm_drop.XXXXXX).err
+"$BIN" mem "$PREFIX" "$READS" >/dev/null 2>"$DROP_ERR"
+if grep -q "attached from shm" "$DROP_ERR"; then
+    echo "FAIL: mem still shows 'attached from shm' after drop" >&2
+    rm -f "$DROP_ERR"
+    exit 1
+fi
+rm -f "$DROP_ERR"
+
+echo "OK"

--- a/test/shm_section_find_test.cpp
+++ b/test/shm_section_find_test.cpp
@@ -1,0 +1,61 @@
+#include "bwa_shm.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "CHECK failed at %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        std::fflush(stderr); \
+        std::abort(); \
+    } \
+} while (0)
+
+int main() {
+    uint8_t buf[1024];
+    std::memset(buf, 0, sizeof(buf));
+
+    bwa_shm_header_t hdr = {};
+    hdr.magic = BWA_SHM_MAGIC;
+    hdr.version = BWA_SHM_VERSION;
+    hdr.n_sections = 2;
+    hdr.total_size = sizeof(buf);
+    std::memcpy(buf, &hdr, sizeof(hdr));
+
+    bwa_shm_section_t s1 = { BWA_SHM_SEC_FMI_SCALARS, 0, 128, 56, 0 };
+    bwa_shm_section_t s2 = { BWA_SHM_SEC_PAC,         0, 192, 789, 0 };
+    std::memcpy(buf + sizeof(hdr),                    &s1, sizeof(s1));
+    std::memcpy(buf + sizeof(hdr) + sizeof(s1),       &s2, sizeof(s2));
+
+    uint64_t off = 0, sz = 0;
+
+    CHECK(bwa_shm_section_find(buf, BWA_SHM_SEC_FMI_SCALARS, &off, &sz) == 0);
+    CHECK(off == 128 && sz == 56);
+
+    off = 0; sz = 0;
+    CHECK(bwa_shm_section_find(buf, BWA_SHM_SEC_PAC, &off, &sz) == 0);
+    CHECK(off == 192 && sz == 789);
+
+    CHECK(bwa_shm_section_find(buf, BWA_SHM_SEC_BNS_AMBS, &off, &sz) == -1);
+    CHECK(bwa_shm_section_find(NULL, BWA_SHM_SEC_PAC, &off, &sz) == -1);
+
+    /* Bad magic. */
+    buf[0] ^= 0xFF;
+    CHECK(bwa_shm_section_find(buf, BWA_SHM_SEC_PAC, &off, &sz) == -1);
+    buf[0] ^= 0xFF;
+
+    /* Bad version. */
+    bwa_shm_header_t bad_ver = hdr;
+    bad_ver.version = 99u;
+    std::memcpy(buf, &bad_ver, sizeof(bad_ver));
+    CHECK(bwa_shm_section_find(buf, BWA_SHM_SEC_PAC, &off, &sz) == -1);
+    std::memcpy(buf, &hdr, sizeof(hdr));
+
+    /* Sanity: lookup works again after restore. */
+    CHECK(bwa_shm_section_find(buf, BWA_SHM_SEC_PAC, &off, &sz) == 0);
+
+    std::printf("shm_section_find_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
Closes #64.

## Summary

Ports the `bwa shm` feature from bwa-mem v1 to bwa-mem2 with strict v1 CLI parity. The bwa-mem2 in-memory index is staged into a POSIX shared-memory segment once; subsequent `bwa-mem2 mem` invocations attach instead of re-reading from disk.

```
bwa-mem2 shm <prefix>     # stage
bwa-mem2 shm -l           # list
bwa-mem2 shm -d           # drop (all; matches v1)
```

After staging, `bwa-mem2 mem <prefix> ...` automatically attaches; SAM is byte-identical to a disk-loaded run.

## What's in the segment

A self-describing buffer (header + section table + 10 sections, 64-byte aligned) covering:
- FMI scalars (`reference_seq_len`, `count[5]`, `sentinel_index`)
- `cp_occ`, `sa_ms_byte`, `sa_ls_word` (the dominant FMI buffers)
- `bntseq_t`, `ambs[]`, `anns[]`, concatenated `name\0 anno\0` strings
- `pac` (from `.pac`)
- ref string (from `.0123`)

Magic `BWAMEM2\0` (LE) + version 1 + `total_size` guard + per-section bound check on attach.

## Streaming pack (no peak-RAM blowup)

Staging avoids the obvious 2× peak-RAM trap. `bwa_shm_compute` reads only the small file headers (`.ann`/`.amb` via `bns_restore` + 48-byte header of `.bwt.2bit.64` + `stat` of `.0123`) to determine the segment size, then `ftruncate`+`mmap` the shm region, and `bwa_shm_pack_into` streams `cp_occ`, `sa_ms_byte`, `sa_ls_word`, `.pac`, and `.0123` directly from disk into the mmap'd region in 16 MiB chunks. The heavy index data never lives in a heap buffer. Peak RAM during stage is `~total_size + a few MB of BNS`, not `2 × total_size`.

## Auto-attach

Three integration points consult `bwa_shm_attach`:
- `FMI_search::load_index` — on hit, calls new `load_index_from_shm` and `bwa_idx_load_ele_from_shm` and returns early; otherwise the existing disk path runs unchanged.
- `indexEle::bwa_idx_load_ele_from_shm` — heap-copies `bns` and `anns` (the mapper mutates them) and aliases the rest into the segment.
- `fastmap.cpp::main_mem` — new `load_ref_string` helper resolves `.0123` from shm or disk; `aux.ref_string_is_shm` gates the eventual `_mm_free`.

`is_shm` gates added to `FMI_search::~FMI_search` so the aliased buffers aren't `_mm_free`'d. The vestigial v1 `is_shm` field on `bwaidx_fm_t` is finally made load-bearing.

## Platforms

Linux + macOS via POSIX `shm_open`. Cross-binary compatible across AVX2, AVX-512, and NEON builds.

## Non-goals (deferred to follow-on PRs, per #64)

1. Staleness validation — re-indexing without `shm -d` first silently uses the stale segment. Documented in README.
2. Per-prefix drop — `-d` is all-or-nothing, matching v1.
3. Basename collision protection — `/data/a/hg38` and `/data/b/hg38` both map to `/bwaidx-hg38`.
4. Windows support.
5. `mlock` / lock-in-RAM semantics.

## Test plan

- [x] `make -j4` clean on macOS Apple Silicon
- [x] `bash test/run_unit_tests.sh` — all unit tests + new shm tests pass:
  - `shm_section_find_test` (lookup primitive: 9 assertions)
  - `shm_pack_round_trip_test` (in-process pack vs. disk-loaded byte equality on phiX)
  - `shm_round_trip_test.sh` (end-to-end byte-identical SAM with vs. without shm; verifies `shm -d` reverts to disk)
- [ ] CI on Linux x86_64 + Linux aarch64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level "shm" command to stage, list, attach and destroy shared-memory (SHM) indexes; alignment runs auto-attach to matching staged indexes to reuse in-memory index data.
* **Documentation**
  * Added SHM workflow guide with explicit warnings about staleness, name collisions, and platform/container sizing limits.
* **Tests**
  * Added SHM regression, section-find and round-trip tests; test harness now builds and runs these checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->