### PR TITLE
feat(shm): add `bwa-mem2 shm --meth` for symmetric meth UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ the index can be staged once into POSIX shared memory:
 # Stage the index. After this, subsequent `mem` runs auto-attach.
 ./bwa-mem2 shm <prefix>
 
+# Stage a `bwa-mem2 index --meth` index. Auto-appends `.bwameth.c2t`
+# so the same plain `<prefix>` works for `index --meth`, `shm --meth`,
+# and `mem --meth`.
+./bwa-mem2 shm --meth <prefix>
+
 # List staged indices.
 ./bwa-mem2 shm -l
 
@@ -279,6 +284,13 @@ same record count, same chrom+pos, same CIGAR for every mapped primary.
 
 - `--set-as-failed {f,r}` — flag alignments aligned to the given strand as QC-fail (`0x200`).
 - `--do-not-penalize-chimeras` — skip the longest-match < 44% chimera heuristic.
+
+### Shared memory
+
+`bwa-mem2 shm --meth ref.fa` stages a meth index the same way
+`bwa-mem2 shm` stages a plain one — see the [shared-memory index](#shared-memory-index-shm)
+section. Pass the same plain `ref.fa` to `index --meth`, `shm --meth`,
+and `mem --meth`; the `.bwameth.c2t` suffix is auto-appended on all three.
 
 ### Legacy bwameth.py-compatible invocation
 

--- a/src/bwa_shm.cpp
+++ b/src/bwa_shm.cpp
@@ -40,6 +40,7 @@
 #include <sys/stat.h>      /* mode constants, stat */
 #include <fcntl.h>         /* O_* */
 #include <unistd.h>        /* close, ftruncate */
+#include <getopt.h>        /* getopt_long for `bwa-mem2 shm --meth ...` */
 #include <errno.h>
 #include <limits.h>        /* PATH_MAX */
 
@@ -767,17 +768,71 @@ int bwa_shm_section_find(const uint8_t *base, uint32_t kind,
     return -1;
 }
 
+/* Resolve the on-disk prefix for `bwa-mem2 shm --meth <idxbase>` so that
+ * the registry basename matches what `bwa-mem2 mem --meth <idxbase>` will
+ * later look up. Mirrors fastmap.cpp's c2t-suffix resolution: append
+ * `.bwameth.c2t` unless `prefix` already ends with it. */
+static int resolve_meth_prefix(const char *prefix, char out[PATH_MAX])
+{
+    static const char SUFFIX[] = ".bwameth.c2t";
+    static const size_t SUFLEN = sizeof(SUFFIX) - 1;
+    size_t plen = std::strlen(prefix);
+    int already = (plen >= SUFLEN) &&
+                  (std::strcmp(prefix + plen - SUFLEN, SUFFIX) == 0);
+    if (already) {
+        if (plen + 1 > (size_t)PATH_MAX) {
+            std::fprintf(stderr, "[E::%s] prefix too long\n", __func__);
+            return -1;
+        }
+        strcpy_s(out, PATH_MAX, prefix);
+    } else {
+        if (plen + SUFLEN + 1 > (size_t)PATH_MAX) {
+            std::fprintf(stderr, "[E::%s] prefix too long for --meth\n", __func__);
+            return -1;
+        }
+        path_concat2(out, prefix, SUFFIX);
+    }
+    return 0;
+}
+
+/* If `<prefix>.0123` is absent but `<prefix>.bwameth.c2t.0123` is present,
+ * the user likely meant `--meth`. Print a hint and return 1. Returns 0
+ * when no hint applies (let the regular stage path produce its own error). */
+static int hint_missing_meth_flag(const char *prefix)
+{
+    char zer_path[PATH_MAX];
+    path_concat2(zer_path, prefix, ".0123");
+    struct stat st;
+    if (stat(zer_path, &st) == 0) return 0;        /* literal index present */
+    if (errno != ENOENT) return 0;                 /* I/O error: defer */
+
+    char c2t_zer[PATH_MAX];
+    path_concat2(c2t_zer, prefix, ".bwameth.c2t.0123");
+    if (stat(c2t_zer, &st) != 0) return 0;         /* no meth index either */
+
+    std::fprintf(stderr,
+        "[E::main_shm] no FMI at '%s.0123' but a meth index is present at "
+        "'%s.bwameth.c2t.*'\n"
+        "             did you mean `bwa-mem2 shm --meth %s`?\n",
+        prefix, prefix, prefix);
+    return 1;
+}
+
 static void print_shm_usage(void)
 {
     std::fprintf(stderr,
-        "\nUsage: bwa-mem2 shm [-d|-l|--help] [idxbase]\n\n"
+        "\nUsage: bwa-mem2 shm [-d|-l|--help] [--meth] [idxbase]\n\n"
         "Options:\n"
         "  -d        destroy all indices in shared memory (matches bwa v1 behavior)\n"
         "  -l        list names of indices in shared memory\n"
+        "  --meth    stage a `bwa-mem2 index --meth` index — auto-appends\n"
+        "            `.bwameth.c2t` to <idxbase>, mirroring `mem --meth`\n"
         "  -h --help print this help and exit\n\n"
         "Stage with no flags: `bwa-mem2 shm <idxbase>` loads the index into\n"
         "POSIX shared memory; subsequent `bwa-mem2 mem <idxbase> ...` runs\n"
-        "auto-attach instead of re-reading from disk.\n\n"
+        "auto-attach instead of re-reading from disk. For meth indices, pass\n"
+        "the same plain `<idxbase>` to all three commands plus `--meth` on\n"
+        "`index`, `shm`, and `mem` (the c2t suffix is auto-appended).\n\n"
         "Footgun: if you re-build the index, run `bwa-mem2 shm -d` first.\n"
         "There is no staleness check -- a stale segment will silently mis-align.\n\n"
         "macOS: POSIX shm has implementation-defined per-segment caps; large\n"
@@ -789,11 +844,11 @@ static void print_shm_usage(void)
 
 int main_shm(int argc, char *argv[])
 {
-    int c, to_list = 0, to_drop = 0, ret = 0;
+    int c, to_list = 0, to_drop = 0, meth = 0, ret = 0;
 
-    /* Pre-scan for --help / -h. getopt's "ld" optstring would treat them as
-     * unknown options and print a generic error, but the top-level usage
-     * (src/main.cpp) advertises `bwa-mem2 <command> --help`, so we honor it. */
+    /* Pre-scan for --help / -h. getopt_long would treat -h as unknown
+     * (no short opt declared) and print a generic error, but the top-level
+     * usage advertises `bwa-mem2 <command> --help`, so we honor both. */
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0) {
             print_shm_usage();
@@ -810,10 +865,15 @@ int main_shm(int argc, char *argv[])
     extern int optreset;
     optreset = 1;
 #endif
-    while ((c = getopt(argc, argv, "ld")) >= 0) {
-        if      (c == 'l') to_list = 1;
-        else if (c == 'd') to_drop = 1;
-        else               return 1;   /* getopt printed the error */
+    static struct option long_opts[] = {
+        {"meth", no_argument, 0, 1000},
+        {0,      0,           0, 0   }
+    };
+    while ((c = getopt_long(argc, argv, "ld", long_opts, NULL)) >= 0) {
+        if      (c == 'l')   to_list = 1;
+        else if (c == 'd')   to_drop = 1;
+        else if (c == 1000)  meth    = 1;
+        else                 return 1;   /* getopt printed the error */
     }
     if (optind == argc && !to_list && !to_drop) {
         print_shm_usage();
@@ -824,13 +884,32 @@ int main_shm(int argc, char *argv[])
             "[E::%s] -l or -d cannot be combined with idxbase\n", __func__);
         return 1;
     }
+    if (meth && (to_list || to_drop)) {
+        std::fprintf(stderr,
+            "[E::%s] --meth cannot be combined with -l or -d\n", __func__);
+        return 1;
+    }
+    if (optind + 1 < argc) {
+        std::fprintf(stderr,
+            "[E::%s] too many positional arguments; expected at most one idxbase\n",
+            __func__);
+        return 1;
+    }
 
     /* Stage. */
     if (optind < argc) {
-        if (bwa_shm_stage(argv[optind]) < 0) {
+        const char *user_prefix = argv[optind];
+        char       resolved[PATH_MAX];
+        if (meth) {
+            if (resolve_meth_prefix(user_prefix, resolved) != 0) return 1;
+            user_prefix = resolved;
+        } else if (hint_missing_meth_flag(user_prefix)) {
+            return 1;
+        }
+        if (bwa_shm_stage(user_prefix) < 0) {
             std::fprintf(stderr,
                 "[E::%s] failed to stage '%s' in shared memory\n",
-                __func__, argv[optind]);
+                __func__, user_prefix);
             ret = 1;
         }
     }

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -218,4 +218,8 @@ ok "shm_pack_round_trip_test"
 (cd "$HERE" && ./shm_round_trip_test.sh) || fail "shm_round_trip_test"
 ok "shm_round_trip_test"
 
+# --- shm --meth flag (parity with mem --meth's c2t-suffix resolution) --------
+(cd "$HERE" && ./shm_meth_test.sh) || fail "shm_meth_test"
+ok "shm_meth_test"
+
 echo "ALL UNIT TESTS PASSED"

--- a/test/shm_meth_test.sh
+++ b/test/shm_meth_test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Regression: `bwa-mem2 shm --meth` resolves the c2t-suffixed prefix the
+# same way `bwa-mem2 mem --meth` does, so an end user passes the same plain
+# FASTA path to all three commands (`index --meth`, `shm --meth`,
+# `mem --meth`) without juggling the `.bwameth.c2t` suffix by hand.
+#
+# Pre-fix, `bwa-mem2 shm <plain>` opens `bns_restore(<plain>)` and fails on
+# `<plain>.ann` when only the meth artifacts are on disk; staging instead
+# required typing `bwa-mem2 shm <plain>.bwameth.c2t`. This test pins the
+# new flag-driven behavior in place.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+BIN=${BIN:-./bwa-mem2}
+
+if [[ ! -x "$BIN" ]]; then
+    echo "FAIL: $BIN not built. Run 'make -j4' first." >&2
+    exit 2
+fi
+
+# Isolated dir so the meth-only artifacts are the *only* index in scope.
+# test/fixtures/phix.fa already has a plain index from other tests, which
+# would mask the negative case below.
+WORKDIR="$(mktemp -d -t shm_meth.XXXXXX)"
+cp test/fixtures/phix.fa "$WORKDIR/ref.fa"
+PLAIN_PREFIX="$WORKDIR/ref.fa"
+C2T_PREFIX="$WORKDIR/ref.fa.bwameth.c2t"
+
+# Drop any stale registry from prior runs and on every exit. Allocate the
+# stderr-capture file once and truncate between cases — avoids mktemp churn
+# and ensures the EXIT trap (which expands $ERR at fire time) cleans up the
+# single live path rather than leaking earlier ones.
+"$BIN" shm -d >/dev/null 2>&1 || true
+ERR="$(mktemp)"
+trap '"$BIN" shm -d >/dev/null 2>&1 || true; rm -rf "$WORKDIR" "$ERR"' EXIT
+
+# Build only the meth index. The plain ref.fa.{0123,ann,...} are NOT built,
+# so this is the exact scenario where the pre-fix `bwa-mem2 shm ref.fa` UX
+# would have failed with `fail to open '...ref.fa.ann'`.
+echo "[setup] bwa-mem2 index --meth $PLAIN_PREFIX"
+"$BIN" index --meth "$PLAIN_PREFIX" >/dev/null 2>&1
+
+# Sanity: the plain index files must be absent (so test cases C and D below
+# actually exercise the wrong-flag path).
+for ext in .0123 .ann .amb .pac .bwt.2bit.64; do
+    if [[ -e "${PLAIN_PREFIX}${ext}" ]]; then
+        echo "FAIL: precondition violated — ${PLAIN_PREFIX}${ext} exists" >&2
+        exit 1
+    fi
+done
+
+# --- A: `shm --meth <plain>` stages under the c2t basename --------------
+echo "[A] bwa-mem2 shm --meth $PLAIN_PREFIX"
+"$BIN" shm --meth "$PLAIN_PREFIX" >/dev/null 2>&1 \
+    || { echo "FAIL A: shm --meth <plain> exited non-zero" >&2; exit 1; }
+
+LIST="$("$BIN" shm -l 2>&1)"
+COUNT_A="$(echo "$LIST" | awk '{print $1}' | grep -xc 'ref.fa.bwameth.c2t' || true)"
+if [[ "$COUNT_A" -ne 1 ]]; then
+    echo "FAIL A: expected exactly one 'ref.fa.bwameth.c2t' entry, got $COUNT_A" >&2
+    echo "----- shm -l -----" >&2
+    echo "$LIST" >&2
+    exit 1
+fi
+"$BIN" shm -d >/dev/null 2>&1
+
+# --- B: mem --meth attaches from the shm segment staged by shm --meth ---
+echo "[B] shm --meth + mem --meth ⇒ 'attached from shm'"
+"$BIN" shm --meth "$PLAIN_PREFIX" >/dev/null 2>&1
+: > "$ERR"
+
+"$BIN" mem --meth "$PLAIN_PREFIX" test/fixtures/reads.fa >/dev/null 2>"$ERR" \
+    || { echo "FAIL B: mem --meth exited non-zero" >&2; cat "$ERR" >&2; exit 1; }
+if ! grep -q "attached from shm" "$ERR"; then
+    echo "FAIL B: mem --meth did not attach from shm (registry mismatch?)" >&2
+    tail -40 "$ERR" >&2
+    exit 1
+fi
+"$BIN" shm -d >/dev/null 2>&1
+
+# --- C: `shm --meth <c2t-suffixed-prefix>` is idempotent ----------------
+echo "[C] bwa-mem2 shm --meth <prefix>.bwameth.c2t (no double-append)"
+"$BIN" shm --meth "$C2T_PREFIX" >/dev/null 2>&1 \
+    || { echo "FAIL C: shm --meth on already-c2t prefix exited non-zero" >&2; exit 1; }
+LIST="$("$BIN" shm -l 2>&1)"
+COUNT_C="$(echo "$LIST" | awk '{print $1}' | grep -xc 'ref.fa.bwameth.c2t' || true)"
+if [[ "$COUNT_C" -ne 1 ]]; then
+    echo "FAIL C: expected exactly one 'ref.fa.bwameth.c2t' entry, got $COUNT_C" >&2
+    echo "----- shm -l -----" >&2
+    echo "$LIST" >&2
+    exit 1
+fi
+if echo "$LIST" | awk '{print $1}' | grep -qx 'ref.fa.bwameth.c2t.bwameth.c2t'; then
+    echo "FAIL C: double-appended 'ref.fa.bwameth.c2t.bwameth.c2t' entry present" >&2
+    exit 1
+fi
+"$BIN" shm -d >/dev/null 2>&1
+
+# --- D: `shm <plain>` (no --meth) errors with a helpful hint ------------
+echo "[D] bwa-mem2 shm <plain>  (only meth artifacts on disk → hint about --meth)"
+: > "$ERR"
+if "$BIN" shm "$PLAIN_PREFIX" >/dev/null 2>"$ERR"; then
+    echo "FAIL D: shm <plain> on a meth-only directory unexpectedly succeeded" >&2
+    cat "$ERR" >&2
+    exit 1
+fi
+if ! grep -q -- "--meth" "$ERR"; then
+    echo "FAIL D: error message did not mention '--meth' as a hint" >&2
+    echo "----- stderr -----" >&2
+    cat "$ERR" >&2
+    exit 1
+fi
+
+# --- E: extra positional arguments after idxbase are rejected -----------
+echo "[E] bwa-mem2 shm --meth <prefix> <typo>  (extra positional rejected)"
+: > "$ERR"
+if "$BIN" shm --meth "$PLAIN_PREFIX" stray-arg >/dev/null 2>"$ERR"; then
+    echo "FAIL E: shm --meth <prefix> <stray-arg> unexpectedly succeeded" >&2
+    cat "$ERR" >&2
+    exit 1
+fi
+if ! grep -qiE "positional|too many|unexpected" "$ERR"; then
+    echo "FAIL E: error message did not flag the extra positional arg" >&2
+    echo "----- stderr -----" >&2
+    cat "$ERR" >&2
+    exit 1
+fi
+
+echo "OK"


### PR DESCRIPTION
## Why

`bwa-mem2 mem --meth <prefix>` auto-appends `.bwameth.c2t` to find the index built by `bwa-mem2 index --meth <prefix>`. `bwa-mem2 shm` did not, so staging a meth index required passing the c2t-suffixed path to `shm` while still passing the plain prefix to `mem` — easy to forget, and the failure surfaces as a confusing `fail to open <prefix>.ann` either at stage or attach time depending on which side got it wrong. Pipelines were carrying a workaround comment explaining the asymmetry.

## What

Add `--meth` to `shm`, mirroring `mem --meth`'s resolution rule. The same plain `<prefix>` now flows through `index --meth`, `shm --meth`, and `mem --meth`:

```sh
bwa-mem2 index --meth ref.fa
bwa-mem2 shm   --meth ref.fa
bwa-mem2 mem   --meth ref.fa R1.fq.gz R2.fq.gz | samtools sort -o out.bam
```

`shm --meth` is idempotent on an already-c2t-suffixed prefix (matches `mem --meth`'s `already_c2t` check). `--meth` cannot be combined with `-l` / `-d`.

To make the wrong-flag case fail loudly instead of silently, `shm <prefix>` (no flag) now stat-probes `<prefix>.0123` first; if the literal index is absent but `<prefix>.bwameth.c2t.0123` is present, it errors with a `did you mean \`bwa-mem2 shm --meth <prefix>\`?` hint rather than the bare BNS-open failure.

## How

- `src/bwa_shm.cpp`:
  - switch `getopt` → `getopt_long` with one long-only option (val 1000, matching `bwtindex.cpp`'s convention for long-only options)
  - new file-static `resolve_meth_prefix()` and `hint_missing_meth_flag()` using the existing `path_concat2` / safestringlib idiom
  - guard: `--meth` is incompatible with `-l` / `-d`
  - usage text refreshed to advertise `--meth` and the all-three-commands convention
- `test/shm_meth_test.sh` (new) exercises:
  - **A** `shm --meth <plain>` registers basename `<plain>.bwameth.c2t`
  - **B** `mem --meth <plain>` attaches from the staged shm segment
  - **C** `shm --meth <c2t-prefix>` is idempotent (no `<>.bwameth.c2t.bwameth.c2t` entry)
  - **D** `shm <plain>` on a meth-only directory errors with a `--meth` hint
- `test/run_unit_tests.sh` wires the new test in after `shm_round_trip_test`.
- `README.md`: documents `shm --meth` in both the shared-memory and bisulfite sections.

## Test plan

- [x] `make arm64 -j4`
- [x] `bash test/shm_meth_test.sh` (passes — all four assertions)
- [x] `bash test/shm_round_trip_test.sh` (still passes — non-meth path unchanged)
- [x] `bash test/shm_pack_round_trip_test.sh` (still passes)
- [x] `./shm_section_find_test` (still passes)
- [x] `./bwa-mem2 shm --help` smoke check
- [x] `./bwa-mem2 shm --meth -l` correctly errors out
- [ ] CI green on Linux runners (will verify after open)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--meth` option to the shared-memory staging command for consistent methylation-aware index handling.

* **Documentation**
  * Updated with usage examples and cross-references for methylation-aware workflow guidance.

* **Bug Fixes**
  * Improved error handling with targeted hints when methylation and non-methylation index variants are mismatched.

* **Tests**
  * Added comprehensive test coverage for methylation-mode staging and usage workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->