### PR TITLE
chore: rename shell vars BWAMEM2/BWA_MEM2[_*] to BWAMEM3/BWA_MEM3[_*]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
 
       - name: Compare bwa and bwa-mem3 output (phiX parity)
         run: |
-          BWA_MEM2="$GITHUB_WORKSPACE/bwa-mem3" \
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
           CI_TEST_DIR=/tmp/ci-test \
           bash test/regression/phix_parity.sh
 
@@ -247,14 +247,14 @@ jobs:
       - name: --bam=6 roundtrip smoke (phiX)
         if: matrix.canonical == true
         run: |
-          BWA_MEM2="$GITHUB_WORKSPACE/bwa-mem3" \
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
           CI_TEST_DIR=/tmp/ci-test \
           bash test/regression/bam_roundtrip.sh
 
       - name: Thread-determinism smoke (phiX, -t 1 vs -t 4)
         if: matrix.canonical == true
         run: |
-          BWA_MEM2="$GITHUB_WORKSPACE/bwa-mem3" \
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
           CI_TEST_DIR=/tmp/ci-test \
           bash test/regression/thread_determinism.sh
 
@@ -295,7 +295,7 @@ jobs:
       - name: Compare chr22 bwa vs bwa-mem3 (parity)
         if: matrix.canonical == true
         run: |
-          BWA_MEM2="$GITHUB_WORKSPACE/bwa-mem3" \
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
           CHR22_FA=/tmp/chr22/chr22.fa \
           CHR22_SIM_DIR=/tmp/chr22-sim \
           bash test/regression/chr22_parity.sh

--- a/bench/config.env.example
+++ b/bench/config.env.example
@@ -2,8 +2,8 @@
 
 # Binaries under test. The "baseline" is whatever main head is built to;
 # "candidate" is the PR branch under test.
-BWA_MEM2_BASELINE="/path/to/main/bwa-mem3"
-BWA_MEM2_CANDIDATE="/path/to/candidate/bwa-mem3"
+BWA_MEM3_BASELINE="/path/to/main/bwa-mem3"
+BWA_MEM3_CANDIDATE="/path/to/candidate/bwa-mem3"
 
 # Index + reads.
 BENCH_INDEX="/path/to/hg38/Homo_sapiens_assembly38.fasta"

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -32,8 +32,8 @@ fi
 # fast (rather than silently picking the candidate path) so a typo like
 # "baseliine" can't quietly run with the wrong binary.
 case "$TAG" in
-  baseline)                  BIN="$BWA_MEM2_BASELINE" ;;
-  candidate|pr-*|perf-*|main-*) BIN="$BWA_MEM2_CANDIDATE" ;;
+  baseline)                  BIN="${BWA_MEM3_BASELINE:?BWA_MEM3_BASELINE is required (set in bench/config.env)}" ;;
+  candidate|pr-*|perf-*|main-*) BIN="${BWA_MEM3_CANDIDATE:?BWA_MEM3_CANDIDATE is required (set in bench/config.env)}" ;;
   *) echo "error: unknown TAG '$TAG' — expected 'baseline', 'candidate', 'pr-*', 'perf-*', or 'main-*'." >&2
      exit 2 ;;
 esac

--- a/scripts/bench_index.sh
+++ b/scripts/bench_index.sh
@@ -17,7 +17,7 @@
 #
 # Environment overrides:
 #   BENCH_DIR        - where to stage work and write results
-#   BWAMEM2          - path to bwa-mem3 binary (default: $ROOT/bwa-mem3)
+#   BWAMEM3          - path to bwa-mem3 binary (default: $ROOT/bwa-mem3)
 #   BWA_TEST_HG38_FASTA / BWA_TEST_HG38_MET_C2T - source FASTA paths
 #   BWA_INDEX_THREADS    - passed to `bwa-mem3 index -t`. Unset = auto-detect.
 #   BWA_INDEX_MAX_MEMORY - passed to `bwa-mem3 index --max-memory`. Unset =
@@ -27,7 +27,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
-BWAMEM2="${BWAMEM2:-$ROOT/bwa-mem3}"
+BWAMEM3="${BWAMEM3:-$ROOT/bwa-mem3}"
 
 # Build the index-builder argv once. Empty defaults mean "let bwa-mem3 pick",
 # which is the documented auto-detect path. Setting an explicit budget makes
@@ -87,11 +87,11 @@ run_one() {
     # set, else nothing" under set -u. Plain "${INDEX_ARGS[@]}" trips
     # `unbound variable` on an empty array under macOS's system bash.
     if [[ "$UNAME_S" == "Darwin" ]]; then
-        /usr/bin/time -l "$BWAMEM2" index ${INDEX_ARGS[@]+"${INDEX_ARGS[@]}"} "$wd/ref.fa" >"$logfile" 2>"$timing" || {
+        /usr/bin/time -l "$BWAMEM3" index ${INDEX_ARGS[@]+"${INDEX_ARGS[@]}"} "$wd/ref.fa" >"$logfile" 2>"$timing" || {
             echo "FAIL: $label build failed"; cat "$timing"; return 1;
         }
     else
-        /usr/bin/time -v "$BWAMEM2" index ${INDEX_ARGS[@]+"${INDEX_ARGS[@]}"} "$wd/ref.fa" >"$logfile" 2>"$timing" || {
+        /usr/bin/time -v "$BWAMEM3" index ${INDEX_ARGS[@]+"${INDEX_ARGS[@]}"} "$wd/ref.fa" >"$logfile" 2>"$timing" || {
             echo "FAIL: $label build failed"; cat "$timing"; return 1;
         }
     fi

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -57,7 +57,7 @@ curl -sL "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/819/615/GCF_000819615
   | gunzip > phix174.fa
 dwgsim -z 42 -N 500 -1 150 -2 150 -r 0.001 -S 2 phix174.fa reads
 cd -
-BWA_MEM2="$(pwd)/bwa-mem3" CI_TEST_DIR=/tmp/ci-test bash test/regression/phix_parity.sh
+BWA_MEM3="$(pwd)/bwa-mem3" CI_TEST_DIR=/tmp/ci-test bash test/regression/phix_parity.sh
 ```
 
 ## Running tests in CI

--- a/test/libsais_chr22_diff_test.sh
+++ b/test/libsais_chr22_diff_test.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
-BWAMEM2="$ROOT/bwa-mem3"
+BWAMEM3="$ROOT/bwa-mem3"
 
 FIXTURE="${BWA_TEST_CHR22_FASTA:-}"
 BASELINE_DIR="${BWA_TEST_CHR22_BASELINE:-}"
@@ -30,7 +30,7 @@ if [[ -z "$BASELINE_DIR" ]]; then
 fi
 
 # Baseline must be a known-good snapshot from a trusted commit (e.g.
-# legacy/sais-lite). Auto-bootstrapping with the CURRENT $BWAMEM2 would
+# legacy/sais-lite). Auto-bootstrapping with the CURRENT $BWAMEM3 would
 # defeat the test: the freshly captured baseline and the just-built
 # index are then both produced by the same backend at the same SHA, so
 # cmp trivially passes regardless of correctness. Operators must seed
@@ -58,14 +58,14 @@ if [[ $baseline_complete -eq 0 ]]; then
     echo "INFO: BWA_TEST_CHR22_BASELINE_BOOTSTRAP=1 -- bootstrapping baseline at $BASELINE_DIR"
     mkdir -p "$BASELINE_DIR"
     cp "$FIXTURE" "$BASELINE_DIR/chr22.fa"
-    "$BWAMEM2" index "$BASELINE_DIR/chr22.fa" >/dev/null
+    "$BWAMEM3" index "$BASELINE_DIR/chr22.fa" >/dev/null
 fi
 
 TD="$(mktemp -d)"
 trap 'rm -rf "$TD"' EXIT
 
 cp "$FIXTURE" "$TD/chr22.fa"
-"$BWAMEM2" index "$TD/chr22.fa" >/dev/null
+"$BWAMEM3" index "$TD/chr22.fa" >/dev/null
 
 FAIL=0
 for ext in "${EXTS[@]}"; do

--- a/test/libsais_determinism_test.sh
+++ b/test/libsais_determinism_test.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
-BWAMEM2="$ROOT/bwa-mem3"
+BWAMEM3="$ROOT/bwa-mem3"
 FA_SRC="$HERE/fixtures/synthetic_1mb.fa"
 [[ -s "$FA_SRC" ]] || { echo "FAIL: $FA_SRC missing"; exit 1; }
 
@@ -16,7 +16,7 @@ for t in 1 4 8; do
     d="$RUN_DIR/t$t"
     mkdir -p "$d"
     cp "$FA_SRC" "$d/t.fa"
-    "$BWAMEM2" index -t "$t" "$d/t.fa" >/dev/null
+    "$BWAMEM3" index -t "$t" "$d/t.fa" >/dev/null
 done
 
 for ext in bwt.2bit.64 0123; do

--- a/test/libsais_hg38_slice_diff_test.sh
+++ b/test/libsais_hg38_slice_diff_test.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
-BWAMEM2="$ROOT/bwa-mem3"
+BWAMEM3="$ROOT/bwa-mem3"
 
 HG38="${BWA_TEST_HG38_FASTA:-}"
 SLICE_DIR="${BWA_TEST_HG38_SLICE_DIR:-${TMPDIR:-/tmp}/hg38-slice}"
@@ -43,7 +43,7 @@ if [[ ! -s "$SLICE_DIR/slice.fa" ]]; then
 fi
 
 # Baseline must be a known-good snapshot from a trusted commit (e.g.
-# legacy/sais-lite). Auto-bootstrapping with the CURRENT $BWAMEM2 would
+# legacy/sais-lite). Auto-bootstrapping with the CURRENT $BWAMEM3 would
 # defeat the test: the freshly captured baseline and the just-built
 # index are then both produced by the same backend at the same SHA, so
 # cmp trivially passes regardless of correctness. The one-time bootstrap
@@ -61,14 +61,14 @@ if [[ ! -s "$SLICE_DIR/baseline/slice.fa.bwt.2bit.64" ]]; then
     echo "INFO: BWA_TEST_HG38_SLICE_BASELINE_BOOTSTRAP=1 -- bootstrapping baseline at $SLICE_DIR/baseline"
     mkdir -p "$SLICE_DIR/baseline"
     cp "$SLICE_DIR/slice.fa" "$SLICE_DIR/baseline/slice.fa"
-    "$BWAMEM2" index "$SLICE_DIR/baseline/slice.fa" >/dev/null
+    "$BWAMEM3" index "$SLICE_DIR/baseline/slice.fa" >/dev/null
 fi
 
 TD="$(mktemp -d)"
 trap 'rm -rf "$TD"' EXIT
 
 cp "$SLICE_DIR/slice.fa" "$TD/slice.fa"
-"$BWAMEM2" index "$TD/slice.fa" >/dev/null
+"$BWAMEM3" index "$TD/slice.fa" >/dev/null
 
 FAIL=0
 for ext in pac ann amb 0123 bwt.2bit.64; do

--- a/test/libsais_index_diff_test.sh
+++ b/test/libsais_index_diff_test.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
-BWAMEM2="$ROOT/bwa-mem3"
+BWAMEM3="$ROOT/bwa-mem3"
 BASELINES="$HERE/fixtures/baselines"
 
 FAIL=0
@@ -21,7 +21,7 @@ trap 'rm -rf "$TD"' EXIT
 for fa in phix.fa synthetic_1mb.fa; do
     [[ -s "$HERE/fixtures/$fa" ]] || { echo "FAIL: source fixture $HERE/fixtures/$fa missing"; exit 1; }
     cp "$HERE/fixtures/$fa" "$TD/$fa"
-    "$BWAMEM2" index "$TD/$fa" >/dev/null 2>&1
+    "$BWAMEM3" index "$TD/$fa" >/dev/null 2>&1
     for ext in 0123 bwt.2bit.64; do
         if ! cmp -s "$BASELINES/$fa.$ext" "$TD/$fa.$ext"; then
             echo "FAIL: $fa.$ext diverges from baseline"

--- a/test/libsais_memory_budget_test.sh
+++ b/test/libsais_memory_budget_test.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
-BWAMEM2="$ROOT/bwa-mem3"
+BWAMEM3="$ROOT/bwa-mem3"
 FA_SRC="$HERE/fixtures/synthetic_1mb.fa"
 [[ -s "$FA_SRC" ]] || { echo "FAIL: $FA_SRC missing"; exit 1; }
 
@@ -48,7 +48,7 @@ for budget_mib in 128 512 2048; do
     trap 'rm -rf "$TD"' EXIT
     cp "$FA_SRC" "$TD/t.fa"
     TIMING="$TD/time.out"
-    "${TIME_CMD[@]}" "$BWAMEM2" index --max-memory "${budget_mib}M" "$TD/t.fa" >"$TD/stdout" 2>"$TIMING" || {
+    "${TIME_CMD[@]}" "$BWAMEM3" index --max-memory "${budget_mib}M" "$TD/t.fa" >"$TD/stdout" 2>"$TIMING" || {
         echo "FAIL: build failed at --max-memory ${budget_mib}M"
         cat "$TIMING" | tail -20
         exit 1

--- a/test/meth/test.sh
+++ b/test/meth/test.sh
@@ -18,13 +18,13 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-BWAMEM2="$HERE/../../bwa-mem3"
+BWAMEM3="$HERE/../../bwa-mem3"
 SAMTOOLS="${SAMTOOLS:-samtools}"
 BWAMETH_DIR="${BWAMETH_DIR:-$HOME/work/git/bwa-meth}"
 BWAMETH_PY="$BWAMETH_DIR/bwameth.py"
 
-if [[ ! -x "$BWAMEM2" ]]; then
-    echo "ERROR: bwa-mem3 binary not found at $BWAMEM2. Run 'make arm64' first."
+if [[ ! -x "$BWAMEM3" ]]; then
+    echo "ERROR: bwa-mem3 binary not found at $BWAMEM3. Run 'make arm64' first."
     exit 2
 fi
 if ! command -v "$SAMTOOLS" >/dev/null 2>&1; then
@@ -39,10 +39,10 @@ cd "$HERE"
 # ---------------------------------------------------------------------------
 
 if [[ ! -f ref.fa.bwameth.c2t.bwt.2bit.64 ]]; then
-    "$BWAMEM2" index --meth ref.fa >/dev/null 2>&1
+    "$BWAMEM3" index --meth ref.fa >/dev/null 2>&1
 fi
 
-"$BWAMEM2" mem --meth -t 2 ref.fa t_R1.fastq.gz 2>/dev/null > /tmp/meth_test.bam
+"$BWAMEM3" mem --meth -t 2 ref.fa t_R1.fastq.gz 2>/dev/null > /tmp/meth_test.bam
 
 EXPECT_EOF="1f8b08040000000000ff0600424302001b0003000000000000000000"
 ACTUAL_EOF="$(tail -c 28 /tmp/meth_test.bam | od -An -v -t x1 | tr -d ' \n')"
@@ -61,7 +61,7 @@ fi
 TOTAL="$("$SAMTOOLS" view -c /tmp/meth_test.bam 2>/dev/null)"
 if [[ "$TOTAL" -lt 1 ]]; then echo "FAIL: zero records in output BAM"; exit 1; fi
 
-"$BWAMEM2" mem --meth --set-as-failed f --do-not-penalize-chimeras \
+"$BWAMEM3" mem --meth --set-as-failed f --do-not-penalize-chimeras \
     ref.fa t_R1.fastq.gz 2>/dev/null > /tmp/meth_test2.bam
 if [[ ! -s /tmp/meth_test2.bam ]]; then
     echo "FAIL: --set-as-failed + --do-not-penalize-chimeras produced empty output"
@@ -95,7 +95,7 @@ export PATH="$(cd "$HERE/../.." && pwd):$PATH"
 # a bwa-mem2 alias on PATH so the oracle resolves to our renamed binary.
 ALIAS_DIR="$(mktemp -d)"
 trap 'rm -rf "$ALIAS_DIR"' EXIT
-ln -sf "$BWAMEM2" "$ALIAS_DIR/bwa-mem2"
+ln -sf "$BWAMEM3" "$ALIAS_DIR/bwa-mem2"
 export PATH="$ALIAS_DIR:$PATH"
 
 if [[ ! -f "$HERE/ref.fa.bwameth.c2t.0123" ]]; then
@@ -107,7 +107,7 @@ pixi run python3 "$BWAMETH_PY" --reference ref.fa t_R1.fastq.gz t_R2.fastq.gz \
 
 pixi run python3 "$BWAMETH_PY" c2t t_R1.fastq.gz t_R2.fastq.gz 2>/dev/null \
     > /tmp/meth_c2t.fq
-"$BWAMEM2" mem --meth -CM -p -T 40 -B 2 -L 10 -U 100 -t 4 \
+"$BWAMEM3" mem --meth -CM -p -T 40 -B 2 -L 10 -U 100 -t 4 \
     ref.fa.bwameth.c2t /tmp/meth_c2t.fq 2>/dev/null > /tmp/meth_mine.bam
 "$SAMTOOLS" view /tmp/meth_mine.bam 2>/dev/null > /tmp/meth_mine.sam
 
@@ -185,10 +185,10 @@ fi
 
 # Fresh index via our own --meth builder.
 rm -f "$HERE/ref.fa.bwameth.c2t"*
-"$BWAMEM2" index --meth ref.fa >/dev/null 2>&1
+"$BWAMEM3" index --meth ref.fa >/dev/null 2>&1
 
 # Single-command end-to-end alignment.
-"$BWAMEM2" mem --meth -t 4 ref.fa t_R1.fastq.gz t_R2.fastq.gz 2>/dev/null > /tmp/meth_e2e.bam
+"$BWAMEM3" mem --meth -t 4 ref.fa t_R1.fastq.gz t_R2.fastq.gz 2>/dev/null > /tmp/meth_e2e.bam
 "$SAMTOOLS" view /tmp/meth_e2e.bam 2>/dev/null > /tmp/meth_e2e.sam
 
 # Oracle: bwameth.py end-to-end on the same raw FASTQs (reuses Layer 2's

--- a/test/regression/bam_roundtrip.sh
+++ b/test/regression/bam_roundtrip.sh
@@ -7,23 +7,23 @@
 # Was: the "--bam=6 roundtrip smoke (phiX)" step inline in ci.yml.
 #
 # Inputs:
-#   BWA_MEM2    — path to bwa-mem3 binary
-#   CI_TEST_DIR — directory containing bwamem2_phix174.fa (pre-indexed),
-#                 bwamem2.sam (from the phix_parity step), and FASTQs
+#   BWA_MEM3    — path to bwa-mem3 binary
+#   CI_TEST_DIR — directory containing bwamem3_phix174.fa (pre-indexed),
+#                 bwamem3.sam (from the phix_parity step), and FASTQs
 set -euo pipefail
 
-: "${BWA_MEM2:?BWA_MEM2 must be set}"
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
 : "${CI_TEST_DIR:?CI_TEST_DIR must be set}"
 
 cd "$CI_TEST_DIR"
-"$BWA_MEM2" mem --bam=6 bwamem2_phix174.fa \
-    reads.bwa.read1.fastq.gz reads.bwa.read2.fastq.gz > bwamem2.bam
-samtools quickcheck bwamem2.bam
+"$BWA_MEM3" mem --bam=6 bwamem3_phix174.fa \
+    reads.bwa.read1.fastq.gz reads.bwa.read2.fastq.gz > bwamem3.bam
+samtools quickcheck bwamem3.bam
 # grep -c exits 1 on zero matches, which would abort the script under
 # `set -euo pipefail` before we can report a real "0 vs 0" result —
 # match the `|| true` pattern used elsewhere (thread_determinism.sh).
-sam_records=$(grep -cv '^@' bwamem2.sam || true)
-bam_records=$(samtools view -c bwamem2.bam)
+sam_records=$(grep -cv '^@' bwamem3.sam || true)
+bam_records=$(samtools view -c bwamem3.bam)
 if [ "$sam_records" != "$bam_records" ]; then
     echo "FAIL: SAM ($sam_records) vs --bam=6 BAM ($bam_records) record count mismatch"
     exit 1

--- a/test/regression/chr22_parity.sh
+++ b/test/regression/chr22_parity.sh
@@ -8,12 +8,12 @@
 # + "Compare chr22 bwa vs bwa-mem3 (parity)" steps inline in ci.yml.
 #
 # Inputs:
-#   BWA_MEM2      — path to the bwa-mem3 binary under test
+#   BWA_MEM3      — path to the bwa-mem3 binary under test
 #   CHR22_FA      — path to chr22.fa (pre-indexed with bwa-mem3 by caller)
 #   CHR22_SIM_DIR — directory containing dwgsim-simulated reads.bwa.read[12].fastq.gz
 set -euo pipefail
 
-: "${BWA_MEM2:?BWA_MEM2 must be set}"
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
 : "${CHR22_FA:?CHR22_FA must be set}"
 : "${CHR22_SIM_DIR:?CHR22_SIM_DIR must be set}"
 
@@ -24,21 +24,21 @@ bwa mem -t 4 "$CHR22_SIM_DIR/bwa_chr22.fa" \
     "$CHR22_SIM_DIR/reads.bwa.read2.fastq.gz" \
     > "$CHR22_SIM_DIR/bwa.sam" 2>"$CHR22_SIM_DIR/bwa.log"
 
-"$BWA_MEM2" mem -t 4 "$CHR22_FA" \
+"$BWA_MEM3" mem -t 4 "$CHR22_FA" \
     "$CHR22_SIM_DIR/reads.bwa.read1.fastq.gz" \
     "$CHR22_SIM_DIR/reads.bwa.read2.fastq.gz" \
-    > "$CHR22_SIM_DIR/bwamem2.sam" 2>"$CHR22_SIM_DIR/bwamem2.log"
+    > "$CHR22_SIM_DIR/bwamem3.sam" 2>"$CHR22_SIM_DIR/bwamem3.log"
 
 cd "$CHR22_SIM_DIR"
 normalize() { grep -v '^@PG' "$1" | grep -v '^@HD' | sed 's/\tMQ:i:[0-9]*//' | sed 's/\tHN:i:[0-9]*//'; }
 normalize bwa.sam     | sort > bwa.normalized.sam
-normalize bwamem2.sam | sort > bwamem2.normalized.sam
+normalize bwamem3.sam | sort > bwamem3.normalized.sam
 echo "bwa records:      $(grep -cv '^@' bwa.normalized.sam)"
-echo "bwa-mem3 records: $(grep -cv '^@' bwamem2.normalized.sam)"
-if diff bwa.normalized.sam bwamem2.normalized.sam > /dev/null 2>&1; then
+echo "bwa-mem3 records: $(grep -cv '^@' bwamem3.normalized.sam)"
+if diff bwa.normalized.sam bwamem3.normalized.sam > /dev/null 2>&1; then
     echo "PASS: bwa == bwa-mem3 on chr22 (50k PE reads)"
 else
     echo "FAIL: chr22 parity diff; first 40 lines:"
-    diff bwa.normalized.sam bwamem2.normalized.sam | head -40
+    diff bwa.normalized.sam bwamem3.normalized.sam | head -40
     exit 1
 fi

--- a/test/regression/phix_parity.sh
+++ b/test/regression/phix_parity.sh
@@ -7,14 +7,14 @@
 # Was: the "Compare bwa and bwa-mem3 output" step inline in ci.yml.
 #
 # Inputs (read from environment):
-#   BWA_MEM2    — path to the bwa-mem3 binary under test
+#   BWA_MEM3    — path to the bwa-mem3 binary under test
 #   CI_TEST_DIR — working directory containing phix174.fa and dwgsim-simulated
 #                 reads.bwa.read[12].fastq.gz (produced by upstream CI steps)
 #
 # Exits 0 on parity, 1 on diff.
 set -euo pipefail
 
-: "${BWA_MEM2:?BWA_MEM2 must be set}"
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
 : "${CI_TEST_DIR:?CI_TEST_DIR must be set}"
 
 cd "$CI_TEST_DIR"
@@ -24,11 +24,11 @@ bwa index bwa_phix174.fa
 bwa mem bwa_phix174.fa reads.bwa.read1.fastq.gz reads.bwa.read2.fastq.gz \
     > bwa.sam 2>bwa.log
 
-cp phix174.fa bwamem2_phix174.fa
-"$BWA_MEM2" index bwamem2_phix174.fa
-"$BWA_MEM2" mem bwamem2_phix174.fa \
+cp phix174.fa bwamem3_phix174.fa
+"$BWA_MEM3" index bwamem3_phix174.fa
+"$BWA_MEM3" mem bwamem3_phix174.fa \
     reads.bwa.read1.fastq.gz reads.bwa.read2.fastq.gz \
-    > bwamem2.sam 2>bwamem2.log
+    > bwamem3.sam 2>bwamem3.log
 
 normalize() {
     grep -v '^@PG' "$1" | grep -v '^@HD' \
@@ -36,15 +36,15 @@ normalize() {
         | sed 's/\tHN:i:[0-9]*//'
 }
 normalize bwa.sam     | sort > bwa.normalized.sam
-normalize bwamem2.sam | sort > bwamem2.normalized.sam
+normalize bwamem3.sam | sort > bwamem3.normalized.sam
 
 echo "bwa aligned records:      $(grep -cv '^@' bwa.normalized.sam)"
-echo "bwa-mem3 aligned records: $(grep -cv '^@' bwamem2.normalized.sam)"
+echo "bwa-mem3 aligned records: $(grep -cv '^@' bwamem3.normalized.sam)"
 
-if diff bwa.normalized.sam bwamem2.normalized.sam > /dev/null 2>&1; then
+if diff bwa.normalized.sam bwamem3.normalized.sam > /dev/null 2>&1; then
     echo "PASS: bwa and bwa-mem3 output is identical (after normalizing headers and MQ tag)"
 else
     echo "FAIL: bwa and bwa-mem3 output differs"
-    diff bwa.normalized.sam bwamem2.normalized.sam | head -40
+    diff bwa.normalized.sam bwamem3.normalized.sam | head -40
     exit 1
 fi

--- a/test/regression/thread_determinism.sh
+++ b/test/regression/thread_determinism.sh
@@ -6,19 +6,19 @@
 # Was: the "Thread-determinism smoke (phiX, -t 1 vs -t 4)" step inline in ci.yml.
 #
 # Inputs:
-#   BWA_MEM2    — path to bwa-mem3 binary
-#   CI_TEST_DIR — directory containing bwamem2_phix174.fa (pre-indexed)
+#   BWA_MEM3    — path to bwa-mem3 binary
+#   CI_TEST_DIR — directory containing bwamem3_phix174.fa (pre-indexed)
 #                 and reads.bwa.read[12].fastq.gz
 set -euo pipefail
 
-: "${BWA_MEM2:?BWA_MEM2 must be set}"
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
 : "${CI_TEST_DIR:?CI_TEST_DIR must be set}"
 
 cd "$CI_TEST_DIR"
-"$BWA_MEM2" mem -t 1 bwamem2_phix174.fa \
+"$BWA_MEM3" mem -t 1 bwamem3_phix174.fa \
     reads.bwa.read1.fastq.gz reads.bwa.read2.fastq.gz 2>/dev/null \
     | grep -v '^@PG' | sort > t1.sam
-"$BWA_MEM2" mem -t 4 bwamem2_phix174.fa \
+"$BWA_MEM3" mem -t 4 bwamem3_phix174.fa \
     reads.bwa.read1.fastq.gz reads.bwa.read2.fastq.gz 2>/dev/null \
     | grep -v '^@PG' | sort > t4.sam
 if ! diff t1.sam t4.sam > /dev/null 2>&1; then

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -6,13 +6,13 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
-BWAMEM2="$ROOT/bwa-mem3"
+BWAMEM3="$ROOT/bwa-mem3"
 FIXTURES="$HERE/fixtures"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "OK:   $*"; }
 
-[[ -x "$BWAMEM2" ]] || fail "bwa-mem3 not built at $BWAMEM2 (run 'make' or 'make arm64' first)"
+[[ -x "$BWAMEM3" ]] || fail "bwa-mem3 not built at $BWAMEM3 (run 'make' or 'make arm64' first)"
 
 # Build the five unit binaries.
 (cd "$HERE" && make) || fail "test/ make failed"
@@ -35,7 +35,7 @@ if [[ ! -s "$FIXTURES/phix.fa.bwt.2bit.64" || \
       ! -s "$FIXTURES/phix.fa.amb"         || \
       ! -s "$FIXTURES/phix.fa.ann"         || \
       ! -s "$FIXTURES/phix.fa.pac" ]]; then
-    "$BWAMEM2" index "$FIXTURES/phix.fa" >/dev/null 2>&1 || fail "bwa-mem3 index on phix.fa failed"
+    "$BWAMEM3" index "$FIXTURES/phix.fa" >/dev/null 2>&1 || fail "bwa-mem3 index on phix.fa failed"
 fi
 
 # --- fmi_test --------------------------------------------------------------
@@ -85,13 +85,13 @@ ok "xeonbsw ($LINES pair scores emitted)"
 # Regression for issue #45 / upstream #293: tabs inside `-R` must not
 # bleed into the @PG CL: value. Uses the same phiX fixture as the rest
 # of the harness (indexed above if needed).
-"$HERE/pg_cl_escape_test.sh" "$BWAMEM2" "$FIXTURES" || fail "pg_cl_escape_test failed"
+"$HERE/pg_cl_escape_test.sh" "$BWAMEM3" "$FIXTURES" || fail "pg_cl_escape_test failed"
 ok "pg_cl_escape_test"
 
 # --- help_prescan_test ----------------------------------------------------
 # `mem --help` pre-scan must not match `--help` when it is the value of
 # an option that takes an argument (-R, -o, --set-as-failed, ...).
-"$HERE/help_prescan_test.sh" "$BWAMEM2" "$FIXTURES" || fail "help_prescan_test failed"
+"$HERE/help_prescan_test.sh" "$BWAMEM3" "$FIXTURES" || fail "help_prescan_test failed"
 ok "help_prescan_test"
 
 # --- smem_lockstep_parity_test --------------------------------------------
@@ -108,7 +108,7 @@ ok "smem_lockstep_parity_test ($CASES_PASSED / $CASES_TOTAL)"
 # SMEM and lockstep-slot buffers are sized per-batch, so these must align
 # cleanly and produce SAM lines.
 for LEN_FQ in long_read_300bp long_read_1kbp long_read_3kbp; do
-    RAW="$("$BWAMEM2" mem "$FIXTURES/phix.fa" "$FIXTURES/${LEN_FQ}.fq" 2>/dev/null)" \
+    RAW="$("$BWAMEM3" mem "$FIXTURES/phix.fa" "$FIXTURES/${LEN_FQ}.fq" 2>/dev/null)" \
         || fail "bwa-mem3 mem ${LEN_FQ}.fq: non-zero exit (crash regression)"
     OUT="$(printf '%s\n' "$RAW" | grep -v '^@' || true)"
     [[ -n "$OUT" ]] || fail "bwa-mem3 mem ${LEN_FQ}.fq: no SAM records emitted"
@@ -159,7 +159,7 @@ with open(out_path, 'w') as out:
         out.write(f'@pe{i}/2\n{r2}\n+\n{q}\n')
 PY
 
-OUT="$("$BWAMEM2" mem -p "$FIXTURES/phix.fa" "$PE_TMP/interleaved.fq" 2>/dev/null)" \
+OUT="$("$BWAMEM3" mem -p "$FIXTURES/phix.fa" "$PE_TMP/interleaved.fq" 2>/dev/null)" \
     || fail "bwa-mem3 mem -p interleaved.fq: non-zero exit (crash regression)"
 RECORDS="$(printf '%s\n' "$OUT" | grep -cv '^@' || true)"
 [[ "$RECORDS" -ge 100 ]] || fail "bwa-mem3 mem -p: expected >=100 records (50 pairs × 2), got $RECORDS"
@@ -168,12 +168,12 @@ ok "bwa-mem3 mem -p interleaved.fq ($RECORDS records)"
 # Empty FASTQ + zero-length-read FASTQ regressions for the empty-batch
 # defensive path in mem_collect_smem / mem_kernel1_core.
 : > "$PE_TMP/empty.fq"
-"$BWAMEM2" mem "$FIXTURES/phix.fa" "$PE_TMP/empty.fq" >/dev/null 2>&1 \
+"$BWAMEM3" mem "$FIXTURES/phix.fa" "$PE_TMP/empty.fq" >/dev/null 2>&1 \
     || fail "bwa-mem3 mem on empty FASTQ: non-zero exit"
 ok "bwa-mem3 mem on empty FASTQ (no crash)"
 
 printf '@zero\n\n+\n\n' > "$PE_TMP/zero.fq"
-"$BWAMEM2" mem "$FIXTURES/phix.fa" "$PE_TMP/zero.fq" >/dev/null 2>&1 \
+"$BWAMEM3" mem "$FIXTURES/phix.fa" "$PE_TMP/zero.fq" >/dev/null 2>&1 \
     || fail "bwa-mem3 mem on zero-length read: non-zero exit"
 ok "bwa-mem3 mem on zero-length read (no crash)"
 


### PR DESCRIPTION
## Summary

Cosmetic follow-up to the recent `bwa-mem2` → `bwa-mem3` project rename. Updates shell variable names that still carried the old project name in benchmark scripts, regression tests, and the CI workflow that sets them. No behavioral change — these are local-scope shell vars and a single env-var contract between CI and the regression scripts.

## Renames

| Old name             | New name             | Scope                                                  |
|----------------------|----------------------|--------------------------------------------------------|
| `BWAMEM2`            | `BWAMEM3`            | local var pinning the binary path in bench/test scripts |
| `BWA_MEM2`           | `BWA_MEM3`           | env var the regression scripts consume; `ci.yml` sets it |
| `BWA_MEM2_BASELINE`  | `BWA_MEM3_BASELINE`  | `bench/run.sh` A/B comparator                          |
| `BWA_MEM2_CANDIDATE` | `BWA_MEM3_CANDIDATE` | `bench/run.sh` A/B comparator                          |

16 files touched: 1 CI workflow, 2 bench files, 1 script, 11 test scripts, 1 testing doc.

## Out of scope

The shared-memory magic constant in `src/bwa_shm.h`:

\`\`\`c
#define BWA_SHM_MAGIC          0x00324D454D415742ull  // "BWAMEM2\0"
\`\`\`

is intentionally **kept** for shm header format compatibility. Renaming it is a breaking change for any pre-existing \`bwa-mem2/bwa-mem3 shm\`-loaded indexes and warrants a \`BWA_SHM_VERSION\` bump on its own; out of scope here.

## Test plan

- [x] \`make -j\` succeeds
- [x] \`make test\` green (doctest unit + integration + kswv_nrow_zero_test + shm_section_find_test)
- [x] \`bash test/run_unit_tests.sh\` green (\`ALL UNIT TESTS PASSED\`)
- [x] Audit residual: \`rg 'BWAMEM2|BWA_MEM2'\` shows only the SHM magic in \`src/bwa_shm.h\` (intentional keep)
- [ ] CI green

## Notes

Self-reviewed: variable renames are mechanical sed across the file list. The CI/script contract (\`ci.yml\` sets \`BWA_MEM3=...\`, regression scripts read \`\$BWA_MEM3\`) is updated on both ends in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing documentation to reflect the latest binary reference.

* **Chores**
  * Updated test infrastructure and benchmarking configurations to use the latest binary version across CI workflows, regression tests, and performance evaluation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->