### PR TITLE
fix(test/meth): alias bwa-mem2 to bwa-mem3 on PATH for bwameth.py oracle

### DIFF
--- a/test/meth/test.sh
+++ b/test/meth/test.sh
@@ -89,6 +89,15 @@ fi
 
 export PATH="$(cd "$HERE/../.." && pwd):$PATH"
 
+# Upstream bwameth.py shells out to `bwa-mem2` by name. After the
+# bwa-mem2 -> bwa-mem3 binary rename, that PATH lookup fails and the
+# (2>/dev/null-silenced) pipeline below exits with no diagnostic. Provide
+# a bwa-mem2 alias on PATH so the oracle resolves to our renamed binary.
+ALIAS_DIR="$(mktemp -d)"
+trap 'rm -rf "$ALIAS_DIR"' EXIT
+ln -sf "$BWAMEM2" "$ALIAS_DIR/bwa-mem2"
+export PATH="$ALIAS_DIR:$PATH"
+
 if [[ ! -f "$HERE/ref.fa.bwameth.c2t.0123" ]]; then
     (cd "$HERE" && pixi run python3 "$BWAMETH_PY" index-mem2 ref.fa >/dev/null 2>&1)
 fi


### PR DESCRIPTION
## Summary

Fixes the long-standing `Linux x86_64 AVX2 (mimalloc)` CI failure on `main` (also seen as the inherited red check on PRs #68, #70, #71).

The bwa-mem2 → bwa-mem3 binary rename broke layers 2/3 of `test/regression/meth_oracle.sh` (which is gated to run on the canonical AVX2-mimalloc job). Layer 1 still passes because it invokes `$BWAMEM2` (which already points at `./bwa-mem3`) by absolute path. Layers 2/3 invoke upstream `bwameth.py` (brentp/bwa-meth), which hardcodes the binary name `bwa-mem2` and shells out via PATH:

```python
# bwameth.py
237:            run("bwa-mem2 index %s" % fa)
377:        cmd += "|bwa-mem2 mem -T 40 -B 2 -L 10 -CM "
```

After the rename, the lookup fails. The pixi pipeline runs with `2>/dev/null`, so the script exits via `set -e` between layers with no diagnostic — the CI log shows `OK layer 1: ...` and then `Process completed with exit code 1` ~250 ms later.

## Fix

In `test/meth/test.sh`, after `PATH` is configured for layer 2, drop a `bwa-mem2 → bwa-mem3` symlink in a temp directory and prepend that to `PATH`. Self-cleans via `trap ... EXIT`. Fully local-portable — helps anyone running `bash test/meth/test.sh` outside CI too — and stays co-located with the only place that calls bwameth.py.

## Test plan

- [ ] CI on this branch: `Linux x86_64 AVX2 (mimalloc)` goes green (Layers 2/3 oracle equivalence runs).
- [ ] All other CI rows remain green.

## Out of scope (followups)

- Drop `2>/dev/null` on the pixi pipeline lines so future failures aren't silent (intentionally not bundled here to keep the fix minimal — happy to send a follow-up).