### PR TITLE
fix(fmi): parenthesize SA_COMPX_MASK precedence in sampled-SA prefetch

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -1639,7 +1639,7 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
         map_pos[j] = map_ar[i];
         offset[j] = 0;
         
-        if (pos & SA_COMPX_MASK == 0) {
+        if ((pos & SA_COMPX_MASK) == 0) {
             _mm_prefetch(&sa_ms_byte[pos >> SA_COMPX], _MM_HINT_T0);
             _mm_prefetch(&sa_ls_word[pos >> SA_COMPX], _MM_HINT_T0);
         }
@@ -1676,7 +1676,7 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
                     map_pos[k] = map_ar[i++];
                     offset[k] = 0;
                     
-                    if (pos & SA_COMPX_MASK == 0) {
+                    if ((pos & SA_COMPX_MASK) == 0) {
                         _mm_prefetch(&sa_ms_byte[pos >> SA_COMPX], _MM_HINT_T0);
                         _mm_prefetch(&sa_ls_word[pos >> SA_COMPX], _MM_HINT_T0);
                     }
@@ -1690,7 +1690,7 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
             }
             else {
                 working_set[k] = sp;
-                if (sp & SA_COMPX_MASK == 0) {
+                if ((sp & SA_COMPX_MASK) == 0) {
                     _mm_prefetch(&sa_ms_byte[sp >> SA_COMPX], _MM_HINT_T0);
                     _mm_prefetch(&sa_ls_word[sp >> SA_COMPX], _MM_HINT_T0);
                 }


### PR DESCRIPTION
## Summary

Three call sites in `get_sa_entries_prefetch` (FMI_search.cpp:1642, 1679, 1693) write:

```c
if (pos & SA_COMPX_MASK == 0) {
```

This parses as `if (pos & (SA_COMPX_MASK == 0))` due to C operator precedence (`==` binds tighter than `&`). With `SA_COMPX_MASK = 0x7`, the inner expression is always false (0), so the whole condition becomes `pos & 0` — always false. The prefetch fast-path **never fires**; every position falls through to the else-branch and prefetches the wrong table.

The other four call sites at lines 1437, 1487, 1536, 1572 already use the correct `((pos & SA_COMPX_MASK) == 0)` form. Only these three sites in `get_sa_entries_prefetch` were missing parens.

## Fix

Add parens at all three sites:

```diff
-if (pos & SA_COMPX_MASK == 0) {
+if ((pos & SA_COMPX_MASK) == 0) {
```

(and the same for `sp` at line 1693)

## Impact

The sampled-SA prefetch hint never fired, so `get_sa_entries_prefetch` was effectively running with no fast-path prefetches for the sampled-SA branch. After the fix, those prefetches issue as intended. Performance impact unmeasured but expected to be material on memory-latency-bound runs (the function is 3.04% of wall on the c7i.4xlarge profile).

## Test plan

- [x] Compiles clean.
- [ ] Smoke run vs baseline: alignments byte-identical (this is purely a hint, no semantic change).
- [ ] A/B on c7i.4xlarge for perf delta (separate follow-up).

## Notes

`gcc -Wparentheses` warns on this pattern; the bug likely landed in a prefetch experiment with that warning suppressed. Worth checking whether `-Wparentheses` is enabled in the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bitmask comparison logic in search operations to improve prefetch path selection consistency and ensure alignment with intended behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->