### PR TITLE
fix(bntseq): bound .alt parse buffer to prevent stack overflow

### DIFF
--- a/src/bntseq.cpp
+++ b/src/bntseq.cpp
@@ -209,17 +209,27 @@ bntseq_t *bns_restore(const char *prefix)
 			kh_val(h, k) = i;
 		}
 		i = 0;
+		int truncated = 0;
 		while ((c = fgetc(fp)) != EOF) {
 			if (c == '\t' || c == '\n' || c == '\r') {
 				str[i] = 0;
-				if (str[0] != '@') {
+				if (!truncated && str[0] != '@') {
 					k = kh_get(str, h, str);
 					if (k != kh_end(h))
 						bns->anns[kh_val(h, k)].is_alt = 1;
 				}
 				while (c != '\n' && c != EOF) c = fgetc(fp);
 				i = 0;
-			} else str[i++] = c; // FIXME: potential segfault here
+				truncated = 0;
+			} else if (i + 1 < (int)sizeof(str)) {
+				str[i++] = c;
+			} else {
+				// Name exceeds sizeof(str)-1; drop remaining chars to avoid
+				// overflowing the stack buffer, and skip the hash lookup so
+				// a truncated prefix can't accidentally match a different
+				// contig that shares those leading bytes.
+				truncated = 1;
+			}
 		}
 		kh_destroy(str, h);
 		fclose(fp);


### PR DESCRIPTION
## Summary

`bns_restore` (bntseq.cpp:212-223) parses the optional `.alt` file by accumulating characters into a 1024-byte stack buffer `char str[1024]`. The fall-through branch:

```c
} else str[i++] = c; // FIXME: potential segfault here
```

has no bounds check, and the `FIXME` comment acknowledges the risk. A `.alt` file with a contig name longer than 1023 characters overruns the stack frame.

## Fix

Add a bounds check; silently truncate names longer than 1023 chars:

```c
} else if (i + 1 < (int)sizeof(str)) {
    str[i++] = c;
}
```

Truncated names miss the hash-table lookup at line 216, so the contig simply isn't flagged `is_alt` — same observable behavior as if the line were absent from the `.alt` file. No new error path; no new memory allocation.

## Impact

**Defensive only.** Production reference genomes have short contig names (`chrUn_KN707xxxv1_decoy` family in HG38 is ~32 chars), well within the 1023-char limit. The fix protects against malformed or adversarial `.alt` files. The original `FIXME` author already flagged this as a known risk.

## Test plan

- [x] Compiles clean.
- [x] Existing `.alt` parsing semantics unchanged for valid inputs (names < 1023 chars).
- [ ] Smoke run vs baseline: alignments byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when processing data with extremely long entry names. Overlong names are now safely truncated instead of causing application crashes with certain malformed input files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->