### PR TITLE
perf(fmi): bump SMEM_LOCKSTEP_N from 8 to 16

### DIFF
--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -91,7 +91,7 @@ typedef struct smem_struct
 #define SAL_PFD 16
 
 #ifndef SMEM_LOCKSTEP_N
-#define SMEM_LOCKSTEP_N 8
+#define SMEM_LOCKSTEP_N 16
 #endif
 
 class FMI_search: public indexEle


### PR DESCRIPTION
## Summary

Bumps the lockstep-batching width for SMEM walks from 8 to 16 reads. PR #58 introduced lockstep batching to expose memory-level parallelism for the FMI's `cp_occ` loads; that change settled on N=8 as the original tuning. A fresh sweep on Sapphire Rapids shows N=16 is consistently faster with no observable downside on this workload.

## A/B (c7i.4xlarge Sapphire Rapids, panel-twist 1M PE 150 bp, t=16, 6 reps each, interleaved)

| | best | mean | median |
|---|---:|---:|---:|
| N=8 (current)  | 55.86 | 56.43 | 56.33 |
| N=12           | 55.72 | 56.37 | 56.26 |
| **N=16 (new)** | **55.67** | **56.17** | **55.88** |

Mean improvement N=8 → N=16: ~0.46% wall (median ~0.80%, best 0.34%). Modest, consistent.

Run setup:
- Binary built from this branch + the post-PR-#69/#70 stack (bns_get_seq_v2 migration + kswv prefetches).
- Interleaved order `n8, n12, n16, n16, n12, n8` per rep × 3 reps = 18 runs, to control for host warmup drift.
- BAMs are byte-identical record-equal across N=8 / 12 / 16 — confirmed via `samtools view` diff on smoke-100K.

## Memory implications

The lockstep buffer is per-thread and sized to `SMEM_LOCKSTEP_N * lockstep_buf_cap[tid]`. Doubling N doubles that ceiling. For short-read 150 bp Illumina the per-slot buffer is small (~8 KB), so extra memory at 16 threads is on the order of 1 MB — negligible vs the >10 GB FMI index.

For long-read workloads (ONT-class, see TODO at `FMI_search.cpp:924` re. cache-only-grows behavior) the high-water mark per thread doubles too. Still trivial compared to the FMI index but worth noting.

## Why not higher (24, 32)?

The win from 8→16 is already small and the extra c7i time wasn't justified given the 0.46% mean delta. Leaving the door open: the macro is `#ifndef`-guarded so a higher value can be set via `EXTRA_CXXFLAGS=-DSMEM_LOCKSTEP_N=...` without modifying source.

## Test plan

- [x] BAM record-equal vs N=8 baseline on smoke-100K.
- [x] 3-rep × 2-direction interleaved A/B on c7i SPR; N=16 wins on best/mean/median.
- [ ] Smoke run via `bwa-mem3-bench` framework (separate confirmatory check).

## Notes

Commit is unsigned — local 1Password biometric was unavailable when this branch was prepared. Will be re-signed when feasible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized batch processing parameters to enhance system performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->