### PR TITLE
perf(ungapped): closed-form HIT for total_mis == 0

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -2584,6 +2584,30 @@ static inline int ungapped_analyze(const uint8_t *qs, const uint8_t *rs, int N,
         return FP_STATUS_TIGHT;
     }
 
+    // Closed-form fast path: total_mis == 0 (perfect-match HIT).
+    //
+    // With no mismatches the scalar walk below is deterministic:
+    //   cur starts at h0 and only increases (+a per iter), so it never
+    //   touches the `cur == 0` early-skip after the first iteration.
+    //   max_sc rises to h0 + N*a; max_i ends at N (the >= tie-break
+    //   updates max_i on every step).
+    //
+    // The h0 > 0 guard preserves bit-identicality with the loop: when
+    // h0 == 0 the loop's `if (cur == 0) continue` inhibits all updates,
+    // leaving max_sc = 0 / max_i = 0; the closed form would instead
+    // compute max_sc = N*a, breaking parity. h0 == 0 is pathological in
+    // practice (caller passes a seed score) but the guard is a single
+    // compare and free.
+    if (total_mis == 0 && h0 > 0) {
+        int score = h0 + N * a;
+        *out_score      = score;
+        *out_qle        = N;
+        *out_gscore     = score;
+        *out_gtle       = N;
+        *out_tight_band = 0;   // unused on HIT (SW skipped)
+        return FP_STATUS_HIT;
+    }
+
     // HIT candidate: run the scalar walk for precise qle / gscore / max_sc.
     //
     // MAIN_CODE* local-SW semantics: once cur==0 in the ungapped path it


### PR DESCRIPTION
## Summary

`ungapped_analyze`'s Phase 3 scalar walk (`bwamem.cpp:2597-2608`) does a Kadane-with-floor running max over N bases. When `total_mis == 0` the walk is deterministic: `cur` strictly ascends from `h0` by `+a` per iteration, never hits the floor, and `max_i` ends at `N`. Substitute the loop with closed-form stores.

```c
if (total_mis == 0 && h0 > 0) {
    int score = h0 + N * a;
    *out_score      = score;
    *out_qle        = N;
    *out_gscore     = score;
    *out_gtle       = N;
    *out_tight_band = 0;
    return FP_STATUS_HIT;
}
```

## Bit-identicality

The `h0 > 0` guard preserves byte-equal SAM with the existing loop. When `h0 == 0`, the loop's `if (cur == 0) continue` inhibits all updates and leaves `max_sc = 0` / `max_i = 0`; the closed form would otherwise compute `max_sc = N*a`, breaking parity. `h0 == 0` is pathological (callers pass a seed score) but the guard is a free compare.

## Performance

- **When fires** (~5-15% of HIT-path calls on 150bp Illumina, given ~2-4% per-base mismatch rate over ~80-base ungapped windows): ~80 cycles → ~5 cycles per call.
- **When doesn't fire** (the common case): one correctly-predicted branch on `total_mis != 0`, ~0-1 cycle.

Aggregate wall impact on c7i SPR: **≤0.4%, most likely 0.05-0.15%** — below the A/B noise floor on panel-twist 1M PE 150bp. **Shipping as a code-clarity / strictly-non-negative change rather than a perf claim.** A bench A/B at this delta would need ~30 reps to cross noise; not worth the c7i time.

## Test plan

- [x] Compiles clean.
- [ ] 100K parity check (BAM record-equal vs current main) — pending c7i validation.
- [ ] Smoke-1M parity via bwa-mem3-bench framework — pending CI run.

## Notes

Sourced from a deep audit of ungapped_analyze's SIMD optimization opportunities. A1 was the only candidate that survived calibration-discounted ROI scoring; all others (Phase 3 SIMD vectorize, single-vector AVX-512 scan, VPOPCNTDQ rewrite, fold-to-single-pass) were killed for higher engineering cost vs. lower expected ROI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Improved processing speed for sequence alignment operations through optimized computational paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->