### PR TITLE
perf(ksort): replace per-call malloc with on-stack buffer for small n

### DIFF
--- a/src/ksort.h
+++ b/src/ksort.h
@@ -191,8 +191,21 @@ typedef struct {
 	}																	\
 	void ks_introsort_##name(size_t n, type_t a[])						\
 	{																	\
+		/* Threshold for the on-stack partition-stack buffer:           \
+		 * d ≤ KS_INTROSORT_STACK_DLIMIT covers n ≤ 2^16 = 65,536, which \
+		 * captures every realistic call in practice. The buffer is     \
+		 * sized to klib's `(sizeof(size_t)*d)+2` formula at d=16:      \
+		 * 8*16+2 = 130 entries × 24 B = ~3,120 B on-stack — well       \
+		 * within OpenMP worker stacks (default 4 MB). For pathologic   \
+		 * n > 2^16, fall through to the legacy malloc path so behavior \
+		 * is unchanged at the boundary. Eliminates the per-call malloc \
+		 * for the common small-n case (~50-100 ns each on glibc;       \
+		 * disproportionately costly at the per-read sort frequency). */ \
+		enum { KS_INTROSORT_STACK_DLIMIT = 16 };                        \
+		ks_isort_stack_t stack_buf[(sizeof(size_t)*KS_INTROSORT_STACK_DLIMIT)+2]; \
 		int d;															\
 		ks_isort_stack_t *top, *stack;									\
+		int stack_heap_alloc = 0;										\
 		type_t rp, swap_tmp;											\
 		type_t *s, *t, *i, *j, *k;										\
 																		\
@@ -202,8 +215,13 @@ typedef struct {
 			return;														\
 		}																\
 		for (d = 2; 1ul<<d < n; ++d);									\
-		stack = (ks_isort_stack_t*)malloc(sizeof(ks_isort_stack_t) * ((sizeof(size_t)*d)+2)); \
-        assert(stack != NULL);                                          \
+		if (d <= KS_INTROSORT_STACK_DLIMIT) {							\
+			stack = stack_buf;											\
+		} else {														\
+			stack = (ks_isort_stack_t*)malloc(sizeof(ks_isort_stack_t) * ((sizeof(size_t)*d)+2)); \
+			assert(stack != NULL);                                      \
+			stack_heap_alloc = 1;										\
+		}																\
 		top = stack; s = a; t = a + (n-1); d <<= 1;						\
 		while (1) {														\
 			if (s < t) {												\
@@ -234,7 +252,7 @@ typedef struct {
 				}														\
 			} else {													\
 				if (top == stack) {										\
-					free(stack);										\
+					if (stack_heap_alloc) free(stack);					\
 					__ks_insertsort_##name(a, a+n);						\
 					return;												\
 				} else { --top; s = (type_t*)top->left; t = (type_t*)top->right; d = top->depth; } \


### PR DESCRIPTION
## Summary

`ks_introsort_##name` (`ksort.h:205`) currently mallocs a partition-stack buffer on every invocation. For sorts called per-read on small arrays — e.g. `mem_sort_dedup_patch` (`bwamem.cpp:443`) sorting `mem_alnreg_t[]` with typical n=5-30 — the malloc dominates the actual sort work: roughly 50-100 ns on glibc per call, paid every time.

Switch to a hybrid: on-stack buffer for n ≤ 65,536 (the common case), malloc fallback for pathologic large n.

```diff
+enum { KS_INTROSORT_STACK_DLIMIT = 16 };
+ks_isort_stack_t stack_buf[(sizeof(size_t)*KS_INTROSORT_STACK_DLIMIT)+2];
+...
-stack = (ks_isort_stack_t*)malloc(sizeof(ks_isort_stack_t) * ((sizeof(size_t)*d)+2));
-assert(stack != NULL);
+if (d <= KS_INTROSORT_STACK_DLIMIT) {
+    stack = stack_buf;
+} else {
+    stack = (ks_isort_stack_t*)malloc(sizeof(ks_isort_stack_t) * ((sizeof(size_t)*d)+2));
+    assert(stack != NULL);
+    stack_heap_alloc = 1;
+}
...
-free(stack);
+if (stack_heap_alloc) free(stack);
```

The on-stack buffer is `8*16+2 = 130` entries × 24 B ≈ **3,120 B** — well within the OpenMP worker stack (4 MB default). For `n ≤ 65,536` (which covers every realistic call in this codebase — `mem_alnreg_v::n` is bounded by per-read seed counts, typically tens), zero allocations.

## Behavior table

| n | Path | Cost vs current |
|---|---|---|
| ≤ 65,536 | on-stack | -50–100 ns / call (the win) |
| > 65,536 | malloc | unchanged |

## Failure modes

- **Stack overflow**: only if `n > 65,536` AND the caller's stack is near-exhausted. Realistic risk: zero. OpenMP workers default to 4 MB stack; this allocates 3 KB.
- **Thread safety**: `stack_buf` is per-function-frame, hence per-thread. No new shared state. Mirrors current re-entrancy guarantees.
- **Bit-identicality**: same algorithm, same comparator, same data movement. Output order unchanged.

## Coverage

The patch is in `ksort.h`, so it benefits **every** `KSORT_INIT`-instantiated introsort user:
- `ks_introsort_mem_ars` (sort by score-then-rb-then-qb)
- `ks_introsort_mem_ars2` (sort by re)
- `ks_introsort_mem_ars_hash` / `ks_introsort_mem_ars_hash2`
- and any other `KSORT_INIT(...)` instantiation.

## Performance projection

`ks_introsort_mem_ars + ks_introsort_mem_ars2` together account for **5.21% of wall** on the post-PR-#69/#70/#75 binary (c7i.4xlarge SPR, panel-twist 1M PE 150bp, t=16). The per-call malloc is a meaningful fraction of that.

- **Conservative range**: 0.2-0.7% wall savings (calibration-discounted; recent audits in this session have over-predicted by ~2-4×)
- **Headline range**: 0.5-1.5% wall

## Test plan

- [x] Compiles clean (commit signed).
- [ ] 100K parity check (BAM record-equal vs current main) — pending c7i validation.
- [ ] 3-rep A/B on c7i SPR vs current `main`.
- [ ] Smoke-1M parity via `bwa-mem3-bench` framework — pending CI.

## Notes

Sourced from two parallel audits + a microbenchmark: `docs/overnight/sort-network-feasibility.md`, `docs/overnight/sort-alternatives-audit.md` in the bench repo. The audits also evaluated SIMD bitonic, radix sort, std::sort drop-in, indirect-sort with key extraction, and composite key packing — most were structurally infeasible or sub-optimal at the workload's actual N (5-30 per call). This patch is the cleanest of the surviving candidates: single header file, no API change, no new dependencies, helps every KSORT_INIT user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal memory allocation efficiency for sorting operations, optimizing performance by reducing unnecessary heap allocations for typical use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->