### PR TITLE
fix(profiling): clamp display_stats nthreads to LIM_C

### DIFF
--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -67,6 +67,19 @@ int display_stats(int nthreads)
     fprintf(stderr, "Processor is running @%lf MHz\n", proc_freq*1.0/1e6);
     fprintf(stderr, "Runtime profile:\n");
 
+    /* tprof[][] has a fixed column dimension of LIM_C (= MAX_THREADS = 256).
+     * Every per-thread aggregation below — both the explicit `for (t=0; t<nthreads;...)`
+     * loops and the find_opt(tprof[X], nthreads, ...) calls — would index past
+     * the column dimension when the user runs with -t > LIM_C, walking into
+     * adjacent globals. Clamp the per-thread profile span to LIM_C; the actual
+     * thread count is already logged above. */
+    if (nthreads > LIM_C) {
+        fprintf(stderr,
+                "WARNING: per-thread profile truncated to %d threads (-t %d > LIM_C=%d)\n",
+                LIM_C, nthreads, LIM_C);
+        nthreads = LIM_C;
+    }
+
     fprintf(stderr, "\n\tTime taken for main_mem function: %0.2lf sec\n\n",
             tprof[MEM][0]*1.0/proc_freq);
 


### PR DESCRIPTION
## Summary

Fixes #62.

`display_stats()` aggregates per-thread profile counters with loops of the form `for (t = 0; t < nthreads; t++) tprof[X][t]` (and `find_opt(tprof[X], nthreads, ...)` calls that do the same dereference internally). `tprof[LIM_R][LIM_C]` is statically sized with `LIM_C = MAX_THREADS = 256`, so any invocation with `-t > 256` reads past the column dimension into adjacent globals or unmapped memory. The contract is documented in `src/macro.h` but had no runtime guard.

This adds a single clamp at the top of `display_stats()`: if `nthreads > LIM_C`, emit a warning and clamp. The actual user-supplied thread count is still printed above the warning ("No. of OMP threads: %d") so the profile output remains honest about what was requested vs. what was profiled.

Preferred over bumping `LIM_C` because growing `tprof` to 1024-wide takes `sizeof(tprof)` from ~0.75 MB to ~3 MB for a feature that, in practice, almost no one uses past 64–128 threads.

## Test plan

- [x] Build clean on arm64 (Apple Silicon).
- [ ] Spot-check existing CI / regression runs still produce identical profiling output for `-t <= 256`.
- [ ] Confirm warning fires once at the top of the profile when invoked with `-t 512` (manual smoke).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profiling output issues that could occur when running with excessive thread counts by implementing automatic limiting and warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->