### PR TITLE
feat(shm): serialize /bwactl RMW with a POSIX named semaphore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ ifneq ($(strip $(DISABLE_BATCHED_MATESW)),)
     CPPFLAGS += -DDISABLE_BATCHED_MATESW=$(DISABLE_BATCHED_MATESW)
 endif
 
-.PHONY:all clean depend multi print-mimalloc-config kswv_nrow_zero_test shm_section_find_test shm_pack_round_trip_test test FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean docs docs-serve docs-cli docs-clean docs-install-tools
+.PHONY:all clean depend multi print-mimalloc-config kswv_nrow_zero_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test test FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean docs docs-serve docs-cli docs-clean docs-install-tools
 .SUFFIXES:.cpp .o
 
 .cpp.o:
@@ -347,22 +347,30 @@ shm_section_find_test: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) tes
 shm_pack_round_trip_test: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_pack_round_trip_test.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/shm_pack_round_trip_test.o $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) -o $@
 
+shm_lock_destroy_test: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_lock_destroy_test.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/shm_lock_destroy_test.o $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) -o $@
+
 test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
 
 # Run the in-tree tests via the unit-test harness in test/, plus the
-# standalone regressions (kswv_nrow_zero_test + shm_section_find_test).
-# shm_pack_round_trip_test runs via test/shm_pack_round_trip_test.sh which
-# builds the phiX index first; invoked from test/run_unit_tests.sh.
-test: test-binaries kswv_nrow_zero_test shm_section_find_test
+# standalone regressions (kswv_nrow_zero_test + shm_section_find_test +
+# shm_lock_destroy_test). shm_pack_round_trip_test runs via
+# test/shm_pack_round_trip_test.sh which builds the phiX index first;
+# invoked from test/run_unit_tests.sh.
+test: test-binaries kswv_nrow_zero_test shm_section_find_test shm_lock_destroy_test
 	./test/bwa_mem3_tests_unit
 	./test/bwa_mem3_tests_integration
 	./kswv_nrow_zero_test
 	./shm_section_find_test
+	./shm_lock_destroy_test
 
 test/kswv_nrow_zero_test.o: test/kswv_nrow_zero_test.cpp
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 test/shm_section_find_test.o: test/shm_section_find_test.cpp
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
+
+test/shm_lock_destroy_test.o: test/shm_lock_destroy_test.cpp
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 $(BWA_LIB):$(OBJS)
@@ -429,7 +437,7 @@ $(MIMALLOC_LIB):
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
 clean: pgo-clean profile-clean lto-clean
-	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test shm_section_find_test shm_pack_round_trip_test bwa-mem3.sse41 bwa-mem3.sse42 bwa-mem3.avx bwa-mem3.avx2 bwa-mem3.avx512bw bwa-mem3.arm64
+	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test bwa-mem3.sse41 bwa-mem3.sse42 bwa-mem3.avx bwa-mem3.avx2 bwa-mem3.avx512bw bwa-mem3.arm64
 	rm -f $(LIBSAIS_OBJS)
 	rm -f src/*.gcno src/*.gcda
 	$(MAKE) -C test clean

--- a/docs/_generated/cli/shm.txt
+++ b/docs/_generated/cli/shm.txt
@@ -17,6 +17,11 @@ the same plain `<idxbase>` to all three commands plus `--meth` on
 Footgun: if you re-build the index, run `bwa-mem3 shm -d` first.
 There is no staleness check -- a stale segment will silently mis-align.
 
+Stuck-lock recovery: concurrent stagers are serialized by a named
+       POSIX semaphore. If a stager is kill -9'd mid-stage, the lock
+       persists and subsequent stages block forever. `bwa-mem3 shm -d`
+       unlinks the semaphore alongside the registry; rerun afterwards.
+
 macOS: POSIX shm has implementation-defined per-segment caps; large
        indices may simply fail to stage. Prefer Linux for production.
 Linux: /dev/shm defaults to ~50% of RAM on bare metal; in containers

--- a/docs/src/cli/shm.md
+++ b/docs/src/cli/shm.md
@@ -84,6 +84,15 @@ transparently.
 > Kubernetes pods. Raise the limit with `--shm-size` (Docker) or an
 > `emptyDir` tmpfs volume with an explicit size (Kubernetes) before attempting
 > to stage a large index.
+>
+> **Note — Stuck-lock recovery**
+>
+> Concurrent `bwa-mem3 shm <prefix>` invocations are serialized by a named
+> POSIX semaphore (`/bwactl_lock`) so the registry stays consistent. POSIX
+> semaphores have no `SEM_UNDO` equivalent: if a stager segfaults or is
+> `kill -9`'d while holding the lock, every subsequent stage will block in
+> `sem_wait` forever. Run `bwa-mem3 shm -d` to recover — it unlinks the
+> semaphore alongside the registry, freeing the next stager.
 
 ---
 

--- a/src/bwa_shm.cpp
+++ b/src/bwa_shm.cpp
@@ -41,6 +41,7 @@
 #include <fcntl.h>         /* O_* */
 #include <unistd.h>        /* close, ftruncate */
 #include <getopt.h>        /* getopt_long for `bwa-mem3 shm --meth ...` */
+#include <semaphore.h>     /* sem_open, sem_wait, sem_post, sem_close, sem_unlink */
 #include <errno.h>
 #include <limits.h>        /* PATH_MAX */
 
@@ -48,6 +49,12 @@
  * (int64_t l_mem, char[] basename) entries. The header is 4 bytes total
  * (two uint16_t fields). next_write_offset starts at 4 on a fresh segment. */
 #define BWA_SHM_CTL_HEADER_BYTES 4
+
+/* Named POSIX semaphore guarding read-modify-write sequences against
+ * /bwactl. Created on first use and unlinked by bwa_shm_destroy alongside
+ * the registry, so `bwa-mem3 shm -d` is the recovery path if a stager
+ * crashes while holding the lock (POSIX semaphores have no SEM_UNDO). */
+#define BWA_SHM_LOCK_NAME "/bwactl_lock"
 
 /* .bwt.2bit.64 prefix: int64_t reference_seq_len, int64_t count[5]. */
 #define BWA_BWT_2BIT_HEADER_BYTES (sizeof(int64_t) * 6)
@@ -88,6 +95,36 @@ static void path_concat2(char out[PATH_MAX], const char *a, const char *b)
     strcat_s(out, PATH_MAX, b);
 }
 
+/* Acquire the cross-process lock that serializes read-modify-write
+ * sequences on /bwactl. POSIX named semaphores work on both Linux and
+ * macOS (unlike flock(2) on POSIX shm fds, which macOS rejects with
+ * EOPNOTSUPP). Returns the open semaphore on success — held by us until
+ * ctl_lock_release — or NULL on failure. */
+static sem_t *ctl_lock_acquire(void)
+{
+    sem_t *s = sem_open(BWA_SHM_LOCK_NAME, O_CREAT, 0644, 1);
+    if (s == SEM_FAILED) {
+        std::fprintf(stderr, "[E::%s] sem_open(%s) failed: %s\n",
+                     __func__, BWA_SHM_LOCK_NAME, std::strerror(errno));
+        return NULL;
+    }
+    while (sem_wait(s) < 0) {
+        if (errno == EINTR) continue;
+        std::fprintf(stderr, "[E::%s] sem_wait(%s) failed: %s\n",
+                     __func__, BWA_SHM_LOCK_NAME, std::strerror(errno));
+        sem_close(s);
+        return NULL;
+    }
+    return s;
+}
+
+static void ctl_lock_release(sem_t *s)
+{
+    if (s == NULL) return;
+    sem_post(s);
+    sem_close(s);
+}
+
 /* Open `/bwactl` read-write, creating it if necessary and zero-initializing
  * a fresh segment with next-write offset = BWA_SHM_CTL_HEADER_BYTES.
  *
@@ -96,13 +133,9 @@ static void path_concat2(char out[PATH_MAX], const char *a, const char *b)
  * closes it after the mapping is no longer needed (typical pattern: close
  * immediately, since the mapping survives close).
  *
- * NOTE: there is no advisory lock around the registry. POSIX shm fds on
- * macOS reject flock(2) with EOPNOTSUPP, so a portable lock would require
- * a side-channel lockfile. We accept the v1 race window here: two
- * concurrent `bwa-mem3 shm <prefix>` invocations may both pass the
- * pre-stage `bwa_shm_test` and append duplicate entries (or have one
- * `O_EXCL`-create the segment and the other discover it via EEXIST). The
- * EEXIST branch in `bwa_shm_stage` treats that as already-staged. */
+ * Concurrent RMW callers must hold ctl_lock_acquire across the open / read
+ * / write / close cycle so the n_entries / next_write fields stay coherent
+ * across processes. */
 static void *ctl_open_rw(int *fd_out)
 {
     int created = 0;
@@ -503,6 +536,12 @@ int bwa_shm_destroy(void)
     int rc = ctl_walk(destroy_cb, NULL);
     if (rc < 0) return rc;
     shm_unlink(BWA_SHM_CTL_NAME);
+    /* Recover from a stuck lock: a stager that segfaulted or was kill -9'd
+     * mid-stage holds the named semaphore until it is unlinked, blocking
+     * every subsequent stager forever. POSIX has no SEM_UNDO, so unlinking
+     * alongside the registry is the operator-visible recovery path. Errors
+     * are ignored (ENOENT is the common case on a clean drop). */
+    sem_unlink(BWA_SHM_LOCK_NAME);
     return 0;
 }
 
@@ -537,15 +576,26 @@ int bwa_shm_stage(const char *prefix)
         return -1;
     }
 
-    /* 2. Open the control segment R/W. There is no advisory lock — see the
-     *    note on ctl_open_rw for why. We re-check the registry below to
-     *    catch the case where another stager appended this prefix between
-     *    our pre-stage bwa_shm_test and now. */
+    /* 2. Acquire the cross-process lock, then open the control segment R/W.
+     *    Holding the lock across the read-modify-write window prevents two
+     *    concurrent stagers from racing each other to append the same
+     *    basename or stomping each other's next_write cursor. The pre-stage
+     *    bwa_shm_test() above is unlocked (a cheap fast path); we re-scan
+     *    the live registry below now that the lock is held to catch the
+     *    case where another stager appended this prefix between our test
+     *    and our acquire. */
+    sem_t *ctl_lock = ctl_lock_acquire();
+    if (ctl_lock == NULL) {
+        bwa_shm_layout_free(&layout);
+        return -1;
+    }
+
     int   ctl_fd  = -1;
     void *ctl_map = ctl_open_rw(&ctl_fd);
     if (ctl_map == NULL) {
         std::fprintf(stderr, "[E::%s] failed to open control segment %s: %s\n",
                      __func__, BWA_SHM_CTL_NAME, std::strerror(errno));
+        ctl_lock_release(ctl_lock);
         bwa_shm_layout_free(&layout);
         return -1;
     }
@@ -568,6 +618,7 @@ int bwa_shm_stage(const char *prefix)
                     "[M::%s] index '%s' was staged by another process\n",
                     __func__, prefix);
                 ctl_close(ctl_map, ctl_fd);
+                ctl_lock_release(ctl_lock);
                 bwa_shm_layout_free(&layout);
                 return 0;
             }
@@ -586,6 +637,7 @@ int bwa_shm_stage(const char *prefix)
                      "[E::%s] control segment full (cannot stage '%s')\n",
                      __func__, name);
         ctl_close(ctl_map, ctl_fd);
+        ctl_lock_release(ctl_lock);
         bwa_shm_layout_free(&layout);
         return -1;
     }
@@ -602,6 +654,7 @@ int bwa_shm_stage(const char *prefix)
             "[M::%s] segment %s already exists; treating as already staged\n",
             __func__, idx_path);
         ctl_close(ctl_map, ctl_fd);
+        ctl_lock_release(ctl_lock);
         bwa_shm_layout_free(&layout);
         return 0;
     }
@@ -609,6 +662,7 @@ int bwa_shm_stage(const char *prefix)
         std::fprintf(stderr, "[E::%s] shm_open(%s) failed: %s\n",
                      __func__, idx_path, std::strerror(errno));
         ctl_close(ctl_map, ctl_fd);
+        ctl_lock_release(ctl_lock);
         bwa_shm_layout_free(&layout);
         return -1;
     }
@@ -619,6 +673,7 @@ int bwa_shm_stage(const char *prefix)
         close(idx_fd);
         shm_unlink(idx_path);
         ctl_close(ctl_map, ctl_fd);
+        ctl_lock_release(ctl_lock);
         bwa_shm_layout_free(&layout);
         return -1;
     }
@@ -630,6 +685,7 @@ int bwa_shm_stage(const char *prefix)
         close(idx_fd);
         shm_unlink(idx_path);
         ctl_close(ctl_map, ctl_fd);
+        ctl_lock_release(ctl_lock);
         bwa_shm_layout_free(&layout);
         return -1;
     }
@@ -641,6 +697,7 @@ int bwa_shm_stage(const char *prefix)
         close(idx_fd);
         shm_unlink(idx_path);
         ctl_close(ctl_map, ctl_fd);
+        ctl_lock_release(ctl_lock);
         bwa_shm_layout_free(&layout);
         return -1;
     }
@@ -658,6 +715,7 @@ int bwa_shm_stage(const char *prefix)
     std::memcpy((uint8_t *)ctl_map + 2, &next_write, sizeof(uint16_t));
 
     ctl_close(ctl_map, ctl_fd);
+    ctl_lock_release(ctl_lock);
 
     std::fprintf(stderr, "[M::%s] staged '%s' (%llu bytes) as %s\n",
                  __func__, name,
@@ -835,6 +893,10 @@ static void print_shm_usage(void)
         "`index`, `shm`, and `mem` (the c2t suffix is auto-appended).\n\n"
         "Footgun: if you re-build the index, run `bwa-mem3 shm -d` first.\n"
         "There is no staleness check -- a stale segment will silently mis-align.\n\n"
+        "Stuck-lock recovery: concurrent stagers are serialized by a named\n"
+        "       POSIX semaphore. If a stager is kill -9'd mid-stage, the lock\n"
+        "       persists and subsequent stages block forever. `bwa-mem3 shm -d`\n"
+        "       unlinks the semaphore alongside the registry; rerun afterwards.\n\n"
         "macOS: POSIX shm has implementation-defined per-segment caps; large\n"
         "       indices may simply fail to stage. Prefer Linux for production.\n"
         "Linux: /dev/shm defaults to ~50%% of RAM on bare metal; in containers\n"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -18,7 +18,7 @@ ok()   { echo "OK:   $*"; }
 (cd "$HERE" && make) || fail "test/ make failed"
 
 # Build any test binaries that live outside test/Makefile.
-( cd "$ROOT" && make -j4 shm_section_find_test shm_pack_round_trip_test ) >/dev/null
+( cd "$ROOT" && make -j4 shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test ) >/dev/null
 
 # synthetic_1mb.fa is checked in alongside its committed baselines so the
 # byte-diff test stays reproducible across Python versions and platforms.
@@ -209,6 +209,11 @@ ok "libsais_memory_budget_test"
 echo "==> shm_section_find_test"
 ( cd "$ROOT" && ./shm_section_find_test )
 echo "OK:   shm_section_find_test"
+
+# --- shm_lock_destroy_test (unit: bwa_shm_destroy unlinks /bwactl_lock) ------
+echo "==> shm_lock_destroy_test"
+( cd "$ROOT" && ./shm_lock_destroy_test )
+echo "OK:   shm_lock_destroy_test"
 
 # --- shm pack round-trip (unit: pack/unpack a phiX segment) ------------------
 (cd "$HERE" && ./shm_pack_round_trip_test.sh) || fail "shm_pack_round_trip_test"

--- a/test/shm_lock_destroy_test.cpp
+++ b/test/shm_lock_destroy_test.cpp
@@ -1,0 +1,80 @@
+/* Verifies that bwa_shm_destroy unlinks the named POSIX semaphore that
+ * guards the /bwactl registry. Together with the lock acquired in
+ * bwa_shm_stage, this is the recovery path for a stager that segfaults or
+ * is kill -9'd while holding the lock — without sem_unlink, the stuck
+ * semaphore would block every subsequent stage forever (POSIX named
+ * semaphores have no SEM_UNDO equivalent).
+ *
+ * Tests:
+ *   1. After bwa_shm_destroy, sem_open with O_CREAT|O_EXCL succeeds — i.e.
+ *      the prior name no longer exists.
+ *   2. The sequence is repeatable (force the semaphore in, destroy, again).
+ */
+
+#include "bwa_shm.h"
+
+#include <semaphore.h>
+#include <fcntl.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#define BWA_SHM_LOCK_NAME "/bwactl_lock"
+
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "CHECK failed at %s:%d: %s (errno=%d %s)\n", \
+                     __FILE__, __LINE__, #cond, errno, std::strerror(errno)); \
+        std::fflush(stderr); \
+        std::abort(); \
+    } \
+} while (0)
+
+static void clear_lock_name(void)
+{
+    /* Best-effort. ENOENT is fine; we just want a clean baseline. */
+    sem_unlink(BWA_SHM_LOCK_NAME);
+}
+
+static void force_lock_exists(void)
+{
+    sem_t *s = sem_open(BWA_SHM_LOCK_NAME, O_CREAT, 0644, 1);
+    CHECK(s != SEM_FAILED);
+    CHECK(sem_close(s) == 0);
+}
+
+static void check_lock_absent(void)
+{
+    /* O_CREAT|O_EXCL fails with EEXIST iff the name is currently linked. */
+    sem_t *t = sem_open(BWA_SHM_LOCK_NAME, O_CREAT | O_EXCL, 0644, 1);
+    CHECK(t != SEM_FAILED);
+    sem_close(t);
+    sem_unlink(BWA_SHM_LOCK_NAME);
+}
+
+int main(void)
+{
+    /* Start from a known-clean state. The registry segment may or may not
+     * exist; either way bwa_shm_destroy is idempotent. */
+    clear_lock_name();
+    CHECK(bwa_shm_destroy() == 0);
+
+    /* 1. Force the semaphore name into existence (simulates a prior stager
+     *    leaving the lock object behind), then destroy must remove it. */
+    force_lock_exists();
+    CHECK(bwa_shm_destroy() == 0);
+    check_lock_absent();
+
+    /* 2. Repeatable. */
+    force_lock_exists();
+    CHECK(bwa_shm_destroy() == 0);
+    check_lock_absent();
+
+    /* 3. Destroy on an already-clean state is still 0 (no semaphore to
+     *    unlink). */
+    CHECK(bwa_shm_destroy() == 0);
+
+    std::printf("shm_lock_destroy_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
Closes #66.

## Summary

`bwa_shm_stage` previously read-modified-wrote the `n_entries` / `next_write` fields of the `/bwactl` registry without an interprocess lock. Two concurrent `bwa-mem3 shm <prefix>` invocations could append duplicate entries (current effects are benign because `bwa_shm_test` returns on first match, but the race still corrupts counters and is a hazard for any future ctl-segment changes).

`flock(2)` on POSIX shm fds is rejected on macOS with `EOPNOTSUPP`, so this uses POSIX named semaphores via `sem_open` / `sem_wait` / `sem_post` — portable on Linux and macOS, per the CodeRabbit suggestion on #65. The lock spans the entire `ctl_open_rw` → re-scan → per-index segment create+pack → ctl write window. The pre-stage `bwa_shm_test` stays unlocked as a fast path; the in-critical-section re-scan catches the case where another stager appended this prefix between our test and our acquire.

## Stuck-lock recovery

POSIX semaphores have no `SEM_UNDO` equivalent: a stager that segfaults or is `kill -9`'d while holding the lock would block every subsequent stage forever. `bwa_shm_destroy` now `sem_unlink`s `/bwactl_lock` alongside the registry, so `bwa-mem3 shm -d` is the operator-visible recovery path. The failure mode is documented in `bwa-mem3 shm --help` and `docs/src/cli/shm.md`.

## Tests

- New `test/shm_lock_destroy_test.cpp` — deterministic unit test: force the named semaphore into existence, call `bwa_shm_destroy`, then `sem_open(O_CREAT|O_EXCL)` must succeed (proving the prior name was unlinked). Wired into `make test` and `bash test/run_unit_tests.sh`.
- Existing `shm_round_trip_test.sh` and `shm_pack_round_trip_test.sh` continue to pass, exercising lock acquisition + release on the happy stage path.

## Acceptance (per #66)

- [x] `bwa_shm_stage` acquires the named semaphore before reading the ctl segment, releases after writing.
- [x] `bwa_shm_destroy` `sem_unlink`s `/bwactl_lock` after the registry walk.
- [x] Concurrent `bwa-mem3 shm <prefix>` and `bwa-mem3 shm <other>` runs produce at most one registry entry per basename (lock + in-critical-section re-scan).
- [x] A simulated stuck-lock state is recoverable via `bwa-mem3 shm -d` (covered by `shm_lock_destroy_test`).
- [x] Documentation updated.

## Test plan

- [x] `make -j4` clean on macOS Apple Silicon
- [x] `bash test/run_unit_tests.sh` — all unit tests pass including the new `shm_lock_destroy_test`
- [ ] CI on Linux x86_64 + Linux aarch64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added recovery mechanism for shared memory locks that may become stuck if a process terminates unexpectedly.

* **Documentation**
  * Added guidance on recovering from stuck locks during shared memory operations.

* **Tests**
  * Added new test to verify proper lock cleanup and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->