### PR TITLE
perf(build): default x86 single-binary baseline to avx2 (was sse41)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,20 @@ jobs:
             run_integration: true
             name: "Linux x86_64 single-binary (mimalloc)"
             artifact_slug: "linux-x86_64-single-mimalloc"
+          # Same single-binary build as the row above, but with the
+          # BASELINE_ARCH override flipped to sse41 (the vintage-host
+          # portability path). PR #83 originally hardcoded the sse41
+          # baseline; the perf-regression fix flipped the default to avx2
+          # and made it tunable. Keep this row so the override path stays
+          # exercised — without it, a future refactor could silently drop
+          # sub-avx2 portability.
+          - os: ubuntu-latest
+            arch_flag: ""
+            baseline_arch: "sse41"
+            use_mimalloc: "1"
+            run_integration: true
+            name: "Linux x86_64 single-binary BASELINE_ARCH=sse41 (mimalloc)"
+            artifact_slug: "linux-x86_64-single-sse41-baseline-mimalloc"
           - os: ubuntu-latest
             arch_flag: "avx2"
             use_mimalloc: "1"
@@ -91,9 +105,16 @@ jobs:
         run: cmake --version
 
       - name: Build bwa-mem3
+        # For arch_flag="" rows the build goes through the single: target,
+        # which honors BASELINE_ARCH (defaults to avx2; override per-row via
+        # matrix.baseline_arch). On ARM rows BASELINE_ARCH is harmless — the
+        # single: recipe short-circuits to the arm64 build before consulting
+        # it. On rows that pin arch=… we hit a single-arch build that bypasses
+        # single: entirely, so BASELINE_ARCH is not used and is omitted.
         run: |
           if [ "${{ matrix.arch_flag }}" = "" ]; then
             make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)" \
+              BASELINE_ARCH=${{ matrix.baseline_arch || 'avx2' }} \
               CXX=${{ matrix.cxx || 'g++' }} USE_MIMALLOC=${{ matrix.use_mimalloc }}
           else
             make -j"$(nproc)" \
@@ -111,9 +132,11 @@ jobs:
         # between libbwa.a and the test binary (notably: sse41 row has
         # no kswv::getScores8 symbol, so tests must be compiled out).
         # For arch_flag="" rows (ARM, macOS, single-binary x86), the parent
-        # build auto-selects ARCH_FLAGS via IS_ARM (ARM) or leaves them empty
-        # (x86 single-binary, which compiled all tier kernels separately and
-        # uses the sse41 baseline for non-kernel TUs).
+        # build auto-selects ARCH_FLAGS via IS_ARM (ARM) or falls back to
+        # the file-default -msse4.1 floor (x86 single-binary, which compiled
+        # all tier kernels separately; the test TU compiles at sse41 here
+        # regardless of BASELINE_ARCH, so kswv tests gate on BWA_TESTS_HAVE_KSWV
+        # and skip when the test TU lacks __AVX2__/__AVX512BW__).
         run: |
           if [ "${{ matrix.arch_flag }}" = "" ]; then
             make test-binaries CXX=${{ matrix.cxx || 'g++' }}

--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,17 @@ src/version.h: FORCE
 
 src/main.o: src/version.h
 
+# Baseline ISA tier for non-kernel TUs in the x86 single-binary build.
+# Defaults to avx2: every host that runs bwa-mem3 in practice has AVX2
+# (Haswell, 2013+; any host with AVX-512 also has AVX2), and dropping the
+# baseline below avx2 measurably slows hot non-kernel paths (chain
+# extension, FMI BWT walks, mate scoring) because the compiler can no
+# longer auto-vectorize them at 256-bit width. Override to sse41 (or
+# sse42, avx) for vintage hardware; the per-tier kernel objects are still
+# compiled at every tier regardless, so kernel dispatch on lower-tier
+# hosts continues to work.
+BASELINE_ARCH ?= avx2
+
 # Single-binary multi-tier build. All kernel TUs are compiled at every
 # tier; the dispatcher picks the right per-tier subclass at runtime.
 # Replaces the `multi` target's 5 sequential clean rebuilds + execv launcher.
@@ -352,11 +363,11 @@ ifneq ($(IS_ARM),)
 	@echo "ARM64 detected - building single arm64 binary instead of multi-tier"
 	$(MAKE) arm64
 else
-	$(MAKE) arch=sse41 EXE=bwa-mem3 CXX="$(CXX)" KERNEL_TIER_OBJS_LINK="$(KERNEL_TIER_OBJS)" all-single
+	$(MAKE) arch=$(BASELINE_ARCH) EXE=bwa-mem3 CXX="$(CXX)" KERNEL_TIER_OBJS_LINK="$(KERNEL_TIER_OBJS)" all-single
 endif
 
-# Internal: builds the single binary with arch=sse41 baseline for non-kernel
-# TUs and links all KERNEL_TIER_OBJS_LINK on top.
+# Internal: builds the single binary with the BASELINE_ARCH tier for
+# non-kernel TUs and links all KERNEL_TIER_OBJS_LINK on top.
 .PHONY: all-single
 all-single: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) $(KERNEL_TIER_OBJS_LINK) src/main.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) src/main.o $(KERNEL_TIER_OBJS_LINK) $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) $(MIMALLOC_LDFLAGS) -o $(EXE)
@@ -377,12 +388,13 @@ $(EXE):$(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) $(if $(filter 1,$(U
 # before the allocation and aborts at a later allocator operation; under
 # asan the write is reported directly.
 #
-# On x86 multi-tier builds, libbwa.a's baseline kswv.o is compiled at
-# -msse4.1 (the single-binary SSE floor), which hits the SSE-only stub that
-# calls exit(). To exercise the real SIMD kernel, compile a native-tier copy
-# of kswv.cpp (src/kswv.native.o) and link it ahead of libbwa.a so the linker
-# picks the native-ISA concrete kswv class.  On arm64 -march=native resolves
-# to the NEON path already covered by the baseline objects.
+# On x86 multi-tier builds, libbwa.a's baseline kswv.o is compiled at the
+# BASELINE_ARCH tier (avx2 by default; sse41 if overridden, in which case
+# the SSE-only stub that calls exit() would fire). Compile a separate
+# native-tier copy of kswv.cpp (src/kswv.native.o) and link it ahead of
+# libbwa.a so the linker picks the host's native-ISA concrete kswv class
+# regardless of BASELINE_ARCH. On arm64 -march=native resolves to the NEON
+# path already covered by the baseline objects.
 src/kswv.native.o: src/kswv.cpp
 	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
 

--- a/src/simd_dispatch.cpp
+++ b/src/simd_dispatch.cpp
@@ -8,6 +8,32 @@
 static int g_tier = BWAMEM3_TIER_NONE;
 static std::once_flag g_init_flag;
 
+/* Build-time tier — what the compiler emitted for this TU and (because the
+ * BASELINE_ARCH knob in the Makefile propagates ARCH_FLAGS into CXXFLAGS for
+ * every non-kernel compile) what every non-kernel TU was compiled at. Used
+ * at init time to flag a gap between the binary's build baseline and the
+ * host's capability — when the host is more capable than the build, hot
+ * non-kernel paths (chain extension, FMI walks, mate scoring) won't be
+ * auto-vectorized at the higher width and the binary leaves measurable
+ * performance on the table. The arm64 branch comes first because the
+ * sse2neon shim sets the SSE feature macros, which would otherwise cause
+ * the SSE branches to fire on aarch64. */
+#if defined(__aarch64__) || defined(__ARM_NEON)
+static constexpr int g_build_tier = BWAMEM3_TIER_NEON;
+#elif defined(__AVX512BW__)
+static constexpr int g_build_tier = BWAMEM3_TIER_AVX512BW;
+#elif defined(__AVX2__)
+static constexpr int g_build_tier = BWAMEM3_TIER_AVX2;
+#elif defined(__AVX__)
+static constexpr int g_build_tier = BWAMEM3_TIER_AVX;
+#elif defined(__SSE4_2__)
+static constexpr int g_build_tier = BWAMEM3_TIER_SSE42;
+#elif defined(__SSE4_1__)
+static constexpr int g_build_tier = BWAMEM3_TIER_SSE41;
+#else
+static constexpr int g_build_tier = BWAMEM3_TIER_NONE;
+#endif
+
 #if defined(__x86_64__) || defined(__i386__)
 static int detect_x86_tier(void)
 {
@@ -65,6 +91,31 @@ static void bwamem3_simd_init_body(void)
     g_tier = BWAMEM3_TIER_NONE;
 #endif
 
+    /* Build-vs-host gap warning. The per-tier kernel TUs are still compiled
+     * at every supported tier and dispatched correctly via this file, so
+     * kernel calls (BSW, kswv, ksw_extend, sam_encode_*) will pick the
+     * host's tier regardless. But every non-kernel TU (bwamem.cpp,
+     * bwamem_pair.cpp, FMI_search.cpp, fastmap.cpp, ...) is compiled once
+     * at the BASELINE_ARCH tier, so when the host is more capable the
+     * compiler can't auto-vectorize those hot paths at the wider width.
+     * Compare on the x86 ordering only; arm64 builds have a single tier.
+     * Use the detected tier (pre-FORCE_TIER) so the warning reflects the
+     * binary's potential vs the host's capability, not the deliberate
+     * runtime override. */
+#if defined(__x86_64__) || defined(__i386__)
+    if (g_build_tier > BWAMEM3_TIER_NONE && g_build_tier < g_tier) {
+        fprintf(stderr,
+                "[W::%s] build baseline %s < host tier %s; non-kernel TUs "
+                "are not auto-vectorized at the higher width (expect "
+                "10-15%% slower hot paths). Rebuild with BASELINE_ARCH=%s "
+                "to recover.\n",
+                __func__,
+                bwamem3_simd_tier_name(g_build_tier),
+                bwamem3_simd_tier_name(g_tier),
+                bwamem3_simd_tier_name(g_tier));
+    }
+#endif
+
     /* Optional override: BWAMEM3_FORCE_TIER=<name> downgrades only.
      * Up-tier requests would SIGILL on the first wider instruction. */
     const char *force = getenv("BWAMEM3_FORCE_TIER");
@@ -97,7 +148,10 @@ static void bwamem3_simd_init_body(void)
     }
 
     if (getenv("BWAMEM3_DEBUG_SIMD")) {
-        fprintf(stderr, "[M::%s] SIMD tier: %s\n", __func__, bwamem3_simd_tier_name(g_tier));
+        fprintf(stderr, "[M::%s] SIMD tier: %s (build baseline: %s)\n",
+                __func__,
+                bwamem3_simd_tier_name(g_tier),
+                bwamem3_simd_tier_name(g_build_tier));
     }
 }
 


### PR DESCRIPTION
## Summary

PR #83 silently dropped the x86 single-binary's non-kernel TU compile from `-mavx2` to `-msse4.1` (it hardcoded `arch=sse41` in the `single:` recipe). On c6a (and every other AVX2+ x86 host) this cost ~+15% user-time on wgs-5M / +11% on wes-5M because hot non-kernel paths (chain extension, FMI BWT walks, mate scoring) lost auto-vectorization at 256-bit width. The per-tier kernel TUs (bandedSWA, kswv, ksw, sam_encode) were correctly compiled at every tier and dispatched at runtime, so kernel-level perf was preserved; only non-kernel TUs regressed.

## What changed (3 self-contained commits)

- **`perf(build): default x86 single-binary baseline to avx2`** — Introduces a tunable `BASELINE_ARCH ?= avx2` and uses it in the `single:` recipe instead of the hardcoded `sse41`. AVX2 has been ubiquitous since Haswell (2013); any host with AVX-512 also has AVX2. Override to `sse41` (or `sse42`, `avx`) for vintage hardware via `BASELINE_ARCH=sse41 make`; per-tier kernel objects are still compiled at every tier so kernel dispatch on lower-tier hosts continues to work.

- **`feat(simd): warn at runtime when build baseline < host tier`** — Detects the build-time tier from the compiler's predefined macros (`__AVX2__`, `__SSE4_1__`, etc., reflecting CXXFLAGS via ARCH_FLAGS via BASELINE_ARCH), compares against the host-detected tier, and prints a one-line stderr warning when there's a gap. Catches future silent perf regressions of this shape immediately at startup. Also annotates the `BWAMEM3_DEBUG_SIMD` banner with the build baseline.

- **`ci: cover BASELINE_ARCH=sse41 override path in matrix`** — Adds a sister row to the existing single-binary x86 entry that builds with `BASELINE_ARCH=sse41`. Keeps the override path exercised so a future refactor can't silently drop sub-AVX2 portability.

## Validation (c6a.4xlarge AMD EPYC 7R13, AVX2 only, 16 threads, hg38, no shm)

User-time matches the prior `multi:avx2` baseline to within ±1% on both samples. Wall-time variance is dominated by mmap-from-disk noise without `bwa shm`, so user-time is the cleaner signal:

| Sample | 20f77e9f `bwa-mem2.avx2` user mean | b9e0b66 `bwa-mem3` user mean | Fixed user mean | Recovered |
|---|---|---|---|---|
| wgs-5M | 2006.79s | 2317.55s (+15.5%) | 1982.43s (-1.2%) | yes |
| wes-5M | 1033.01s | 1131.14s (+11.1%) | 1022.27s (-1.0%) | yes |

Binary instruction-mix sanity (objdump):

| Op | OLD `bwa-mem2.avx2` | NEW broken (`b9e0b66`) | NEW fixed |
|---|---|---|---|
| `vmovdqu` | 4250 | 207 | 4380 |
| `movups` | 384 | 2570 | 484 |
| `movaps` | 834 | 1955 | 1170 |

Runtime warning verified on c6a:

- **default avx2 build** → no warning at startup, dispatcher reports `avx2`
- **`BASELINE_ARCH=sse41` build** → warns: `[W::bwamem3_simd_init_body] build baseline sse42 < host tier avx2; non-kernel TUs are not auto-vectorized at the higher width (expect 10-15% slower hot paths). Rebuild with BASELINE_ARCH=avx2 to recover.`

(The warning reports `sse42` because Amazon Linux 2023's gcc was configured with `--with-arch_64=x86-64-v2`, so `__SSE4_2__` is defined even with `-msse4.1`. Truthful — the binary CAN emit SSE4.2 instructions on AL2023 — and the actionable advice "rebuild with BASELINE_ARCH=avx2" is correct. On vanilla gcc the warning would say `sse41`.)

## Caveat

The default-built binary now requires AVX2 to even run. Sub-AVX2 hosts (CPUs from before 2013) will SIGILL on the first AVX2 instruction in any non-kernel TU. For those hosts, build with `BASELINE_ARCH=sse41 make`. This matches the practical constraint of fg-labs's bench/CI fleet and any modern deployment; the override path is preserved and CI-tested.

## Test plan

- [ ] CI matrix passes on the existing default-avx2 single-binary row
- [ ] CI matrix passes on the new `BASELINE_ARCH=sse41` single-binary row
- [ ] `make` on a c6a/c7i/c7a host produces an AVX2-baseline binary (no warning at startup)
- [ ] `BASELINE_ARCH=sse41 make` on an AVX2 host produces a binary that runs correctly and warns at startup
- [ ] `kswv_nrow_zero_test` still passes (verified locally on c6a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime warnings to alert users when their binary was built with narrower CPU architecture support than their system provides.

* **Improvements**
  * Enhanced SIMD initialization diagnostics to display build baseline architecture information.

* **Chores**
  * Expanded CI testing matrix to improve architecture coverage validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->