### PR TITLE
fix(matesw): copy ref slice before ksw_align2 to avoid SIGSEGV on shm-backed ref_string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,11 +396,12 @@ kswv_nrow_zero_test: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB) src/kswv.native.o tes
 # libbwa.a, which then lacks kswv::getScores8 — the BWA_TESTS_HAVE_KSWV
 # macro guards the test away).
 .PHONY: test-binaries
-# $(SAFE_STR_LIB) is a real link-time dep: test/Makefile's
+# $(SAFE_STR_LIB) and $(HTS_LIB) are real link-time deps: test/Makefile's
 # bwa_mem3_tests_unit recipe references ../ext/safestringlib/libsafestring.a
-# directly. Without this prereq, callers that skip the bwa-mem3 binary
-# build (which builds it as a side-effect of $(EXE) deps) link-fail.
-test-binaries: $(BWA_LIB) $(SAFE_STR_LIB)
+# and ../ext/htslib/libhts.a directly. Without these prereqs, callers that
+# skip the bwa-mem3 binary build (which builds them as a side-effect of
+# $(EXE) deps) link-fail.
+test-binaries: $(BWA_LIB) $(SAFE_STR_LIB) $(HTS_LIB)
 	$(MAKE) -C test framework unit integration \
 	    CXX="$(CXX)" \
 	    COVERAGE=$(COVERAGE) \

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -1284,10 +1284,19 @@ int mem_matesw_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
                 // fprintf(stderr, "Re-routing: Encountered -ve index for "
                 // "gcnt: %d, look into pre.\n", gcnt + r);
                 assert(ref != 0);
-                aln = ksw_align2(l_ms, seq, re - rb, ref, 5,
+                // ksw_align2 reverses its target argument in place via
+                // revseq (see ksw.cpp:375,381). When mmc->ref_string is
+                // shm-backed (PROT_READ mmap of /dev/shm/bwaidx-*), that
+                // write SIGSEGVs. Copy the slice into a writable scratch
+                // buffer before handing it to ksw_align2.
+                int64_t ref_len = re - rb;
+                uint8_t *ref_rw = (uint8_t*) malloc((size_t)ref_len);
+                assert(ref_rw != NULL);
+                memcpy(ref_rw, ref, (size_t)ref_len);
+                aln = ksw_align2(l_ms, seq, ref_len, ref_rw, 5,
                                  opt->mat, opt->o_del, opt->e_del,
                                  opt->o_ins, opt->e_ins, xtra, 0);
-
+                free(ref_rw);
             }
             else
                 aln = *(*myaln + index);

--- a/test/Makefile
+++ b/test/Makefile
@@ -34,15 +34,15 @@ ifneq ($(IS_ARM),)
             $(error libomp not found: install with `brew install libomp`, or set LIBOMP_PREFIX to its install prefix)
         endif
         CXXFLAGS ?= -std=c++11 -O2 -Xpreprocessor -fopenmp -I$(LIBOMP_PREFIX)/include
-        LIBS     ?= -L.. -L$(LIBOMP_PREFIX)/lib -lomp -lbwa ../ext/libsais/src/libsais.o ../ext/libsais/src/libsais64.o -lz -framework Accelerate ../ext/safestringlib/libsafestring.a
+        LIBS     ?= -L.. -L$(LIBOMP_PREFIX)/lib -lomp -lbwa ../ext/libsais/src/libsais.o ../ext/libsais/src/libsais64.o -lz -framework Accelerate ../ext/safestringlib/libsafestring.a ../ext/htslib/libhts.a -lpthread
     else
         CXXFLAGS ?= -std=c++11 -O2 -fopenmp
-        LIBS     ?= -L.. -fopenmp -lbwa ../ext/libsais/src/libsais.o ../ext/libsais/src/libsais64.o -lz ../ext/safestringlib/libsafestring.a
+        LIBS     ?= -L.. -fopenmp -lbwa ../ext/libsais/src/libsais.o ../ext/libsais/src/libsais64.o -lz ../ext/safestringlib/libsafestring.a ../ext/htslib/libhts.a -lpthread
     endif
 else
     CXX      ?= g++
     CXXFLAGS ?= -std=c++11 -fopenmp -mtune=native -march=native
-    LIBS     ?= -L.. -fopenmp -lbwa ../ext/libsais/src/libsais.o ../ext/libsais/src/libsais64.o -lz ../ext/safestringlib/libsafestring.a
+    LIBS     ?= -L.. -fopenmp -lbwa ../ext/libsais/src/libsais.o ../ext/libsais/src/libsais64.o -lz ../ext/safestringlib/libsafestring.a ../ext/htslib/libhts.a -lpthread
 endif
 
 ifneq ($(IS_ARM),)

--- a/test/unit/test_mem_matesw_post_no_ref_string_writes.cpp
+++ b/test/unit/test_mem_matesw_post_no_ref_string_writes.cpp
@@ -1,0 +1,181 @@
+// Regression test: mem_matesw_batch_post must not write to mmc->ref_string.
+//
+// Bug: PR #76 wired mem_matesw_batch_pre/post to bns_fetch_seq_v2, which
+// returns a pointer into mmc->ref_string instead of a malloc'd copy.
+// mem_matesw_batch_post's `index == -1` fallback then passed that pointer
+// directly to ksw_align2, whose internal revseq() reverses its `target`
+// argument in place via xor-swap. With shm-backed ref_string (PROT_READ
+// mmap'd /dev/shm/bwaidx-*), that in-place write SIGSEGVs.
+//
+// We can't detect the mutation by comparing bytes before/after the call:
+// ksw_align2 calls revseq twice (lines 375 and 381 of ksw.cpp) so the net
+// effect on the buffer is zero. To detect the *write attempt* itself we
+// place ref_string in an mprotect(PROT_READ) page, fork, and run the
+// function in the child. Pre-fix, the child SIGSEGVs at the first revseq.
+// Post-fix, it exits cleanly.
+
+#include "doctest/doctest.h"
+
+extern "C" {
+#include "bntseq.h"
+}
+#include "bwamem.h"
+
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#define _set_pac(pac, l, c) ((pac)[(l) >> 2] |= (c) << ((~(l) & 3) << 1))
+
+namespace {
+
+// In-child callable: builds minimal bns + ms inputs, then calls
+// mem_matesw_batch_post against a PROT_READ ref_string. _exit on success;
+// SIGSEGV terminates if the function writes to ref_string.
+[[noreturn]] void child_run_matesw_post(uint8_t *ro_ref_string,
+                                        int64_t l_pac) {
+    // Restore default SIGSEGV disposition so the kernel terminates the
+    // child with WTERMSIG=SIGSEGV rather than running doctest's inherited
+    // crash handler (which would emit a redundant doctest report).
+    std::signal(SIGSEGV, SIG_DFL);
+    std::signal(SIGABRT, SIG_DFL);
+
+    // Pack the same bases that ro_ref_string holds (forward half).
+    std::vector<uint8_t> pac(static_cast<size_t>((l_pac + 3) / 4 + 1), 0);
+    for (int64_t i = 0; i < l_pac; ++i) {
+        _set_pac(pac.data(), i, ro_ref_string[i]);
+    }
+
+    bntann1_t anns[1];
+    std::memset(anns, 0, sizeof(anns));
+    anns[0].offset = 0;
+    anns[0].len    = static_cast<int32_t>(l_pac);
+    anns[0].name   = const_cast<char *>("chr_test");
+    anns[0].anno   = const_cast<char *>("");
+
+    bntseq_t bns;
+    std::memset(&bns, 0, sizeof(bns));
+    bns.l_pac   = l_pac;
+    bns.n_seqs  = 1;
+    bns.anns    = anns;
+    bns.n_holes = 0;
+    bns.ambs    = nullptr;
+
+    mem_opt_t *opt = mem_opt_init();
+    if (opt == nullptr) _exit(2);
+
+    // FF orientation only (r==0). FF skips the reverse-complement detour
+    // (is_rev=false) so ms is passed straight through to ksw_align2 as
+    // `query`. ksw_align2 calls revseq on `target` only when its first SW
+    // score >= xtra & 0xffff (= opt->min_seed_len * opt->a = 19). Aligning
+    // ms against itself (ms = first 100 bytes of the rescue region) gives
+    // score 100, which clears that threshold.
+    mem_pestat_t pes[4];
+    std::memset(pes, 0, sizeof(pes));
+    pes[1].failed = 1;
+    pes[2].failed = 1;
+    pes[3].failed = 1;
+    pes[0].failed = 0;
+    pes[0].low    = 50;
+    pes[0].high   = 250;
+    pes[0].avg    = 150.0;
+    pes[0].std    = 30.0;
+
+    // Anchor: forward strand at 200..300. For r=0 (is_rev=false,
+    // is_larger=true): rb = a.rb + low = 250, re = a.rb + high + l_ms
+    // = 550. re-rb = 300 >= opt->min_seed_len = 19.
+    mem_alnreg_t a;
+    std::memset(&a, 0, sizeof(a));
+    a.rid           = 0;
+    a.rb            = 200;
+    a.re            = 300;
+    a.qb            = 0;
+    a.qe            = 100;
+    a.score         = 100;
+    a.is_alt        = 0;
+    a.secondary     = -1;
+    a.secondary_all = -1;
+
+    constexpr int l_ms = 100;
+    std::vector<uint8_t> ms(l_ms);
+    for (int i = 0; i < l_ms; ++i) ms[i] = ro_ref_string[250 + i];
+
+    mem_alnreg_v ma;
+    std::memset(&ma, 0, sizeof(ma));
+
+    int32_t gar[4] = {-1, -1, -1, -1};
+
+    kswr_t *aln_storage = nullptr;
+    kswr_t **myaln = &aln_storage;
+
+    mem_cache mmc;
+    std::memset(&mmc, 0, sizeof(mmc));
+    mmc.ref_string = ro_ref_string;
+
+    // The buggy index == -1 path inside this call passes a slice of
+    // mmc->ref_string straight to ksw_align2, which writes via revseq.
+    (void)mem_matesw_batch_post(opt, &bns, pac.data(), pes,
+                                &a, l_ms, ms.data(),
+                                &ma, myaln, /*gcnt*/0, gar, &mmc);
+
+    free(opt);
+    if (ma.a) free(ma.a);
+    _exit(0);
+}
+
+}  // namespace
+
+TEST_CASE("mem_matesw_batch_post does not write to read-only ref_string "
+          "(shm + ksw_align2 revseq regression)") {
+    constexpr int64_t L = 1024;
+    const size_t page = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const size_t alloc =
+        ((static_cast<size_t>(2 * L) + page - 1) / page) * page;
+
+    // mmap a writable region, populate the ref bytes, then mprotect to
+    // PROT_READ. Any write attempt by mem_matesw_batch_post downstream
+    // generates SIGSEGV in the child.
+    uint8_t *ref_string = static_cast<uint8_t *>(
+        mmap(nullptr, alloc, PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    REQUIRE(ref_string != MAP_FAILED);
+
+    for (int64_t i = 0; i < L; ++i) {
+        ref_string[i] = static_cast<uint8_t>(i & 3);
+    }
+    for (int64_t i = 0; i < L; ++i) {
+        ref_string[2 * L - 1 - i] = static_cast<uint8_t>(3 ^ ref_string[i]);
+    }
+    REQUIRE(mprotect(ref_string, alloc, PROT_READ) == 0);
+
+    pid_t pid = fork();
+    REQUIRE(pid >= 0);
+
+    if (pid == 0) {
+        child_run_matesw_post(ref_string, L);
+    }
+
+    int status = 0;
+    REQUIRE(waitpid(pid, &status, 0) == pid);
+
+    munmap(ref_string, alloc);
+
+    if (WIFSIGNALED(status)) {
+        MESSAGE("child terminated by signal ", WTERMSIG(status),
+                " (SIGSEGV=", SIGSEGV, ")");
+    } else if (WIFEXITED(status)) {
+        MESSAGE("child exited with code ", WEXITSTATUS(status));
+    }
+
+    // Pre-fix: SIGSEGV at the first revseq inside ksw_align2.
+    // Post-fix: clean exit because mem_matesw_batch_post copied the slice.
+    CHECK_FALSE(WIFSIGNALED(status));
+    CHECK(WIFEXITED(status));
+    CHECK(WEXITSTATUS(status) == 0);
+}


### PR DESCRIPTION
## Summary

- `mem_matesw_batch_post`'s `index == -1` fallback (`src/bwamem_pair.cpp:1283`) aliases `mmc->ref_string` (via `bns_fetch_seq_v2`) into `ksw_align2`, whose internal `revseq()` writes back through that pointer (`src/ksw.cpp:375,381`)
- With shm staging, `bwa_shm_attach` mmaps `ref_string` `PROT_READ` (`src/bwa_shm.cpp:761`), so the write SIGSEGVs the worker thread
- Fix copies the slice into a heap scratch before `ksw_align2`, mirroring what `mem_matesw_batch_pre` already does (line 1195) into `seqBufRef`

## Repro

On `c8g.4xlarge` (Graviton 4) with hg38 + panel-twist-5M (twist UMI panel, 5M paired reads):

1. `bwa-mem3 shm $REF`
2. `bwa-mem3 mem -t 16 $REF $R1 $R2 | samtools view -b -o out.bam`

| run | wall | %CPU | records | records-MD5 |
|---|---|---|---|---|
| `b9e0b66` no-shm (broken bin, OK config) | 167s | 1449% | 8,100,270 | `5db872ea…26176c7` |
| `b9e0b66` + **shm** (the bug) | **319s** | **78%** (~5% eff.) | **0** (SIGSEGV) | n/a |
| `b9e0b66` + **fix** + shm | **172s** | **1480%** | **8,100,270** | **`5db872ea…26176c7`** ✓ |

Records-only MD5 of the fixed shm run is byte-identical to the no-shm baseline.

## Note on the original investigation

This perf signature (319 s wall, ~5 % effective CPU on 16 cores) matches the original c8g panel-twist-5M failure originally attributed to PR #83 (320 s wall, mean_load 80 / 5 % effective). The original report also stated 8,100,270 records were emitted at 0 % concordance — our raw repro produces 0 records before the SIGSEGV kills the process. Most plausible reconciliation: in the bench's containerized pipeline, `samtools view` on the receive end of the pipe captured records emitted before the worker SIGSEGV, with content already corrupted from earlier mate-rescue passes that wrote into bytes the read-only mmap couldn't actually mutate. We didn't fully reproduce that, but the fix is unambiguous regardless: post-fix output is byte-identical to baseline.

## Test plan

- [x] New unit test `test/unit/test_mem_matesw_post_no_ref_string_writes.cpp` reproduces the bug via `mprotect(PROT_READ)` + `fork()` and validates the fix
- [x] All 11 existing unit tests still pass (2,863,533 assertions)
- [x] Full c8g 5M panel-twist + shm: records-only MD5 byte-identical to no-shm baseline
- [ ] Cross-check on x86 with shm staging once CI picks it up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory handling in mate-rescue fallback to avoid writes into read-only reference data by using a temporary writable buffer.

* **Tests**
  * Added a regression test that verifies mate-rescue operations do not modify read-only reference memory.

* **Chores**
  * Updated build/test Makefiles to ensure consistent library linking across platforms and to require all libs for test binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->