### PR TITLE
perf(x86): cap avx512bw autovec at 256-bit; bwa_shm /dev/shm preflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,19 +227,44 @@ else ifeq ($(arch),avx2)
 		ARCH_FLAGS=-mavx2
 	endif
 else ifeq ($(arch),avx512)
+	# Legacy alias for arch=avx512bw (preserved for backward compat with
+	# pre-PR #16 invocations). Keep flags identical to the avx512bw branch
+	# below — including the -mprefer-vector-width=256 / -qopt-zmm-usage=low
+	# autovec cap. See the avx512bw branch for the rationale.
 	ifeq ($(CXX), icpc)
-		ARCH_FLAGS=-xCORE-AVX512
+		ARCH_FLAGS=-xCORE-AVX512 -qopt-zmm-usage=low
 	else
-		ARCH_FLAGS=-mavx512f -mavx512bw
+		ARCH_FLAGS=-mavx512f -mavx512bw -mprefer-vector-width=256
 	endif
 else ifeq ($(arch),avx512bw)
 	# Explicit BW target: double the lane width vs AVX2 (64x8-bit / 32x16-bit).
 	# AVX-512BW implies AVX-512F; -mavx512bw alone enables BW+F on gcc/clang
 	# but we list both flags for clarity.
+	#
+	# -mprefer-vector-width=256 (gcc/clang) / -qopt-zmm-usage=low (icpc):
+	# keep AVX-512BW *capabilities* available (32 zmm registers, mask
+	# registers, byte/word lane permutes, gather/scatter) but cap the
+	# auto-vectorizer's preferred SIMD width at 256-bit. Two effects:
+	#   1. AMD Zen 4 (c7a / Genoa) splits 512-bit AVX-512 ops into
+	#      2x 256-bit µops per op. For short-trip-count auto-vec loops
+	#      that's a regression — 2x latency without amortizing the
+	#      reduced iteration count, plus more I-cache pressure. Capping
+	#      at 256-bit keeps the compiler from widening those loops.
+	#   2. Intel Sapphire Rapids (c7i / m7i) has native 512-bit
+	#      execution but pays a ~3-5% AVX-512 frequency downclock under
+	#      sustained heavy use, plus AVX-512↔AVX2 transition penalties
+	#      when non-kernel TUs running 512-bit code call into
+	#      explicitly-256-bit kernel TUs. Capping at 256-bit avoids
+	#      both.
+	# Empirical: c7a wgs-5M shm-warmed -4.4% wall vs avx2 baseline
+	# (vanilla avx512bw was -2.2%, the cap adds another 2% on top).
+	# c7i wgs-5M is a wash either way (-0.7%). The hand-tuned 512-bit
+	# kernel TUs are unaffected — they use intrinsics, not auto-vec.
+	# Canonical mitigation per FFmpeg, libvpx, ISPC docs.
 	ifeq ($(CXX), icpc)
-		ARCH_FLAGS=-xCORE-AVX512
+		ARCH_FLAGS=-xCORE-AVX512 -qopt-zmm-usage=low
 	else
-		ARCH_FLAGS=-mavx512f -mavx512bw
+		ARCH_FLAGS=-mavx512f -mavx512bw -mprefer-vector-width=256
 	endif
 else ifeq ($(arch),native)
 	ARCH_FLAGS=-march=native

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -59,6 +59,7 @@
 - [Features](whats-different/features.md)
 - [Architecture support](whats-different/arch-support.md)
 - [Build & infrastructure](whats-different/build-infra.md)
+- [`BASELINE_ARCH=avx512bw` build flag](whats-different/avx512-baseline.md)
 - [Upstream PR status](whats-different/upstream-prs.md)
 
 # Developer Guide

--- a/docs/src/whats-different/avx512-baseline.md
+++ b/docs/src/whats-different/avx512-baseline.md
@@ -1,0 +1,319 @@
+# `BASELINE_ARCH=avx512bw` build flag
+
+This page documents the empirical perf characterization of building
+bwa-mem3 with `BASELINE_ARCH=avx512bw` and the
+`-mprefer-vector-width=256` mitigation that ships as part of that
+target.
+
+## Background: BASELINE_ARCH
+
+bwa-mem3 ships a single x86 binary with all five SIMD tiers
+(sse41 / sse42 / avx / avx2 / avx512bw) compiled for the hand-tuned
+kernel TUs (`KERNEL_SRCS` in the Makefile: `bandedSWA`, `kswv`, `ksw`,
+`sam_encode`). The runtime dispatcher in `src/simd_dispatch.cpp` picks
+the right tier per kernel call based on `__builtin_cpu_supports`.
+
+Everything outside `KERNEL_SRCS` — `bwamem.cpp`, `bwamem_pair.cpp`,
+`FMI_search.cpp`, `fastmap.cpp`, `bntseq.cpp`, etc. — is compiled
+**once** at the tier set by the `BASELINE_ARCH` Makefile variable
+(default: `avx2`). The compiler can auto-vectorize loops in those TUs
+at up to that tier's width.
+
+PR #84 raised the default from `sse41` to `avx2` after measuring
+~10-15% wall-time gains on AVX2 hosts (c6a, etc.) when the
+auto-vectorizer could finally widen hot non-kernel loops to 256-bit.
+
+## The naive expectation: avx2 → avx512bw should give another tier
+
+Following PR #84's logic, you might expect `BASELINE_ARCH=avx512bw` to
+unlock another ~10-15% on AVX-512BW hosts (c7a, c7i, m7i) by widening
+auto-vectorization to 512-bit. **It does not.** The avx2 → avx512bw
+transition has fundamentally different hardware economics from the
+sse41 → avx2 transition.
+
+## The two AVX-512 perf hazards
+
+### 1. AMD Zen 4 µop-split (c7a)
+
+AMD's Zen 4 cores (c7a / Genoa, c8a / Bergamo) implement 512-bit AVX-512
+operations by issuing **2× 256-bit µops per 512-bit op**. For
+auto-vectorized loops:
+
+- Iteration latency doubles.
+- Iteration count only halves if the trip count is large enough.
+  Short-trip loops eat the 2× latency without amortizing.
+- 512-bit instruction encodings are larger → more I-cache pressure.
+
+Net: loops that auto-vectorized productively at 256-bit AVX2 lose
+performance when the compiler widens them to 512-bit.
+
+### 2. Intel Sapphire Rapids transition + downclock (c7i / m7i)
+
+Intel's Sapphire Rapids has native 512-bit execution units, so the
+µop-split issue does not apply. But it pays:
+
+- ~3-5% AVX-512 frequency downclock under sustained heavy 512-bit use.
+- AVX-512 ↔ AVX2 transition penalties when non-kernel TUs running
+  512-bit code call into the 256-bit hand-tuned kernel TUs (which
+  always run at host tier via the dispatcher).
+
+Net: small or zero gain from widening, often offset by the transition
+costs.
+
+## Mitigation: `-mprefer-vector-width=256`
+
+The canonical mitigation (used by FFmpeg, libvpx, Intel ISPC) is to
+**keep AVX-512BW *capabilities* available but cap auto-vectorization at
+256-bit width**. The flag `-mprefer-vector-width=256` (gcc / clang) /
+`-qopt-zmm-usage=low` (icpc) does exactly that:
+
+- The compiler can still emit AVX-512BW instructions where it
+  explicitly needs them (mask registers, byte/word lane permutes,
+  gather/scatter, the 32-zmm register file).
+- The auto-vectorizer's preferred SIMD width stays at 256-bit, dodging
+  Zen 4's µop-split and Intel's downclock/transition costs.
+
+The Makefile bakes this flag into `arch=avx512bw` directly. Hand-tuned
+512-bit kernel intrinsics in `KERNEL_SRCS` are unaffected — the cap is
+about auto-vec, not intrinsics.
+
+## Empirical numbers
+
+c7a.4xlarge (AMD EPYC 9R14, Zen 4) and c7i.4xlarge
+(Intel Xeon Platinum 8488C, Sapphire Rapids) running the bench's
+wgs-5M sample (1kg HG00096, 5M PE reads on hg38), shm-warmed via
+`bwa-mem3 shm`, 3 reps median, timing via [tricord]
+(`fg-labs/tricord`):
+
+| host | avx2 | avx512bw | avx512bw + pvw256 (default) |
+|------|------|----------|-----------------------------|
+| c7a (Zen 4) | 105.70 s | 103.40 s (−2.2%) | **101.03 s (−4.4%)** |
+| c7i (Sapphire Rapids) | 156.50 s | 155.47 s (−0.7%) | 155.41 s (−0.7%) |
+
+[tricord]: https://github.com/fg-labs/tricord
+
+The gain is real but small. Defaulting `BASELINE_ARCH=avx2` for x86
+distribution is still correct: it's portable across every x86 host and
+loses only ~2-4% to the host-locked avx512bw build on AVX-512 hosts.
+
+## Why the runtime warning was misleading
+
+Earlier versions of `src/simd_dispatch.cpp` printed at startup:
+
+```text
+[W::bwamem3_simd_init_body] build baseline avx2 < host tier avx512bw;
+non-kernel TUs are not auto-vectorized at the higher width (expect
+10-15% slower hot paths). Rebuild with BASELINE_ARCH=avx512bw to recover.
+```
+
+The "10-15%" figure was the **sse41 → avx2** transition on AVX2-only
+hosts (PR #84's measurement, before avx2 became the default). It did
+not generalize to **avx2 → avx512bw** for the µop-split / downclock /
+transition reasons above. The warning was demoted to BWAMEM3_DEBUG_SIMD
+gating in a follow-up commit; the recommendation reflects the actual
+measurements (typically <2% wall-time gain on AVX-512 hosts).
+
+## When to use `BASELINE_ARCH=avx512bw`
+
+- **Production fleets pinned to AVX-512BW hosts (c7a / c7i / m7i):** ship
+  a host-locked build for the small (~2-4%) extra gain. The Makefile's
+  `arch=avx512bw` includes the `-mprefer-vector-width=256` cap by
+  default, which is empirically the right choice for both Zen 4 and
+  Sapphire Rapids. The binary will SIGILL on hosts below avx2; pair
+  with explicit Batch queue / image plumbing.
+- **Mixed fleets / generic x86 distribution:** stay on the default
+  `BASELINE_ARCH=avx2`. The 2-4% gap is small enough that portability
+  is worth it.
+
+## Reproducer
+
+The investigation harness lives at
+`scripts/perf-diff-baseline-arch.sh`. It builds N variants of bwa-mem3
+with different `BASELINE_ARCH` and `EXTRA_CXXFLAGS` settings, runs each
+through `tricord` (or `perf record` for hot-function diffs), and emits
+per-variant median tables. Example usage:
+
+```bash
+scripts/perf-diff-baseline-arch.sh \
+    --ref hg38.fasta --r1 r1.fq.gz --r2 r2.fq.gz \
+    --out out/ --reps 3 --threads 16 \
+    --variants 'avx2:,avx512bw:,avx512bw-pvw256:-mprefer-vector-width=256'
+```
+
+Requires `tricord` on the PATH (`cargo install tricord`).
+`/dev/shm` must be ≥18 GB to stage the hg38 FMI index — on a default
+EC2 instance that means `mount -o remount,size=28g /dev/shm`.
+
+## Bench-side caveats
+
+The bench's Phase C report (May 2026) reported a +14% c7a regression
+when comparing the bench's portable image vs the host-locked
+`avx512bw` image inside AWS Batch. That delta does not reproduce on a
+single-instance bare-metal measurement. A 4-way disambiguation test
+(c7a.4xlarge, wgs-5M, shm-warmed, 3 reps each — see "Reproducer" above)
+attributes the gap to two independent bench-side factors:
+
+| variant | wall (s) | vs A |
+|---|---|---|
+| A: AL2023-built avx512bw, bare-metal | 99.50 | (baseline) |
+| B: AL2023-built avx512bw, in bench Docker image | 102.30 | +2.8% |
+| C: bench-image avx512bw binary, bare-metal | 117.03 | +17.6% |
+| D: bench-image avx512bw binary, in bench Docker image | 118.44 | +19.0% |
+
+The findings:
+
+1. **Build-environment matters more than container.** The bench's
+   `:316dba6-avx512bw` image binary, run **bare-metal** on the same
+   c7a.4xlarge with the same input, is +17.6% slower than a fresh
+   AL2023-built binary from the same SHA with the same `BASELINE_ARCH`.
+   - **AL2023** ships `gcc 11.5.0` and defaults to `-no-pie`. Output is
+     a non-PIE ELF.
+   - **Debian bookworm** (the bench's Dockerfile base) ships `gcc 12.x`
+     and defaults to `-pie`. Output is a PIE ELF.
+   - PIE adds indirection through a GOT for every global reference and
+     is well-known to cost 5–15% on tight CPU loops. Combined with
+     gcc-11 vs gcc-12 codegen differences this comfortably accounts
+     for the +17.6%.
+2. **Docker container overhead is small (~3%).** A→B and C→D both show
+   ~2–3% wall-time delta when wrapping the same binary in the bench's
+   image. Consistent with the broader literature on cgroup-namespaced
+   compute-bound workloads.
+3. **The bench's portable `:316dba6` image is built with
+   `BASELINE_ARCH=sse41`, not `avx2`.** Direct evidence from the
+   binary's startup banner inside the container:
+   `[W::bwamem3_simd_init_body] build baseline sse41 < host tier
+   avx512bw`. The banner is generated from compile-time macros in
+   `simd_dispatch.cpp` and unambiguously testifies to the build flags
+   used. Why it's sse41 (rather than the post-PR-#84 default of avx2)
+   is bench-side mystery — possibilities include an explicit
+   `BASELINE_ARCH=sse41` build-arg, a Makefile-default change between
+   the prior portable build and SHA 316dba6, or an environment quirk
+   in the Docker build. The Phase C report's "42/42 saw avx2 warning"
+   summary likely reflects a different prior run, not the current
+   `:316dba6` portable image.
+
+The Phase C report's headline "+14% c7a regression for avx512bw" is
+therefore comparing an **sse41-built portable image at +17.6%
+build-environment penalty** against a **`BASELINE_ARCH=avx512bw`
+binary at the same +17.6% penalty plus Zen 4's µop-split cost** —
+which roughly cancels for a small absolute delta in either direction.
+None of it is bwa-mem3's BASELINE_ARCH knob's fault.
+
+These are bench-side concerns. The bwa-mem3 fix
+(`-mprefer-vector-width=256` for `arch=avx512bw`) stands on its own
+bare-metal merit: −2.2% on Zen 4 vs avx2 vanilla, plus −2.2%
+incremental from the cap; wash on Sapphire Rapids.
+
+### Bench-side toolchain attribution
+
+The +17.6% bare-metal delta between the bench's bookworm-built binary
+and an AL2023-built binary was decomposed via a six-variant single-host
+test (c7a.4xlarge, wgs-5M, shm-warmed, 5 reps each, tricord median):
+
+| variant | gcc | PIE | CET (`endbr64`) | wall (s) | vs AL2023 |
+|---|---|---|---|---|---|
+| AL2023 default                                  | 11.5.0 | no  | 8 (libc init only)  | **98.28**  | (baseline) |
+| bookworm + gcc-11                               | 11.4.0 | yes | 3 (libc init only)  | **100.16** | +1.9% |
+| bookworm default                                | 12.2.0 | yes | 3 (libc init only)  | **117.21** | +19.3% |
+| bookworm + `-no-pie`                            | 12.2.0 | no  | 3                   | **118.98** | +21.1% |
+| bookworm + `-fcf-protection=none`               | 12.2.0 | yes | 3                   | **118.40** | +20.5% |
+| bookworm + `-no-pie -fcf-protection=none`       | 12.2.0 | no  | 3                   | **116.84** | +18.9% |
+
+Findings:
+
+- **The +17.6% delta is gcc-11 vs gcc-12 codegen, not any hardening
+  flag.** Switching gcc inside Debian bookworm (keeping PIE on, keeping
+  whatever default CET there is, keeping every other Debian default)
+  recovers the perf to within 2% of AL2023.
+- **Disabling PIE in bookworm gcc-12 has no measurable effect.** Median
+  118.98s with `-no-pie` vs 117.21s default — within rep-to-rep noise.
+  The 5–15% PIE penalty cited in the literature doesn't manifest for
+  bwa-mem3's intrinsic-heavy hot path; GOT indirection is rare on
+  tight inner loops.
+- **Disabling CET in bookworm gcc-12 has no measurable effect.** Both
+  bookworm-default and `-fcf-protection=none` builds emit only ~3
+  `endbr64` instructions in 7.6 MB of binary (libc init code).
+  Something — probably bwa-mem3's `-mavx512f -mavx512bw` per-tier
+  kernel flags, or a `#pragma GCC` somewhere — suppresses CET emission
+  regardless of the flag. So disabling it removes nothing.
+- **The combined `-no-pie -fcf-protection=none` build is statistically
+  indistinguishable from the default.** Both PIE and CET are noise.
+
+So the actionable bench-side fix isn't `-no-pie` or
+`-fcf-protection=none` — it's "use gcc-11". The six-variant table
+above is the only data we have; gcc-13 was not tested here, and the
+postscript below shows that gcc-13 / gcc-14 do *not* recover the gap
+without #88's source-side fix. A one-liner for the bench Dockerfile:
+
+```dockerfile
+RUN apt-get install -y gcc-11 g++-11
+RUN cd fg-labs && CC=gcc-11 CXX=g++-11 make BASELINE_ARCH=... -j
+```
+
+…recovers ~17% wall-time **uniformly across every Batch worker, every
+arch**. That's a much bigger lever than the bwa-mem3-side
+`-mprefer-vector-width=256` mitigation here, which is ~2–4% on c7a and
+wash on c7i. But it's bench infra, not bwa-mem3 source.
+
+(The deeper question — *why* is gcc-12 codegen ~19% slower than gcc-11
+on Zen 4 for this workload? — was followed up in [#88]; see the
+postscript below.)
+
+The bwa-mem3-side conclusion stands on its own bare-metal merit:
+`-mprefer-vector-width=256` for `arch=avx512bw` is a real ~2–4% win on
+c7a and a wash on c7i, independent of toolchain and container
+concerns.
+
+### Postscript: gcc-12 attribution closed by #88
+
+The "use gcc-11" recommendation above was the actionable bench-side
+fix at the time this page was written. [#88] (`perf(fmi): inline
+backwardExt to recover gcc 12+ wall-clock regression`) has since
+identified the underlying mechanism and closed the gap in source — so
+on current main no compiler pin is required.
+
+Profile attribution on a fresh c7a.8xlarge run with `perf record
+--no-children` localized ~9 percentage points of wall-time to
+`FMI_search::backwardExt`'s self-time (12.5% on gcc-11 vs 21.5% on
+gcc-14). Disassembly histograms were nearly identical between
+compilers (~110 instructions, 8 scalar `popcntq`, 25 mov each); IPC
+fell from 1.77 to 1.60. `perf annotate` isolated a single instruction
+at 42% of the function's samples on gcc-14: `vmovdqu %ymm0, (%r8)` —
+the 32-byte AVX store of the `SMEM` return value through SysV's
+hidden-pointer convention. The matching argument-load
+(`mov 0x30(%rbp), %r10` for `smem.s` from the caller's stack push) was
+next-hottest at 17%. Together those two instructions accounted for
+~60% of the function's self-time.
+
+The fix in #88 is a one-line attribute change: marking
+`backwardExt` `__attribute__((always_inline))` removes the call
+boundary at all 9 hot call sites in `getSMEMs*` and
+`ls_advance_*`. Without a call boundary the `SMEM` struct stays in
+caller registers across the would-be call site — no struct push, no
+return-slot store, no `vzeroupper`.
+
+Post-#88 numbers on c7a.8xlarge (hg38 wgs-5M, shm-warmed, `-t 32`, 5
+reps mean, single-binary at `BASELINE_ARCH=avx2`):
+
+| binary           | wall (s) | vs gcc-14 | vs gcc-11 | IPC  |
+|------------------|----------|-----------|-----------|------|
+| main + gcc-11    | 64.59    | −6.6%     | baseline  | 1.77 |
+| main + gcc-14    | 69.16    | baseline  | +7.07%    | 1.60 |
+| **#88 + gcc-14** | **61.94**| **−10.4%**| **−4.10%**| **1.83** |
+
+So the gcc-11 vs gcc-12 attribution above was the surface symptom of
+an ABI-level inefficiency that was costing cycles on gcc-11 too — the
+always-inline fix beats gcc-11 baseline by 4.10%, not just gcc-14. The
+empirical table and findings list in the previous section remain
+accurate as an investigation snapshot at commit `316dba6` (the pre-#88
+state); the bench-side `gcc-11` recommendation it produced is
+obsolete.
+
+[#88]: https://github.com/fg-labs/bwa-mem3/pull/88
+
+## See also
+
+- [SIMD dispatch architecture](../developer-guide/simd-dispatch.md)
+  — how the runtime kernel dispatcher picks a tier
+- [Build & infrastructure](build-infra.md) — the broader build layout
+- [Architecture support](arch-support.md) — per-host SIMD coverage

--- a/scripts/perf-diff-baseline-arch.sh
+++ b/scripts/perf-diff-baseline-arch.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+# scripts/perf-diff-baseline-arch.sh
+#
+# A/B comparison harness for BASELINE_ARCH choices on a single host.
+# Builds bwa-mem3 with two (or more) different non-kernel ARCH_FLAGS
+# values, runs each on the same input, and emits a comparison table.
+#
+# Both builds use the production `single` target, so the per-tier kernel
+# objects (bandedSWA, kswv, ksw, sam_encode at every tier) are identical
+# between runs and the runtime dispatcher picks the host's tier
+# regardless. The only thing that differs between runs is the
+# auto-vectorization width and ISA used by NON-kernel TUs — which is
+# what we attribute when investigating BASELINE_ARCH choices.
+#
+# Modes:
+#   time    — wrap each run with `tricorder` (fg-labs/tricord). Same tool
+#             the bwa-mem3-bench Snakemake workflow uses, so the wall /
+#             cpu_time / max_rss / io numbers are directly comparable to
+#             benchmark.db rows. Fast (one invocation per rep). Default.
+#   record  — `perf record -F 999 -g --call-graph dwarf` × 1 rep per
+#             variant. Used for finding individual hot functions where one
+#             variant beats another. For Phase 3 pragma-target candidate
+#             selection.
+#
+# Variants are passed as a comma-separated list of <label>:<flags>
+# tokens. Examples:
+#   --variants 'avx2:,avx512bw:'
+#       avx2 = default ARCH_FLAGS for arch=avx2
+#       avx512bw = default ARCH_FLAGS for arch=avx512bw
+#   --variants 'avx2:,avx512bw:,avx512bw-pvw256:-mprefer-vector-width=256'
+#       three-way comparison; the third variant builds avx512bw with
+#       the autovec-width cap appended via EXTRA_CXXFLAGS.
+#
+# Usage:
+#   scripts/perf-diff-baseline-arch.sh \
+#       --ref <ref.fa> --r1 <r1.fq.gz> --r2 <r2.fq.gz> \
+#       --out <out_dir> [--mode time|record] [--reps N] [--threads T] \
+#       [--variants <label>:<extra_flags>,...] [--no-shm]
+#
+# Output files in <out_dir> (mode=time):
+#   bwa-mem3.<label>           — built binary per variant
+#   tric-<label>-rep<N>.tsv    — tricorder TSV per rep
+#   summary.csv                — median per variant per metric
+#   delta.csv                  — variant deltas vs the first variant
+# Output files (mode=record):
+#   record-<label>.data        — perf.data per variant
+#   record-<label>.txt         — perf report --stdio
+#   delta.tsv                  — function self-time delta (variant 2 vs 1)
+#
+# Requires: g++ ≥ 11; tricorder (cargo install tricord) on PATH for
+# mode=time; perf for mode=record. Run on the target host (c7a / c7i /
+# m7i / etc.). Lower kernel.perf_event_paranoid (-1 on a throwaway box).
+# /dev/shm must hold the staged FMI index when --no-shm is not set
+# (~17 GB for hg38; remount with `mount -o remount,size=28g /dev/shm`
+# if the default tmpfs is too small).
+
+set -euo pipefail
+
+REF=""
+R1=""
+R2=""
+OUT=""
+MODE="time"
+REPS=3
+THREADS="$(nproc 2>/dev/null || echo 4)"
+VARIANTS_RAW="avx2:,avx512bw:"
+USE_SHM=1
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ref)       REF="$2"; shift 2 ;;
+        --r1)        R1="$2"; shift 2 ;;
+        --r2)        R2="$2"; shift 2 ;;
+        --out)       OUT="$2"; shift 2 ;;
+        --mode)      MODE="$2"; shift 2 ;;
+        --reps)      REPS="$2"; shift 2 ;;
+        --threads)   THREADS="$2"; shift 2 ;;
+        --variants)  VARIANTS_RAW="$2"; shift 2 ;;
+        --no-shm)    USE_SHM=0; shift ;;
+        -h|--help)
+            sed -n '/^# /,/^$/p' "$0" | sed 's/^# //;s/^#$//' | head -55
+            exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+: "${REF:?--ref is required}"
+: "${R1:?--r1 is required}"
+: "${R2:?--r2 is required}"
+: "${OUT:?--out is required}"
+
+case "$MODE" in
+    time|record) ;;
+    *) echo "--mode must be time or record (got: $MODE)" >&2; exit 2 ;;
+esac
+
+if [ "$MODE" = "time" ] && ! command -v tricorder >/dev/null 2>&1; then
+    echo "tricorder not found on PATH; install with: cargo install tricord" >&2
+    exit 2
+fi
+
+REF="$(readlink -f "$REF")"
+R1="$(readlink -f "$R1")"
+R2="$(readlink -f "$R2")"
+mkdir -p "$OUT"
+OUT="$(readlink -f "$OUT")"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Parse VARIANTS_RAW into parallel arrays LABELS / FLAGS.
+LABELS=()
+FLAGS=()
+IFS=',' read -ra _VARIANTS <<< "$VARIANTS_RAW"
+for v in "${_VARIANTS[@]}"; do
+    label="${v%%:*}"
+    flags="${v#*:}"
+    LABELS+=("$label")
+    FLAGS+=("$flags")
+done
+echo "Variants: ${#LABELS[@]}"
+for i in "${!LABELS[@]}"; do
+    echo "  ${LABELS[$i]}: arch_flags+='${FLAGS[$i]}'"
+done
+
+# Cleanup helper: remove only bwa-mem3's own build artifacts.
+clean_bwamem3_only() {
+    cd "$REPO_ROOT"
+    rm -f src/*.o src/*/*.o libbwa.a bwa-mem3 src/version.h
+    rm -f src/*.gcno src/*.gcda
+}
+
+# Build one variant. The label maps to BASELINE_ARCH (first segment
+# before any '-'); the flags string is appended via EXTRA_CXXFLAGS.
+build_one() {
+    local label="$1" flags="$2"
+    cd "$REPO_ROOT"
+    clean_bwamem3_only
+    echo "=== Building variant=$label flags='$flags' ==="
+    local baseline="${label%%-*}"
+    EXTRA_CXXFLAGS="$flags" make BASELINE_ARCH="$baseline" -j"$THREADS" >&2
+    cp bwa-mem3 "$OUT/bwa-mem3.$label"
+    echo "=== Built $OUT/bwa-mem3.$label ==="
+}
+
+run_tricord_rep() {
+    local label="$1" rep="$2"
+    local bin="$OUT/bwa-mem3.$label"
+    local tsv="$OUT/tric-$label-rep$rep.tsv"
+    echo "=== tricord $label rep $rep ==="
+    tricorder --out "$tsv" -- \
+        "$bin" mem -t "$THREADS" "$REF" "$R1" "$R2" \
+        > /dev/null 2>"$OUT/stderr-$label-rep$rep.log"
+}
+
+run_record() {
+    local label="$1"
+    local bin="$OUT/bwa-mem3.$label"
+    local data="$OUT/record-$label.data"
+    local txt="$OUT/record-$label.txt"
+    echo "=== perf record $label ==="
+    perf record -F 999 -g --call-graph dwarf -o "$data" -- \
+        "$bin" mem -t "$THREADS" "$REF" "$R1" "$R2" > /dev/null
+    perf report -i "$data" --no-children --stdio --percent-limit 0.05 \
+        --demangle > "$txt"
+}
+
+# Build all variants.
+for i in "${!LABELS[@]}"; do
+    build_one "${LABELS[$i]}" "${FLAGS[$i]}"
+done
+
+# Shared-memory FMI index prewarm/teardown. Mirrors the bench's pattern:
+# pull the ~17 GB hg38 index load out of the timed region so wall times
+# reflect alignment work only. Index data is binary-independent (same
+# source SHA across variants), so one prewarm covers every variant.
+shm_cleanup() {
+    if [ "$USE_SHM" = "1" ] && [ -n "${SHM_PREWARM_BIN:-}" ]; then
+        echo "=== shm teardown ==="
+        "$SHM_PREWARM_BIN" shm -d 2>/dev/null || true
+    fi
+}
+trap shm_cleanup EXIT
+
+if [ "$USE_SHM" = "1" ]; then
+    SHM_PREWARM_BIN="$OUT/bwa-mem3.${LABELS[0]}"
+    echo "=== shm prewarm via $SHM_PREWARM_BIN ==="
+    "$SHM_PREWARM_BIN" shm -d 2>/dev/null || true
+    "$SHM_PREWARM_BIN" shm "$REF"
+fi
+
+# Run.
+if [ "$MODE" = "time" ]; then
+    for label in "${LABELS[@]}"; do
+        for rep in $(seq 1 "$REPS"); do
+            run_tricord_rep "$label" "$rep"
+        done
+    done
+
+    # tricorder TSV columns (header + 1 data row):
+    #   s  h:m:s  max_rss  max_vms  max_uss  max_pss  io_in  io_out  mean_load  cpu_time
+    # We summarize the numeric columns we care about: s, max_rss, io_in,
+    # io_out, mean_load, cpu_time. The metric label "s" is renamed to
+    # "wall_seconds" for clarity.
+    {
+        echo "variant,metric,median"
+        for label in "${LABELS[@]}"; do
+            for col_idx in 1 3 7 8 9 10; do
+                # Map col_idx → metric name
+                case $col_idx in
+                    1)  metric=wall_seconds ;;
+                    3)  metric=max_rss_mib ;;
+                    7)  metric=io_in_mib ;;
+                    8)  metric=io_out_mib ;;
+                    9)  metric=mean_load_pct_one_core ;;
+                    10) metric=cpu_seconds ;;
+                esac
+                vals=()
+                for rep in $(seq 1 "$REPS"); do
+                    local_tsv="$OUT/tric-$label-rep$rep.tsv"
+                    [ -f "$local_tsv" ] || continue
+                    v=$(awk -v c=$col_idx 'NR==2{print $c}' "$local_tsv")
+                    [ -n "$v" ] && [ "$v" != "NA" ] && [ "$v" != "-" ] && vals+=("$v")
+                done
+                if [ ${#vals[@]} -gt 0 ]; then
+                    median=$(printf '%s\n' "${vals[@]}" | sort -n | \
+                        awk -v n=${#vals[@]} 'NR==int((n+1)/2)')
+                    echo "$label,$metric,$median"
+                fi
+            done
+        done
+    } > "$OUT/summary.csv"
+
+    BASE_LABEL="${LABELS[0]}"
+    {
+        echo "variant,metric,base_median,variant_median,abs_delta,rel_delta_pct"
+        awk -F',' -v base="$BASE_LABEL" '
+            NR==1 {next}
+            { val[$1, $2] = $3; seen_var[$1] = 1; seen_m[$2] = 1 }
+            END {
+                for (var in seen_var) {
+                    if (var == base) continue
+                    for (m in seen_m) {
+                        b = val[base, m] + 0
+                        v = val[var, m] + 0
+                        if (b == 0) continue
+                        absd = v - b
+                        rel = (absd / b) * 100
+                        printf "%s,%s,%g,%g,%g,%.2f\n", var, m, b, v, absd, rel
+                    }
+                }
+            }
+        ' "$OUT/summary.csv"
+    } | sort -t',' -k1,1 -k2,2 > "$OUT/delta.csv"
+
+    echo
+    echo "=== Summary (tricord median of $REPS reps) ==="
+    column -t -s',' < "$OUT/summary.csv"
+    echo
+    echo "=== Deltas vs $BASE_LABEL ==="
+    column -t -s',' < "$OUT/delta.csv"
+    echo
+    echo "Files: $OUT/summary.csv $OUT/delta.csv"
+
+elif [ "$MODE" = "record" ]; then
+    for label in "${LABELS[@]}"; do
+        run_record "$label"
+    done
+
+    # Build per-function self-time delta (variant 2 vs variant 1).
+    extract_self_time() {
+        awk '
+            /^[[:space:]]*[0-9]/ {
+                pct = $1; gsub(/%/, "", pct);
+                for (i = 1; i <= NF; i++) {
+                    if ($i == "[.]" || $i == "[k]") {
+                        sym = "";
+                        for (j = i+1; j <= NF; j++) {
+                            sym = (sym == "" ? $j : sym " " $j);
+                        }
+                        print sym "\t" pct;
+                        next;
+                    }
+                }
+            }
+        ' "$1"
+    }
+
+    if [ ${#LABELS[@]} -ge 2 ]; then
+        L0="${LABELS[0]}"
+        L1="${LABELS[1]}"
+        extract_self_time "$OUT/record-$L0.txt" | sort -k1,1 > "$OUT/.self-$L0.tsv"
+        extract_self_time "$OUT/record-$L1.txt" | sort -k1,1 > "$OUT/.self-$L1.tsv"
+        awk -F'\t' -v l0="$L0" -v l1="$L1" '
+            NR==FNR { a[$1] = $2; next }
+            { b[$1] = $2 }
+            END {
+                for (s in a) all[s] = 1
+                for (s in b) all[s] = 1
+                printf "function\tself_%s_pct\tself_%s_pct\tabs_delta_pct\trel_delta_pct\n", l0, l1
+                for (s in all) {
+                    av = (s in a) ? a[s] + 0 : 0
+                    bv = (s in b) ? b[s] + 0 : 0
+                    absd = bv - av
+                    rel = (av > 0) ? (absd / av) * 100 : 0
+                    printf "%s\t%.3f\t%.3f\t%.3f\t%.2f\n", s, av, bv, absd, rel
+                }
+            }
+        ' "$OUT/.self-$L0.tsv" "$OUT/.self-$L1.tsv" \
+          | { read -r header; printf '%s\n' "$header"; sort -t$'\t' -k4,4 -gr; } \
+          > "$OUT/delta.tsv"
+        rm -f "$OUT/.self-$L0.tsv" "$OUT/.self-$L1.tsv"
+
+        echo
+        echo "=== Top 30 functions by abs_delta_pct ($L1 vs $L0) ==="
+        head -31 "$OUT/delta.tsv" | column -t -s$'\t'
+        echo
+        echo "Files: $OUT/delta.tsv"
+    fi
+fi

--- a/src/bwa_shm.cpp
+++ b/src/bwa_shm.cpp
@@ -38,6 +38,7 @@
 #include <cstring>
 #include <sys/mman.h>      /* shm_open, mmap, munmap */
 #include <sys/stat.h>      /* mode constants, stat */
+#include <sys/statvfs.h>   /* statvfs — /dev/shm capacity preflight */
 #include <fcntl.h>         /* O_* */
 #include <unistd.h>        /* close, ftruncate */
 #include <getopt.h>        /* getopt_long for `bwa-mem3 shm --meth ...` */
@@ -640,6 +641,54 @@ int bwa_shm_stage(const char *prefix)
         ctl_lock_release(ctl_lock);
         bwa_shm_layout_free(&layout);
         return -1;
+    }
+
+    /* 4b. /dev/shm capacity preflight.
+     *
+     * ftruncate on a tmpfs file lazily reserves space — it succeeds even
+     * when the requested size exceeds the tmpfs limit. The actual ENOSPC
+     * surfaces during pack_into's freads as SIGBUS / EFAULT when a page
+     * fault on a write to the mmap'd region cannot allocate a backing
+     * page. The user-visible failure is then a confusing
+     * `[fread] Bad address` from err_fread_noeof, with no indication
+     * that /dev/shm was the cause.
+     *
+     * statvfs("/dev/shm") tells us the tmpfs's available bytes up-front,
+     * so we can refuse cleanly with a message that points at the actual
+     * fix. Default tmpfs size on Linux is RAM/2 (e.g. 16 GB on a 32 GB
+     * c7a.4xlarge / c7i.4xlarge), so the hg38 FMI index (~17 GB
+     * total_size) doesn't fit out of the box on common AWS instance
+     * sizes. The remediation is a one-liner — `mount -o remount,size=…`
+     * — but only useful if the user knows that's the problem. */
+    {
+        struct statvfs svfs;
+        if (statvfs("/dev/shm", &svfs) == 0) {
+            /* f_bavail is in units of f_frsize (fundamental block size),
+             * not f_bsize (preferred I/O block size); on Linux tmpfs the
+             * two are equal but POSIX permits them to differ (e.g. ZFS
+             * reports f_frsize=1MiB), so use f_frsize for portability. */
+            uint64_t avail = (uint64_t)svfs.f_frsize * (uint64_t)svfs.f_bavail;
+            if ((uint64_t)layout.total_size > avail) {
+                std::fprintf(stderr,
+                    "[E::%s] /dev/shm has %llu bytes free but staging '%s' "
+                    "needs %llu bytes. Remount with larger size, e.g. "
+                    "`sudo mount -o remount,size=%lluG /dev/shm`.\n",
+                    __func__,
+                    (unsigned long long)avail,
+                    name,
+                    (unsigned long long)layout.total_size,
+                    (unsigned long long)((layout.total_size + (1ULL<<30) - 1) / (1ULL<<30) + 2));
+                ctl_close(ctl_map, ctl_fd);
+                ctl_lock_release(ctl_lock);
+                bwa_shm_layout_free(&layout);
+                return -1;
+            }
+        }
+        /* statvfs failure (e.g. /dev/shm not present, ENOSYS on exotic
+         * kernels) is non-fatal — fall through and let the existing
+         * shm_open / ftruncate / pack_into path run. The pre-existing
+         * (less helpful) error message in pack_into is still better
+         * than refusing to stage based on a missing diagnostic. */
     }
 
     /* 5. Create the per-index segment. EEXIST means another stager raced us

--- a/src/simd_dispatch.cpp
+++ b/src/simd_dispatch.cpp
@@ -91,27 +91,46 @@ static void bwamem3_simd_init_body(void)
     g_tier = BWAMEM3_TIER_NONE;
 #endif
 
-    /* Build-vs-host gap warning. The per-tier kernel TUs are still compiled
+    /* Build-vs-host gap (debug-only).
+     *
+     * The per-tier kernel TUs (KERNEL_SRCS in the Makefile) are compiled
      * at every supported tier and dispatched correctly via this file, so
      * kernel calls (BSW, kswv, ksw_extend, sam_encode_*) will pick the
-     * host's tier regardless. But every non-kernel TU (bwamem.cpp,
-     * bwamem_pair.cpp, FMI_search.cpp, fastmap.cpp, ...) is compiled once
-     * at the BASELINE_ARCH tier, so when the host is more capable the
-     * compiler can't auto-vectorize those hot paths at the wider width.
-     * Compare on the x86 ordering only; arm64 builds have a single tier.
-     * Use the detected tier (pre-FORCE_TIER) so the warning reflects the
-     * binary's potential vs the host's capability, not the deliberate
-     * runtime override. */
+     * host's tier regardless of BASELINE_ARCH. Every non-kernel TU
+     * (bwamem.cpp, bwamem_pair.cpp, FMI_search.cpp, fastmap.cpp, ...) is
+     * compiled once at BASELINE_ARCH, so a build_tier < host_tier mismatch
+     * means the compiler couldn't auto-vectorize those hot paths at the
+     * higher width.
+     *
+     * Earlier versions of bwa-mem3 emitted a [W::] warning here promising
+     * "10-15%% slower hot paths, rebuild with BASELINE_ARCH=<host_tier>
+     * to recover". Empirically (c7a / c7i wgs-5M shm-warmed bare-metal,
+     * tricord) the gap is much smaller than that and the recommendation
+     * is not always applicable:
+     *   - avx2 -> avx512bw: c7a -2.2%%, c7i -0.7%% (wash, both cases)
+     *   - avx2 -> avx512bw + -mprefer-vector-width=256 (the default for
+     *     arch=avx512bw): c7a -4.4%%, c7i -0.7%%
+     *   - sse41 -> avx2: ~+10-15%% on AVX2 hosts (the original PR #84
+     *     measurement that motivated raising the default to avx2)
+     * The "10-15%%" figure was the sse41->avx2 transition on AVX2-only
+     * hosts; it does not generalize to avx2->avx512bw.
+     *
+     * The warning is now BWAMEM3_DEBUG_SIMD-gated to avoid spamming a
+     * misleading recommendation in production logs. The per-stage tier
+     * report below already covers the diagnostic case. */
 #if defined(__x86_64__) || defined(__i386__)
-    if (g_build_tier > BWAMEM3_TIER_NONE && g_build_tier < g_tier) {
+    if (g_build_tier > BWAMEM3_TIER_NONE && g_build_tier < g_tier
+        && getenv("BWAMEM3_DEBUG_SIMD")) {
         fprintf(stderr,
-                "[W::%s] build baseline %s < host tier %s; non-kernel TUs "
-                "are not auto-vectorized at the higher width (expect "
-                "10-15%% slower hot paths). Rebuild with BASELINE_ARCH=%s "
-                "to recover.\n",
+                "[M::%s] build baseline %s < host tier %s; non-kernel TUs "
+                "compiled for %s. Hot kernel paths self-dispatch at host tier "
+                "regardless. Rebuilding with BASELINE_ARCH=%s typically "
+                "yields <2%% wall-time gain on AVX-512 hosts (PR #84's "
+                "10-15%% figure was the sse41->avx2 transition).\n",
                 __func__,
                 bwamem3_simd_tier_name(g_build_tier),
                 bwamem3_simd_tier_name(g_tier),
+                bwamem3_simd_tier_name(g_build_tier),
                 bwamem3_simd_tier_name(g_tier));
     }
 #endif


### PR DESCRIPTION
## Summary

Two changes from the bwa-mem3-bench c7a / c7i Phase C investigation, both on the x86 build path:

- **AVX-512 autovec cap.** `arch=avx512bw` (and legacy `arch=avx512`) compile with `-mprefer-vector-width=256` (gcc/clang) / `-qopt-zmm-usage=low` (icpc). Per-tier hand-tuned kernel TUs (bandedSWA, kswv, ksw, sam_encode) use intrinsics so the cap is a no-op for them — the runtime dispatcher still picks the host's tier and 512-bit kernel paths run at full width. Empirical (c7a.4xlarge / c7i.4xlarge wgs-5M, shm-warmed, tricord median of 3 reps): c7a -4.4% wall vs avx2 baseline (-2.2% before the cap); c7i wash either way (-0.7%). Also demotes the `[W::bwamem3_simd_init_body]` startup warning to `BWAMEM3_DEBUG_SIMD`-gated — its "10-15% slower hot paths" claim was the sse41 → avx2 transition (PR #84) and does not generalize to avx2 → avx512bw. New `docs/src/whats-different/avx512-baseline.md` page covers the journey, with a postscript that supersedes the original "use gcc-11 in the Dockerfile" recommendation: the gcc-11 vs gcc-12 attribution was the surface symptom of the SysV-ABI struct-return inefficiency closed in #88, and on current main no compiler pin is required.
- **`/dev/shm` capacity preflight.** When tmpfs at `/dev/shm` is smaller than the index `total_size`, `ftruncate` succeeds lazily and the actual ENOSPC surfaces during `pack_into`'s freads as `[fread] Bad address` with no indication that `/dev/shm` was the cause. Add a `statvfs("/dev/shm")` preflight before `shm_open` so we fail cleanly with a message that names `/dev/shm` and includes a `mount -o remount,size=...` hint. Bites the common case of default-sized tmpfs on AWS (RAM/2 ≈ 16 GB on c7a.4xlarge / c7i.4xlarge, hg38 stages ~17 GB). `statvfs` failure (no `/dev/shm`, restricted sandbox, ENOSYS) is non-fatal.

## Test plan

- [ ] `make arch=avx512bw` builds on x86 with gcc-11 and gcc-15
- [ ] `make` on Apple Silicon arm64 builds cleanly
- [ ] hg38 index stage on a host with undersized `/dev/shm` prints the new `[E::bwa_shm_stage]` message instead of `[fread] Bad address`
- [ ] `mdbook build docs` renders the `avx512-baseline.md` page including the new "Postscript: gcc-12 attribution closed by #88" section
- [ ] c7a.4xlarge wgs-5M tricord A/B reproduces -4.4% wall vs the avx2 baseline
- [ ] c7i.4xlarge wgs-5M tricord A/B confirms no regression vs avx2 baseline