### PR TITLE
perf(fmi): inline backwardExt to recover gcc 12+ wall-clock regression

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -1341,34 +1341,10 @@ void FMI_search::sortSMEMs(SMEM *matchArray,
 }
 
 
-SMEM FMI_search::backwardExt(SMEM smem, uint8_t a)
-{
-    //beCalls++;
-    uint8_t b;
-
-    int64_t k[4], l[4], s[4];
-    for(b = 0; b < 4; b++)
-    {
-        int64_t sp = (int64_t)(smem.k);
-        int64_t ep = (int64_t)(smem.k) + (int64_t)(smem.s);
-        GET_OCC(sp, b, occ_id_sp, y_sp, occ_sp, one_hot_bwt_str_c_sp, match_mask_sp);
-        GET_OCC(ep, b, occ_id_ep, y_ep, occ_ep, one_hot_bwt_str_c_ep, match_mask_ep);
-        k[b] = count[b] + occ_sp;
-        s[b] = occ_ep - occ_sp;
-    }
-
-    int64_t sentinel_offset = 0;
-    if((smem.k <= sentinel_index) && ((smem.k + smem.s) > sentinel_index)) sentinel_offset = 1;
-    l[3] = smem.l + sentinel_offset;
-    l[2] = l[3] + s[3];
-    l[1] = l[2] + s[2];
-    l[0] = l[1] + s[1];
-
-    smem.k = k[a];
-    smem.l = l[a];
-    smem.s = s[a];
-    return smem;
-}
+/* FMI_search::backwardExt is now defined inline in FMI_search.h
+ * (issue #87) so the body inlines into all 9 hot callers, eliminating
+ * the SysV-ABI struct-by-value pass and return-slot store that dominate
+ * self-time on gcc 12+. */
 
 int64_t FMI_search::get_sa_entry(int64_t pos)
 {

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -256,7 +256,43 @@ private:
         uint8_t *shm_base;
         size_t   shm_len;
 
-        SMEM backwardExt(SMEM smem, uint8_t a);
+        /* Defined inline so all hot callers (getSMEMs* and ls_advance_*)
+         * fully absorb the body and pay no struct-by-value pass / return
+         * cost. backwardExt is called ~10^9 times per 5M-pair WGS run, so
+         * the SysV-ABI hidden-pointer dance for the 24-byte SMEM struct
+         * dominates self-time on gcc 12+ (issue #87): a single output store
+         * `vmovdqu %ymm0, (%r8)` writing the return SMEM hits 42% of the
+         * function's CPU samples on c7a (Zen 4) with gcc-14, with the
+         * matching argument load close behind. always_inline removes the
+         * call boundary and recovers the full gcc-11 baseline (and beats
+         * it by ~4% wall-clock on c7a wgs-5M shm-warmed). */
+        __attribute__((always_inline)) inline
+        SMEM backwardExt(SMEM smem, uint8_t a) const
+        {
+            uint8_t b;
+            int64_t k[4], l[4], s[4];
+            for (b = 0; b < 4; b++) {
+                int64_t sp = (int64_t)(smem.k);
+                int64_t ep = (int64_t)(smem.k) + (int64_t)(smem.s);
+                GET_OCC(sp, b, occ_id_sp, y_sp, occ_sp, one_hot_bwt_str_c_sp, match_mask_sp);
+                GET_OCC(ep, b, occ_id_ep, y_ep, occ_ep, one_hot_bwt_str_c_ep, match_mask_ep);
+                k[b] = count[b] + occ_sp;
+                s[b] = occ_ep - occ_sp;
+            }
+
+            int64_t sentinel_offset = 0;
+            if ((smem.k <= sentinel_index) && ((smem.k + smem.s) > sentinel_index))
+                sentinel_offset = 1;
+            l[3] = smem.l + sentinel_offset;
+            l[2] = l[3] + s[3];
+            l[1] = l[2] + s[2];
+            l[0] = l[1] + s[1];
+
+            smem.k = k[a];
+            smem.l = l[a];
+            smem.s = s[a];
+            return smem;
+        }
 
     // ----- Lockstep SMEM batching internals -----
     // Defined in FMI_search.cpp. Phases and per-slot state are scoped to


### PR DESCRIPTION
## Summary

Forces `FMI_search::backwardExt` to inline at all 9 hot call sites in `getSMEMs*` and `ls_advance_*`. This eliminates the SysV-ABI struct-by-value pass and return-slot store that dominate the function's self-time on gcc 12+, recovering the wall-clock regression tracked in #87 and beating the gcc-11 baseline.

Two-line source change: move the body into `FMI_search.h` as `__attribute__((always_inline)) inline ... const`, remove the out-of-line definition in `FMI_search.cpp`. No behavioral change, no signature change, no new APIs.

Closes #87.

## Empirical results

c7a.8xlarge (Zen 4, 32 vCPU), hg38 wgs-5M shm-warmed, `-t 32`, 5 reps mean, single-binary build at `BASELINE_ARCH=avx2`:

| binary | wall mean | vs gcc-14 | vs gcc-11 | cycles | IPC |
| --- | --- | --- | --- | --- | --- |
| main + gcc-11 | 64.59s ± 0.5% | -6.6% | baseline | 5.33×10¹² | 1.77 |
| main + gcc-14 | 69.16s ± 0.8% | baseline | **+7.07%** (regression) | 5.94×10¹² | 1.60 |
| **this PR + gcc-14** | **61.94s ± 0.5%** | **-10.4%** | **-4.10% FASTER than gcc-11** | **4.98×10¹²** | **1.83** |

The fix recovers the gcc-12+ wall-clock regression and marginally beats the gcc-11 baseline (IPC 1.83 > 1.77) — even on gcc-11 the function-call boundary was costing a few cycles per invocation.

## Why this works

Diagnosis tracked in #87. Summary:

- `perf record --no-children` attributes the regression to `FMI_search::backwardExt`'s **self-time** (12.5% on gcc-11 vs 21.5% on gcc-14, +9 pp).
- Disassembly histograms are nearly identical between compilers (102 vs 111 instructions, same 8 scalar `popcntq`, 25 vs 24 `mov`). Not an instruction-count regression.
- IPC drops from 1.77 to 1.60 — same instructions, more cycles per instruction. Microarchitectural.
- `perf annotate` isolates a single instruction at **42.28% of backwardExt's samples** on gcc-14: `vmovdqu %ymm0, (%r8)` — the 32-byte AVX store of the SMEM return value through SysV's hidden-pointer convention. The matching argument-load `mov 0x30(%rbp), %r10` (smem.s from the caller's stack push) is next-hottest at 17%. Together ~60% of self-time.
- Hand-written AVX-512 intrinsic kernels were tried first (see #87 findings) and **did not help on Zen 4**: `vpopcntq` and 8 pipelined scalar `popcntq` have the same throughput, and the intrinsic body left the prologue/return-store pattern untouched.
- `__attribute__((always_inline))` removes the call boundary entirely. Caller-side SMEM stays in registers across the would-be call site; no struct push, no return-slot store, no `vzeroupper`. The 60% of self-time tied to those two instructions disappears.

## Variants considered (results in #87 findings doc)

- **V1: pass `const SMEM&`** — fixes the input side but leaves the return-by-value path (still 33.5% on the return store, IPC 1.61). Rejected.
- **V2: `__attribute__((always_inline))`** — this PR. Simplest change (1-line attribute, 9-callsite inlining handled by the compiler). Cleanest signal across 5 reps.
- **V3: separate `int64_t k/l/s` by reference** — also fixes the regression (61.81s mean, IPC 1.79), but requires rewriting all 9 call sites and touches the function signature. V3's wall-clock signal had higher run-to-run variance (4.2% vs V2's 0.5%).

## Cross-architecture

The change is compiler-agnostic and architecture-agnostic. `__attribute__((always_inline))` is gcc + clang + Apple clang compatible. Caller-side register-pressure increases negligibly (each of the 9 call sites grows by ~110 instructions / ~400 bytes). On arm64 (Apple Silicon, Graviton) the calling convention differs and the regression pattern likely doesn't exist — `always_inline` is at worst neutral, at best a small win.

The CI matrix (`.github/workflows/ci.yml`) covers SSE4.1 / AVX2 (Linux x86_64) + Linux ARM64 + macOS ARM64; cross-arch compile cleanliness rides on those. Local `make arm64 && make test` on macOS ARM64 passes with no behavioral change (11/11 doctest cases, 2,889,774 assertions, all regression scripts OK).

## `const`-correctness

`backwardExt` is now marked `const`. The body does not modify any member of `FMI_search`; the explicit `const` lets the compiler hoist member-pointer loads (`cp_occ`, `one_hot_mask_array`, `count`) out of caller-side loops without aliasing concerns.

## Test plan

- [x] `make arm64 && make test` clean on macOS arm64 (11/11 doctest, all regression scripts OK)
- [ ] CI matrix passes on every row (SSE4.1, AVX2, Linux ARM64, macOS ARM64; ±mimalloc)
- [x] c7a wgs-5M shm-warmed wall-clock matches or beats gcc-11 scalar baseline (measured: -4.10% faster)
- [ ] Optional: c7i wgs-5M shm-warmed wall-clock confirmation on Sapphire Rapids — not measured this round; CI matrix doesn't include c7i, but the source change is uarch-agnostic so the fix mechanism applies identically. Happy to spin up a c7i smoke if reviewer wants the cross-uarch number before merge.

## Related

- Closes #87
- PR #86 ("perf(x86): cap avx512bw autovec at 256-bit; shm preflight; gcc-11 doc") added the gcc-11 advisory as a short-term mitigation. Once this PR lands the advisory can be demoted or removed in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal search implementation restructured with method inlining in header file.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/88)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->