### PR TITLE
feat(meth): emit Bismark-compatible XR/XG/XM auxiliary tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/memcpy_bwamem.o src/kthread.
 			src/kstring.o src/bntseq.o src/bwamem.o src/profiling.o \
 			src/FMI_search.o src/read_index_ele.o src/bwamem_pair.o src/bwa.o \
 			src/bwamem_extra.o src/kopen.o src/bam_writer.o src/meth_bam.o \
+			src/meth_orig_ref.o src/meth_xm.o \
 			src/packed_text.o src/fm_index_writer.o src/index_prelude.o \
 			src/system.o src/libsais_build.o \
 			src/bwa_shm.o src/simd_dispatch.o
@@ -707,48 +708,177 @@ depend:
 
 # DO NOT DELETE
 
-src/FMI_search.o: src/FMI_search.h src/bntseq.h src/read_index_ele.h
-src/FMI_search.o: src/utils.h src/macro.h src/bwa.h src/bwt.h
+src/FMI_search.o: src/bwa_madvise.h src/bwa_shm.h src/FMI_search.h
+src/FMI_search.o: src/simd_compat.h src/read_index_ele.h src/utils.h
+src/FMI_search.o: src/bntseq.h src/macro.h src/bwa.h src/bwt.h
+src/FMI_search.o: src/memcpy_bwamem.h src/safestringlib.h
+src/FMI_search.o: ext/safestringlib/include/safe_mem_lib.h
+src/FMI_search.o: ext/safestringlib/include/safe_lib.h
+src/FMI_search.o: ext/safestringlib/include/safe_types.h
+src/FMI_search.o: ext/safestringlib/include/safe_lib_errno.h
+src/FMI_search.o: ext/safestringlib/include/safe_str_lib.h src/profiling.h
 src/FMI_search.o: src/libsais_build.h
-src/libsais_build.o: src/libsais_build.h src/fm_index_writer.h src/index_prelude.h
-src/libsais_build.o: src/packed_text.h src/utils.h src/macro.h
-src/libsais_build.o: ext/libsais/include/libsais.h ext/libsais/include/libsais64.h
-src/bandedSWA.o: src/bandedSWA.h src/macro.h
-src/bntseq.o: src/bntseq.h src/utils.h src/macro.h src/kseq.h src/khash.h
-src/bwa.o: src/bntseq.h src/bwa.h src/bwt.h src/macro.h src/ksw.h src/utils.h
-src/bwa.o: src/kstring.h src/kvec.h src/kseq.h
+src/bam_writer.o: ext/htslib/htslib/sam.h ext/htslib/htslib/hts.h
+src/bam_writer.o: ext/htslib/htslib/hts_defs.h ext/htslib/htslib/hts_log.h
+src/bam_writer.o: ext/htslib/htslib/kstring.h ext/htslib/htslib/kroundup.h
+src/bam_writer.o: ext/htslib/htslib/hts_endian.h ext/htslib/htslib/kstring.h
+src/bam_writer.o: src/bam_writer.h src/bwa.h src/bntseq.h src/bwt.h
+src/bam_writer.o: src/macro.h src/bwamem.h src/kthread.h src/bandedSWA.h
+src/bam_writer.o: src/simd_compat.h src/kernel_dispatch.h src/kstring.h
+src/bam_writer.o: src/ksw.h src/kvec.h src/ksort.h src/utils.h
+src/bam_writer.o: src/profiling.h src/FMI_search.h src/read_index_ele.h
+src/bam_writer.o: src/cigar_util.h
+src/bandedSWA.o: src/kernel_dispatch.h src/bandedSWA.h src/macro.h
+src/bandedSWA.o: src/simd_compat.h
+src/bntseq.o: src/bntseq.h src/utils.h src/macro.h src/kseq.h
+src/bntseq.o: src/memcpy_bwamem.h src/safestringlib.h
+src/bntseq.o: ext/safestringlib/include/safe_mem_lib.h
+src/bntseq.o: ext/safestringlib/include/safe_lib.h
+src/bntseq.o: ext/safestringlib/include/safe_types.h
+src/bntseq.o: ext/safestringlib/include/safe_lib_errno.h
+src/bntseq.o: ext/safestringlib/include/safe_str_lib.h src/khash.h
+src/bwa.o: src/bntseq.h src/bwa.h src/bwt.h src/macro.h src/ksw.h
+src/bwa.o: src/kernel_dispatch.h src/simd_compat.h src/utils.h src/kstring.h
+src/bwa.o: src/kvec.h src/u8vec_scratch.h src/safestringlib.h
+src/bwa.o: ext/safestringlib/include/safe_mem_lib.h
+src/bwa.o: ext/safestringlib/include/safe_lib.h
+src/bwa.o: ext/safestringlib/include/safe_types.h
+src/bwa.o: ext/safestringlib/include/safe_lib_errno.h
+src/bwa.o: ext/safestringlib/include/safe_str_lib.h src/kseq.h
+src/bwa.o: src/memcpy_bwamem.h
+src/bwa_shm.o: src/bwa_shm.h src/bwa.h src/bntseq.h src/bwt.h src/macro.h
+src/bwa_shm.o: src/FMI_search.h src/simd_compat.h src/read_index_ele.h
+src/bwa_shm.o: src/utils.h src/safestringlib.h
+src/bwa_shm.o: ext/safestringlib/include/safe_mem_lib.h
+src/bwa_shm.o: ext/safestringlib/include/safe_lib.h
+src/bwa_shm.o: ext/safestringlib/include/safe_types.h
+src/bwa_shm.o: ext/safestringlib/include/safe_lib_errno.h
+src/bwa_shm.o: ext/safestringlib/include/safe_str_lib.h
 src/bwamem.o: src/bwamem.h src/bwt.h src/bntseq.h src/bwa.h src/macro.h
-src/bwamem.o: src/kthread.h src/bandedSWA.h src/kstring.h src/ksw.h
-src/bwamem.o: src/kvec.h src/ksort.h src/utils.h src/profiling.h
-src/bwamem.o: src/FMI_search.h src/read_index_ele.h src/kbtree.h
+src/bwamem.o: src/kthread.h src/bandedSWA.h src/simd_compat.h
+src/bwamem.o: src/kernel_dispatch.h src/kstring.h src/ksw.h src/kvec.h
+src/bwamem.o: src/ksort.h src/utils.h src/profiling.h src/FMI_search.h
+src/bwamem.o: src/read_index_ele.h src/memcpy_bwamem.h src/safestringlib.h
+src/bwamem.o: ext/safestringlib/include/safe_mem_lib.h
+src/bwamem.o: ext/safestringlib/include/safe_lib.h
+src/bwamem.o: ext/safestringlib/include/safe_types.h
+src/bwamem.o: ext/safestringlib/include/safe_lib_errno.h
+src/bwamem.o: ext/safestringlib/include/safe_str_lib.h src/bam_writer.h
+src/bwamem.o: src/meth_bam.h src/u8vec_scratch.h src/sam_encode.h
+src/bwamem.o: src/kbtree.h
 src/bwamem_extra.o: src/bwa.h src/bntseq.h src/bwt.h src/macro.h src/bwamem.h
-src/bwamem_extra.o: src/kthread.h src/bandedSWA.h src/kstring.h src/ksw.h
-src/bwamem_extra.o: src/kvec.h src/ksort.h src/utils.h src/profiling.h
-src/bwamem_extra.o: src/FMI_search.h src/read_index_ele.h
+src/bwamem_extra.o: src/kthread.h src/bandedSWA.h src/simd_compat.h
+src/bwamem_extra.o: src/kernel_dispatch.h src/kstring.h src/ksw.h src/kvec.h
+src/bwamem_extra.o: src/ksort.h src/utils.h src/profiling.h src/FMI_search.h
+src/bwamem_extra.o: src/read_index_ele.h
 src/bwamem_pair.o: src/kstring.h src/bwamem.h src/bwt.h src/bntseq.h
 src/bwamem_pair.o: src/bwa.h src/macro.h src/kthread.h src/bandedSWA.h
-src/bwamem_pair.o: src/ksw.h src/kvec.h src/ksort.h src/utils.h
-src/bwamem_pair.o: src/profiling.h src/FMI_search.h src/read_index_ele.h
-src/bwamem_pair.o: src/kswv.h
+src/bwamem_pair.o: src/simd_compat.h src/kernel_dispatch.h src/ksw.h
+src/bwamem_pair.o: src/kvec.h src/ksort.h src/utils.h src/profiling.h
+src/bwamem_pair.o: src/FMI_search.h src/read_index_ele.h src/bam_writer.h
+src/bwamem_pair.o: src/u8vec_scratch.h src/kswv.h
 src/bwtindex.o: src/bntseq.h src/bwa.h src/bwt.h src/macro.h src/utils.h
-src/bwtindex.o: src/FMI_search.h src/read_index_ele.h
-src/fastmap.o: src/fastmap.h src/bwa.h src/bntseq.h src/bwt.h src/macro.h
-src/fastmap.o: src/bwamem.h src/kthread.h src/bandedSWA.h src/kstring.h
-src/fastmap.o: src/ksw.h src/kvec.h src/ksort.h src/utils.h src/profiling.h
-src/fastmap.o: src/FMI_search.h src/read_index_ele.h src/kseq.h
+src/bwtindex.o: src/FMI_search.h src/simd_compat.h src/read_index_ele.h
+src/bwtindex.o: src/kseq.h src/memcpy_bwamem.h src/safestringlib.h
+src/bwtindex.o: ext/safestringlib/include/safe_mem_lib.h
+src/bwtindex.o: ext/safestringlib/include/safe_lib.h
+src/bwtindex.o: ext/safestringlib/include/safe_types.h
+src/bwtindex.o: ext/safestringlib/include/safe_lib_errno.h
+src/bwtindex.o: ext/safestringlib/include/safe_str_lib.h src/system.h
+src/fastmap.o: src/bwa_madvise.h src/fastmap.h src/bwa.h src/bntseq.h
+src/fastmap.o: src/bwt.h src/macro.h src/bwamem.h src/kthread.h
+src/fastmap.o: src/bandedSWA.h src/simd_compat.h src/kernel_dispatch.h
+src/fastmap.o: src/kstring.h src/ksw.h src/kvec.h src/ksort.h src/utils.h
+src/fastmap.o: src/profiling.h src/FMI_search.h src/read_index_ele.h
+src/fastmap.o: src/kseq.h src/memcpy_bwamem.h src/safestringlib.h
+src/fastmap.o: ext/safestringlib/include/safe_mem_lib.h
+src/fastmap.o: ext/safestringlib/include/safe_lib.h
+src/fastmap.o: ext/safestringlib/include/safe_types.h
+src/fastmap.o: ext/safestringlib/include/safe_lib_errno.h
+src/fastmap.o: ext/safestringlib/include/safe_str_lib.h src/bam_writer.h
+src/fastmap.o: src/meth_bam.h src/meth_orig_ref.h src/bwa_shm.h
+src/fm_index_writer.o: src/fm_index_writer.h src/FMI_search.h
+src/fm_index_writer.o: src/simd_compat.h src/read_index_ele.h src/utils.h
+src/fm_index_writer.o: src/bntseq.h src/macro.h src/bwa.h src/bwt.h
+src/fm_index_writer.o: src/io_utils.h
+src/index_prelude.o: src/index_prelude.h src/io_utils.h src/utils.h
+src/index_prelude.o: src/packed_text.h
+src/kopen.o: src/memcpy_bwamem.h src/safestringlib.h
+src/kopen.o: ext/safestringlib/include/safe_mem_lib.h
+src/kopen.o: ext/safestringlib/include/safe_lib.h
+src/kopen.o: ext/safestringlib/include/safe_types.h
+src/kopen.o: ext/safestringlib/include/safe_lib_errno.h
+src/kopen.o: ext/safestringlib/include/safe_str_lib.h
 src/kstring.o: src/kstring.h
-src/ksw.o: src/ksw.h src/macro.h
-src/kswv.o: src/kswv.h src/macro.h src/ksw.h src/bandedSWA.h
+src/ksw.o: src/kernel_dispatch.h src/simd_compat.h src/ksw.h src/macro.h
+src/kswv.o: src/kernel_dispatch.h src/kswv.h src/macro.h src/ksw.h
+src/kswv.o: src/simd_compat.h src/bandedSWA.h src/neon_utils.h
 src/kthread.o: src/kthread.h src/macro.h src/bwamem.h src/bwt.h src/bntseq.h
-src/kthread.o: src/bwa.h src/bandedSWA.h src/kstring.h src/ksw.h src/kvec.h
+src/kthread.o: src/bwa.h src/bandedSWA.h src/simd_compat.h
+src/kthread.o: src/kernel_dispatch.h src/kstring.h src/ksw.h src/kvec.h
 src/kthread.o: src/ksort.h src/utils.h src/profiling.h src/FMI_search.h
 src/kthread.o: src/read_index_ele.h
+src/libsais_build.o: src/libsais_build.h src/fm_index_writer.h
+src/libsais_build.o: src/index_prelude.h src/io_utils.h src/utils.h
+src/libsais_build.o: src/macro.h src/packed_text.h
+src/libsais_build.o: ext/libsais/include/libsais.h
+src/libsais_build.o: ext/libsais/include/libsais64.h
 src/main.o: src/main.h src/kstring.h src/utils.h src/macro.h src/bandedSWA.h
-src/main.o: src/profiling.h
-src/profiling.o: src/macro.h
+src/main.o: src/simd_compat.h src/kernel_dispatch.h src/profiling.h
+src/main.o: src/fastmap.h src/bwa.h src/bntseq.h src/bwt.h src/bwamem.h
+src/main.o: src/kthread.h src/ksw.h src/kvec.h src/ksort.h src/FMI_search.h
+src/main.o: src/read_index_ele.h src/kseq.h src/memcpy_bwamem.h
+src/main.o: src/safestringlib.h ext/safestringlib/include/safe_mem_lib.h
+src/main.o: ext/safestringlib/include/safe_lib.h
+src/main.o: ext/safestringlib/include/safe_types.h
+src/main.o: ext/safestringlib/include/safe_lib_errno.h
+src/main.o: ext/safestringlib/include/safe_str_lib.h src/simd_dispatch.h
+src/main.o: src/version.h src/bwa_shm.h ext/mimalloc/include/mimalloc.h
+src/memcpy_bwamem.o: src/memcpy_bwamem.h src/safestringlib.h
+src/memcpy_bwamem.o: ext/safestringlib/include/safe_mem_lib.h
+src/memcpy_bwamem.o: ext/safestringlib/include/safe_lib.h
+src/memcpy_bwamem.o: ext/safestringlib/include/safe_types.h
+src/memcpy_bwamem.o: ext/safestringlib/include/safe_lib_errno.h
+src/memcpy_bwamem.o: ext/safestringlib/include/safe_str_lib.h
+src/meth_bam.o: ext/htslib/htslib/sam.h ext/htslib/htslib/hts.h
+src/meth_bam.o: ext/htslib/htslib/hts_defs.h ext/htslib/htslib/hts_log.h
+src/meth_bam.o: ext/htslib/htslib/kstring.h ext/htslib/htslib/kroundup.h
+src/meth_bam.o: ext/htslib/htslib/hts_endian.h ext/htslib/htslib/kstring.h
+src/meth_bam.o: src/meth_bam.h src/bwa.h src/bntseq.h src/bwt.h src/macro.h
+src/meth_bam.o: src/bwamem.h src/kthread.h src/bandedSWA.h src/simd_compat.h
+src/meth_bam.o: src/kernel_dispatch.h src/kstring.h src/ksw.h src/kvec.h
+src/meth_bam.o: src/ksort.h src/utils.h src/profiling.h src/FMI_search.h
+src/meth_bam.o: src/read_index_ele.h src/bam_writer.h src/cigar_util.h
+src/meth_bam.o: src/meth_orig_ref.h src/meth_xm.h src/version.h
+src/meth_orig_ref.o: src/meth_orig_ref.h src/bntseq.h src/meth_bam.h
+src/meth_orig_ref.o: src/bwa.h src/bwt.h src/macro.h src/bwamem.h
+src/meth_orig_ref.o: src/kthread.h src/bandedSWA.h src/simd_compat.h
+src/meth_orig_ref.o: src/kernel_dispatch.h src/kstring.h src/ksw.h src/kvec.h
+src/meth_orig_ref.o: src/ksort.h src/utils.h src/profiling.h src/FMI_search.h
+src/meth_orig_ref.o: src/read_index_ele.h
+src/meth_xm.o: src/meth_xm.h src/meth_orig_ref.h src/bntseq.h src/meth_bam.h
+src/meth_xm.o: src/bwa.h src/bwt.h src/macro.h src/bwamem.h src/kthread.h
+src/meth_xm.o: src/bandedSWA.h src/simd_compat.h src/kernel_dispatch.h
+src/meth_xm.o: src/kstring.h src/ksw.h src/kvec.h src/ksort.h src/utils.h
+src/meth_xm.o: src/profiling.h src/FMI_search.h src/read_index_ele.h
+src/packed_text.o: src/packed_text.h src/utils.h
+src/profiling.o: src/macro.h src/bwa.h src/bntseq.h src/bwt.h src/profiling.h
 src/read_index_ele.o: src/read_index_ele.h src/utils.h src/bntseq.h
-src/read_index_ele.o: src/macro.h
-src/utils.o: src/utils.h src/ksort.h src/kseq.h
-src/memcpy_bwamem.o: src/memcpy_bwamem.h
-src/bam_writer.o: src/bam_writer.h src/bwamem.h src/bwa.h src/bntseq.h
-src/meth_bam.o: src/meth_bam.h src/bwamem.h src/bwa.h src/bntseq.h src/version.h
+src/read_index_ele.o: src/macro.h src/safestringlib.h
+src/read_index_ele.o: ext/safestringlib/include/safe_mem_lib.h
+src/read_index_ele.o: ext/safestringlib/include/safe_lib.h
+src/read_index_ele.o: ext/safestringlib/include/safe_types.h
+src/read_index_ele.o: ext/safestringlib/include/safe_lib_errno.h
+src/read_index_ele.o: ext/safestringlib/include/safe_str_lib.h
+src/read_index_ele.o: src/bwa_madvise.h src/bwa_shm.h
+src/sam_encode.o: src/sam_encode.h src/kernel_dispatch.h
+src/simd_dispatch.o: src/simd_dispatch.h src/bandedSWA.h src/macro.h
+src/simd_dispatch.o: src/simd_compat.h src/kernel_dispatch.h src/kswv.h
+src/simd_dispatch.o: src/ksw.h src/sam_encode.h
+src/system.o: src/system.h
+src/utils.o: src/utils.h src/ksort.h src/kseq.h src/memcpy_bwamem.h
+src/utils.o: src/safestringlib.h ext/safestringlib/include/safe_mem_lib.h
+src/utils.o: ext/safestringlib/include/safe_lib.h
+src/utils.o: ext/safestringlib/include/safe_types.h
+src/utils.o: ext/safestringlib/include/safe_lib_errno.h
+src/utils.o: ext/safestringlib/include/safe_str_lib.h

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+Release 0.2.0-pre (2026-05-09)
+---------------------------------
+
+* `mem --meth` emits Bismark-compatible auxiliary tags `XR:Z`
+  (read conversion `CT`/`GA`), `XG:Z` (genome strand `CT`/`GA`),
+  and `XM:Z` (per-base methylation call string). These replace the
+  prior bwameth-style `YS:Z`/`YC:Z`/`YD:Z` on output (still used
+  internally for SEQ restoration). The reference-annotation `XR:Z`
+  from `-V` is suppressed under `--meth` to avoid colliding with the
+  Bismark semantics. See `docs/src/methylation/tags.md`.
+
 Release 0.1.0-pre (2026-04-28)
 ---------------------------------
 

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -51,8 +51,9 @@ Bisulfite (--meth) options:
                  with `bwa-mem3 index --meth` (emits ref.fa.bwameth.c2t).
    --set-as-failed f|r
                  flag alignments to the matching strand ('f' or 'r') as QC-fail (0x200)
-   --do-not-penalize-chimeras
-                 disable the longest-match <44% chimera heuristic (no 0x200 / MAPQ cap)
+   --chimera-qc
+                 enable the bwameth.py-style longest-match <44% chimera heuristic
+                 (sets 0x200, clears 0x2, caps MAPQ at 1). Off by default; not in Bismark.
 Supplementary MAPQ rescoring (fg-labs extension):
    --supp-rep-hard-cap INT
                  force MAPQ=0 for supplementary alignments whose chain contains any seed

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -46,9 +46,9 @@
 - [Overview](methylation/overview.md)
 - [bwameth.py drop-in mapping](methylation/bwameth-mapping.md)
 - [Conversion details (C->T, G->A)](methylation/conversion.md)
-- [SAM tags: YS, YC, YD](methylation/tags.md)
+- [SAM tags: XR, XG, XM](methylation/tags.md)
 - [Chimera QC and header rewriting](methylation/post-processing.md)
-- [Flags: --set-as-failed, --do-not-penalize-chimeras](methylation/flags.md)
+- [Flags: --set-as-failed, --chimera-qc](methylation/flags.md)
 - [Interop with external bwameth.py c2t](methylation/external-c2t.md)
 
 # What's Different from bwa-mem2

--- a/docs/src/best-practices/methylation.md
+++ b/docs/src/best-practices/methylation.md
@@ -54,15 +54,18 @@ bwa-mem3 mem --meth --set-as-failed r --bam=0 -t 16 ref.fa R1.fq.gz R2.fq.gz \
   | samtools sort -@ 4 -o out.bam -
 ```
 
-**Chimeric reads from long-read-length protocols.** By default, `--meth`
-applies a chimera QC heuristic: if the longest matching run (CIGAR `M`/`=`/`X`
-operations) is less than 44% of the read length, the alignment is flagged
-`0x200` (QC fail), the paired flag `0x2` is cleared, and MAPQ is capped at 1.
-If your protocol produces legitimate long reads where this heuristic
-over-aggressively flags alignments, pass `--do-not-penalize-chimeras`:
+**Chimera QC is opt-in** (matches Bismark default). bwameth.py applies a
+chimera heuristic that flags reads whose longest matching run
+(CIGAR `M`/`=`/`X`) is less than 44 % of the read length: `0x200` set,
+`0x2` cleared, MAPQ capped at 1. `bwa-mem3 --meth` does **not** apply
+this by default — the runtime posture matches Bismark, where no such
+heuristic exists.
+
+If your library is PBAT / scBS-Seq (where intra-fragment chimerism is
+common) or you want bwameth.py-equivalent flagging, pass `--chimera-qc`:
 
 ```bash
-bwa-mem3 mem --meth --do-not-penalize-chimeras --bam=0 -t 16 ref.fa R1.fq.gz R2.fq.gz \
+bwa-mem3 mem --meth --chimera-qc --bam=0 -t 16 ref.fa R1.fq.gz R2.fq.gz \
   | samtools sort -@ 4 -o out.bam -
 ```
 
@@ -79,19 +82,18 @@ The `--meth` output BAM is designed to be a drop-in replacement for the output
 of the `bwameth.py` pipeline. The following downstream tools have been used
 successfully with `bwa-mem3 --meth` output:
 
-- **MethylDackel** — extracts methylation calls from the `YD:Z:` strand tag.
-- **Bismark** — accepts the bwameth-convention `YD:Z:` strand annotation.
-- **PileOMeth** — reads the standard bisulfite BAM format.
-
-If a tool requires the `XB:Z:` tag convention used by Bismark's own aligner
-rather than the `YD:Z:` convention, a conversion step is needed before
-methylation calling.
+- **`bismark_methylation_extractor`**, **methylKit `processBismarkAln`**,
+  **methtuple**, **DMRfinder**, **epialleleR** — read the Bismark `XR:Z`,
+  `XG:Z`, `XM:Z` tags directly from `--meth` output.
+- **MethylDackel** — reads `XG:Z` (and ignores the bwameth-convention `YD:Z:`
+  if present, which `--meth` no longer emits).
+- **biscuit per-read tools** — read `XG:Z`.
 
 ---
 
 **See also:**
 [Methylation Reference: Overview](../methylation/overview.md) ·
-[SAM tags: YS, YC, YD](../methylation/tags.md) ·
-[Flags: --set-as-failed, --do-not-penalize-chimeras](../methylation/flags.md) ·
+[SAM tags: XR, XG, XM](../methylation/tags.md) ·
+[Flags: --set-as-failed, --chimera-qc](../methylation/flags.md) ·
 [Quick start: methylation alignment](../getting-started/quick-meth.md) ·
 [Output format](output-format.md)

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -243,11 +243,13 @@ Forces the QC-fail bit (`0x200`) on all alignments to the forward (`f`) or
 reverse (`r`) bisulfite strand. Used when one strand is known to be
 unreliable for a given library preparation.
 
-#### `--do-not-penalize-chimeras` — disable chimera heuristic
+#### `--chimera-qc` — opt in to bwameth.py-style chimera heuristic
 
-Disables the longest-match < 44% chimera heuristic that would otherwise set
-`0x200`, clear `0x2`, and cap MAPQ at 1 for likely chimeric alignments.
-Use when the default chimera filter is too aggressive for your library type.
+Off by default (matches Bismark, which has no equivalent heuristic).
+When set, mapped records whose longest M/=/X CIGAR run is less than 44 % of
+the read length get `0x200` set, `0x2` cleared, and MAPQ capped at 1. Useful
+for PBAT / scBS-Seq libraries where intra-fragment chimerism is common, or
+when reproducing bwameth.py output bit-for-bit.
 
 ### Threading
 

--- a/docs/src/getting-started/quick-meth.md
+++ b/docs/src/getting-started/quick-meth.md
@@ -45,9 +45,9 @@ auto-appends `.bwameth.c2t` to the reference path when `--meth` is active.
 external tools:
 
 1. **Inline c2t read conversion.** R1 reads have every `C` converted to `T` before alignment;
-   R2 reads have every `G` converted to `A`. The original unconverted sequence is preserved in
-   the `YS:Z:` SAM tag. The conversion direction for each read is recorded in `YC:Z:` (value
-   `CT` or `GA`), matching the bwameth.py convention.
+   R2 reads have every `G` converted to `A`. The original unconverted sequence is restored
+   into the BAM `SEQ` field on emit. The conversion direction is reported per record in the
+   Bismark `XR:Z` tag (value `CT` for R1/SE, `GA` for R2).
 
 2. **bwameth.py-equivalent scoring defaults.** `--meth` sets `-B 2 -L 10 -U 100 -T 40 -CM`
    automatically. These match the defaults used by bwameth.py and are optimized for
@@ -57,8 +57,8 @@ external tools:
 3. **Inline BAM post-processing.** After alignment, bwa-mem3 rewrites the SAM stream in-process:
    - `@SQ` headers with `f`/`r` prefixes (e.g. `fchr1`, `rchr1`) are collapsed back to one
      entry per real chromosome (`chr1`). Read-level `RNAME` fields are rewritten to match.
-   - Each mapped record gains a `YD:Z:` tag (`f` for forward-strand, `r` for reverse-strand)
-     indicating which converted strand the read aligned to.
+   - Each mapped record gains Bismark `XG:Z` (genome strand: `CT` for top-strand
+     alignment, `GA` for bottom-strand) and `XM:Z` (per-base methylation call string).
    - Chimera QC: reads whose longest `M`/`=`/`X` run is less than 44% of the read length are
      flagged `0x200` (QC-fail), have flag `0x2` (proper pair) cleared, and have MAPQ capped at 1.
    - Pair-level QC-fail propagation: if one mate is QC-failed, the other mate is also flagged.
@@ -69,8 +69,9 @@ external tools:
    downstream `samtools sort` to read BAM natively. The stream is still fully readable by any
    htslib-based tool.
 
-For full details on each tag, the chimera QC heuristic, and the `--set-as-failed` and
-`--do-not-penalize-chimeras` flags, see the [Methylation Reference](../methylation/overview.md).
+For full details on each tag, the optional chimera QC heuristic, and the
+`--set-as-failed` / `--chimera-qc` flags, see the
+[Methylation Reference](../methylation/overview.md).
 
 ---
 

--- a/docs/src/methylation/external-c2t.md
+++ b/docs/src/methylation/external-c2t.md
@@ -47,20 +47,25 @@ Key points for this pattern:
   paired-end reads (bwameth.py c2t emits interleaved output to stdout).
 - Use `/dev/stdin` as the reads argument to read from the pipe.
 - The `bwa-mem3 --meth` inline c2t conversion is **not** applied when the
-  reads arrive pre-converted; however, `YS:Z:` and `YC:Z:` tags are only
-  written by the inline conversion path. If you need those tags in the output,
-  you must either use the integrated mode (no external c2t step) or ensure
-  your external preprocessor emits compatible comments in the FASTQ.
+  reads arrive pre-converted. `XR:Z` (read conversion) and `XG:Z` (genome
+  strand) are still emitted on every record; `XM:Z` (per-base methylation
+  call string) is emitted on every mapped record. `XR:Z` is derived from
+  the inline carrier the c2t step normally writes — when reads are
+  pre-converted, the carrier is absent unless the external preprocessor
+  emits it as a FASTQ comment (see warning below).
 
-> **Warning — YS:Z: and YC:Z: require integrated mode**
+> **Warning — `XR:Z:` requires the inline carrier**
 >
-> When reads are pre-converted by an external tool and piped in, the inline
-> c2t step in `src/fastmap.cpp` is bypassed. `YS:Z:` and `YC:Z:` tags will
-> not be present in the output BAM unless the external converter writes them
-> as FASTQ comment fields in the format `YS:Z:<seq>\tYC:Z:<dir>` and those
-> comments are passed through. MethylDackel and similar callers use `YS:Z:`
-> to restore original bases for methylation calling; if the tag is absent,
-> they fall back to reading SEQ directly, which may affect accuracy.
+> `XR:Z:` records the read's bisulfite-conversion direction (`CT` for top-
+> strand, `GA` for bottom-strand R2). bwa-mem3's inline c2t step records
+> that direction into the FASTQ comment as `YS:Z:<seq>\tYC:Z:<dir>`, which
+> the BAM emitter then reads to set `XR:Z:` (the `YS`/`YC` carrier itself
+> is dropped from BAM output). When reads are pre-converted externally and
+> piped in, the inline c2t step in `src/fastmap.cpp` is bypassed. If your
+> external preprocessor does not emit a compatible `YC:Z:` comment field,
+> `XR:Z:` will be absent from the output BAM. `XG:Z:` and `XM:Z:` are
+> unaffected — they're derived from the reference contig direction and
+> CIGAR walk, not from the carrier.
 
 ## Header rewriting and BAM post-processing with external c2t
 
@@ -68,28 +73,28 @@ Whether reads are converted inline or externally, all BAM post-processing steps
 apply identically when `--meth` is active:
 
 - `@SQ` header consolidation (f/r contigs → one entry per chromosome).
-- `YD:Z:` tag emission from the contig name prefix.
-- Chimera QC heuristic (unless `--do-not-penalize-chimeras` is set).
+- Bismark `XR:Z` / `XG:Z` / `XM:Z` auxiliary tag emission.
+- Chimera QC heuristic (only when `--chimera-qc` is set; off by default).
 - Pair-level QC-fail propagation.
 - `@PG ID:bwa-mem3-meth` insertion.
 
 The post-processing pipeline depends only on the reference contig names (to
-determine `YD:Z:`) and the alignment flags — not on whether reads were
+determine `XG:Z`) and the alignment flags — not on whether reads were
 converted inline or externally.
 
 ## Summary of path variants
 
-| Reference arg | Read source | Auto-append? | Inline c2t? | `YS:Z:` emitted? |
-|---------------|-------------|-------------|------------|-----------------|
-| `ref.fa` | Raw FASTQ | Yes (→ `ref.fa.bwameth.c2t`) | Yes | Yes |
-| `ref.fa.bwameth.c2t` | Raw FASTQ | No | Yes | Yes |
-| `ref.fa.bwameth.c2t` | Pre-converted (pipe) | No | No | No (unless pre-emitted) |
+| Reference arg | Read source | Auto-append? | Inline c2t? | `XR/XG/XM` emitted? |
+|---------------|-------------|-------------|------------|---------------------|
+| `ref.fa` | Raw FASTQ | Yes (→ `ref.fa.bwameth.c2t`) | Yes | All three |
+| `ref.fa.bwameth.c2t` | Raw FASTQ | No | Yes | All three |
+| `ref.fa.bwameth.c2t` | Pre-converted (pipe) | No | No | `XG`/`XM` always; `XR` only if external preprocessor emits the `YC:Z` carrier |
 
 ---
 
 **See also:**
 [Overview](overview.md) ·
 [Conversion details](conversion.md) ·
-[SAM tags: YS, YC, YD](tags.md) ·
+[SAM tags: XR, XG, XM](tags.md) ·
 [bwameth.py drop-in mapping](bwameth-mapping.md) ·
 [Related Projects: bwameth.py](../related-projects/bwameth.md)

--- a/docs/src/methylation/flags.md
+++ b/docs/src/methylation/flags.md
@@ -1,4 +1,4 @@
-# Flags: --set-as-failed, --do-not-penalize-chimeras
+# Flags: --set-as-failed, --chimera-qc
 
 `bwa-mem3 --meth` adds two flags that control QC behavior during BAM
 post-processing. Both flags affect the chimera QC and strand-filtering logic
@@ -17,20 +17,19 @@ of alignment quality or CIGAR structure.
 
 **Effect on records:**
 
-When `--set-as-failed f` (or `r`) is set and a mapped record's `YD:Z:` strand
-matches the specified value, the record's SAM flag has `0x200` set. The chimera
-heuristic then runs on top of the already-set flag, but since `0x200` is already
-present, it can only enforce additional constraints (clearing `0x2`, capping
-MAPQ). QC-fail propagation then spreads the flag to all records in the read
-group.
+When `--set-as-failed f` (or `r`) is set and a mapped record's strand matches
+the specified value, the record's SAM flag has `0x200` set. If `--chimera-qc`
+is also active, the chimera heuristic runs on top, possibly clearing `0x2` and
+capping MAPQ. QC-fail propagation then spreads the flag to all records in the
+read group.
 
 **When to use it:**
 
-Some experimental designs produce reads that are expected to align exclusively to
-one strand. Flagging the other strand as QC-failed before downstream analysis
-prevents spurious methylation calls from mis-strand alignments. It is also
-useful for diagnosing library preparation issues: run once with `--set-as-failed r`
-and once without to compare yield on each strand.
+Some experimental designs produce reads that are expected to align exclusively
+to one strand. Flagging the other strand as QC-failed before downstream
+analysis prevents spurious methylation calls from mis-strand alignments. It is
+also useful for diagnosing library preparation issues: run once with
+`--set-as-failed r` and once without to compare yield on each strand.
 
 > **Warning — All records on the strand are flagged**
 >
@@ -39,55 +38,63 @@ and once without to compare yield on each strand.
 > complementary strand due to library structure. Use this flag only when your
 > library is expected to be strand-specific.
 
-## `--do-not-penalize-chimeras`
+## `--chimera-qc`
 
-Disables the chimera QC heuristic entirely.
+Enables the bwameth.py-style longest-M chimera heuristic. **Off by default**;
+this is the Bismark-equivalent posture, since Bismark itself does not apply
+this kind of QC heuristic.
 
-Without this flag, any mapped record whose longest M/=/X CIGAR run covers less
-than 44% of the read length receives:
+When `--chimera-qc` is set, any mapped record whose longest M/=/X CIGAR run
+covers less than 44 % of the read length receives:
 
 - `0x200` (QC fail) set.
 - `0x2` (proper pair) cleared.
 - MAPQ capped at 1.
 
-With `--do-not-penalize-chimeras`, none of these penalties are applied. Records
-are written with the MAPQ and flags as determined by the alignment kernel. The
-chimera check in `meth_mem_aln_to_bam` is skipped entirely.
+QC-fail propagation across the read group also applies.
 
 **When to use it:**
 
-The 44% threshold was calibrated for standard mammalian whole-genome bisulfite
-sequencing (WGBS) libraries with typical read lengths. For short reads (< 50 bp),
-reads with large insertions, or amplicon designs where short alignments are
-expected, the heuristic can produce excessive false-positive flagging. In those
-cases, disable it and apply a custom chimera filter downstream.
+The 44 % threshold was calibrated by bwameth.py for standard mammalian whole-
+genome bisulfite-sequencing (WGBS) libraries with typical read lengths and is
+helpful on PBAT / scBS-Seq libraries where intra-fragment chimeras are common.
+For Bismark-equivalent output (and most directional EM-seq / WGBS workflows),
+leave it off.
 
-It is also useful when benchmarking: comparing `bwa-mem3 --meth` output against
-bwameth.py output on a specific dataset is cleaner when chimera filtering is
-disabled, since bwameth.py's chimera logic may differ in edge cases.
+It is also useful when benchmarking: comparing `bwa-mem3 --meth` output
+against bwameth.py output is cleaner with `--chimera-qc` enabled, since
+bwameth.py's chimera logic always runs.
 
 > **Note — Pair-level propagation still applies**
 >
-> `--do-not-penalize-chimeras` only suppresses the chimera heuristic.
-> If `--set-as-failed` is also active, those flags are still set, and
-> `meth_bam_group_propagate_qcfail` still propagates any `0x200` flags
-> across the read group.
+> `--chimera-qc` controls only whether the heuristic itself runs.
+> `--set-as-failed` is independent: when active, those flags are still set,
+> and `meth_bam_group_propagate_qcfail` propagates any `0x200` flags across
+> the read group regardless of `--chimera-qc`.
 
 ## Flag interaction summary
 
 | Condition | `0x200` set? | `0x2` cleared? | MAPQ capped? |
 |-----------|-------------|----------------|--------------|
-| Normal aligned record | No | No | No |
-| Chimera heuristic triggers (default) | Yes | Yes | Yes (≤1) |
+| Normal aligned record (default, no flags) | No | No | No |
+| `--chimera-qc` triggers (longest M/=/X < 44%) | Yes | Yes | Yes (≤1) |
 | `--set-as-failed` strand matches | Yes | No | No |
-| Both chimera + `--set-as-failed` active | Yes | Yes | Yes (≤1) |
-| `--do-not-penalize-chimeras` only | No | No | No |
+| Both `--chimera-qc` + `--set-as-failed` active | Yes | Yes | Yes (≤1) |
+
+## `-V` reference annotation `XR:Z` is suppressed under `--meth`
+
+`bwa-mem3 mem -V` normally emits the contig annotation as an `XR:Z`
+auxiliary field. Under `--meth`, `XR:Z` carries the Bismark
+read-conversion direction (`CT`/`GA`) instead. The reference-annotation
+`XR:Z` is silently suppressed when `--meth` is active so the two uses
+don't collide. There is no flag to override this — `-V` is a no-op for
+`XR:Z` under `--meth`. See [tags.md](tags.md).
 
 ---
 
 **See also:**
 [Overview](overview.md) ·
 [Chimera QC and header rewriting](post-processing.md) ·
-[SAM tags: YS, YC, YD](tags.md) ·
+[SAM tags: XR, XG, XM](tags.md) ·
 [Best Practices → Methylation defaults](../best-practices/methylation.md) ·
 [CLI Reference → mem](../cli/mem.md)

--- a/docs/src/methylation/overview.md
+++ b/docs/src/methylation/overview.md
@@ -8,12 +8,15 @@ reference, and one `bwa-mem3 mem --meth` aligns and post-processes reads from
 raw FASTQ to sorted-ready BAM.
 
 The output BAM is structurally equivalent to what the bwameth.py pipeline
-produces: consolidated `@SQ` headers (one entry per real chromosome rather than
-one per doubled-reference contig), `YS:Z:` / `YC:Z:` tags carrying the
-original pre-conversion read sequence and the conversion direction, `YD:Z:`
-indicating the strand hypothesis, chimera QC flags, and a `@PG ID:bwa-mem3-meth`
-provenance entry. Downstream tools that consume bwameth.py output — including
-MethylDackel and Bismark — work without change.
+produces: consolidated `@SQ` headers (one entry per real chromosome rather
+than one per doubled-reference contig), Bismark-compatible `XR:Z` (read
+conversion `CT`/`GA`), `XG:Z` (genome strand `CT`/`GA`), and `XM:Z`
+(per-base methylation call string) auxiliary tags, optional chimera QC flags
+(`--chimera-qc`, off by default to match Bismark), and a
+`@PG ID:bwa-mem3-meth` provenance entry. Every Bismark-native tool
+(`bismark_methylation_extractor`, methylKit, methtuple, DMRfinder,
+epialleleR), MethylDackel, and biscuit's per-read methylation tools read
+the BAM directly without conversion.
 
 ## Pipeline at a glance
 
@@ -23,19 +26,21 @@ files are required.
 
 ```mermaid
 flowchart LR
-    A[Raw FASTQ\nR1 / R2] -->|inline C→T / G→A| B[c2t-converted reads\n+ YS:Z + YC:Z in comment]
+    A[Raw FASTQ\nR1 / R2] -->|inline C→T / G→A| B[c2t-converted reads\n+ internal YS/YC carrier]
     B -->|bwa mem core| C[mem_aln_t\nalignments vs doubled ref]
     C -->|chrom map\nf/r → real chr| D[header rewrite\n@SQ consolidated]
-    D -->|YD:Z tagging\nchimera QC\nQC-fail propagation| E[BAM output\nwb0 uncompressed]
+    D -->|XR/XG/XM Bismark tags\noptional --chimera-qc\nQC-fail propagation| E[BAM output\nwb0 uncompressed]
 ```
 
 Steps:
 
-1. **FASTQ ingest with inline c2t conversion.** R1 bases have every `C` replaced
-   with `T`; R2 bases have every `G` replaced with `A`. The original bases are
-   preserved in a `YS:Z:` comment field and the conversion direction is stored in
-   `YC:Z:`. This conversion happens in-memory — the FASTQ is never written to
-   disk in converted form.
+1. **FASTQ ingest with inline c2t conversion.** R1 bases have every `C`
+   replaced with `T`; R2 bases have every `G` replaced with `A`. The
+   original bases and conversion direction are kept on an internal carrier
+   on each read (in `bseq1_t.comment`); they are never emitted to BAM as
+   tags themselves but feed the BAM-write step (SEQ restoration, `XR:Z`
+   derivation). This conversion happens in-memory — the FASTQ is never
+   written to disk in converted form.
 
 2. **Alignment against the doubled reference.** The converted reads are aligned
    against the `ref.fa.bwameth.c2t` reference, which contains both a forward
@@ -47,13 +52,15 @@ Steps:
    single `@SQ SN:chr1` entry in the output BAM header. RNAME and RNEXT fields
    in each record are rewritten to the consolidated name.
 
-4. **Tag emission and QC.** Each aligned record receives a `YD:Z:{f,r}` tag
-   indicating which strand it mapped to. The chimera QC heuristic flags records
-   whose longest M/=/X CIGAR run covers less than 44% of the read length.
-   QC-fail flags propagate across all records in a read group. The original
-   pre-c2t sequence from `YS:Z:` is copied back into the BAM SEQ field so that
-   methylation callers (e.g. MethylDackel) see real cytosines rather than the
-   converted sequence.
+4. **Tag emission and QC.** Each aligned record receives Bismark-compatible
+   `XR:Z` (read conversion direction), `XG:Z` (genome strand), and `XM:Z`
+   (per-base methylation call string) auxiliary tags. With opt-in
+   `--chimera-qc` (off by default — matches Bismark), records whose longest
+   M/=/X CIGAR run covers less than 44 % of the read length are flagged
+   `0x200`; QC-fail flags then propagate across all records in a read group.
+   The original pre-c2t sequence is copied back into the BAM SEQ field so
+   methylation callers see real cytosines rather than the converted
+   sequence.
 
 5. **BAM output.** Records are written as uncompressed BAM (`wb0` mode via
    htslib). The `@PG ID:bwa-mem3-meth` line records the exact command line.
@@ -82,6 +89,6 @@ samtools index out.bam
 **See also:**
 [bwameth.py drop-in mapping](bwameth-mapping.md) ·
 [Conversion details](conversion.md) ·
-[SAM tags: YS, YC, YD](tags.md) ·
+[SAM tags: XR, XG, XM](tags.md) ·
 [Chimera QC and header rewriting](post-processing.md) ·
 [Quick start: methylation alignment](../getting-started/quick-meth.md)

--- a/docs/src/methylation/post-processing.md
+++ b/docs/src/methylation/post-processing.md
@@ -39,13 +39,17 @@ output contig index is `cmap->out_tid[p.rid]`.
 > distance rather than zero (which would happen if the mismatched internal TIDs
 > were used).
 
-## Chimera QC heuristic
+## Chimera QC heuristic (opt-in)
 
-bwameth.py applies a heuristic to flag reads that look like chimeric fragments:
-if the longest contiguous alignment run (sum of M/=/X CIGAR operations) covers
-less than 44% of the read length, the read is considered a potential chimera.
+bwameth.py applies a heuristic to flag reads that look like chimeric
+fragments: if the longest contiguous alignment run (sum of M/=/X CIGAR
+operations) covers less than 44 % of the read length, the read is
+considered a potential chimera. **Bismark does not apply this kind of
+heuristic.**
 
-`bwa-mem3 --meth` applies the same heuristic inside `meth_mem_aln_to_bam`:
+`bwa-mem3 --meth` makes this opt-in via `--chimera-qc` (default off, so
+the runtime posture matches Bismark). When enabled, the check inside
+`meth_mem_aln_to_bam` does:
 
 ```text
 if (100 * longest_M_run < 44 * l_seq):
@@ -54,15 +58,16 @@ if (100 * longest_M_run < 44 * l_seq):
     mapq   =  min(mapq, 1)
 ```
 
-The threshold constant is `MIN_LONGEST_M_PCT = 44` (defined at the top of
-`src/meth_bam.cpp`). The longest run is computed by `cigar_longest_m_mem`
-from `src/cigar_util.cpp`, which counts M, `=`, and X operations.
+The threshold constant is `MIN_LONGEST_M_PCT = 44` (defined at the top
+of `src/meth_bam.cpp`). The longest run is computed by
+`cigar_longest_m_mem` from `src/cigar_util.cpp`, which counts M, `=`,
+and X operations.
 
-The chimera heuristic is only applied to mapped records (`!(flag & 0x4) &&
-direction != 0`). Unmapped records are not touched.
+The chimera heuristic is only applied to mapped records (`!(flag & 0x4)
+&& direction != 0`). Unmapped records are not touched.
 
-To disable this heuristic, pass `--do-not-penalize-chimeras`. See
-[Flags](flags.md) for details.
+See [Flags](flags.md) for when to use `--chimera-qc` (PBAT / scBS-Seq;
+bwameth.py-equivalence runs).
 
 ## `--set-as-failed` strand filtering
 
@@ -122,7 +127,7 @@ and reproducibility.
 
 **See also:**
 [Overview](overview.md) ·
-[SAM tags: YS, YC, YD](tags.md) ·
-[Flags: --set-as-failed, --do-not-penalize-chimeras](flags.md) ·
+[SAM tags: XR, XG, XM](tags.md) ·
+[Flags: --set-as-failed, --chimera-qc](flags.md) ·
 [Conversion details](conversion.md) ·
 [User Guide → Output: SAM/BAM, headers, tags](../user-guide/output.md)

--- a/docs/src/methylation/tags.md
+++ b/docs/src/methylation/tags.md
@@ -1,106 +1,136 @@
-# SAM Tags: YS, YC, YD
+# SAM Tags: XR, XG, XM (Bismark-compatible)
 
-`bwa-mem3 --meth` emits three methylation-specific auxiliary tags that carry
-the information downstream methylation callers need. Two of these (`YS:Z:` and
-`YC:Z:`) are set during FASTQ ingest and pass through the alignment kernel
-unchanged. The third (`YD:Z:`) is set during BAM post-processing based on the
-contig name of the alignment.
+`bwa-mem3 mem --meth` emits three Bismark-compatible auxiliary tags on
+each output record: `XR:Z`, `XG:Z`, and `XM:Z`. These tags are read by
+`bismark_methylation_extractor`, `deduplicate_bismark`, methylKit
+`processBismarkAln`, methtuple, DMRfinder, epialleleR, MethylDackel, and
+biscuit's per-read methylation tools.
 
 ## Tag reference
 
-### `YS:Z:` — original (pre-conversion) sequence
+### `XR:Z` — read conversion direction
 
 | Property | Value |
 |----------|-------|
 | Type | `Z` (NUL-terminated string) |
-| Length | Equal to `l_seq` (full read length) |
-| Set by | FASTQ ingest (`src/fastmap.cpp` meth_mode block) |
+| Values | `CT` (R1 / SE) or `GA` (R2) |
+| Set by | `meth_mem_aln_to_bam` from FASTQ-ingest carrier (`s->comment`'s YC payload) |
 | Emitted on | All records (mapped and unmapped) |
 
-`YS:Z:` holds the original base sequence of the read **before** the C→T or
-G→A conversion. The value is the ASCII string of bases as read from the FASTQ,
-in read order (not reverse-complemented).
+`XR:Z` records which conversion was applied to the read at FASTQ ingest:
 
-This tag serves two purposes:
-
-1. **SEQ restoration.** `meth_mem_aln_to_bam` copies the `YS:Z:` payload back
-   into the BAM SEQ field (with reverse-complement when `is_rev` is set) so
-   that methylation callers see real cytosines. Without this restoration the SEQ
-   field would show only `T`s where `C`s existed in the original read.
-
-2. **Downstream inspection.** Tools that need to examine the unconverted sequence
-   independently of the BAM SEQ field can read `YS:Z:` directly.
-
-> **Note — Format inside the comment buffer**
->
-> Internally, the ingest code stores the value as
-> `YS:Z:<bases>\tYC:Z:<dir>` starting at offset 0 of `bseq1_t.comment`.
-> `meth_mem_aln_to_bam` locates the payload at `comment + 5` (past the
-> `YS:Z:` prefix). The two tags are always co-emitted in this order.
-
-### `YC:Z:` — conversion direction
-
-| Property | Value |
-|----------|-------|
-| Type | `Z` (NUL-terminated string) |
-| Values | `CT` (R1, C→T) or `GA` (R2, G→A) |
-| Set by | FASTQ ingest (`src/fastmap.cpp` meth_mode block) |
-| Emitted on | All records |
-
-`YC:Z:` records which conversion was applied to the read:
-
-- `CT` — C→T conversion applied; this is an R1 read (or a single-end read).
+- `CT` — C→T conversion applied; this is an R1 read or single-end read.
 - `GA` — G→A conversion applied; this is an R2 read.
 
-bwameth.py uses `YC:Z:` for the same purpose and with the same values. Tools
-such as MethylDackel use `YC:Z:` to determine which cytosines to call as
-methylated. `YC:Z:CT` records are candidates for CpG methylation on the top
-strand; `YC:Z:GA` records are candidates on the bottom strand.
-
-### `YD:Z:` — strand hypothesis
+### `XG:Z` — genome strand of the alignment
 
 | Property | Value |
 |----------|-------|
 | Type | `Z` (NUL-terminated string) |
-| Values | `f` (forward / top strand) or `r` (reverse / bottom strand) |
-| Set by | `meth_mem_aln_to_bam` (`src/meth_bam.cpp`) |
-| Emitted on | Mapped records only (not unmapped) |
+| Values | `CT` (aligned to original top, `f-`-prefixed contig) or `GA` (aligned to original bottom, `r-`-prefixed contig) |
+| Set by | `meth_mem_aln_to_bam` from `meth_chrom_map_t.direction` |
+| Emitted on | Mapped records only |
 
-`YD:Z:` records which strand of the doubled reference the read aligned to. The
-value is derived from the `f`/`r` prefix on the internal contig name via the
-`meth_chrom_map_t.direction` array. Unmapped reads do not receive `YD:Z:`.
+`XG:Z` indicates which doubled-reference strand the read aligned to:
 
-- `f` — the read aligned to an `f`-prefixed contig (the C→T projection of the
-  top strand).
-- `r` — the read aligned to an `r`-prefixed contig (the G→A projection of the
-  bottom strand).
+- `CT` — read aligned to the C→T-projected forward strand (OT).
+- `GA` — read aligned to the G→A-projected forward strand (OB).
 
-This tag is used by `--set-as-failed` (see [Flags](flags.md)) and is also
-consumed by downstream methylation callers to confirm which strand each
-alignment supports.
+For properly paired directional reads, R1 and R2 of a fragment naturally
+share `XG:Z`. Discordant pairs (already flagged with `0x200` by the
+chimera-QC heuristic) may see `XG:Z` diverge between mates.
 
-## Tag emission summary
+### `XM:Z` — methylation call string
 
-| Tag | Records | Source |
-|-----|---------|--------|
-| `YS:Z:` | All | FASTQ ingest (comment buffer) |
-| `YC:Z:` | All | FASTQ ingest (comment buffer) |
-| `YD:Z:` | Mapped only | `meth_mem_aln_to_bam` from chrom map |
+| Property | Value |
+|----------|-------|
+| Type | `Z` (NUL-terminated string) |
+| Length | Equal to `SEQ` length |
+| Set by | `meth_build_xm` (`src/meth_xm.cpp`) walking SEQ-orientation read against un-converted ref |
+| Emitted on | Mapped records only |
 
-> **Tip — Checking tags with samtools**
->
-> To inspect these tags on a BAM file:
->
->     samtools view out.bam | cut -f12- | grep -oP 'Y[SCD]:Z:[^\t]+'
->
-> Or use `samtools view -H` to confirm the `@PG ID:bwa-mem3-meth` entry is
-> present and the `@SQ` lines are consolidated (no `f`/`r` prefixes).
+Per-base methylation call. Each character corresponds to one SEQ base:
 
----
+| char | meaning |
+|------|---------|
+| `z` / `Z` | unmethylated / methylated C in CpG context |
+| `x` / `X` | unmethylated / methylated C in CHG context |
+| `h` / `H` | unmethylated / methylated C in CHH context |
+| `u` / `U` | unmethylated / methylated C in unknown context (N within 1 or 2 bp downstream of the C, on the read's source strand) |
+| `.`       | non-C reference at this position, sequencing mismatch (read base ≠ C/T at a ref C), insertion, soft clip, or N at the C position itself |
 
-**See also:**
-[Overview](overview.md) ·
-[Conversion details](conversion.md) ·
-[Chimera QC and header rewriting](post-processing.md) ·
-[Flags: --set-as-failed, --do-not-penalize-chimeras](flags.md) ·
-[User Guide → Output: SAM/BAM, headers, tags](../user-guide/output.md)
+The string is in SEQ orientation (matches the BAM SEQ field): for reads
+with the `0x10` flag set, both SEQ and `XM:Z` are reverse-complemented
+relative to FASTQ-original orientation.
+
+## Computation
+
+Under `--meth`, the doubled c2t reference (`<prefix>.bwameth.c2t.*`) is
+folded once at startup into an in-memory un-converted pac (the
+`meth_orig_ref` module — `src/meth_orig_ref.cpp`). The fold uses
+`(f, r) → original` recovery on every position via a 5-row table:
+
+| f[P] | r[P] | original[P] |
+|------|------|-------------|
+| T    | T    | T           |
+| T    | C    | C           |
+| G    | A    | G           |
+| A    | A    | A           |
+| N    | N    | N (via `bns->ambs`) |
+
+Per mapped record, `meth_build_xm` slices the un-converted forward-strand
+window at the read's footprint plus 2 bp of context on either side, then
+walks the BAM CIGAR jointly over the restored SEQ and the ref window.
+The classifier matches Bismark's `methylation_call`:
+
+```
+match position with ref[t] == 'C' (top strand) or 'G' (bottom strand):
+    determine context from ref[t±1], ref[t±2]
+        N in either context base    -> u/U (unknown context)
+        ref[t±1] == G/C (per strand) -> z/Z (CpG)
+        ref[t±2] == G/C (per strand) -> x/X (CHG)
+        otherwise                    -> h/H (CHH)
+    determine methylation:
+        read base == C/G (per strand) -> uppercase (methylated)
+        read base == T/A (per strand) -> lowercase (unmethylated)
+        otherwise                      -> '.'
+insertion / soft clip                  -> '.' per consumed read base
+deletion / N op                         -> no XM emit
+hard clip / pad                         -> no XM emit
+```
+
+The `top vs bottom strand` choice is driven by `XG:Z` (= cmap
+direction), **not** by the SAM 0x10 (RC) flag. CTOT reads (R2 mapped
+forward to a top-strand contig with 0x10 set) and OB reads (R1 mapped
+RC to a bottom-strand contig) are both handled by reading the rule
+table from the strand encoded in `XG`. The walk runs in SEQ orientation
+throughout — no RC of the ref slice or the read.
+
+For bottom-strand methylation, the C of interest at forward position P
+is encoded as a G on the forward strand (complement of bottom-strand C).
+The downstream context on the bottom strand corresponds to *upstream*
+positions on the forward strand; the classifier indexes `ref[t-1]` and
+`ref[t-2]` instead of `ref[t+1]` and `ref[t+2]`, and looks for a `C`
+(forward) instead of a `G` to flag CpG.
+
+## Inspecting tags with samtools
+
+```
+samtools view out.bam | head -1 | tr '\t' '\n' | grep -E '^X[RGM]:'
+```
+
+Expected output looks like:
+
+```
+XR:Z:CT
+XG:Z:CT
+XM:Z:..z..h..Z..x..h.....Z..
+```
+
+## See also
+
+- [Overview](overview.md)
+- [Conversion details](conversion.md)
+- [Chimera QC and header rewriting](post-processing.md)
+- [Flags: --set-as-failed, --chimera-qc](flags.md)
+- [User Guide → Output: SAM/BAM, headers, tags](../user-guide/output.md)

--- a/docs/src/related-projects/bwameth.md
+++ b/docs/src/related-projects/bwameth.md
@@ -26,11 +26,12 @@ bundled with the original script.
 alignment pipeline. It inlines the C-to-T and G-to-A conversion, runs the bwa-mem3
 alignment engine (with all of its correctness fixes and SIMD speedups), rewrites the
 `@SQ` headers to collapse the per-strand contig pairs back to canonical chromosome names,
-applies chimera QC, and emits a `@PG ID:bwa-mem3-meth` header. The output BAM is
-compatible with the same downstream tabulation tools that consume bwameth.py output.
+emits Bismark-compatible `XR:Z` / `XG:Z` / `XM:Z` auxiliary tags, and writes a
+`@PG ID:bwa-mem3-meth` header. The bwameth.py-style chimera QC heuristic is
+available via `--chimera-qc` (off by default — Bismark behavior).
 The [Methylation Reference](../methylation/overview.md) section documents the full
-implementation in detail, including the `YS:Z:`, `YC:Z:`, and `YD:Z:` tags and the
-`--set-as-failed` and `--do-not-penalize-chimeras` flags.
+implementation in detail, including the Bismark `XR:Z` / `XG:Z` / `XM:Z` tags and
+the `--set-as-failed` / `--chimera-qc` flags.
 
 > **Tip — Interop with the bwameth.py c2t step**
 >

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -156,7 +156,7 @@ int bam_writer_close(bam_writer_t *w)
  * (A/i/f/Z/H) are handled; B (typed array) is skipped because parsing it
  * is non-trivial and FASTQ comments effectively never use it. Malformed
  * tokens are skipped silently. */
-static void append_sam_aux_tokens(struct bam1_t *b, const char *s)
+static void append_sam_aux_tokens(struct bam1_t *b, const char *s, int meth_mode)
 {
     if (s == NULL) return;
     while (*s) {
@@ -167,6 +167,15 @@ static void append_sam_aux_tokens(struct bam1_t *b, const char *s)
         size_t tok_len = (size_t)(s - tok);
         /* Need at least "XX:T:" (5 chars) and a non-empty value. */
         if (tok_len < 6 || tok[2] != ':' || tok[4] != ':') continue;
+        /* Under --meth, the YS:Z and YC:Z tokens in s->comment are internal
+         * carriers only (used by meth_mem_aln_to_bam for SEQ restoration and
+         * XR:Z derivation). Suppress them here so the BAM output carries
+         * only the Bismark XR:Z/XG:Z/XM:Z tag set. */
+        if (meth_mode
+                && ((tok[0] == 'Y' && tok[1] == 'S')
+                 || (tok[0] == 'Y' && tok[1] == 'C'))) {
+            continue;
+        }
         char tag[2] = { tok[0], tok[1] };
         char type   = tok[3];
         const char *val  = tok + 5;
@@ -412,12 +421,14 @@ extern "C" void bam_writer_append_generic_aux(struct bam1_t *b,
      * SAM-text aux tokens and emit each as a packed BAM aux so the BAM and
      * SAM paths carry the same tags. */
     if (s->comment != NULL && s->comment[0] != '\0') {
-        append_sam_aux_tokens(b, s->comment);
+        append_sam_aux_tokens(b, s->comment, opt->meth_mode);
     }
 
     /* Reference annotation (-V / MEM_F_REF_HDR). Mirrors mem_aln2sam: emit
-     * bns->anns[rid].anno as XR:Z, replacing TAB with SPACE. */
-    if ((opt->flag & MEM_F_REF_HDR) && rid >= 0 &&
+     * bns->anns[rid].anno as XR:Z, replacing TAB with SPACE. Suppressed
+     * under --meth because that mode repurposes XR:Z for the Bismark
+     * read-conversion direction (see docs/src/methylation/tags.md). */
+    if ((opt->flag & MEM_F_REF_HDR) && !opt->meth_mode && rid >= 0 &&
         bns != NULL && bns->anns[rid].anno != NULL &&
         bns->anns[rid].anno[0] != '\0') {
         const char *anno = bns->anns[rid].anno;

--- a/src/bntseq.cpp
+++ b/src/bntseq.cpp
@@ -253,8 +253,9 @@ void bns_destroy(bntseq_t *bns)
 	}
 }
 
-#define _set_pac(pac, l, c) ((pac)[(l)>>2] |= (c)<<((~(l)&3)<<1))
-#define _get_pac(pac, l) ((pac)[(l)>>2]>>((~(l)&3)<<1)&3)
+/* _get_pac and _set_pac now published in bntseq.h so meth_orig_ref.cpp
+ * (and any other in-tree caller that needs inline 2-bit decode) can use
+ * them without re-defining. */
 
 static uint8_t *add1(const kseq_t *seq, bntseq_t *bns, uint8_t *pac, int64_t *m_pac, int *m_seqs, int *m_holes, bntamb1_t **q)
 {
@@ -411,65 +412,94 @@ int bns_intv2rid(const bntseq_t *bns, int64_t rb, int64_t re)
 	return rid_b == rid_e? rid_b : -1;
 }
 
-int bns_cnt_ambi(const bntseq_t *bns, int64_t pos_f, int len, int *ref_id)
+/* Iterate ambs intervals overlapping [pos_f, pos_f + len). Sorted by
+ * offset. The pre-existing bns_cnt_ambi did binary-search-then-break-on-
+ * first-overlap, which under-counts when a window legitimately overlaps
+ * two intervals; folding the count through this iterator fixes that as
+ * a side effect. */
+int bns_iter_ambi(const bntseq_t *bns, int64_t pos_f, int len,
+                  bns_amb_visit_fn fn, void *ctx)
 {
-	int left, mid, right, nn;
-	if (ref_id) *ref_id = bns_pos2rid(bns, pos_f);
-	left = 0; right = bns->n_holes; nn = 0;
+	int left, mid, right;
+	int64_t window_end = pos_f + len;
+	int rc = 0;
+	if (bns == NULL || bns->n_holes == 0 || len <= 0 || fn == NULL) return 0;
+
+	/* Lower-bound on offset+len: find the first amb whose end-position
+	 * is greater than pos_f (i.e. whose interval can possibly overlap). */
+	left = 0; right = bns->n_holes;
 	while (left < right) {
 		mid = (left + right) >> 1;
-		if (pos_f >= bns->ambs[mid].offset + bns->ambs[mid].len) left = mid + 1;
-		else if (pos_f + len <= bns->ambs[mid].offset) right = mid;
-		else { // overlap
-			if (pos_f >= bns->ambs[mid].offset) {
-				nn += bns->ambs[mid].offset + bns->ambs[mid].len < pos_f + len?
-					bns->ambs[mid].offset + bns->ambs[mid].len - pos_f : len;
-			} else {
-				nn += bns->ambs[mid].offset + bns->ambs[mid].len < pos_f + len?
-					bns->ambs[mid].len : len - (bns->ambs[mid].offset - pos_f);
-			}
-			break;
-		}
+		if ((int64_t)(bns->ambs[mid].offset + bns->ambs[mid].len) <= pos_f) left = mid + 1;
+		else right = mid;
 	}
-	return nn;
+
+	/* Walk forward through overlapping ambs until we run off the end. */
+	for (int i = left; i < bns->n_holes; ++i) {
+		const bntamb1_t *a = &bns->ambs[i];
+		if ((int64_t)a->offset >= window_end) break;
+		int64_t st = (int64_t)a->offset > pos_f ? (int64_t)a->offset : pos_f;
+		int64_t en = (int64_t)(a->offset + a->len) < window_end
+		             ? (int64_t)(a->offset + a->len) : window_end;
+		if (st >= en) continue;
+		rc = fn(st, en, ctx);
+		if (rc != 0) return rc;
+	}
+	return rc;
 }
 
-uint8_t *bns_get_seq(int64_t l_pac, const uint8_t *pac, int64_t beg, int64_t end, int64_t *len)
+namespace {
+struct cnt_ambi_ctx { int nn; };
+int cnt_ambi_visit(int64_t st, int64_t en, void *ctx) {
+	((cnt_ambi_ctx *)ctx)->nn += (int)(en - st);
+	return 0; /* keep iterating */
+}
+}
+
+int bns_cnt_ambi(const bntseq_t *bns, int64_t pos_f, int len, int *ref_id)
 {
-	uint8_t *seq = 0;
+	if (ref_id) *ref_id = bns_pos2rid(bns, pos_f);
+	cnt_ambi_ctx ctx = { 0 };
+	bns_iter_ambi(bns, pos_f, len, cnt_ambi_visit, &ctx);
+	return ctx.nn;
+}
+
+void bns_get_seq_into(int64_t l_pac, const uint8_t *pac,
+                      int64_t beg, int64_t end,
+                      uint8_t *dst, int64_t *len_out)
+{
 	if (end < beg) end ^= beg, beg ^= end, end ^= beg; // if end is smaller, swap
 	if (end > l_pac<<1) end = l_pac<<1;
 	if (beg < 0) beg = 0;
 	if (beg >= l_pac || end <= l_pac) {
 		int64_t k, l = 0;
-		*len = end - beg;
-		seq = (uint8_t*) malloc(end - beg + 64);		
-        assert(seq != NULL);
+		*len_out = end - beg;
 		if (beg >= l_pac) { // reverse strand
 			int64_t beg_f = (l_pac<<1) - 1 - end;
 			int64_t end_f = (l_pac<<1) - 1 - beg;
 			for (k = end_f; k > beg_f; --k) {
-				seq[l++] = 3 - _get_pac(pac, k);
+				dst[l++] = 3 - _get_pac(pac, k);
 			}
 		} else { // forward strand
 			for (k = beg; k < end; ++k) {
-				seq[l++] = _get_pac(pac, k);
+				dst[l++] = _get_pac(pac, k);
 			}
 		}
-	} else *len = 0; // if bridging the forward-reverse boundary, return nothing
-	return seq;
+	} else {
+		*len_out = 0; // if bridging the forward-reverse boundary, return nothing
+	}
 }
 
-uint8_t *bns_fetch_seq(const bntseq_t *bns, const uint8_t *pac, int64_t *beg, int64_t mid, int64_t *end, int *rid)
+void bns_fetch_seq_into(const bntseq_t *bns, const uint8_t *pac,
+                        int64_t *beg, int64_t mid, int64_t *end, int *rid,
+                        uint8_t *dst, int64_t *len_out)
 {
-	int64_t far_beg, far_end, len;
+	int64_t far_beg, far_end;
 	int is_rev;
-	uint8_t *seq;
 
 	if (*end < *beg) *end ^= *beg, *beg ^= *end, *end ^= *beg; // if end is smaller, swap
-	// printf("%ld %ld %ld\n", *beg, mid, *end);
 	assert(*beg <= mid && mid < *end);
-	
+
 	*rid = bns_pos2rid(bns, bns_depos(bns, mid, &is_rev));
 	far_beg = bns->anns[*rid].offset;
 	far_end = far_beg + bns->anns[*rid].len;
@@ -481,14 +511,13 @@ uint8_t *bns_fetch_seq(const bntseq_t *bns, const uint8_t *pac, int64_t *beg, in
 	*beg = *beg > far_beg? *beg : far_beg;
 	*end = *end < far_end? *end : far_end;
 
-	seq = bns_get_seq(bns->l_pac, pac, *beg, *end, &len);
+	bns_get_seq_into(bns->l_pac, pac, *beg, *end, dst, len_out);
 
-	if (seq == 0 || *end - *beg != len) {
-		fprintf(stderr, "[E::%s] begin=%ld, mid=%ld, end=%ld, len=%ld, seq=%p, rid=%d, far_beg=%ld, far_end=%ld\n",
-				__func__, (long)*beg, (long)mid, (long)*end, (long)len, seq, *rid, (long)far_beg, (long)far_end);
+	if (*end - *beg != *len_out) {
+		fprintf(stderr, "[E::%s] begin=%ld, mid=%ld, end=%ld, len=%ld, rid=%d, far_beg=%ld, far_end=%ld\n",
+				__func__, (long)*beg, (long)mid, (long)*end, (long)(*len_out), *rid, (long)far_beg, (long)far_end);
 	}
-	assert(seq && *end - *beg == len); // assertion failure should never happen
-	return seq;
+	assert(*end - *beg == *len_out); // assertion failure should never happen
 }
 
 // Zero-copy v2 variants. Identical semantics to bns_get_seq / bns_fetch_seq

--- a/src/bntseq.h
+++ b/src/bntseq.h
@@ -65,6 +65,22 @@ typedef struct {
 
 extern unsigned char nst_nt4_table[256];
 
+/* 2-bit pac primitives — published so callers in other TUs (e.g. the
+ * meth XM:Z slice path) can decode bases inline without going through
+ * the malloc'ing bns_get_seq path. `pac` is the standard 2-bit packed
+ * buffer (4 bases/byte, top-first); `l` is the global bp offset.
+ *
+ * Arguments must be side-effect-free: `l` is evaluated 3x in _get_pac
+ * and 3x in _set_pac. The macro bodies are fully parenthesized so that
+ * arithmetic on the result (e.g. `_get_pac(pac, i) + 1`) sees the
+ * intended `& 3` masking instead of `& (3 + 1)`. */
+#ifndef _get_pac
+#define _get_pac(pac, l) ((((pac)[(l) >> 2]) >> ((~(l) & 3) << 1)) & 3)
+#endif
+#ifndef _set_pac
+#define _set_pac(pac, l, c) ((pac)[(l) >> 2] |= (uint8_t)((c) << ((~(l) & 3) << 1)))
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -76,8 +92,28 @@ extern "C" {
 	int64_t bns_fasta2bntseq(gzFile fp_fa, const char *prefix, int for_only);
 	int bns_pos2rid(const bntseq_t *bns, int64_t pos_f);
 	int bns_cnt_ambi(const bntseq_t *bns, int64_t pos_f, int len, int *ref_id);
-	uint8_t *bns_get_seq(int64_t l_pac, const uint8_t *pac, int64_t beg, int64_t end, int64_t *len);
-	uint8_t *bns_fetch_seq(const bntseq_t *bns, const uint8_t *pac, int64_t *beg, int64_t mid, int64_t *end, int *rid);
+	/* Iterate over the bns->ambs intervals overlapping [pos_f, pos_f + len),
+	 * in sorted (offset) order. `fn` receives the half-open interval
+	 * [amb_st, amb_en) clipped to [pos_f, pos_f + len) plus the caller
+	 * context. Iteration stops when fn returns nonzero. Returns the last
+	 * fn return value (0 if no intervals visited). */
+	typedef int (*bns_amb_visit_fn)(int64_t amb_st, int64_t amb_en, void *ctx);
+	int bns_iter_ambi(const bntseq_t *bns, int64_t pos_f, int len,
+	                  bns_amb_visit_fn fn, void *ctx);
+	/* Decode forward/reverse-complement bases [beg, end) of `pac` into
+	 * caller-provided `dst` (capacity must be >= max(end - beg, 0)).
+	 * `dst` is filled with 2-bit-decoded bases (0..3 = A/C/G/T); ambiguous
+	 * (N) positions are NOT marked here — callers that care consult
+	 * bns->ambs separately (see bns_iter_ambi). On bridging the
+	 * forward/reverse boundary `*len_out` is set to 0 and dst is
+	 * untouched. Otherwise `*len_out == end - beg` (after end-clamp to
+	 * `2 * l_pac` and beg-clamp to 0). */
+	void bns_get_seq_into(int64_t l_pac, const uint8_t *pac,
+	                      int64_t beg, int64_t end,
+	                      uint8_t *dst, int64_t *len_out);
+	void bns_fetch_seq_into(const bntseq_t *bns, const uint8_t *pac,
+	                        int64_t *beg, int64_t mid, int64_t *end, int *rid,
+	                        uint8_t *dst, int64_t *len_out);
 	// Zero-copy v2 variants used by mem_chain2aln_across_reads_V2 and the
 	// mem_matesw_batch_* path. Return a pointer into the pre-unpacked
 	// `ref_string` (the .0123 reference materialized at startup); no

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -38,6 +38,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "utils.h"
 #include "kstring.h"
 #include "kvec.h"
+#include "u8vec_scratch.h"
 #include <string>
 
 #include "safestringlib.h"
@@ -268,7 +269,13 @@ uint32_t *bwa_gen_cigar2(const int8_t mat[25], int o_del, int e_del, int o_ins, 
     if (n_cigar) *n_cigar = 0;
     if (NM) *NM = -1;
     if (l_query <= 0 || rb >= re || (rb < l_pac && re > l_pac)) return 0; // reject if negative length or bridging the forward and reverse strand
-    rseq = bns_get_seq(l_pac, pac, rb, re, &rlen);
+    {
+        static thread_local u8vec_scratch_t t_rseq;
+        size_t want = (size_t)((re - rb) + 64);  // +64 keeps the "+64" headroom the old malloc had
+        if (t_rseq.v.m < want) kv_resize(uint8_t, t_rseq.v, want);
+        bns_get_seq_into(l_pac, pac, rb, re, t_rseq.v.a, &rlen);
+        rseq = t_rseq.v.a;
+    }
     if (re - rb != rlen) goto ret_gen_cigar; // possible if out of range
     if (rb >= l_pac) { // then reverse both query and rseq; this is to ensure indels to be placed at the leftmost position
         for (i = 0; i < l_query>>1; ++i)
@@ -341,7 +348,7 @@ uint32_t *bwa_gen_cigar2(const int8_t mat[25], int o_del, int e_del, int o_ins, 
             tmp = query[i], query[i] = query[l_query - 1 - i], query[l_query - 1 - i] = tmp;
 
 ret_gen_cigar:
-    free(rseq);
+    /* rseq aliases thread-local kvec scratch in this function; do not free. */
     return cigar;
 }
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -33,6 +33,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "memcpy_bwamem.h"
 #include "bam_writer.h"
 #include "meth_bam.h"
+#include "u8vec_scratch.h"
 #include <inttypes.h>      /* PRId64 for int64_t fprintf format strings */
 
 #include "sam_encode.h"
@@ -438,11 +439,18 @@ int mem_seed_sw(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
     }
     if (qe - qb >= MEM_SHORT_LEN || re - rb >= MEM_SHORT_LEN) return -1; // the seed seems good enough; no need to do SW
 
-    rseq = bns_fetch_seq(bns, pac, &rb, mid, &re, &rid);
-    // No qry-profile cache: each seed slices a different sub-query
-    // (query+qb, qe-qb), so ksw_align2 always builds a fresh profile.
-    x = ksw_align2(qe - qb, (uint8_t*)query + qb, re - rb, rseq, 5, opt->mat, opt->o_del, opt->e_del, opt->o_ins, opt->e_ins, KSW_XSTART, NULL);
-    free(rseq);
+    {
+        static thread_local u8vec_scratch_t t_rseq;
+        size_t want = (size_t)((re - rb) + 64);
+        if (t_rseq.v.m < want) kv_resize(uint8_t, t_rseq.v, want);
+        int64_t rlen;
+        bns_fetch_seq_into(bns, pac, &rb, mid, &re, &rid, t_rseq.v.a, &rlen);
+        rseq = t_rseq.v.a;
+        // No qry-profile cache: each seed slices a different sub-query
+        // (query+qb, qe-qb), so ksw_align2 always builds a fresh profile.
+        x = ksw_align2(qe - qb, (uint8_t*)query + qb, re - rb, rseq, 5, opt->mat, opt->o_del, opt->e_del, opt->o_ins, opt->e_ins, KSW_XSTART, NULL);
+        /* rseq aliases thread-local scratch; do not free. */
+    }
     return x.score;
 }
 
@@ -1842,7 +1850,9 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
     if (p->HN >= 0) { kputsn_u("\tHN:i:", 6, str); kputw_u(p->HN, str); }
 
     if (s->comment) { kputc_u('\t', str); kputs_u(s->comment, str); }
-    if ((opt->flag&MEM_F_REF_HDR) && p->rid >= 0 && bns->anns[p->rid].anno != 0 && bns->anns[p->rid].anno[0] != 0) {
+    if ((opt->flag&MEM_F_REF_HDR) && !opt->meth_mode && p->rid >= 0 && bns->anns[p->rid].anno != 0 && bns->anns[p->rid].anno[0] != 0) {
+        /* Suppressed under --meth: that mode repurposes XR:Z for the Bismark
+         * read-conversion direction (see docs/src/methylation/tags.md). */
         int tmp;
         kputsn_u("\tXR:Z:", 6, str);
         tmp = (int)str->l;

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -110,7 +110,7 @@ typedef struct mem_opt_t {
     int    bam_level;       // 0..9, BGZF deflate level (0 = uncompressed)
     int    meth_mode;       // 1 = bisulfite mode (--meth); implies bam_mode
     char   meth_set_as_failed;// 'f', 'r', or 0 — flag reads on that strand 0x200
-    int    meth_no_chim;    // 1 to skip the longest-M <44% chimera heuristic
+    int    meth_chimera_qc; // 1 to enable bwameth.py-style longest-M <44% chimera heuristic (default off; not in Bismark)
     int    supp_rep_hard_cap; // supp alnregs whose chain's seeds share >=this many genome hits are forced to MAPQ=0; 0 disables
 } mem_opt_t;
 

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -37,6 +37,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "bwamem.h"
 #include "bam_writer.h"
 #include "kvec.h"
+#include "u8vec_scratch.h"
 #include "utils.h"
 #include "ksw.h"
 #include "bandedSWA.h"
@@ -202,7 +203,14 @@ int mem_matesw(const mem_opt_t *opt, const bntseq_t *bns,
         }
         if (rb < 0) rb = 0;
         if (re > l_pac<<1) re = l_pac<<1;
-        if (rb < re) ref = bns_fetch_seq(bns, pac, &rb, (rb+re)>>1, &re, &rid);
+        static thread_local u8vec_scratch_t t_ref;
+        if (rb < re) {
+            size_t want = (size_t)((re - rb) + 64);
+            if (t_ref.v.m < want) kv_resize(uint8_t, t_ref.v, want);
+            int64_t rlen;
+            bns_fetch_seq_into(bns, pac, &rb, (rb+re)>>1, &re, &rid, t_ref.v.a, &rlen);
+            ref = t_ref.v.a;
+        }
         if (a->rid == rid && re - rb >= opt->min_seed_len) { // no funny things happening
             kswr_t aln;
             mem_alnreg_t b;
@@ -279,7 +287,7 @@ int mem_matesw(const mem_opt_t *opt, const bntseq_t *bns,
         if (n) ma->n = mem_dedup_patch(opt, 0, 0, 0, ma->n, ma->a); // sam_improvements
         #endif
         if (rev) free(rev);
-        free(ref);
+        /* ref aliases t_ref thread-local scratch; do not free. */
     }
     return n;
 }

--- a/src/bwtindex.cpp
+++ b/src/bwtindex.cpp
@@ -83,6 +83,10 @@ static int meth_c2t_is_fresh(const char *in_fa, const char *out_fa)
     return b.st_mtime >= a.st_mtime;
 }
 
+/* (No separate un-converted-pac emission. `bwa-mem3 mem --meth` recovers
+ * original ref bases at runtime via per-record dual-slice from idx->pac
+ * — see src/meth_orig_ref.cpp.) */
+
 static int meth_index_c2t_build(const char *fa)
 {
     char out_fa[PATH_MAX];

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -42,6 +42,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "FMI_search.h"
 #include "bam_writer.h"
 #include "meth_bam.h"
+#include "meth_orig_ref.h"
 #include "bwa_shm.h"
 
 #if AFF && (__linux__)
@@ -890,8 +891,9 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                 with `bwa-mem3 index --meth` (emits ref.fa.bwameth.c2t).\n");
     fprintf(stderr, "   --set-as-failed f|r\n");
     fprintf(stderr, "                 flag alignments to the matching strand ('f' or 'r') as QC-fail (0x200)\n");
-    fprintf(stderr, "   --do-not-penalize-chimeras\n");
-    fprintf(stderr, "                 disable the longest-match <44%% chimera heuristic (no 0x200 / MAPQ cap)\n");
+    fprintf(stderr, "   --chimera-qc\n");
+    fprintf(stderr, "                 enable the bwameth.py-style longest-match <44%% chimera heuristic\n");
+    fprintf(stderr, "                 (sets 0x200, clears 0x2, caps MAPQ at 1). Off by default; not in Bismark.\n");
     fprintf(stderr, "Supplementary MAPQ rescoring (fg-labs extension):\n");
     fprintf(stderr, "   --supp-rep-hard-cap INT\n");
     fprintf(stderr, "                 force MAPQ=0 for supplementary alignments whose chain contains any seed\n");
@@ -996,15 +998,16 @@ int main_mem(int argc, char *argv[])
     // comment: added option '5' in the list
     //
     // Long-only options for bisulfite mode (bwa-mem3 meth fork):
-    //   --meth                      Enable inline bwameth-style c2t + post-processing + BAM output.
-    //                               Expects a reference built with `bwa-mem3 index --meth`.
-    //   --set-as-failed f|r         Flag alignments to this strand as QC-fail (0x200)
-    //   --do-not-penalize-chimeras  Skip the longest-match <44% chimera heuristic
+    //   --meth              Enable inline bwameth-style c2t + post-processing + BAM output.
+    //                       Expects a reference built with `bwa-mem3 index --meth`.
+    //   --set-as-failed f|r Flag alignments to this strand as QC-fail (0x200)
+    //   --chimera-qc        Enable the bwameth.py-style longest-M <44% chimera heuristic
+    //                       (off by default; not part of Bismark)
     enum {
         OPT_BAM = 1000,
         OPT_METH,
         OPT_METH_SET_AS_FAILED,
-        OPT_METH_NO_CHIMERA,
+        OPT_METH_CHIMERA_QC,
         OPT_SUPP_REP_HARD_CAP,
         OPT_HELP,
     };
@@ -1012,7 +1015,7 @@ int main_mem(int argc, char *argv[])
         {"bam",                      optional_argument, 0, OPT_BAM},
         {"meth",                     no_argument,       0, OPT_METH},
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
-        {"do-not-penalize-chimeras", no_argument,       0, OPT_METH_NO_CHIMERA},
+        {"chimera-qc",               no_argument,       0, OPT_METH_CHIMERA_QC},
         {"supp-rep-hard-cap",        required_argument, 0, OPT_SUPP_REP_HARD_CAP},
         {"help",                     no_argument,       0, OPT_HELP},
         {0, 0, 0, 0}
@@ -1152,8 +1155,8 @@ int main_mem(int argc, char *argv[])
             }
             opt->meth_set_as_failed = optarg[0];
         }
-        else if (c == OPT_METH_NO_CHIMERA) {
-            opt->meth_no_chim = 1;
+        else if (c == OPT_METH_CHIMERA_QC) {
+            opt->meth_chimera_qc = 1;
         }
         else if (c == OPT_SUPP_REP_HARD_CAP) {
             char *end = NULL;
@@ -1411,6 +1414,15 @@ int main_mem(int argc, char *argv[])
             delete aux.fmi;
             return 1;
         }
+        g_meth_orig_ref = meth_orig_ref_load(aux.fmi->idx->bns,
+                                             aux.fmi->idx->pac, g_meth_cmap);
+        if (g_meth_orig_ref == NULL) {
+            fprintf(stderr, "ERROR: meth: failed to build un-converted ref view\n");
+            meth_chrom_map_free(g_meth_cmap); g_meth_cmap = NULL;
+            free(opt);
+            delete aux.fmi;
+            return 1;
+        }
     }
     (void)is_o;
     (void)hdr_line;
@@ -1425,12 +1437,25 @@ int main_mem(int argc, char *argv[])
             delete aux.fmi;
             return 1;
         }
+        g_meth_orig_ref = meth_orig_ref_load(aux.fmi->idx->bns,
+                                             aux.fmi->idx->pac, g_meth_cmap);
+        if (g_meth_orig_ref == NULL) {
+            fprintf(stderr, "ERROR: meth: failed to build un-converted ref view\n");
+            meth_chrom_map_free(g_meth_cmap); g_meth_cmap = NULL;
+            free(opt);
+            delete aux.fmi;
+            return 1;
+        }
+        fprintf(stderr,
+                "[bwa-mem3:--meth] un-converted reference loaded "
+                "(%d chrom(s)).\n", g_meth_cmap->n_output);
         const char *meth_out_path = is_o ? out_path : "-";
         extern char *bwa_pg;
         g_meth_bam_writer = meth_bam_writer_open(meth_out_path, g_meth_cmap, bwa_pg, NULL,
                                                  opt->bam_level);
         if (g_meth_bam_writer == NULL) {
             fprintf(stderr, "ERROR: meth: failed to open BAM writer for '%s'\n", meth_out_path);
+            meth_orig_ref_free(g_meth_orig_ref); g_meth_orig_ref = NULL;
             meth_chrom_map_free(g_meth_cmap); g_meth_cmap = NULL;
             free(opt);
             delete aux.fmi;
@@ -1521,11 +1546,15 @@ int main_mem(int argc, char *argv[])
         }
         g_meth_bam_writer = NULL;
     }
-    /* Free g_meth_cmap independently of g_meth_bam_writer: under
-     * -DDISABLE_OUTPUT the writer is never opened, but the chrom map is
-     * still built so per-record paths see consistent tagging. The
-     * branch above only fires when the writer exists, so freeing the
-     * map there would leak on the DISABLE_OUTPUT path. */
+    /* Free g_meth_cmap and g_meth_orig_ref independently of g_meth_bam_writer:
+     * under -DDISABLE_OUTPUT the writer is never opened, but the chrom map
+     * and orig-ref recovery are still built so per-record paths see
+     * consistent tagging. The branch above only fires when the writer
+     * exists, so freeing here covers the DISABLE_OUTPUT path. */
+    if (meth_mode_local && g_meth_orig_ref != NULL) {
+        meth_orig_ref_free(g_meth_orig_ref);
+        g_meth_orig_ref = NULL;
+    }
     if (meth_mode_local && g_meth_cmap != NULL) {
         meth_chrom_map_free(g_meth_cmap);
         g_meth_cmap = NULL;

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -8,6 +8,8 @@
 #include "meth_bam.h"
 #include "bam_writer.h"
 #include "cigar_util.h"
+#include "meth_orig_ref.h"
+#include "meth_xm.h"
 #include "version.h"
 
 #include <cstdio>
@@ -43,7 +45,8 @@ meth_chrom_map_t *meth_chrom_map_build_from_bns(const bntseq_t *bns)
         m->direction    = (char *)   calloc((size_t)m->n_internal, sizeof(char));
         m->output_names = (char **)  calloc((size_t)m->n_internal, sizeof(char *));
         m->output_lens  = (int64_t *)calloc((size_t)m->n_internal, sizeof(int64_t));
-        if (!m->out_tid || !m->direction || !m->output_names || !m->output_lens) {
+        if (!m->out_tid || !m->direction
+                || !m->output_names || !m->output_lens) {
             meth_chrom_map_free(m);
             return NULL;
         }
@@ -74,6 +77,7 @@ meth_chrom_map_t *meth_chrom_map_build_from_bns(const bntseq_t *bns)
             m->out_tid[i] = idx;
         }
     }
+
     return m;
 }
 
@@ -346,7 +350,7 @@ int meth_mem_aln_to_bam(bam1_t *b,
         if (opt->meth_set_as_failed != 0 && opt->meth_set_as_failed == direction) {
             flag16 |= 0x200;
         }
-        if (!opt->meth_no_chim && p.n_cigar > 0 && s->l_seq > 0) {
+        if (opt->meth_chimera_qc && p.n_cigar > 0 && s->l_seq > 0) {
             int lm = cigar_longest_m_mem(p.cigar, p.n_cigar);
             if (100 * lm < MIN_LONGEST_M_PCT * s->l_seq) {
                 flag16 |= 0x200;
@@ -354,6 +358,23 @@ int meth_mem_aln_to_bam(bam1_t *b,
                 if (mapq > 1) mapq = 1;
             }
         }
+    }
+
+    /* Build XM:Z BEFORE bam_set1 frees seq_text and bam_cigar. Stashed for
+     * appending after the bam_set1 call below — bam_aux_append needs the
+     * record to be initialized first.
+     *
+     * is_top_strand keys off `direction` (the cmap f/r tag = XG:Z), NOT
+     * the SAM 0x10 RC flag: methylation is on the top strand when the
+     * fragment was OT (any read mapped to f-contig, including CTOT
+     * is_rev=1 R2s) and on the bottom strand when the fragment was OB. */
+    char *xm = NULL;
+    if (mapped && seq_text != NULL && bam_cigar != NULL && l_emit > 0) {
+        int is_top_strand = (direction == 'f') ? 1 : 0;
+        xm = meth_build_xm(g_meth_orig_ref, tid, (int64_t)p.pos,
+                           is_top_strand,
+                           bam_cigar, (int)bam_n_cigar,
+                           seq_text, (int)l_emit);
     }
 
     /* Build the bam1_t. bam_set1 handles 4-bit packing, name storage, etc. */
@@ -373,7 +394,7 @@ int meth_mem_aln_to_bam(bam1_t *b,
     free(bam_cigar);
     free(seq_text);
     free(qual_bin);
-    if (ret < 0) return -1;
+    if (ret < 0) return -1;  /* xm aliases thread-local scratch; no free */
 
     /* Aux tags — roughly match mem_aln2sam emission order */
     if (p.n_cigar > 0) {
@@ -476,15 +497,42 @@ int meth_mem_aln_to_bam(bam1_t *b,
             bam_aux_append(b, "XA", 'Z', (int)xa.l + 1, (const uint8_t *)xa.s);
         free(xa.s);
     }
-    /* YD:Z — meth strand hypothesis */
+    /* Bismark-compatible XR:Z (read conversion) emitted on every record;
+     * XG:Z (genome strand) and XM:Z (methylation call string) only on
+     * mapped records. The YC:Z payload in s->comment carries the (CT|GA)
+     * value (the comment buffer is "YS:Z:<seq>\tYC:Z:<dir>", see
+     * src/fastmap.cpp:415-425). Locate it with a marker search rather
+     * than l_seq arithmetic so any future YS framing change (alternate
+     * prefix length, prior FASTQ comments folded in) stays detectable. */
+    {
+        const char *xr = NULL;
+        if (s->comment != NULL) {
+            const char *yc = strstr(s->comment, "\tYC:Z:");
+            if (yc != NULL) {
+                const char *p2 = yc + 6;  /* skip "\tYC:Z:" */
+                if      (p2[0] == 'C' && p2[1] == 'T') xr = "CT";
+                else if (p2[0] == 'G' && p2[1] == 'A') xr = "GA";
+            }
+        }
+        if (xr != NULL) {
+            bam_aux_append(b, "XR", 'Z', 3, (const uint8_t *)xr);
+        }
+    }
     if (mapped) {
-        char yd[2] = { direction, '\0' };
-        bam_aux_append(b, "YD", 'Z', 2, (const uint8_t *)yd);
+        const char *xg = (direction == 'f') ? "CT" : "GA";
+        bam_aux_append(b, "XG", 'Z', 3, (const uint8_t *)xg);
+        if (xm != NULL) {
+            /* xm aliases thread-local scratch in meth_xm.cpp; do not free. */
+            bam_aux_append(b, "XM", 'Z', (int)l_emit + 1,
+                           (const uint8_t *)xm);
+        }
     }
 
-    /* Generic aux shared with the --bam path so --meth -C emits FASTQ tags
-     * plus the YS:Z/YC:Z meth tags that `fastmap.cpp` built into s->comment,
-     * and --meth -V emits XR:Z. p.rid here is the bwa-mem3 internal contig
+    /* Generic aux shared with the --bam path so --meth -C emits FASTQ tags.
+     * The YS:Z/YC:Z meth carriers in s->comment are filtered inside
+     * append_sam_aux_tokens under opt->meth_mode so they don't leak into
+     * the BAM output (they're internal carriers only — XR:Z replaces YC,
+     * SEQ restoration replaces YS). p.rid is the bwa-mem3 internal contig
      * index (pre-remap), which is what bns uses. */
     bam_writer_append_generic_aux(b, s, opt, bns, p.rid);
 

--- a/src/meth_bam.h
+++ b/src/meth_bam.h
@@ -68,7 +68,7 @@ int meth_bam_writer_close(meth_bam_writer_t *w);
 /* Convert one alignment to a bam1_t with meth transforms applied:
  *   - chrom rewrite: p->rid → cmap->out_tid[p->rid]
  *   - YD:Z:{f,r} tag from cmap->direction[p->rid]
- *   - chimera QC (unless opt->meth_no_chim): if longest M/=/X run < 44%
+ *   - chimera QC (only when opt->meth_chimera_qc is set): if longest M/=/X run < 44%
  *     of l_seq, set 0x200, clear 0x2, cap mapq at 1
  *   - opt->meth_set_as_failed forces 0x200 on the matching strand
  * Caller owns `b`. Returns 0 on success, -1 on error. */

--- a/src/meth_orig_ref.cpp
+++ b/src/meth_orig_ref.cpp
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "meth_orig_ref.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+struct meth_orig_ref_s {
+    /* Borrowed (not owned) — these point at the bwaidx_t already loaded
+     * by bwa_idx_load_from_disk for alignment. */
+    const bntseq_t *bns;
+    const uint8_t  *pac;
+
+    /* Per real-chrom: bns rid for f and r contig at this real chrom, plus
+     * the chrom length on the un-doubled forward axis. n_chroms ==
+     * cmap->n_output; arrays indexed by real_tid. */
+    int      n_chroms;
+    int     *f_rid;       /* length n_chroms; -1 if no 'f'-contig at real_tid */
+    int     *r_rid;       /* length n_chroms; -1 if no 'r'-contig at real_tid */
+    int64_t *chrom_len;   /* length n_chroms; bns->anns[f_rid].len */
+};
+
+meth_orig_ref_t *g_meth_orig_ref = NULL;
+
+namespace {
+
+/* (f, r) -> original 2-bit base. Returns 0xff for an illegal pair (treated
+ * by caller as N — bwa's random-fill of ambi positions can produce one). */
+inline uint8_t recover_pair(uint8_t f, uint8_t r) {
+    /* 2-bit: A=0, C=1, G=2, T=3.
+     *   (f=A, r=A) -> A    forward original A
+     *   (f=T, r=C) -> C    C in f got C->T; r left alone
+     *   (f=G, r=A) -> G    f left alone; G in r got G->A
+     *   (f=T, r=T) -> T    forward original T
+     */
+    if (f == 0 && r == 0) return 0;
+    if (f == 3 && r == 1) return 1;
+    if (f == 2 && r == 0) return 2;
+    if (f == 3 && r == 3) return 3;
+    return 0xff;
+}
+
+}  // namespace
+
+extern "C"
+meth_orig_ref_t *meth_orig_ref_load(const bntseq_t *bns, const uint8_t *pac,
+                                    const meth_chrom_map_t *cmap)
+{
+    if (bns == NULL || pac == NULL || cmap == NULL) return NULL;
+    meth_orig_ref_t *o = (meth_orig_ref_t *)calloc(1, sizeof(*o));
+    if (o == NULL) return NULL;
+    o->bns = bns;
+    o->pac = pac;
+    o->n_chroms = cmap->n_output;
+    if (o->n_chroms <= 0) return o;
+
+    o->f_rid     = (int *)    malloc((size_t)o->n_chroms * sizeof(int));
+    o->r_rid     = (int *)    malloc((size_t)o->n_chroms * sizeof(int));
+    o->chrom_len = (int64_t *)malloc((size_t)o->n_chroms * sizeof(int64_t));
+    if (o->f_rid == NULL || o->r_rid == NULL || o->chrom_len == NULL) {
+        meth_orig_ref_free(o); return NULL;
+    }
+    for (int t = 0; t < o->n_chroms; ++t) {
+        o->f_rid[t]     = -1;
+        o->r_rid[t]     = -1;
+        o->chrom_len[t] = cmap->output_lens[t];
+    }
+    /* Walk cmap to fill in f_rid and r_rid per real_tid. */
+    for (int rid = 0; rid < cmap->n_internal; ++rid) {
+        int t = cmap->out_tid[rid];
+        if (t < 0 || t >= o->n_chroms) continue;
+        if (cmap->direction[rid] == 'f' && o->f_rid[t] < 0) o->f_rid[t] = rid;
+        if (cmap->direction[rid] == 'r' && o->r_rid[t] < 0) o->r_rid[t] = rid;
+    }
+    /* Defensive: every real chrom should have both sibling rids. If not
+     * (malformed cmap or single-direction index), fail load and let the
+     * caller surface a clean error. */
+    for (int t = 0; t < o->n_chroms; ++t) {
+        if (o->f_rid[t] < 0 || o->r_rid[t] < 0) {
+            fprintf(stderr,
+                    "ERROR: meth: real chrom %d (\"%s\") missing %s sibling contig\n",
+                    t, cmap->output_names[t],
+                    o->f_rid[t] < 0 ? "f-prefixed" : "r-prefixed");
+            meth_orig_ref_free(o);
+            return NULL;
+        }
+    }
+    return o;
+}
+
+namespace {
+
+/* bns_iter_ambi callback context: write 'N' over [st, en) of dst, where
+ * st/en are global-pac offsets that we translate back to dst[] indices
+ * via pac_off (the f-contig's offset for this slice) and st_dst (the
+ * caller's chrom-relative start). */
+struct n_mask_ctx {
+    uint8_t *dst;
+    int64_t  pac_off;
+    int64_t  st_dst;
+};
+
+int n_mask_visit(int64_t amb_st, int64_t amb_en, void *vctx)
+{
+    n_mask_ctx *c = (n_mask_ctx *)vctx;
+    int64_t lo = amb_st - c->pac_off - c->st_dst;
+    int64_t hi = amb_en - c->pac_off - c->st_dst;
+    for (int64_t j = lo; j < hi; ++j) c->dst[j] = 'N';
+    return 0;
+}
+
+}  // namespace
+
+extern "C"
+void meth_orig_ref_slice(const meth_orig_ref_t *o,
+                         int real_tid, int64_t st, int64_t en,
+                         uint8_t *dst)
+{
+    if (o == NULL || dst == NULL || en <= st) return;
+    static const char NT_ASCII[4] = {'A', 'C', 'G', 'T'};
+    int64_t out_len = en - st;
+    if (real_tid < 0 || real_tid >= o->n_chroms) {
+        std::memset(dst, 'N', (size_t)out_len);
+        return;
+    }
+    int64_t chrom_len = o->chrom_len[real_tid];
+    int64_t f_off = o->bns->anns[o->f_rid[real_tid]].offset;
+    int64_t r_off = o->bns->anns[o->r_rid[real_tid]].offset;
+
+    /* Per-position dual decode: read f and r 2-bit bytes, fold via the
+     * 5-row recovery table. OOB chrom-relative positions emit 'N'. */
+    for (int64_t i = 0; i < out_len; ++i) {
+        int64_t p = st + i;
+        if (p < 0 || p >= chrom_len) { dst[i] = 'N'; continue; }
+        uint8_t f = _get_pac(o->pac, f_off + p);
+        uint8_t r = _get_pac(o->pac, r_off + p);
+        uint8_t orig = recover_pair(f, r);
+        dst[i] = (orig <= 3) ? (uint8_t)NT_ASCII[orig] : 'N';
+    }
+
+    /* Mask N over bns->ambs intervals overlapping our slice on EITHER
+     * the f-contig or r-contig coordinates — both contigs in the doubled
+     * pac correspond to the same real-chrom forward axis, and bwa indexes
+     * Ns from both halves into bns->ambs at index time. */
+    int64_t st_clipped = (st < 0 ? 0 : st);
+    int64_t en_clipped = (en > chrom_len ? chrom_len : en);
+    int64_t pac_len = en_clipped - st_clipped;
+    if (pac_len > 0) {
+        for (int side = 0; side < 2; ++side) {
+            int64_t side_off = (side == 0) ? f_off : r_off;
+            n_mask_ctx ctx = { dst, side_off, st };
+            bns_iter_ambi(o->bns, side_off + st_clipped, (int)pac_len,
+                          n_mask_visit, &ctx);
+        }
+    }
+}
+
+extern "C"
+void meth_orig_ref_free(meth_orig_ref_t *o)
+{
+    if (o == NULL) return;
+    free(o->f_rid);
+    free(o->r_rid);
+    free(o->chrom_len);
+    free(o);
+}

--- a/src/meth_orig_ref.h
+++ b/src/meth_orig_ref.h
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef BWAMEM3_METH_ORIG_REF_H
+#define BWAMEM3_METH_ORIG_REF_H
+
+#include <stdint.h>
+
+#include "bntseq.h"
+#include "meth_bam.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Lazy un-converted reference for `bwa-mem3 mem --meth`. Holds borrowed
+ * references to the doubled c2t bns and pac (already loaded for alignment)
+ * plus a cmap-derived sibling rid table used to find the f/r contig pair
+ * for each real chromosome. Read-only after build; safe to share across
+ * worker threads.
+ *
+ * Per-record slice does dual-pac decode: read the f-contig and r-contig
+ * windows at the same forward-genome offset from the doubled pac, fold
+ * via a 5-row (f, r) -> original table, mask N positions via
+ * bns_iter_ambi over the doubled bns->ambs. No separate un-converted pac
+ * is materialized — reuses idx->pac in place.
+ *
+ * Memory cost: zero new pac storage; two int* sibling-rid arrays of
+ * length cmap->n_output (a few KB on hg38). */
+typedef struct meth_orig_ref_s meth_orig_ref_t;
+
+/* Build from an already-loaded doubled-c2t bns + pac (same handles
+ * passed to the rest of bwa-mem3). cmap is consulted to find each
+ * real chrom's f-rid and r-rid. Returns NULL on alloc failure or if
+ * any real chrom is missing one direction (defensive: bwa-mem3 index
+ * --meth always emits both f-<chr> and r-<chr>). */
+meth_orig_ref_t *meth_orig_ref_load(const bntseq_t *bns, const uint8_t *pac,
+                                    const meth_chrom_map_t *cmap);
+
+/* Slice un-converted forward-strand bases [st, en) of chrom `real_tid`
+ * into caller-owned `dst` (capacity must be >= en - st). Encoding is
+ * ASCII ('A'/'C'/'G'/'T'/'N'). OOB positions and bns->ambs overlaps
+ * fill with 'N'. `real_tid` indexes cmap->output_names. */
+void meth_orig_ref_slice(const meth_orig_ref_t *o,
+                         int real_tid, int64_t st, int64_t en,
+                         uint8_t *dst);
+
+void meth_orig_ref_free(meth_orig_ref_t *o);
+
+/* Global instance, populated once in fastmap.cpp under --meth. */
+extern meth_orig_ref_t *g_meth_orig_ref;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/meth_xm.cpp
+++ b/src/meth_xm.cpp
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: MIT */
+
+#include "meth_xm.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+#include "kstring.h"
+
+/* Thread-local growable scratch for the per-record ref-window slice and
+ * the assembled XM:Z payload. Reused across calls; capacity grows on
+ * demand via ks_resize and is freed at thread exit by the RAII wrapper.
+ *
+ * The kstring_t pattern matches the rest of meth_bam.cpp (XA, SA tag
+ * builders), but those use stack-allocated kstrings that malloc + free
+ * per record. Promoting them to thread_local removes the per-record
+ * allocator round-trip on the BAM-emission hot path. */
+namespace {
+struct ks_scratch_t {
+    kstring_t buf{0, 0, nullptr};
+    ~ks_scratch_t() { free(buf.s); }
+};
+}
+static thread_local ks_scratch_t t_ref_scratch;
+static thread_local ks_scratch_t t_xm_scratch;
+
+/* Per-source-strand rule table, indexed by is_top_strand (1 = top, 0 = bottom).
+ *
+ * For top-strand methylation (XG:Z:CT, i.e. f-contig alignment): the C of
+ * interest is the forward-strand C; methylated reads as 'C', unmethylated
+ * as 'T'; downstream context on top is forward[P+1], forward[P+2]; CpG
+ * marker downstream is 'G'. Note the SAM 0x10 (RC) flag is independent —
+ * CTOT reads (R2 mapped to top with 0x10 set) have is_top_strand=1.
+ *
+ * For bottom-strand methylation (XG:Z:GA, i.e. r-contig alignment): the
+ * C of interest is a forward G (bottom-strand C); methylated reads as
+ * 'G' (after BAM SEQ orientation), unmethylated as 'A'; downstream context
+ * on bottom is upstream on forward — forward[P-1], forward[P-2]; CpG
+ * marker downstream-on-bottom is 'C' on forward (complement of G).
+ *
+ * Both strand cases consume seq_text and ref_buf in SEQ orientation
+ * (= forward-genome orientation per BAM convention).
+ */
+static const char C_MARKER[2]       = {'G', 'C'};  /* [bottom, top] */
+static const char METH_MARKER[2]    = {'G', 'C'};
+static const char UNMETH_MARKER[2]  = {'A', 'T'};
+static const char CTX_CPG_MARKER[2] = {'C', 'G'};
+
+extern "C"
+char *meth_build_xm(const meth_orig_ref_t *o, int real_tid,
+                    int64_t pos, int is_top_strand,
+                    const uint32_t *bam_cigar, int n_cigar,
+                    const char *seq_text, int l_emit)
+{
+    if (o == NULL || bam_cigar == NULL || seq_text == NULL || l_emit <= 0)
+        return NULL;
+
+    /* Compute ref length on bam_cigar (M/D/N/=/X consume ref). */
+    int64_t rlen = 0;
+    for (int i = 0; i < n_cigar; ++i) {
+        int op = (int)(bam_cigar[i] & 0xf);
+        int len = (int)(bam_cigar[i] >> 4);
+        if (op == 0 /*M*/ || op == 2 /*D*/ || op == 3 /*N*/
+                || op == 7 /*=*/ || op == 8 /*X*/)
+            rlen += len;
+    }
+
+    /* Slice forward-genome ref [pos - 2, pos + rlen + 2). The +/-2 covers
+     * both is_rev=0 (downstream context lookahead by +2) and is_rev=1
+     * (downstream-on-bottom lookahead by -2 on forward). OOB filled with N
+     * by meth_orig_ref_slice. Both ref_buf and xm reuse thread-local
+     * kstring_t scratch — no per-record malloc/free on the hot path. */
+    int64_t buf_len = rlen + 4;
+    ks_resize(&t_ref_scratch.buf, (size_t)buf_len);
+    if (t_ref_scratch.buf.s == NULL) return NULL;
+    uint8_t *ref_buf = (uint8_t *)t_ref_scratch.buf.s;
+    meth_orig_ref_slice(o, real_tid, pos - 2, pos + rlen + 2, ref_buf);
+
+    ks_resize(&t_xm_scratch.buf, (size_t)l_emit + 1);
+    if (t_xm_scratch.buf.s == NULL) return NULL;
+    char *xm = t_xm_scratch.buf.s;
+
+    int r = 0;        /* read cursor (index into seq_text and into xm) */
+    int64_t t = 0;    /* ref cursor (offset from `pos` on forward strand) */
+    int idx = is_top_strand ? 1 : 0;
+    char c_marker      = C_MARKER[idx];
+    char meth_marker   = METH_MARKER[idx];
+    char unmeth_marker = UNMETH_MARKER[idx];
+    char cpg_marker    = CTX_CPG_MARKER[idx];
+
+    for (int i = 0; i < n_cigar && r < l_emit; ++i) {
+        int op = (int)(bam_cigar[i] & 0xf);
+        int len = (int)(bam_cigar[i] >> 4);
+        switch (op) {
+            case 0: /* M */
+            case 7: /* = */
+            case 8: /* X */
+                for (int k = 0; k < len && r < l_emit; ++k) {
+                    int64_t ref_idx = t + 2;  /* into ref_buf (which starts -2) */
+                    char rb = (char)ref_buf[ref_idx];
+                    char read_b = seq_text[r];
+                    if (rb != c_marker) {
+                        xm[r] = '.';
+                    } else {
+                        int64_t ctx1_idx = is_top_strand ? ref_idx + 1 : ref_idx - 1;
+                        int64_t ctx2_idx = is_top_strand ? ref_idx + 2 : ref_idx - 2;
+                        char ctx1 = (ctx1_idx >= 0 && ctx1_idx < buf_len)
+                                        ? (char)ref_buf[ctx1_idx] : 'N';
+                        char ctx2 = (ctx2_idx >= 0 && ctx2_idx < buf_len)
+                                        ? (char)ref_buf[ctx2_idx] : 'N';
+                        char meth_state;
+                        if (read_b == meth_marker)        meth_state = 'M';
+                        else if (read_b == unmeth_marker) meth_state = 'U';
+                        else                              meth_state = '.';
+                        if (meth_state == '.') {
+                            xm[r] = '.';
+                        } else if (ctx1 == 'N' || ctx1 == 'X') {
+                            xm[r] = (meth_state == 'M') ? 'U' : 'u';
+                        } else if (ctx1 == cpg_marker) {
+                            xm[r] = (meth_state == 'M') ? 'Z' : 'z';
+                        } else if (ctx2 == 'N' || ctx2 == 'X') {
+                            xm[r] = (meth_state == 'M') ? 'U' : 'u';
+                        } else if (ctx2 == cpg_marker) {
+                            xm[r] = (meth_state == 'M') ? 'X' : 'x';
+                        } else {
+                            xm[r] = (meth_state == 'M') ? 'H' : 'h';
+                        }
+                    }
+                    ++r;
+                    ++t;
+                }
+                break;
+            case 1: /* I */
+            case 4: /* S */
+                for (int k = 0; k < len && r < l_emit; ++k) {
+                    xm[r++] = '.';
+                }
+                break;
+            case 2: /* D */
+            case 3: /* N */
+                t += len;
+                break;
+            case 5: /* H */
+            case 6: /* P */
+            default:
+                /* No read or ref consume. */
+                break;
+        }
+    }
+
+    /* Defensive padding if cigar walk ended short of l_emit. */
+    while (r < l_emit) xm[r++] = '.';
+    xm[l_emit] = '\0';
+    return xm;
+}

--- a/src/meth_xm.h
+++ b/src/meth_xm.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef BWAMEM3_METH_XM_H
+#define BWAMEM3_METH_XM_H
+
+#include <stdint.h>
+
+#include "meth_orig_ref.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Build a Bismark XM:Z payload (length l_emit, NUL-terminated). NULL on
+ * alloc failure.
+ *
+ * Ownership: the returned pointer aliases a thread-local growable scratch
+ * buffer owned by the helper. Caller MUST NOT free it. The pointer is
+ * valid until the next call to meth_build_xm from the same thread. Pass
+ * the bytes directly to bam_aux_append (which copies them into the BAM
+ * record) or copy elsewhere before the next call.
+ *
+
+ *   o            : un-converted reference (forward-strand bases per real chrom)
+ *   real_tid     : index into o's per-chrom array (== cmap->out_tid[p->rid])
+ *   pos          : 0-based forward-genome alignment start
+ *   is_top_strand: 1 if methylation events are on the top (forward) strand,
+ *                  0 if on the bottom strand. This is determined by the
+ *                  XG:Z value, NOT by the SAM 0x10 flag: XG:Z:CT (= cmap
+ *                  direction 'f') => top strand; XG:Z:GA (= 'r') => bottom.
+ *   bam_cigar    : CIGAR in BAM op encoding (0=M, 1=I, 2=D, 3=N, 4=S, 5=H, 6=P, 7==, 8=X)
+ *   n_cigar      : number of cigar ops
+ *   seq_text     : SEQ-orientation read bases (ASCII A/C/G/T), length l_emit
+ *   l_emit       : SEQ length emitted to BAM (post supp soft-clip trim)
+ *
+ * Output XM matches Bismark's methylation_call: per-base char in SEQ
+ * orientation, with z/Z (CpG), x/X (CHG), h/H (CHH), u/U (unknown), '.' for
+ * everything else. */
+char *meth_build_xm(const meth_orig_ref_t *o, int real_tid,
+                    int64_t pos, int is_top_strand,
+                    const uint32_t *bam_cigar, int n_cigar,
+                    const char *seq_text, int l_emit);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/u8vec_scratch.h
+++ b/src/u8vec_scratch.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef BWAMEM3_U8VEC_SCRATCH_H
+#define BWAMEM3_U8VEC_SCRATCH_H
+
+#include <cstdint>
+#include <cstdlib>
+
+#include "kvec.h"
+
+/* Named typedef for a kvec of uint8_t. kvec_t(uint8_t) on its own expands
+ * to a fresh anonymous struct at each macro call, so it can't be used
+ * across function boundaries. Naming it once here makes it a regular
+ * struct type that callers can declare thread_local, pass by pointer,
+ * etc. The kv_* macros operate on the public (n, m, a) fields and work
+ * with this typedef unchanged. */
+typedef struct { size_t n, m; uint8_t *a; } u8vec_t;
+
+/* Thread-local scratch holder. Initializes the kvec on construction
+ * (n = m = 0, a = NULL) and frees the underlying buffer on thread exit
+ * (or process exit for threads that don't terminate first). Use as:
+ *
+ *     static thread_local u8vec_scratch_t t_buf;
+ *     if (t_buf.v.m < want) kv_resize(uint8_t, t_buf.v, want);
+ *     ... write into t_buf.v.a ... no free needed ...
+ *
+ * One scratch instance per logical buffer per thread; the per-call cost
+ * is a single capacity check + amortized realloc-on-grow via kv_resize.
+ */
+struct u8vec_scratch_t {
+    u8vec_t v;
+    u8vec_scratch_t() { kv_init(v); }
+    ~u8vec_scratch_t() { kv_destroy(v); }
+};
+
+#endif

--- a/test/meth/test.sh
+++ b/test/meth/test.sh
@@ -8,13 +8,15 @@
 #   - produces uncompressed BAM readable by samtools
 #   - @PG ID:bwa-mem3-meth present
 #   - BGZF EOF marker at tail
-#   - --set-as-failed / --do-not-penalize-chimeras parse cleanly
+#   - --set-as-failed / --chimera-qc parse cleanly
 #
 # Layer 2 (runs if pixi + bwameth.py available):  equivalence to bwameth.py.
 #   Builds a bwameth c2t reference, c2t-converts reads, runs BOTH the
 #   bwameth.py Python pipeline and `bwa-mem3 mem --meth` on the same
-#   converted reads, and diffs structural fields + YD:Z tags + flag
-#   distribution. Currently zero diff on the bwa-meth/example fixture.
+#   converted reads, and diffs structural fields (QNAME, FLAG, RNAME,
+#   POS, MAPQ, CIGAR, RNEXT, PNEXT) only. Tag-value parity moved to
+#   test_bismark_tags.sh (holodeck golden) since the two pipelines now
+#   emit different tag schemas (Bismark XR/XG/XM vs bwameth YS/YC/YD).
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -61,14 +63,76 @@ fi
 TOTAL="$("$SAMTOOLS" view -c /tmp/meth_test.bam 2>/dev/null)"
 if [[ "$TOTAL" -lt 1 ]]; then echo "FAIL: zero records in output BAM"; exit 1; fi
 
-"$BWAMEM3" mem --meth --set-as-failed f --do-not-penalize-chimeras \
+"$BWAMEM3" mem --meth --set-as-failed f --chimera-qc \
     ref.fa t_R1.fastq.gz 2>/dev/null > /tmp/meth_test2.bam
 if [[ ! -s /tmp/meth_test2.bam ]]; then
-    echo "FAIL: --set-as-failed + --do-not-penalize-chimeras produced empty output"
+    echo "FAIL: --set-as-failed + --chimera-qc produced empty output"
     exit 1
 fi
 
 echo "OK layer 1: bwa-mem3 mem --meth (records=$TOTAL, BGZF-EOF ok, @PG bwa-mem3-meth ok)"
+
+# --- Bismark XR:Z / XG:Z / XM:Z emission assertions ----------------------
+# Every primary mapped record (FLAG & 0x904 == 0) must carry XR:Z:(CT|GA),
+# XG:Z:(CT|GA), and XM:Z whose payload length equals SEQ length. Unmapped
+# records (FLAG & 0x4) carry XR:Z only. No record emits the legacy Y* tags.
+
+PRIMARY_MAPPED_NO_XR=$("$SAMTOOLS" view -F 0x904 /tmp/meth_test.bam \
+    | mawk '!/\tXR:Z:(CT|GA)/{n++} END{print n+0}')
+if [[ "$PRIMARY_MAPPED_NO_XR" -ne 0 ]]; then
+    echo "FAIL: $PRIMARY_MAPPED_NO_XR primary mapped record(s) missing XR:Z:(CT|GA)"
+    exit 1
+fi
+
+PRIMARY_MAPPED_NO_XG=$("$SAMTOOLS" view -F 0x904 /tmp/meth_test.bam \
+    | mawk '!/\tXG:Z:(CT|GA)/{n++} END{print n+0}')
+if [[ "$PRIMARY_MAPPED_NO_XG" -ne 0 ]]; then
+    echo "FAIL: $PRIMARY_MAPPED_NO_XG primary mapped record(s) missing XG:Z:(CT|GA)"
+    exit 1
+fi
+
+XM_LEN_BAD=$("$SAMTOOLS" view -F 0x904 /tmp/meth_test.bam \
+    | mawk '
+        {
+            seq_len = length($10)
+            xm_len = -1
+            for (i = 12; i <= NF; i++) {
+                if (substr($i, 1, 5) == "XM:Z:") { xm_len = length($i) - 5; break }
+            }
+            if (xm_len < 0) { n++; next }
+            if (xm_len != seq_len) n++
+        }
+        END { print n+0 }')
+if [[ "$XM_LEN_BAD" -ne 0 ]]; then
+    echo "FAIL: $XM_LEN_BAD record(s) with missing or wrong-length XM:Z"
+    exit 1
+fi
+
+UNMAPPED_BAD=$("$SAMTOOLS" view -f 0x4 /tmp/meth_test.bam \
+    | mawk '
+        {
+            has_xr = 0; has_xg = 0; has_xm = 0
+            for (i = 12; i <= NF; i++) {
+                if (substr($i, 1, 5) == "XR:Z:") has_xr = 1
+                if (substr($i, 1, 5) == "XG:Z:") has_xg = 1
+                if (substr($i, 1, 5) == "XM:Z:") has_xm = 1
+            }
+            if (!has_xr || has_xg || has_xm) n++
+        }
+        END { print n+0 }')
+if [[ "$UNMAPPED_BAD" -ne 0 ]]; then
+    echo "FAIL: $UNMAPPED_BAD unmapped record(s) with wrong tag set (XR required, XG/XM forbidden)"
+    exit 1
+fi
+
+Y_LEAKS=$("$SAMTOOLS" view /tmp/meth_test.bam \
+    | grep -cE '\b(YS|YC|YD):[ZA]:' || true)
+if [[ "$Y_LEAKS" -ne 0 ]]; then
+    echo "FAIL: $Y_LEAKS record(s) still emit YS/YC/YD legacy tags"
+    exit 1
+fi
+
+echo "OK layer 1 Bismark tags: XR/XG/XM well-formed, no Y* leak"
 
 # ---------------------------------------------------------------------------
 # Layer 2: bwa-meth equivalence (requires pixi + bwameth.py + toolshed)
@@ -107,7 +171,10 @@ pixi run python3 "$BWAMETH_PY" --reference ref.fa t_R1.fastq.gz t_R2.fastq.gz \
 
 pixi run python3 "$BWAMETH_PY" c2t t_R1.fastq.gz t_R2.fastq.gz 2>/dev/null \
     > /tmp/meth_c2t.fq
-"$BWAMEM3" mem --meth -CM -p -T 40 -B 2 -L 10 -U 100 -t 4 \
+# --chimera-qc: bwa-mem3's chimera heuristic is off by default (Bismark
+# behavior); enable it here so the structural diff against bwameth.py
+# (which always applies the heuristic) sees matching FLAG/MAPQ values.
+"$BWAMEM3" mem --meth --chimera-qc -CM -p -T 40 -B 2 -L 10 -U 100 -t 4 \
     ref.fa.bwameth.c2t /tmp/meth_c2t.fq 2>/dev/null > /tmp/meth_mine.bam
 "$SAMTOOLS" view /tmp/meth_mine.bam 2>/dev/null > /tmp/meth_mine.sam
 
@@ -139,15 +206,6 @@ TWO="$(diff <(norm /tmp/meth_mine.sam | cut -f6) \
              <(norm /tmp/meth_oracle_records.sam | cut -f6) | wc -l | tr -d ' ')"
 if [[ "$TWO" != "0" ]]; then echo "FAIL layer 2: CIGAR diff ($TWO lines)"; exit 1; fi
 
-for d in f r; do
-    MINE_YD="$(grep -c "YD:Z:$d" /tmp/meth_mine.sam || true)"
-    ORACLE_YD="$(grep -c "YD:Z:$d" /tmp/meth_oracle_records.sam || true)"
-    if [[ "$MINE_YD" != "$ORACLE_YD" ]]; then
-        echo "FAIL layer 2: YD:Z:$d count mismatch (mine=$MINE_YD oracle=$ORACLE_YD)"
-        exit 1
-    fi
-done
-
 MINE_N="$(wc -l < /tmp/meth_mine.sam | tr -d ' ')"
 ORACLE_N="$(wc -l < /tmp/meth_oracle_records.sam | tr -d ' ')"
 if [[ "$MINE_N" != "$ORACLE_N" ]]; then
@@ -155,9 +213,13 @@ if [[ "$MINE_N" != "$ORACLE_N" ]]; then
     exit 1
 fi
 
-MINE_F="$(grep -c YD:Z:f /tmp/meth_mine.sam || true)"
-MINE_R="$(grep -c YD:Z:r /tmp/meth_mine.sam || true)"
-echo "OK layer 2: bwa-mem3 mem --meth matches bwameth.py (records=$MINE_N, YD:Z:f=$MINE_F YD:Z:r=$MINE_R)"
+# bwameth.py emits YD/YC/YS; bwa-mem3 emits Bismark XR/XG/XM. We don't
+# diff tag values across the two pipelines (different tag schemas).
+# Tag-value golden truth lives in Layer 3 (test_bismark_tags.sh) which
+# compares against holodeck's Bismark-compatible golden BAM.
+MINE_XG_F="$(grep -c 'XG:Z:CT' /tmp/meth_mine.sam || true)"
+MINE_XG_R="$(grep -c 'XG:Z:GA' /tmp/meth_mine.sam || true)"
+echo "OK layer 2: bwa-mem3 mem --meth matches bwameth.py structurally (records=$MINE_N, XG:Z:CT=$MINE_XG_F XG:Z:GA=$MINE_XG_R)"
 
 # ---------------------------------------------------------------------------
 # Layer 3: full-pipeline end-to-end — `bwa-mem3 index --meth` + `mem --meth`
@@ -187,8 +249,10 @@ fi
 rm -f "$HERE/ref.fa.bwameth.c2t"*
 "$BWAMEM3" index --meth ref.fa >/dev/null 2>&1
 
-# Single-command end-to-end alignment.
-"$BWAMEM3" mem --meth -t 4 ref.fa t_R1.fastq.gz t_R2.fastq.gz 2>/dev/null > /tmp/meth_e2e.bam
+# Single-command end-to-end alignment.  --chimera-qc enabled here for
+# parity with bwameth.py's always-on heuristic; default bwa-mem3 --meth
+# behavior is no chimera QC (Bismark default).
+"$BWAMEM3" mem --meth --chimera-qc -t 4 ref.fa t_R1.fastq.gz t_R2.fastq.gz 2>/dev/null > /tmp/meth_e2e.bam
 "$SAMTOOLS" view /tmp/meth_e2e.bam 2>/dev/null > /tmp/meth_e2e.sam
 
 # Oracle: bwameth.py end-to-end on the same raw FASTQs (reuses Layer 2's

--- a/test/meth/test_bismark_tags.sh
+++ b/test/meth/test_bismark_tags.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Layer 3: holodeck golden-truth XR/XG/XM diff.
+#
+# Builds holodeck from a pinned SHA (nh/bisulfite-conversion HEAD as of the
+# spec date), simulates paired-end reads with --methylation-mode em-seq, runs
+# `bwa-mem3 mem --meth` on the simulated FASTQ, and stream-diffs the
+# (qname, flag, XR, XG, XM) tuples on primary alignments. Expected divergence
+# on a clean simulator + bwa-mem3 run is 0 records.
+#
+# Skip if cargo is not on PATH (needed to build holodeck).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BWAMEM3="$HERE/../../bwa-mem3"
+SAMTOOLS="${SAMTOOLS:-samtools}"
+
+# Pinned holodeck SHA (HEAD of nh/bisulfite-conversion at spec date).
+HOLODECK_SHA="d240816c8c2dfbd72bdb3386679d0ad4d4f223e6"
+HOLODECK_REPO="https://github.com/fg-labs/holodeck.git"
+HOLODECK_DIR="${HOLODECK_DIR:-/tmp/holodeck-${HOLODECK_SHA:0:8}}"
+HOLODECK_BIN="${HOLODECK_DIR}/target/release/holodeck"
+
+if [[ ! -x "$BWAMEM3" ]]; then
+    echo "ERROR: bwa-mem3 not built at $BWAMEM3 (run 'make' or 'make arm64' first)." >&2
+    exit 2
+fi
+if ! command -v "$SAMTOOLS" >/dev/null 2>&1; then
+    echo "ERROR: samtools not found on PATH." >&2
+    exit 2
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "SKIP layer 3: cargo not on PATH (needed to build holodeck)"
+    exit 0
+fi
+
+if [[ ! -x "$HOLODECK_BIN" ]]; then
+    echo "[layer 3] cloning + building holodeck @ $HOLODECK_SHA ..."
+    rm -rf "$HOLODECK_DIR"
+    git clone --filter=blob:none "$HOLODECK_REPO" "$HOLODECK_DIR" >/dev/null 2>&1
+    git -C "$HOLODECK_DIR" checkout "$HOLODECK_SHA" >/dev/null 2>&1
+    (cd "$HOLODECK_DIR" && cargo build --release --quiet)
+fi
+
+cd "$HERE"
+
+# Refresh the bwa-mem3 c2t index for the existing test fixture.
+if [[ ! -f ref.fa.bwameth.c2t.bwt.2bit.64 ]]; then
+    "$BWAMEM3" index --meth ref.fa >/dev/null 2>&1
+fi
+
+# Index the original ref.fa with samtools faidx (holodeck needs .fai).
+[[ -f ref.fa.fai ]] || "$SAMTOOLS" faidx ref.fa
+
+PREFIX="/tmp/holodeck-bismark-tags"
+rm -f "$PREFIX".* "$PREFIX".golden.bam
+
+"$HOLODECK_BIN" simulate \
+    -r ref.fa \
+    -o "$PREFIX" \
+    --methylation-mode em-seq \
+    --methylation-rate 0.7 \
+    --methylation-conversion-rate 0.99 \
+    --golden-bam \
+    --simple-names \
+    --seed 42 \
+    -c 30 -l 150 -t 2 \
+    >/dev/null 2>&1
+
+GOLDEN_BAM="${PREFIX}.golden.bam"
+R1="${PREFIX}.r1.fastq.gz"
+R2="${PREFIX}.r2.fastq.gz"
+
+if [[ ! -s "$GOLDEN_BAM" || ! -s "$R1" || ! -s "$R2" ]]; then
+    echo "FAIL layer 3: holodeck did not produce expected outputs"
+    ls -la "${PREFIX}".* 2>&1 | head -10
+    exit 1
+fi
+
+# Run bwa-mem3 on the simulated FASTQs.
+MINE_BAM="/tmp/bismark-tags-mine.bam"
+"$BWAMEM3" mem --meth -t 2 ref.fa "$R1" "$R2" 2>/dev/null > "$MINE_BAM"
+
+# Sort both by qname so per-qname comparison is straightforward.
+"$SAMTOOLS" sort -n -@ 2 -O bam -o "${PREFIX}.golden.qsort.bam"  "$GOLDEN_BAM"
+"$SAMTOOLS" sort -n -@ 2 -O bam -o "${PREFIX}.mine.qsort.bam"    "$MINE_BAM"
+
+# Extract (qname, flag, pos, cigar, XR, XG, XM) per primary record
+# (flag & 0x904 == 0: mapped, not secondary, not supplementary). The pos+cigar
+# pair lets us tell which records have identical alignments — bwa-mem3 may
+# extend the alignment past where holodeck soft-clipped (or vice versa), and
+# in those cases the XM strings will legitimately differ at the ends. We
+# require XR/XG to match always, and XM to match exactly only on records
+# with matching (pos, cigar).
+extract_tags() {
+    "$SAMTOOLS" view "$1" \
+        | mawk -F '\t' '
+            # Bitwise AND for mawk (no built-in band, no hex literals).
+            # 0x904 == 2308 (unmapped|secondary|supplementary).
+            # 0x40  == 64   (first segment / R1).
+            function bit_any(a, mask,    rest, m, abit, mbit) {
+                rest = a
+                m = mask
+                while (m > 0) {
+                    abit = rest % 2
+                    mbit = m % 2
+                    if (abit == 1 && mbit == 1) return 1
+                    rest = int(rest / 2)
+                    m    = int(m / 2)
+                }
+                return 0
+            }
+            {
+                if (bit_any($2, 2308)) next
+                xr = ""; xg = ""; xm = ""
+                for (i = 12; i <= NF; i++) {
+                    if (substr($i, 1, 5) == "XR:Z:") xr = substr($i, 6)
+                    if (substr($i, 1, 5) == "XG:Z:") xg = substr($i, 6)
+                    if (substr($i, 1, 5) == "XM:Z:") xm = substr($i, 6)
+                }
+                is_r1 = bit_any($2, 64)
+                printf "%s\t%d\t%s\t%s\t%s\t%s\t%s\n",
+                       $1, is_r1, $4, $6, xr, xg, xm
+            }
+        ' \
+        | sort -k1,1 -k2,2n
+}
+
+extract_tags "${PREFIX}.golden.qsort.bam" > "${PREFIX}.golden.tags"
+extract_tags "${PREFIX}.mine.qsort.bam"   > "${PREFIX}.mine.tags"
+
+# Join on (qname, is_r1) and assert XR/XG always match, XM matches when
+# (pos, cigar) match.
+mawk_check=$(mawk -F '\t' '
+    BEGIN {
+        # Read golden into associative arrays keyed by qname\tis_r1.
+        while ((getline line < "'"${PREFIX}.golden.tags"'") > 0) {
+            split(line, f, "\t")
+            key = f[1] "\t" f[2]
+            g_pos[key]   = f[3]
+            g_cigar[key] = f[4]
+            g_xr[key]    = f[5]
+            g_xg[key]    = f[6]
+            g_xm[key]    = f[7]
+        }
+        close("'"${PREFIX}.golden.tags"'")
+    }
+    {
+        key = $1 "\t" $2
+        if (!(key in g_pos)) { uniq_mine++; next }
+        n_total++
+        if ($5 != g_xr[key]) { fail_xr++; if (fail_xr <= 3) print "XR diff " key " mine=" $5 " gold=" g_xr[key] }
+        if ($6 != g_xg[key]) { fail_xg++; if (fail_xg <= 3) print "XG diff " key " mine=" $6 " gold=" g_xg[key] }
+        if ($3 == g_pos[key] && $4 == g_cigar[key]) {
+            n_aln_match++
+            if ($7 == g_xm[key]) {
+                n_xm_match++
+            } else {
+                if (fail_xm <= 3) {
+                    print "XM diff (same aln) " key " pos=" $3 " cigar=" $4
+                    print "  mine: " $7
+                    print "  gold: " g_xm[key]
+                }
+                fail_xm++
+            }
+        } else {
+            n_aln_diverge++
+        }
+        # Same length always.
+        if (length($7) != length(g_xm[key])) fail_xmlen++
+    }
+    END {
+        printf "%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+               n_total+0, n_aln_match+0, n_xm_match+0,
+               fail_xr+0, fail_xg+0, fail_xm+0, fail_xmlen+0, n_aln_diverge+0
+    }
+' "${PREFIX}.mine.tags" 2>&1)
+
+# Last line of mawk_check is the tab-separated summary; everything before is diags.
+SUMMARY=$(echo "$mawk_check" | tail -1)
+DIAGS=$(echo "$mawk_check" | sed '$d')
+read -r N_TOTAL N_ALN_MATCH N_XM_MATCH FAIL_XR FAIL_XG FAIL_XM FAIL_XMLEN N_ALN_DIVERGE <<<"$(echo "$SUMMARY" | tr '\t' ' ')"
+
+echo "Layer 3 summary:"
+echo "  records compared:             $N_TOTAL"
+echo "  alignment match (pos+cigar):  $N_ALN_MATCH"
+echo "  alignment diverged:           $N_ALN_DIVERGE"
+echo "  XM match given matching aln:  $N_XM_MATCH / $N_ALN_MATCH"
+echo "  XR mismatches:                $FAIL_XR"
+echo "  XG mismatches:                $FAIL_XG"
+echo "  XM mismatches (aln match):    $FAIL_XM"
+echo "  XM length mismatches:         $FAIL_XMLEN"
+
+if [[ "$FAIL_XR" -ne 0 || "$FAIL_XG" -ne 0 || "$FAIL_XMLEN" -ne 0 ]]; then
+    echo "FAIL layer 3: XR/XG/XM-length mismatches"
+    echo "$DIAGS" | head -20
+    exit 1
+fi
+
+if [[ "$FAIL_XM" -ne 0 ]]; then
+    echo "FAIL layer 3: XM diverges from holodeck golden on records with matching alignment"
+    echo "$DIAGS" | head -20
+    exit 1
+fi
+
+echo "OK layer 3: XR/XG/XM Bismark golden-truth match (records=$N_TOTAL, aln-match=$N_ALN_MATCH, XM-match=$N_XM_MATCH)"

--- a/test/unit/meth_orig_ref_fixture.h
+++ b/test/unit/meth_orig_ref_fixture.h
@@ -1,0 +1,119 @@
+// Shared test fixture for tests that need a loaded meth_orig_ref_t. Builds
+// an in-memory doubled-c2t bns + pac (matching what bwa-mem3 index --meth
+// produces) from a forward-strand sequence, then constructs a cmap and
+// calls meth_orig_ref_load. Same code path the production runtime uses.
+
+#ifndef BWAMEM3_TEST_METH_ORIG_REF_FIXTURE_H
+#define BWAMEM3_TEST_METH_ORIG_REF_FIXTURE_H
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "bntseq.h"
+#include "meth_bam.h"
+#include "meth_orig_ref.h"
+
+namespace meth_test {
+
+inline uint8_t base_to_2bit(char c) {
+    switch (c) {
+        case 'A': return 0;
+        case 'C': return 1;
+        case 'G': return 2;
+        case 'T': return 3;
+        default:  return 0;  // N or unknown -> A (ambs side-table marks N)
+    }
+}
+
+inline void pac_pack_set(uint8_t *pac, int64_t i, uint8_t v) {
+    pac[i >> 2] |= (uint8_t)(v << ((~i & 3) << 1));
+}
+
+/* RAII fixture that owns:
+ *   - a doubled-c2t bns (one chrom, contigs r-X then f-X)
+ *   - a packed c2t pac (G->A on r-X, C->T on f-X)
+ *   - the cmap built from the doubled bns
+ *   - a meth_orig_ref_t loaded against bns + pac + cmap
+ *
+ * Construct from a forward-strand sequence (one chrom). Test code uses
+ * .orig (the loaded handle) and .real_tid (always 0) for slice calls. */
+struct OrigRefFixture {
+    bntseq_t                  bns{};
+    std::vector<bntann1_t>    anns;
+    std::vector<bntamb1_t>    ambs;
+    std::vector<std::string>  name_storage;
+    std::vector<uint8_t>      pac;
+    meth_chrom_map_t         *cmap = nullptr;
+    meth_orig_ref_t          *orig = nullptr;
+    int                       real_tid = 0;
+
+    explicit OrigRefFixture(const std::string &forward_seq) {
+        const int len = (int)forward_seq.size();
+        bns.l_pac = (int64_t)len * 2;
+        bns.n_seqs = 2;
+        anns.resize(2);
+        name_storage = {"rX", "fX"};
+        for (int i = 0; i < 2; ++i) {
+            anns[i] = bntann1_t{};
+            anns[i].offset = (int64_t)i * len;
+            anns[i].len    = len;
+            anns[i].name   = const_cast<char *>(name_storage[i].c_str());
+            anns[i].anno   = const_cast<char *>("");
+        }
+        bns.anns = anns.data();
+
+        /* ambs: any 'N' in the input marks a 1-bp interval on BOTH halves
+         * of the doubled pac (matching what bwa-mem3 index --meth produces).
+         * bns_iter_ambi binary-searches bns->ambs assuming non-decreasing
+         * offset+len, so emit all r-X intervals (offsets 0..len-1) before
+         * any f-X interval (offsets len..2*len-1) to preserve that order. */
+        for (int half = 0; half < 2; ++half) {
+            for (int i = 0; i < len; ++i) {
+                if (forward_seq[i] != 'N') continue;
+                bntamb1_t a;
+                a.offset = anns[half].offset + i;
+                a.len = 1;
+                a.amb = 'N';
+                ambs.push_back(a);
+            }
+        }
+        bns.ambs = ambs.data();
+        bns.n_holes = (int)ambs.size();
+
+        const int pac_bytes = ((int)bns.l_pac + 3) / 4;
+        pac.assign(pac_bytes, 0);
+        /* r-X: G->A applied to the forward strand. */
+        for (int i = 0; i < len; ++i) {
+            char b = forward_seq[i];
+            char projected = (b == 'G') ? 'A' : b;
+            pac_pack_set(pac.data(), anns[0].offset + i, base_to_2bit(projected));
+        }
+        /* f-X: C->T applied to the forward strand. */
+        for (int i = 0; i < len; ++i) {
+            char b = forward_seq[i];
+            char projected = (b == 'C') ? 'T' : b;
+            pac_pack_set(pac.data(), anns[1].offset + i, base_to_2bit(projected));
+        }
+
+        cmap = meth_chrom_map_build_from_bns(&bns);
+        if (cmap == nullptr) std::abort();
+        orig = meth_orig_ref_load(&bns, pac.data(), cmap);
+        if (orig == nullptr) std::abort();
+    }
+
+    ~OrigRefFixture() {
+        if (orig) meth_orig_ref_free(orig);
+        if (cmap) meth_chrom_map_free(cmap);
+    }
+
+    OrigRefFixture(const OrigRefFixture &) = delete;
+    OrigRefFixture &operator=(const OrigRefFixture &) = delete;
+};
+
+}  // namespace meth_test
+
+#endif

--- a/test/unit/test_bns_get_seq_parity.cpp
+++ b/test/unit/test_bns_get_seq_parity.cpp
@@ -1,12 +1,12 @@
-// Parity test: bns_get_seq (legacy on-the-fly unpack) vs bns_get_seq_v2
+// Parity test: bns_get_seq_into (caller-buffer write) vs bns_get_seq_v2
 // (zero-copy pointer into pre-unpacked ref_string).
 //
-// Why this matters: upstream v2.2.1 left bns_get_seq_v2 half-applied — it's
-// only called from one site in the mainline alignment loop; four other
-// callers still use the legacy bns_get_seq path (3.7% of compute on c7i SPR
-// per `perf record`). Before converting those callers, we want a hard
-// byte-identity guarantee that the two functions return the same bases for
-// the same input range.
+// Why this matters: bns_get_seq_into and bns_get_seq_v2 are the two ways
+// in-tree callers fetch ref bases — the former does inline 2-bit decode
+// into a caller buffer; the latter returns a pointer into a pre-decoded
+// .0123 ref_string. Both must return byte-identical bases for the same
+// input range, since callers pick one path based on whether ref_string
+// is materialized in their context.
 //
 // Test strategy: build a small synthetic packed reference (.pac-style 2-bit
 // packed), independently build the equivalent ref_string (forward + reverse
@@ -28,13 +28,13 @@
 
 #include "bntseq.h"
 
-// _set_pac is private to bntseq.cpp. Mirror it here for fixture generation.
-// Format: byte (k>>2) holds 4 bases at positions 4k..4k+3 (top-first).
+// _set_pac is published by bntseq.h.
+//
+// Pac layout: byte (k>>2) holds 4 bases at positions 4k..4k+3 (top-first).
 //   pac[i] bit 7:6 = base at position 4i+0
 //   pac[i] bit 5:4 = base at position 4i+1
 //   pac[i] bit 3:2 = base at position 4i+2
 //   pac[i] bit 1:0 = base at position 4i+3
-#define _set_pac(pac, l, c) ((pac)[(l) >> 2] |= (c) << ((~(l) & 3) << 1))
 
 namespace {
 
@@ -60,42 +60,40 @@ void build_synthetic_ref(std::mt19937 &rng, int64_t l_pac, std::vector<uint8_t> 
 }
 
 // Run both functions for one (beg, end) and assert byte-identical output.
-// Skip cases where the legacy fn returns nullptr (boundary-bridging) — both
-// should return *len = 0 there but neither produces bytes to compare.
+// Skip cases where bns_get_seq_into reports *len_out = 0 (boundary-bridging).
 void check_range(int64_t l_pac, const uint8_t *pac, const uint8_t *ref_string,
                  int64_t beg, int64_t end) {
-    int64_t len_legacy = 0;
-    uint8_t *legacy = bns_get_seq(l_pac, pac, beg, end, &len_legacy);
+    // bns_get_seq_into needs caller buffer >= |end - beg|. Allocate worst-case
+    // (2 * l_pac) and zero so any unwritten bytes show up as a CHECK miss.
+    std::vector<uint8_t> into_buf(2 * l_pac, 0xff);
+    int64_t len_into = 0;
+    bns_get_seq_into(l_pac, pac, beg, end, into_buf.data(), &len_into);
 
-    // bns_get_seq_v2 expects a scratch buffer (`seqb`); legacy v2 paths
-    // ignore it (the function returns a ref_string pointer directly), but we
-    // pass a real one to match the production call shape.
+    // bns_get_seq_v2 expects a scratch buffer (`seqb`); the function ignores
+    // it (returns a ref_string pointer directly), but we pass a real one to
+    // match the production call shape.
     std::vector<uint8_t> scratch(2 * l_pac, 0xff);
     int64_t len_v2 = 0;
     uint8_t *v2 = bns_get_seq_v2(l_pac, pac, beg, end, &len_v2,
                                  const_cast<uint8_t *>(ref_string), scratch.data());
 
-    CHECK(len_legacy == len_v2);
-    if (len_legacy == 0) {
-        // Boundary-bridging: both should report empty; legacy returns NULL,
-        // v2 still returns a pointer (not used). Nothing to compare.
-        free(legacy);
+    CHECK(len_into == len_v2);
+    if (len_into == 0) {
+        // Boundary-bridging: both should report empty.
         return;
     }
-    REQUIRE(legacy != nullptr);
     REQUIRE(v2 != nullptr);
-    for (int64_t i = 0; i < len_legacy; ++i) {
+    for (int64_t i = 0; i < len_into; ++i) {
         CAPTURE(beg);
         CAPTURE(end);
         CAPTURE(i);
-        CHECK(static_cast<int>(legacy[i]) == static_cast<int>(v2[i]));
+        CHECK(static_cast<int>(into_buf[i]) == static_cast<int>(v2[i]));
     }
-    free(legacy);
 }
 
 }  // namespace
 
-TEST_CASE("bns_get_seq vs v2: forward strand exhaustive small ref") {
+TEST_CASE("bns_get_seq_into vs v2: forward strand exhaustive small ref") {
     std::mt19937 rng(0x5EEDu);
     constexpr int64_t L = 64;
     std::vector<uint8_t> pac, ref_string;
@@ -109,7 +107,7 @@ TEST_CASE("bns_get_seq vs v2: forward strand exhaustive small ref") {
     }
 }
 
-TEST_CASE("bns_get_seq vs v2: reverse strand exhaustive small ref") {
+TEST_CASE("bns_get_seq_into vs v2: reverse strand exhaustive small ref") {
     std::mt19937 rng(0xC0FFEEu);
     constexpr int64_t L = 64;
     std::vector<uint8_t> pac, ref_string;
@@ -123,7 +121,7 @@ TEST_CASE("bns_get_seq vs v2: reverse strand exhaustive small ref") {
     }
 }
 
-TEST_CASE("bns_get_seq vs v2: bridging forward/reverse boundary returns empty") {
+TEST_CASE("bns_get_seq_into vs v2: bridging forward/reverse boundary returns empty") {
     std::mt19937 rng(0xBEEFu);
     constexpr int64_t L = 64;
     std::vector<uint8_t> pac, ref_string;
@@ -132,25 +130,25 @@ TEST_CASE("bns_get_seq vs v2: bridging forward/reverse boundary returns empty") 
     // beg < l_pac, end > l_pac → should return *len = 0 in both.
     for (int64_t beg : {int64_t{0}, int64_t{1}, int64_t{L / 2}, int64_t{L - 1}}) {
         for (int64_t end : {int64_t{L + 1}, int64_t{L + L / 2}, int64_t{2 * L}}) {
-            int64_t len_legacy = 0, len_v2 = 0;
-            uint8_t *legacy = bns_get_seq(L, pac.data(), beg, end, &len_legacy);
+            int64_t len_into = 0, len_v2 = 0;
+            std::vector<uint8_t> into_buf(2 * L, 0xff);
+            bns_get_seq_into(L, pac.data(), beg, end, into_buf.data(), &len_into);
             std::vector<uint8_t> scratch(2 * L, 0xff);
             (void)bns_get_seq_v2(L, pac.data(), beg, end, &len_v2,
                                  ref_string.data(), scratch.data());
-            CHECK(len_legacy == 0);
+            CHECK(len_into == 0);
             CHECK(len_v2 == 0);
-            free(legacy);
         }
     }
 }
 
-TEST_CASE("bns_get_seq vs v2: swapped beg/end (XOR-swap path)") {
+TEST_CASE("bns_get_seq_into vs v2: swapped beg/end (XOR-swap path)") {
     std::mt19937 rng(0xDEADu);
     constexpr int64_t L = 64;
     std::vector<uint8_t> pac, ref_string;
     build_synthetic_ref(rng, L, pac, ref_string);
 
-    // Swap path: legacy does `if (end < beg) end ^= beg, beg ^= end, end ^= beg`.
+    // Swap path: bns_get_seq_into does `if (end < beg) end ^= beg, beg ^= end, end ^= beg`.
     // v2 does the same. Both should produce the same canonicalized [beg, end).
     check_range(L, pac.data(), ref_string.data(), /*beg=*/40, /*end=*/10);
     check_range(L, pac.data(), ref_string.data(), /*beg=*/L + 30, /*end=*/L + 5);
@@ -172,7 +170,7 @@ TEST_CASE("bns_get_seq_v2: NULL ref_string returns NULL with *len = 0") {
     CHECK(len == 0);
 }
 
-TEST_CASE("bns_get_seq vs v2: large random ref, randomized ranges") {
+TEST_CASE("bns_get_seq_into vs v2: large random ref, randomized ranges") {
     std::mt19937 rng(0x900DCAFEu);
     constexpr int64_t L = 16384;  // larger to exercise unaligned reads
     std::vector<uint8_t> pac, ref_string;

--- a/test/unit/test_meth_orig_ref.cpp
+++ b/test/unit/test_meth_orig_ref.cpp
@@ -1,0 +1,155 @@
+// Unit tests for src/meth_orig_ref.{h,cpp} and the meth_chrom_map_t
+// basics. The orig-ref module is a lazy view over the doubled-c2t bns +
+// pac that recovers original ref bases per slice via dual 2-bit decode +
+// the 5-row (f, r) -> original table. Tests build a tiny in-memory
+// doubled bns + pac fixture and exercise the slice paths.
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "doctest/doctest.h"
+
+#include "bntseq.h"
+#include "meth_bam.h"
+#include "meth_orig_ref.h"
+#include "meth_orig_ref_fixture.h"
+
+namespace {
+
+struct synth_bns_t {
+    bntseq_t bns;
+    std::vector<bntann1_t> anns;
+    std::vector<bntamb1_t> ambs;
+    std::vector<std::string> name_storage;
+};
+
+void build_synth_doubled_bns(synth_bns_t &s, int n_real, int per_len) {
+    s.bns = bntseq_t{};
+    s.bns.l_pac = (int64_t)n_real * 2 * per_len;
+    s.bns.n_seqs = n_real * 2;
+    s.anns.resize(s.bns.n_seqs);
+    s.name_storage.reserve((size_t)s.bns.n_seqs);
+    for (int i = 0; i < n_real; ++i) {
+        for (int half = 0; half < 2; ++half) {
+            int rid = i * 2 + half;
+            char prefix = (half == 0) ? 'r' : 'f';
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "%cchr%d", prefix, i);
+            s.name_storage.push_back(std::string(buf));
+            bntann1_t &a = s.anns[rid];
+            a.offset = (int64_t)rid * per_len;
+            a.len    = per_len;
+            a.n_ambs = 0;
+            a.gi     = 0;
+            a.is_alt = 0;
+            a.name   = const_cast<char *>(s.name_storage.back().c_str());
+            a.anno   = const_cast<char *>("");
+        }
+    }
+    s.bns.anns = s.anns.data();
+    s.bns.ambs = s.ambs.data();
+    s.bns.n_holes = 0;
+}
+
+}  // namespace
+
+TEST_CASE("meth_chrom_map: collapses f/r doubled contigs to one output per real chrom") {
+    synth_bns_t s;
+    build_synth_doubled_bns(s, /*n_real=*/3, /*per_len=*/16);
+
+    meth_chrom_map_t *cmap = meth_chrom_map_build_from_bns(&s.bns);
+    REQUIRE(cmap != nullptr);
+    CHECK(cmap->n_internal == 6);
+    CHECK(cmap->n_output == 3);
+
+    CHECK(cmap->out_tid[0] == cmap->out_tid[1]);
+    CHECK(cmap->out_tid[2] == cmap->out_tid[3]);
+    CHECK(cmap->out_tid[4] == cmap->out_tid[5]);
+
+    CHECK(cmap->direction[0] == 'r');
+    CHECK(cmap->direction[1] == 'f');
+    CHECK(cmap->direction[2] == 'r');
+    CHECK(cmap->direction[3] == 'f');
+
+    CHECK(std::string(cmap->output_names[0]) == "chr0");
+    CHECK(std::string(cmap->output_names[1]) == "chr1");
+    CHECK(std::string(cmap->output_names[2]) == "chr2");
+
+    meth_chrom_map_free(cmap);
+}
+
+TEST_CASE("meth_orig_ref: 5-row recovery returns original bases through slice") {
+    /* All four bases per the 5-row table:
+     *   pos 0: A -> (f=A, r=A)
+     *   pos 1: C -> (f=T, r=C)
+     *   pos 2: G -> (f=G, r=A)
+     *   pos 3: T -> (f=T, r=T)
+     */
+    meth_test::OrigRefFixture f("ACGT");
+    uint8_t out[4];
+    std::memset(out, 0, sizeof(out));
+    meth_orig_ref_slice(f.orig, f.real_tid, 0, 4, out);
+    CHECK(std::string((char *)out, 4) == "ACGT");
+}
+
+TEST_CASE("meth_orig_ref: OOB slice positions emit 'N'") {
+    meth_test::OrigRefFixture f("ACGT");
+    uint8_t out[8];
+    std::memset(out, 0, sizeof(out));
+    meth_orig_ref_slice(f.orig, f.real_tid, -2, 6, out);
+    /* expect: N N A C G T N N */
+    CHECK(out[0] == 'N');
+    CHECK(out[1] == 'N');
+    CHECK(out[2] == 'A');
+    CHECK(out[3] == 'C');
+    CHECK(out[4] == 'G');
+    CHECK(out[5] == 'T');
+    CHECK(out[6] == 'N');
+    CHECK(out[7] == 'N');
+}
+
+TEST_CASE("meth_orig_ref: ambs intervals fill with 'N'") {
+    /* "ACNTACNT" — N at pos 2 and pos 6. The fixture marks both via
+     * bns->ambs on each half of the doubled pac, just like bwa indexer
+     * does at index time. */
+    meth_test::OrigRefFixture f("ACNTACNT");
+    uint8_t out[8];
+    std::memset(out, 0, sizeof(out));
+    meth_orig_ref_slice(f.orig, f.real_tid, 0, 8, out);
+    CHECK(std::string((char *)out, 8) == "ACNTACNT");
+}
+
+TEST_CASE("meth_orig_ref_load: NULL bns/pac returns NULL") {
+    meth_chrom_map_t cmap{};
+    cmap.n_internal = 0;
+    cmap.n_output = 0;
+    CHECK(meth_orig_ref_load(nullptr, nullptr, &cmap) == nullptr);
+}
+
+TEST_CASE("OrigRefFixture: bns.ambs is sorted by offset (bns_iter_ambi precondition)") {
+    /* bns_iter_ambi binary-searches bns->ambs assuming non-decreasing
+     * offset+len. With 2+ 'N's in the source sequence the fixture must
+     * lay out all r-X (low-offset) intervals before all f-X intervals
+     * to keep that invariant. Regression for the interleaved-push bug. */
+    meth_test::OrigRefFixture f("NNANNA");
+    REQUIRE(f.bns.n_holes >= 2);
+    for (int i = 1; i < f.bns.n_holes; ++i) {
+        CHECK(f.bns.ambs[i - 1].offset <= f.bns.ambs[i].offset);
+    }
+}
+
+TEST_CASE("meth_orig_ref: multi-N forward sequence masks every N via slice") {
+    /* End-to-end check that exercises bns_iter_ambi over an ambs array
+     * with multiple entries per side. The previous interleaved fixture
+     * ordering caused bns_iter_ambi's binary search to skip valid
+     * overlapping intervals (and, with 3+ N's, walk into the wrong half
+     * and translate to negative dst[] indices). */
+    meth_test::OrigRefFixture f("NNNAN");
+    uint8_t out[5];
+    std::memset(out, 0, sizeof(out));
+    meth_orig_ref_slice(f.orig, f.real_tid, 0, 5, out);
+    CHECK(std::string((char *)out, 5) == "NNNAN");
+}

--- a/test/unit/test_meth_xm_build.cpp
+++ b/test/unit/test_meth_xm_build.cpp
@@ -1,0 +1,137 @@
+// Unit tests for src/meth_xm.cpp — the Bismark XM:Z walk. Exercises
+// CpG/CHG/CHH context, mismatches, indels, soft clips, unknown context,
+// out-of-bounds context, and both top/bottom strand orientations.
+//
+// Each test builds a tiny on-disk un-converted index via OrigRefFixture
+// (writes a temp fa + bns_fasta2bntseq + meth_orig_ref_load), then drives
+// meth_build_xm against it. Same code path the production runtime uses.
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "doctest/doctest.h"
+
+#include "meth_xm.h"
+#include "meth_orig_ref_fixture.h"
+
+namespace {
+
+inline uint32_t bam_cigar_pack(uint32_t len, uint32_t op) {
+    return (len << 4) | (op & 0xf);
+}
+
+}  // namespace
+
+TEST_CASE("meth_build_xm: is_top_strand=1 simple matches; CpG/CHG/CHH; methylated/unmethylated") {
+    // ref: A C G T C A G T C A T A   (positions 0..11)
+    //   pos 1: C; ref[2]=G            -> CpG
+    //   pos 4: C; ref[5]=A; ref[6]=G  -> CHG
+    //   pos 8: C; ref[9]=A; ref[10]=T -> CHH
+    meth_test::OrigRefFixture f("ACGTCAGTCATA");
+
+    // pos 1 methylated (read=C), pos 4 unmethylated (read=T), pos 8 methylated (read=C).
+    const std::string read = "ACGTTAGTCATA";
+    uint32_t cigar[] = { bam_cigar_pack(12, /*M*/0) };
+    char *xm = meth_build_xm(f.orig, f.real_tid, /*pos=*/0, /*is_top_strand=*/1,
+                             cigar, 1, read.c_str(), (int)read.size());
+    REQUIRE(xm != nullptr);
+    CHECK(std::string(xm) == ".Z..x...H...");
+}
+
+TEST_CASE("meth_build_xm: is_top_strand=0 mirrors (G-marker, upstream context)") {
+    // forward = T A C T C G A T A T   (positions 0..9)
+    //   pos 5 = G (bottom-strand C). Bottom-strand context-1 = forward[4] = C
+    //   (bottom 'G' downstream) -> CpG.
+    meth_test::OrigRefFixture f("TACTCGATAT");
+
+    // perfect match -> read=G at pos 5 = methylated CpG -> Z
+    const std::string read_meth = "TACTCGATAT";
+    uint32_t cigar[] = { bam_cigar_pack(10, /*M*/0) };
+    char *xm = meth_build_xm(f.orig, f.real_tid, /*pos=*/0, /*is_top_strand=*/0,
+                             cigar, 1, read_meth.c_str(), (int)read_meth.size());
+    REQUIRE(xm != nullptr);
+    CHECK(std::string(xm) == ".....Z....");
+
+    // unmethylated -> read=A at pos 5 -> z
+    const std::string read_unmeth = "TACTCAATAT";
+    char *xm2 = meth_build_xm(f.orig, f.real_tid, 0, /*is_top_strand=*/0,
+                              cigar, 1, read_unmeth.c_str(), (int)read_unmeth.size());
+    REQUIRE(xm2 != nullptr);
+    CHECK(std::string(xm2) == ".....z....");
+}
+
+TEST_CASE("meth_build_xm: insertion emits '.' per inserted base; deletion no emit") {
+    meth_test::OrigRefFixture f("ACGTACGT");
+
+    // 2M, 2I (inserted "GG"), 6M.
+    const std::string read = "ACGGGTACGT";
+    uint32_t cigar[] = {
+        bam_cigar_pack(2, /*M*/0),
+        bam_cigar_pack(2, /*I*/1),
+        bam_cigar_pack(6, /*M*/0),
+    };
+    char *xm = meth_build_xm(f.orig, f.real_tid, /*pos=*/0, /*is_top_strand=*/1,
+                             cigar, 3, read.c_str(), (int)read.size());
+    REQUIRE(xm != nullptr);
+    CHECK(std::string(xm) == ".Z.....Z..");
+
+    // Deletion case.
+    const std::string read_d = "ACACGT";
+    uint32_t cigar_d[] = {
+        bam_cigar_pack(2, /*M*/0),
+        bam_cigar_pack(2, /*D*/2),
+        bam_cigar_pack(4, /*M*/0),
+    };
+    char *xm_d = meth_build_xm(f.orig, f.real_tid, 0, /*is_top_strand=*/1,
+                               cigar_d, 3, read_d.c_str(), (int)read_d.size());
+    REQUIRE(xm_d != nullptr);
+    CHECK(std::string(xm_d) == ".Z.Z..");
+}
+
+TEST_CASE("meth_build_xm: soft-clip emits '.' per clipped base") {
+    meth_test::OrigRefFixture f("ACGT");
+    const std::string read = "NNACGT";
+    uint32_t cigar[] = {
+        bam_cigar_pack(2, /*S*/4),
+        bam_cigar_pack(4, /*M*/0),
+    };
+    char *xm = meth_build_xm(f.orig, f.real_tid, /*pos=*/0, /*is_top_strand=*/1,
+                             cigar, 2, read.c_str(), (int)read.size());
+    REQUIRE(xm != nullptr);
+    CHECK(std::string(xm) == "...Z..");
+}
+
+TEST_CASE("meth_build_xm: read base != C and != T at ref-C emits '.'") {
+    meth_test::OrigRefFixture f("ACGT");
+    // ref pos 1 = C (CpG); read at pos 1 = 'A' (mismatch, neither C nor T).
+    const std::string read = "AAGT";
+    uint32_t cigar[] = { bam_cigar_pack(4, /*M*/0) };
+    char *xm = meth_build_xm(f.orig, f.real_tid, 0, /*is_top_strand=*/1,
+                             cigar, 1, read.c_str(), (int)read.size());
+    REQUIRE(xm != nullptr);
+    CHECK(std::string(xm) == "....");
+}
+
+TEST_CASE("meth_build_xm: ref N at context emits 'u'/'U' (unknown context)") {
+    meth_test::OrigRefFixture f("ACNTA");
+    const std::string read = "ACNTA";
+    uint32_t cigar[] = { bam_cigar_pack(5, /*M*/0) };
+    char *xm = meth_build_xm(f.orig, f.real_tid, 0, /*is_top_strand=*/1,
+                             cigar, 1, read.c_str(), (int)read.size());
+    REQUIRE(xm != nullptr);
+    // pos 1: C, ref[2]=N -> unknown, read=C meth -> 'U'
+    CHECK(std::string(xm) == ".U...");
+}
+
+TEST_CASE("meth_build_xm: out-of-bounds context (read aligned at end of contig)") {
+    // ref: T A C  (3 bp). Read aligns at pos 0, len 3. ref[3] OOB -> 'N'.
+    meth_test::OrigRefFixture f("TAC");
+    const std::string read = "TAC";
+    uint32_t cigar[] = { bam_cigar_pack(3, /*M*/0) };
+    char *xm = meth_build_xm(f.orig, f.real_tid, 0, /*is_top_strand=*/1,
+                             cigar, 1, read.c_str(), (int)read.size());
+    REQUIRE(xm != nullptr);
+    CHECK(std::string(xm) == "..U");
+}


### PR DESCRIPTION
## Summary

`bwa-mem3 mem --meth` now emits Bismark `XR:Z` (read conversion), `XG:Z` (genome strand), and `XM:Z` (methylation call string) so the output BAM works directly with `bismark_methylation_extractor`, methylKit, methtuple, DMRfinder, epialleleR (and continues to work with MethylDackel and biscuit). The bwameth-style `YS:Z`/`YC:Z`/`YD:Z` tags are dropped from output (kept internally for SEQ restoration). `-V` `XR:Z` is suppressed under `--meth` to avoid the collision.

## How

The doubled c2t pac (`f-<chr>` + `r-<chr>`) is folded once at startup into an in-memory un-converted reference via a 5-row `(f, r) → original` recovery table. No on-disk format change. Per mapped record, `meth_build_xm` slices the recovered ref at the alignment footprint and walks BAM CIGAR jointly over SEQ and the ref window per Bismark's `methylation_call` ladder. Strand pick is driven by `XG:Z`, not by SAM `0x10`, so CTOT/OB reads are handled correctly.

## Test plan

- [ ] CI unit tests green.
- [ ] `test/meth/test.sh` Layers 1+2+3 pass.
- [ ] `test/meth/test_bismark_tags.sh` (new holodeck-driven golden-truth diff) passes — currently 179627/179627 XM-match on records with matching alignment, 0 XR/XG mismatches.
- [ ] Manual: `MethylDackel extract` and `bismark_methylation_extractor` run cleanly on a sorted `--meth` BAM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * mem --meth now emits Bismark-compatible tags XR:Z, XG:Z and XM:Z and restores original pre-conversion SEQ.
  * New opt-in chimera QC flag (--chimera-qc) implementing the longest-match <44% heuristic.

* **Bug Fixes**
  * Suppress conflicting XR:Z reference annotation under --meth to avoid tag collisions.

* **Documentation**
  * Comprehensive docs updated for XR/XG/XM tags, chimera QC behavior, and workflow guidance.

* **Tests**
  * Added unit and end-to-end tests validating XR/XG/XM emission, XM construction, and chimera-QC behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/90)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->