### PR TITLE
docs(install): list autoconf/automake/libomp/zlib system prereqs

### DIFF
--- a/docs/src/developer-guide/building.md
+++ b/docs/src/developer-guide/building.md
@@ -7,8 +7,12 @@ This page documents every build target available in the Makefile and what each p
 - A C++14-capable compiler: GCC 7+ or Clang 6+ on Linux; Clang 15+ (Xcode) on macOS.
 - GNU make 3.81+.
 - CMake 3.12+ (required only when `USE_MIMALLOC=1`, which is the default).
-- libomp (macOS only): `brew install libomp`. libsais uses OpenMP for parallel suffix-array construction.
+- autoconf, automake, autoconf-archive, libtool, pkg-config — `ext/htslib`'s build runs `autoreconf -i && ./configure` and locates zlib via `pkg-config`.
+- zlib development headers — htslib links against zlib.
+- OpenMP runtime — libsais uses OpenMP for parallel suffix-array construction. Linux + GCC: libgomp ships with the compiler, nothing extra to install. Linux + Clang: `libomp-dev` (Debian) / `libomp-devel` (RHEL). macOS: `brew install libomp`; the Makefile auto-detects the Homebrew prefix or honours `LIBOMP_PREFIX`.
 - Git submodules initialised: `git submodule update --init --recursive`.
+
+See [Getting Started → Installation](../getting-started/installation.md) for the full per-platform install commands.
 
 > **Warning — Submodules must be present**
 >

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -17,10 +17,54 @@ Until the Bioconda package is available, build from source using the steps below
 
 ### Prerequisites
 
-- A C++17 compiler (GCC 8+ or Clang 7+)
-- GNU make
-- Rust toolchain (for `cargo install` of mdbook tools, not required for the aligner itself)
-- Git (for submodule checkout)
+bwa-mem3 vendors several libraries as git submodules. Building from source requires the toolchain to compile bwa-mem3 itself plus the bootstrap tools each vendored library needs.
+
+| Tool | Why it's needed | Minimum version |
+|------|-----------------|-----------------|
+| C++14 compiler (GCC or Clang) | bwa-mem3 itself | GCC 8+ / Clang 7+ |
+| GNU make | top-level build | 3.81+ |
+| Git | submodule checkout (with `--recursive`) | any recent |
+| autoconf, automake, autoconf-archive, libtool | `ext/htslib` runs `autoreconf -i && ./configure` during build | any recent |
+| pkg-config | htslib's `configure` uses it to locate zlib | any recent |
+| zlib development headers | htslib links against zlib | any recent |
+| OpenMP runtime | `ext/libsais` uses OpenMP for parallel suffix-array construction | see notes below |
+| CMake 3.12+ | building bundled mimalloc (default; skip if you pass `USE_MIMALLOC=0`) | 3.12+ |
+
+> **OpenMP notes.**
+> - On **Linux with GCC**, libgomp ships with the compiler — no extra package needed.
+> - On **Linux with Clang**, install `libomp-dev` (Debian/Ubuntu) or `libomp-devel` (RHEL/Fedora).
+> - On **macOS**, install Homebrew's `libomp` (`brew install libomp`). The Makefile auto-detects the Homebrew prefix; set `LIBOMP_PREFIX=/path/to/libomp` if you installed it elsewhere.
+
+#### Install prerequisites by platform
+
+**Debian / Ubuntu:**
+```bash
+sudo apt-get install \
+    build-essential git cmake pkg-config \
+    autoconf automake autoconf-archive libtool \
+    zlib1g-dev \
+    libomp-dev          # only needed if building with Clang
+```
+
+**RHEL / Fedora / Amazon Linux:**
+```bash
+sudo dnf install \
+    gcc gcc-c++ make git cmake pkgconfig \
+    autoconf automake autoconf-archive libtool \
+    zlib-devel \
+    libomp-devel        # only needed if building with Clang
+```
+
+**macOS (Homebrew):**
+```bash
+xcode-select --install   # Apple Clang + git + make
+brew install \
+    cmake pkg-config \
+    autoconf automake autoconf-archive libtool \
+    libomp
+```
+
+> **What happens if a prereq is missing.** The Makefile fails fast with an actionable error: a missing `libomp` on macOS, a missing `autoreconf`, or a missing `cmake` each produce a one-line hint pointing at the install command above. There is no need to install everything optimistically — install only what the error message asks for if you prefer.
 
 ### Clone and build
 


### PR DESCRIPTION
## Summary

- The Makefile builds vendored `ext/htslib` via `autoreconf -i && ./configure`, `ext/libsais` with OpenMP, and `ext/mimalloc` via CMake. None of those system-side prereqs are listed in the install docs today, so a fresh host fails the first `make` until users discover them by reading the Makefile's error hints.
- This PR augments the user-facing `docs/src/getting-started/installation.md` with a complete prereqs table plus copy-paste install commands for Debian/Ubuntu, RHEL/Fedora, and macOS, and adds autoconf/automake/pkg-config + the full Linux-GCC vs Linux-Clang vs macOS OpenMP guidance to the developer-guide `docs/src/developer-guide/building.md`.

## Test plan

- [ ] `make docs` renders cleanly (mdbook builds without warnings).
- [ ] Eyeball the rendered installation page — the prereqs table and the three platform install snippets are readable.
- [ ] No broken internal cross-links (the user-doc snippet references the developer-guide page and vice versa).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded build prerequisites to list needed build tools, zlib development headers, and OpenMP runtime requirements.
  * Added OS/compiler-specific OpenMP guidance (Linux GCC/Clang, macOS/Homebrew) with LIBOMP_PREFIX notes and included submodule initialization in prerequisites.
  * Replaced short list with a detailed prerequisites table and platform-specific install commands for Debian/Ubuntu, RHEL/Fedora/Amazon Linux, and macOS.
  * Added guidance on build failures and common resolution hints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/93)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->