### PR TITLE
docs(install): fix RHEL/Fedora package name pkgconfig → pkgconf-pkg-config

### DIFF
--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -49,7 +49,7 @@ sudo apt-get install \
 **RHEL / Fedora / Amazon Linux:**
 ```bash
 sudo dnf install \
-    gcc gcc-c++ make git cmake pkgconfig \
+    gcc gcc-c++ make git cmake pkgconf-pkg-config \
     autoconf automake autoconf-archive libtool \
     zlib-devel \
     libomp-devel        # only needed if building with Clang


### PR DESCRIPTION
## Summary

Follow-up to #93. The `pkgconfig` package does not exist on modern Fedora/RHEL (8+) or Amazon Linux — the correct package providing the `pkg-config` command is `pkgconf-pkg-config` (a shim on top of pkgconf). Updates the `dnf install` line in the installation guide.

CodeRabbit flagged this after #93 merged.

## Test plan

- [ ] `mdbook build` succeeds (covered by the `build mdbook + drift check CLI snippets` CI job)
- [ ] Manual: `sudo dnf install pkgconf-pkg-config` resolves on a RHEL 9 / Fedora 40+ host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation prerequisites command for RHEL/Fedora/Amazon Linux distributions to use the correct package name for pkg-config provider.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/94)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->