### PR TITLE
docs: pre-release documentation pass for v0.2.0-pre

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,77 @@
-Release 0.2.0-pre (2026-05-09)
+Release 0.2.0-pre (2026-05-13)
 ---------------------------------
+
+Operational / packaging
+
+* Single-binary SIMD dispatch on x86 (#83). The previous multi-binary
+  build (`make multi` producing five `bwa-mem3.<tier>` ISA variants plus
+  a `runsimd.cpp` launcher that `execv`'d the matching tier) is replaced
+  by a single binary that contains compiled kernels for every supported
+  tier (`sse41` / `sse42` / `avx` / `avx2` / `avx512bw`) and selects one
+  in process at startup via `__builtin_cpu_supports`. Install size drops
+  from ~120 MB to ~25 MB; per-call overhead is one indirect branch
+  (~0.3 ns after BTB warm-up). No `.<tier>` companion files are produced
+  or needed. See `docs/src/developer-guide/launcher.md`.
+* `BWAMEM3_FORCE_TIER=<tier>` and `BWAMEM3_DEBUG_SIMD=1` env vars (#83).
+  `BWAMEM3_FORCE_TIER` is downgrade-only and replaces the prior
+  "exec the `bwa-mem3.sse41` binary" A/B-testing pattern; up-tier or
+  unrecognized requests are rejected with a stderr warning.
+* `BASELINE_ARCH=avx2` is the new default for non-kernel translation
+  units on x86 (#84, supersedes the SSE4.1 floor that PR #83 originally
+  shipped with). Override via `make BASELINE_ARCH=<tier>`. AVX-512BW
+  hosts using `BASELINE_ARCH=avx512bw` see a small additional speedup
+  on Zen 4 with `-mprefer-vector-width=256` (#86) and roughly flat
+  results on Sapphire Rapids — see
+  `docs/src/whats-different/avx512-baseline.md` for the characterization.
+* Host-floor precheck (#95). `bwa-mem3 mem`, `bwa-mem3 index`, and
+  `bwa-mem3 shm` refuse to run with exit code 2 and an `[E::bwamem3]`
+  stderr message when the host CPU does not meet the build's compile-time
+  SIMD floor, instead of SIGILL-ing deep in alignment. `bwa-mem3 version`,
+  `--help`, and `-h` are exempt and always succeed.
+* `bwa-mem3 version` now prints `SIMD floor:` (build's required minimum)
+  and `SIMD runtime:` (resolved tier) lines on stdout, plus a
+  `[W::bwa-mem3]` warning on stderr (exit 0) if the host is below the
+  floor. See `docs/src/getting-started/host-requirements.md`.
+* `bwa-mem3 shm` performs a `statvfs("/dev/shm")` capacity preflight
+  (#86). When `/dev/shm` is too small for the index, the stage aborts
+  with an `[E::bwa_shm_stage]` message naming `/dev/shm`, the required
+  size, and a `mount -o remount,size=...` hint — replacing the prior
+  `[fread] Bad address` failure mode. `statvfs` failures (no `/dev/shm`,
+  restricted sandbox) are non-fatal and the stage proceeds.
+
+Methylation
 
 * `mem --meth` emits Bismark-compatible auxiliary tags `XR:Z`
   (read conversion `CT`/`GA`), `XG:Z` (genome strand `CT`/`GA`),
-  and `XM:Z` (per-base methylation call string). These replace the
-  prior bwameth-style `YS:Z`/`YC:Z`/`YD:Z` on output (still used
-  internally for SEQ restoration). The reference-annotation `XR:Z`
-  from `-V` is suppressed under `--meth` to avoid colliding with the
-  Bismark semantics. See `docs/src/methylation/tags.md`.
+  and `XM:Z` (per-base methylation call string) (#90). These replace
+  the prior bwameth-style `YS:Z` / `YC:Z` / `YD:Z` on output (still
+  used internally for SEQ restoration). The reference-annotation
+  `XR:Z` from `-V` is suppressed under `--meth` to avoid colliding
+  with the Bismark semantics. Downstream tools that previously read
+  `YS:Z` / `YC:Z` / `YD:Z` must be pointed at the corresponding
+  `XR:Z` / `XG:Z` and the per-base `XM:Z`. See
+  `docs/src/methylation/tags.md`.
+
+Correctness
+
+* Fixed SIGSEGV in `mem_matesw` on shm-backed `ref_string` (#85).
+  `ksw_align2` mutates its reference slice in place; when the slice
+  pointed into a read-only shm segment, this faulted. Now copies the
+  slice before passing it in.
+
+Performance
+
+* x86 wall-time improvements on the bench (vs the 0.1.0-pre baseline):
+  AVX2 (c6a) −17 to −22%, AVX-512 AMD Zen4 (c7a) −16 to −24%, AVX-512
+  Intel SPR (c7i) −28 to −30% across wgs / wes / panel-twist 5M-read
+  samples. Concordance vs upstream `bwa-mem2 v2.2.1` remains
+  100.0000% on all non-methylation cells. arm64 (c7g / c8g) is flat
+  (within ±2%). The wins are attributable primarily to (a) capping
+  AVX-512BW auto-vectorization at 256-bit on the `avx512bw` target
+  (#86) and (b) inlining `FMI_search::backwardExt` to recover a
+  gcc 12+ wall-clock regression (#88). See
+  `docs/src/performance/overview.md` for the reference numbers across
+  architectures.
 
 Release 0.1.0-pre (2026-04-28)
 ---------------------------------

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -68,7 +68,7 @@
 
 - [Building from source](developer-guide/building.md)
 - [SIMD dispatch architecture](developer-guide/simd-dispatch.md)
-- [Multi-binary launcher (x86)](developer-guide/launcher.md)
+- [Single-binary SIMD dispatch (x86)](developer-guide/launcher.md)
 - [Apple Silicon / NEON port](developer-guide/neon-port.md)
 - [Regression test framework](developer-guide/regression-tests.md)
 - [Release process](developer-guide/release.md)

--- a/docs/src/best-practices/anti-patterns.md
+++ b/docs/src/best-practices/anti-patterns.md
@@ -47,49 +47,57 @@ missing symbols, or at runtime with missing index files.
 > If `make` reports missing headers (e.g. `htslib/hts.h: No such file or
 > directory`), the submodules were not initialized.
 
-## Building without an arch target on a known CPU
+## Leaving `BASELINE_ARCH` at the default on a known higher-tier CPU
 
-The default `make` (no `arch=`) builds the multi-binary launcher suite on x86.
-On a production server with a known CPU family, this is unnecessary: the
-launcher adds a small cpuid dispatch overhead on every invocation, and the
-extra binaries consume disk space. More importantly, building without an
-explicit `arch=` means the compiler cannot assume any ISA beyond SSE4.1, so
-AVX2- and AVX-512-specific optimizations are not applied to the base binary.
+The default `make` (no `arch=`) builds the multi-tier single binary
+with non-kernel TUs compiled at `BASELINE_ARCH=avx2`. On a production
+server with a known higher-tier CPU family, this leaves auto-vectorized
+non-kernel hot paths at 256-bit width when the host could go wider, or
+keeps the host-floor precheck at `avx2` when the deployment surface is
+strictly AVX-512. Pass `BASELINE_ARCH=` (or build a single-tier binary
+with `arch=`) to align the build with the deployment:
 
 > **Warning — Suboptimal build on known hardware**
 >
-> On a server with a known CPU family, always pass an explicit `arch=`:
->
 > ```bash
-> make arch=avx2        # for Broadwell/Skylake and later x86
-> make arch=avx512bw    # for Cascade Lake, Ice Lake, Sapphire Rapids
-> make arch=arm64       # for Apple Silicon, AWS Graviton
+> # Single multi-tier binary with non-kernel TUs at the host's tier:
+> make BASELINE_ARCH=avx512bw      # Cascade Lake / Ice Lake / Sapphire Rapids / Zen 4
+>
+> # Single-tier binary (no dispatch table; smallest install) when the cluster
+> # is uniform and you don't need cross-tier portability:
+> make arch=avx2                   # Broadwell/Skylake and later x86
+> make arch=avx512bw               # Cascade Lake / Sapphire Rapids
+> make arch=arm64                  # Apple Silicon / AWS Graviton
 > ```
 >
-> The `make multi` target (or bare `make` on x86) is appropriate when you are
-> building a binary that will be distributed and run on multiple CPU families,
-> or when the target CPU is genuinely unknown.
+> The default (`make` with no overrides) is appropriate when the binary
+> will be distributed across multiple CPU families or when the target
+> CPU is genuinely unknown. Note that `BASELINE_ARCH=avx512bw` does not
+> always win over `avx2` even on AVX-512 hosts — see
+> [`BASELINE_ARCH=avx512bw` build flag](../whats-different/avx512-baseline.md)
+> for the empirical perf characterization.
 
 See [SIMD dispatch matrix](../performance/simd-dispatch.md) for the full set
-of targets.
+of targets and the in-process dispatch architecture.
 
 ## Mixing bwa-mem3 and bwa-mem2 outputs in the same pipeline
 
 bwa-mem3 adds several custom SAM tags that bwa-mem2 does not emit: `HN:i`
 (total number of primary alignments — both reported and suppressed — that the
 aligner found for this read, before the `-h` supplementary cap is applied),
-and — in `--meth` mode —
-`YS:Z:`, `YC:Z:`, and `YD:Z:`. It also rewrites `@SQ` header lines in
-`--meth` mode (collapsing `f`/`r` strand prefixes back to one entry per
-chromosome).
+and — in `--meth` mode — the Bismark-compatible `XR:Z` (read conversion
+direction), `XG:Z` (genome strand), and `XM:Z` (per-base methylation call
+string) tags. It also rewrites `@SQ` header lines in `--meth` mode
+(collapsing `f`/`r` strand prefixes back to one entry per chromosome).
 
 > **Warning — Header and tag mismatch**
 >
 > Do not merge BAM files produced by bwa-mem3 and bwa-mem2 without verifying
 > that the `@PG` headers and custom tags are handled correctly by the downstream
 > tool. In methylation workflows, a bwa-mem2 BAM mixed into a bwa-mem3 `--meth`
-> pipeline will be missing `YD:Z:` strand annotations, which will cause
-> methylation callers to silently drop or misclassify those records.
+> pipeline will be missing the `XR:Z` / `XG:Z` / `XM:Z` Bismark annotations,
+> which will cause methylation callers to silently drop or misclassify those
+> records.
 
 If you must merge outputs from both tools, run `samtools view -H` on both
 files and confirm that `@SQ` lines are consistent and that the downstream tool

--- a/docs/src/best-practices/build.md
+++ b/docs/src/best-practices/build.md
@@ -4,13 +4,14 @@ This page describes the recommended build configuration for production use of bw
 
 ## Choose the right arch target
 
-The default `make` invocation builds the multi-binary launcher on x86 (or a
-single ARM64 binary on Apple Silicon). For production servers where the CPU
-family is known, specify the target explicitly so the compiler can generate
-tighter code and the binary does not need the launcher overhead:
+The default `make` invocation builds a single multi-tier binary on x86
+(or a single NEON binary on arm64). For production clusters where the
+CPU family is uniform, you can trim further by building one tier only —
+the binary drops the per-tier dispatch table and ships a single kernel
+path:
 
 ```bash
-# Most modern x86-64 servers (Skylake or later):
+# Most modern x86-64 servers (Haswell or later):
 make arch=avx2
 
 # Intel Cascade Lake / Sapphire Rapids, AWS c7i/m7i:
@@ -20,9 +21,12 @@ make arch=avx512bw
 make arch=arm64
 ```
 
-Omit `arch=` if the deployment target is heterogeneous or unknown; `make`
-(with no arguments) builds the full multi-binary suite on x86 and selects the
-fastest variant at runtime via `cpuid`.
+Omit `arch=` if the deployment target is heterogeneous or unknown; the
+default `make` produces a single binary that includes every supported
+x86 tier and dispatches at runtime via `__builtin_cpu_supports`. Tune
+the non-kernel TU compile baseline with `BASELINE_ARCH=` (default
+`avx2`) — see
+[Single-binary SIMD dispatch (x86)](../developer-guide/launcher.md).
 
 See [SIMD dispatch matrix](../performance/simd-dispatch.md) for the full list
 of targets and which kernels each vectorizes.

--- a/docs/src/best-practices/output-format.md
+++ b/docs/src/best-practices/output-format.md
@@ -48,9 +48,10 @@ contend. A 16:8 split (bwa-mem3:samtools) works well on 24-core machines.
 ## Methylation output
 
 The `--meth` path always writes uncompressed BAM internally, regardless of
-the `--bam` flag.  The post-processing step (header rewrite, chimera QC,
-`YD:Z:` tag) is performed inline before the record is handed to htslib, so the
-same pipeline shape applies:
+the `--bam` flag.  The post-processing step (header rewrite, Bismark
+`XR:Z` / `XG:Z` / `XM:Z` tag emission, opt-in chimera QC) is performed
+inline before the record is handed to htslib, so the same pipeline shape
+applies:
 
 ```bash
 bwa-mem3 mem --meth --bam=0 -t 16 ref.fa R1.fq.gz R2.fq.gz \

--- a/docs/src/cli/shm.md
+++ b/docs/src/cli/shm.md
@@ -85,6 +85,21 @@ transparently.
 > `emptyDir` tmpfs volume with an explicit size (Kubernetes) before attempting
 > to stage a large index.
 >
+> **Note — `/dev/shm` capacity preflight (PR #86)**
+>
+> Before opening the segment, `bwa-mem3 shm` calls `statvfs("/dev/shm")` and
+> compares the available bytes against the index's `total_size`. If `/dev/shm`
+> is too small the stage aborts cleanly with an `[E::bwa_shm_stage]` message
+> that names `/dev/shm`, the required size, and a `mount -o remount,size=...`
+> hint. This replaces the previous failure mode where `ftruncate` succeeded
+> lazily and `pack_into` later surfaced ENOSPC as `[fread] Bad address` with
+> no indication that `/dev/shm` was the cause. The preflight is best-effort:
+> a `statvfs` failure (no `/dev/shm`, restricted sandbox, ENOSYS) is
+> non-fatal and the stage proceeds. As a rough sizing guide, hg38 stages
+> ~17 GB; AWS instances default to RAM/2 (so c7a.4xlarge / c7i.4xlarge at
+> 32 GB get ~16 GB of `/dev/shm`, which is just under the index size — a
+> `remount,size=28g` is the documented fix).
+>
 > **Note — Stuck-lock recovery**
 >
 > Concurrent `bwa-mem3 shm <prefix>` invocations are serialized by a named

--- a/docs/src/cli/version.md
+++ b/docs/src/cli/version.md
@@ -1,8 +1,15 @@
 # version
 
-`bwa-mem3 version` prints the release version of the binary and, when
-mimalloc is compiled in, the mimalloc version. It is a quick way to confirm
-which build is on `PATH` and whether the allocator is active.
+`bwa-mem3 version` prints the release version, the build's compiled-in
+SIMD floor, the SIMD tier resolved at runtime, and (when mimalloc is
+compiled in) the mimalloc version. It is the canonical way to confirm
+which build is on `PATH`, what host class it requires, and what kernel
+path it will dispatch to.
+
+`bwa-mem3 version` always exits 0 — even on a host below the build's
+SIMD floor — so operators can introspect a binary on a host that cannot
+actually run alignment. `bwa-mem3 <subcommand> --help` and `-h` share
+the same property.
 
 ## Synopsis
 
@@ -12,40 +19,57 @@ which build is on `PATH` and whether the allocator is active.
 
 ## Common usage
 
-Confirm the installed version and allocator:
+Confirm the installed version, SIMD floor, and resolved tier:
 
 ```sh
 ./bwa-mem3 version
 ```
 
-A typical run prints two lines (the mimalloc line goes to stderr and the
-version string to stdout, so the order in a merged stream is not guaranteed):
+A typical run on an AVX-512BW host with the default `BASELINE_ARCH=avx2`
+build prints (mimalloc line on stderr, the rest on stdout — order in a
+merged stream is not guaranteed):
 
 ```text
+v0.2.0-pre-12-gabcdef1
+SIMD floor: avx2 (x86-64-v3, Haswell 2013+); kernels: sse41 sse42 avx avx2 avx512bw
+SIMD runtime: avx512bw (BWAMEM3_FORCE_TIER unset)
 mimalloc 3.3.0
-v0.1.0-pre-7-g613a4dc
 ```
 
-The first line is the mimalloc version (present only when `USE_MIMALLOC=1`,
-the default). The second line is the bwa-mem3 version string, derived from
-`git describe` at build time and stored as `PACKAGE_VERSION` in the binary.
-When building from a tarball without git history, the fallback value is set
-via `FG_LABS_VERSION_FALLBACK` at compile time.
+- **version line** — bwa-mem3's release string, derived from
+  `git describe` at build time and stored as `PACKAGE_VERSION` in the
+  binary. When building from a tarball without git history, the
+  fallback value is set via `FG_LABS_VERSION_FALLBACK` at compile time.
+- **`SIMD floor:`** — the compile-time minimum the binary requires.
+  Set by `BASELINE_ARCH` (default `avx2`) and listed alongside the
+  per-tier kernel set the binary carries.
+- **`SIMD runtime:`** — the tier resolved at startup by
+  `__builtin_cpu_supports` (or `BWAMEM3_FORCE_TIER` if set in the
+  environment). On arm64 this is always `neon`.
+- **mimalloc line** — present only when `USE_MIMALLOC=1` (the default).
+
+On a host below the SIMD floor, `version` also writes a
+`[W::bwa-mem3]` warning on **stderr** identifying the gap (and the
+alignment subcommands will refuse to run with exit code 2 — see
+[Host requirements](../getting-started/host-requirements.md) for the
+exit-2 message format and rebuild instructions).
 
 ## Notes / Gotchas
 
-> **Note — mimalloc line goes to stderr, version to stdout**
+> **Tip — `version | grep` is safe in CI**
 >
-> The mimalloc line is printed to stderr and the version string to stdout.
-> Scripts that capture the version should redirect stderr appropriately or
-> use `bwa-mem3 version 2>/dev/null`.
+> The version, `SIMD floor:`, and `SIMD runtime:` lines all go to stdout;
+> the mimalloc line and any host-below-floor warning go to stderr. So
+> `bwa-mem3 version | grep '^SIMD'` works in CI scripts even on hosts
+> that cannot run alignment. Use `2>/dev/null` to suppress the mimalloc
+> and warning lines if you want stdout only.
 >
 > **Tip — No mimalloc line means USE_MIMALLOC=0**
 >
-> If only the version string appears and no mimalloc line, the binary was built
-> without the bundled allocator (`make USE_MIMALLOC=0`). See
-> [User Guide — Memory allocator (mimalloc)](../user-guide/allocator.md) for
-> when this is appropriate.
+> If no mimalloc line appears, the binary was built without the bundled
+> allocator (`make USE_MIMALLOC=0`). See
+> [User Guide — Memory allocator (mimalloc)](../user-guide/allocator.md)
+> for when this is appropriate.
 
 ---
 

--- a/docs/src/developer-guide/building.md
+++ b/docs/src/developer-guide/building.md
@@ -28,13 +28,34 @@ See [Getting Started → Installation](../getting-started/installation.md) for t
 make
 ```
 
-On x86 hosts this is equivalent to `make multi` (see below). On Apple Silicon and other aarch64 hosts the Makefile detects the architecture and builds a single ARM64 binary instead.
+On x86 hosts this is equivalent to `make single` (see below): one binary
+containing all five SIMD tiers, dispatched in process at startup. On
+Apple Silicon and other aarch64 hosts the Makefile detects the
+architecture and builds a single ARM64 binary with one NEON kernel TU.
 
 The resulting binary is `bwa-mem3` in the repo root.
 
-### Single-arch x86 builds
+### Single multi-tier x86 build (default on x86)
 
-Pass `arch=<target>` to compile a single binary with a specific ISA level:
+```bash
+make single                       # alias of the default `make`
+make BASELINE_ARCH=avx512bw       # raise non-kernel TU compile baseline
+make BASELINE_ARCH=sse41          # lower it for pre-Haswell hosts
+```
+
+Builds one `bwa-mem3` binary. The four hand-tuned kernel TUs in
+`KERNEL_SRCS` (`bandedSWA.cpp`, `kswv.cpp`, `ksw.cpp`,
+`sam_encode.cpp`) are compiled five times each — once per supported
+tier (`sse41` / `sse42` / `avx` / `avx2` / `avx512bw`) — and dispatched
+at runtime via `__builtin_cpu_supports`. Non-kernel TUs compile once at
+`BASELINE_ARCH` (default `avx2` since PR #84). See
+[Single-binary SIMD dispatch (x86)](launcher.md) for the full design.
+
+### Single-tier x86 builds
+
+Pass `arch=<target>` to compile a single binary with kernels for **one
+tier only** (no runtime dispatch table — useful on clusters with uniform
+hardware):
 
 | Command | SIMD level | `ARCH_FLAGS` |
 |---|---|---|
@@ -42,18 +63,14 @@ Pass `arch=<target>` to compile a single binary with a specific ISA level:
 | `make arch=sse42` | SSE4.2 | `-msse … -msse4.2` |
 | `make arch=avx` | AVX | `-mavx` |
 | `make arch=avx2` | AVX2 | `-mavx2` |
-| `make arch=avx512bw` | AVX-512BW | `-mavx512f -mavx512bw` |
+| `make arch=avx512bw` | AVX-512BW | `-mavx512f -mavx512bw -mprefer-vector-width=256` |
 | `make arch=native` | host CPU features | `-march=native` |
 
-For Intel compiler (`icpc` / `icpx`) the flags differ slightly; see the Makefile for the `ifeq ($(CXX), icpc)` branches.
-
-### Multi-binary x86 build (default on x86)
-
-```bash
-make multi
-```
-
-Builds five ISA-specific binaries (`bwa-mem3.sse41`, `bwa-mem3.sse42`, `bwa-mem3.avx`, `bwa-mem3.avx2`, `bwa-mem3.avx512bw`) plus the thin launcher `bwa-mem3` that execs the best-matching binary at runtime. See [Multi-binary launcher](launcher.md) for details.
+For Intel compiler (`icpc` / `icpx`) the flags differ slightly; see the
+Makefile for the `ifeq ($(CXX), icpc)` branches. The `avx512bw` target
+keeps the `-mprefer-vector-width=256` cap from PR #86 — see
+[`BASELINE_ARCH=avx512bw` build flag](../whats-different/avx512-baseline.md)
+for the empirical perf characterization.
 
 ### ARM64 / Apple Silicon build
 
@@ -61,7 +78,8 @@ Builds five ISA-specific binaries (`bwa-mem3.sse41`, `bwa-mem3.sse42`, `bwa-mem3
 make arch=arm64
 ```
 
-Compiles a single binary `bwa-mem3.arm64` and creates a symlink `bwa-mem3 -> bwa-mem3.arm64`. See [Apple Silicon / NEON port](neon-port.md) for background.
+Compiles a single binary `bwa-mem3` with one NEON kernel TU. See
+[Apple Silicon / NEON port](neon-port.md) for background.
 
 ## Tuned builds
 
@@ -154,7 +172,7 @@ Removes only the mdbook build output (`docs/book/`). Covered in [Developer Guide
 
 **See also:**
 [SIMD dispatch architecture](simd-dispatch.md) ·
-[Multi-binary launcher](launcher.md) ·
+[Single-binary SIMD dispatch (x86)](launcher.md) ·
 [Best Practices → Build](../best-practices/build.md) ·
 [Performance → PGO build](../performance/pgo.md) ·
 [Apple Silicon / NEON port](neon-port.md)

--- a/docs/src/developer-guide/launcher.md
+++ b/docs/src/developer-guide/launcher.md
@@ -1,83 +1,208 @@
-# Multi-binary launcher (x86)
+# Single-binary SIMD dispatch (x86)
 
-On x86 Linux and x86 macOS, `bwa-mem3` is a thin launcher binary rather than the aligner itself. Its sole job is to detect the host CPU's capabilities at startup and exec the best-matching ISA-specific binary in the same directory.
+On x86 Linux and x86 macOS, `bwa-mem3` is a **single binary** that
+contains compiled kernels for every supported SIMD tier
+(`sse41` / `sse42` / `avx` / `avx2` / `avx512bw`). At startup the binary
+detects the host CPU's capabilities and selects the matching tier in
+process, without `fork` or `exec`. There is no separate launcher binary
+and no `bwa-mem3.<tier>` variant files on disk.
 
-ARM / Apple Silicon does not use this mechanism. The `make arm64` target creates a symlink `bwa-mem3 -> bwa-mem3.arm64`; there is only one NEON instruction-set level on all current ARM64 CPUs.
+ARM / Apple Silicon does not need tier dispatch at all: there is only
+one NEON instruction-set level across current ARM64 CPUs, so the arm64
+build is a single binary with one kernel TU. The dispatch machinery
+described below is only meaningful on x86.
 
-## What `make multi` produces
+This design replaces the multi-binary `execv` launcher inherited from
+bwa-mem2. The motivation, validation, and trade-offs are tracked in
+[PR #83](https://github.com/fg-labs/bwa-mem3/pull/83); the AVX-512
+auto-vectorization cap that ships alongside it is documented in
+[`BASELINE_ARCH=avx512bw` build flag](../whats-different/avx512-baseline.md).
+
+## What the build produces
 
 ```bash
-make multi
+make            # default: single multi-tier binary, BASELINE_ARCH=avx2
+make single     # explicit alias of the default target
 ```
 
-Produces six files in the repo root:
+Produces **one** file in the repo root:
 
-| File | ISA | ARCH_FLAGS |
+| File | Contains | Non-kernel TU compile flags |
 |---|---|---|
-| `bwa-mem3` | launcher (no aligner code) | compiled from `src/runsimd.cpp` |
-| `bwa-mem3.sse41` | SSE4.1 | `-msse -msse2 -msse3 -mssse3 -msse4.1` |
-| `bwa-mem3.sse42` | SSE4.2 | adds `-msse4.2` |
-| `bwa-mem3.avx` | AVX | `-mavx` |
-| `bwa-mem3.avx2` | AVX2 | `-mavx2` |
-| `bwa-mem3.avx512bw` | AVX-512BW | `-mavx512f -mavx512bw` |
+| `bwa-mem3` | All 5 x86 tier kernels + dispatcher + non-kernel TUs | `BASELINE_ARCH` (default `avx2`) |
 
-The six binaries must reside in the same directory for the launcher to find them.
-
-## How the launcher selects a binary
-
-`src/runsimd.cpp` calls `cpuid` (via the `__cpuid` intrinsic or a hand-rolled `CPUID` wrapper) to read the CPU's feature flags and picks the highest ISA level supported by the CPU:
-
-1. Check `CPUID` leaf 7 for AVX-512BW → exec `bwa-mem3.avx512bw`
-2. Check `CPUID` leaf 7 for AVX2 → exec `bwa-mem3.avx2`
-3. Check `CPUID` leaf 1 for AVX → exec `bwa-mem3.avx`
-4. Check `CPUID` leaf 1 for SSE4.2 → exec `bwa-mem3.sse42`
-5. Fallback → exec `bwa-mem3.sse41`
-
-The launcher calls `execv` with the same `argv` that was passed to it. The selected binary's `main()` therefore receives the original arguments unchanged. The `@PG CL:` tag in the output SAM/BAM records the original invocation, not the ISA-suffixed binary name.
-
-> **Note — exec replaces the process**
->
-> The launcher does not fork. It calls execv(), which replaces the launcher process
-> image with the ISA-specific binary. There is no wrapper process resident in memory
-> during alignment.
-
-## Using a specific ISA binary directly
-
-You can bypass the launcher and invoke a specific binary directly:
+The five kernel translation units listed in the Makefile's `KERNEL_SRCS`
+(`bandedSWA.cpp`, `kswv.cpp`, `ksw.cpp`, `sam_encode.cpp`) are compiled
+five times each, once per tier, with tier-specific `-m...` flags. Every
+non-kernel TU is compiled once at the `BASELINE_ARCH` tier.
+`BASELINE_ARCH` defaults to `avx2` (PR #84) and can be set on the
+`make` line:
 
 ```bash
-./bwa-mem3.avx2 mem -t 16 ref.fa r1.fq.gz r2.fq.gz
+make BASELINE_ARCH=avx512bw       # for an AVX-512BW-only fleet
+make BASELINE_ARCH=sse41          # for pre-Haswell hosts (~10–15% slower on AVX2)
 ```
 
-This is useful when benchmarking a particular ISA level, testing a regression, or deploying in an environment where only one binary is installed. The ISA-specific binary behaves identically to the launcher output for that ISA — there is no functional difference.
+Lowering `BASELINE_ARCH` reduces the supported host floor and is the
+documented escape hatch for vintage hardware. Raising it locks the
+binary to that host class and disables the host-floor precheck for
+lower tiers. The `bwa-mem3 version` banner prints the resulting
+`SIMD floor:` line so operators can confirm the build matches the
+intended deployment surface — see
+[Host requirements](../getting-started/host-requirements.md) and
+[`BASELINE_ARCH=avx512bw` build flag](../whats-different/avx512-baseline.md).
+
+For ARM, `make arm64` produces a single binary with a single NEON
+kernel TU; no dispatch table is generated.
+
+## Runtime tier selection
+
+`src/simd_dispatch.cpp` provides three pieces:
+
+- `bwamem3_simd_init()` — idempotent initializer called from
+  `main.cpp`. Caches the host's raw capability into a file-scope
+  `g_host_capability` and the effective dispatch tier into a separate
+  `g_tier` (the two differ when `BWAMEM3_FORCE_TIER` is set).
+- An enum of supported tiers (`sse41` → `sse42` → `avx` → `avx2` → `avx512bw`,
+  plus `neon` on arm64) and `bwamem3_simd_tier_name()` for stderr
+  reporting.
+- Per-kernel factory functions (`make_bsw_kernel_<tier>`,
+  `make_kswv_kernel_<tier>`) and free-function dispatch wrappers
+  (`ksw_extend2`, `ksw_global2`, `ksw_extend`, `ksw_global`,
+  `ksw_align2`, `ksw_align`, `sam_encode_*`) that switch on `g_tier`
+  and call into the matching mangled per-tier symbol.
+
+x86 detection uses `__builtin_cpu_supports` directly; arm64 reports
+`neon` unconditionally. The selection happens once at startup and the
+result is cached in a TU-level global — subsequent kernel calls pay a
+single indirect-call overhead through a vtable (for the
+`BandedPairWiseSW` / `kswv` factories) or an `extern "C"` wrapper (for
+the `ksw_*` free functions). Per PR #83 measurement, the indirect call
+costs ~0.3 ns after BTB warm-up, so a 1M-read alignment with ~100M
+kernel calls adds roughly 30 ms — well below run-to-run noise on every
+tested host.
+
+## Symbol mangling per tier
+
+`src/kernel_dispatch.h` is a preprocessor-only header that renames
+kernel-exported symbols according to a `KERNEL_VARIANT=_<tier>` macro.
+Each kernel TU is compiled `N` times with a different
+`-DKERNEL_VARIANT=_<tier>` plus the matching `-m...` flags, producing
+per-tier mangled symbols that link cleanly into one binary without ODR
+collision.
+
+`bandedSWA.h` adds an abstract `IBandedPairWiseSW` interface;
+`BandedPairWiseSW` is `final` and inherits from it. `kswv.h` mirrors
+this with `Ikswv`. The dispatcher TU sees only the interface; the
+factory implementations in each per-tier kernel TU see the full
+concrete class layout via the rename. This separation sidesteps the
+ODR risk that would arise if the dispatcher TU and the factory TUs
+both included the full class definition.
+
+Internal aux helpers in `ksw.cpp` (`ksw_qinit`, `ksw_u8`, `ksw_i16`)
+are forced `static` so the per-tier compiles don't multi-define them.
+The SAM seq/qual encoder previously inlined in `bwamem.cpp` was lifted
+into a free-standing `src/sam_encode.{h,cpp}` translation unit so it
+participates in per-tier compilation and benefits from the
+auto-vectorizer's tier-specific `vmovdqu` / VEX / EVEX encoding wins.
+
+## Environment overrides
+
+Two environment variables exposed at runtime:
+
+| Variable | Behavior |
+|---|---|
+| `BWAMEM3_FORCE_TIER=<tier>` | Force the dispatcher to use `<tier>` (one of `sse41` `sse42` `avx` `avx2` `avx512bw`). **Downgrade-only:** requests above the detected host tier (which would SIGILL on the first wider instruction) and unrecognized names are rejected with a stderr warning and the dispatcher falls back to the detected tier. Replaces the prior "exec the `bwa-mem3.sse41` binary" pattern for A/B regression testing on AVX-512 hosts. |
+| `BWAMEM3_DEBUG_SIMD=1` | Print a one-line `[I::bwamem3_simd_init_body]` banner at startup naming the build baseline (`g_build_tier`), the detected host capability, and the resolved dispatch tier. Also enables the build-baseline-vs-host gap warning that PR #84 originally emitted unconditionally and PR #86 demoted to debug-only. |
+
+Both are read once during `bwamem3_simd_init()` and ignored after that
+call returns.
+
+## Host-floor enforcement
+
+`bwa-mem3 mem`, `bwa-mem3 index`, and `bwa-mem3 shm` all call
+`bwamem3_enforce_host_floor()` early in `main()` (PR #95). The check
+compares `g_host_capability` against the compile-time `g_build_tier`
+(derived from compiler predefined macros, reflecting whichever
+`BASELINE_ARCH` was set at build time) and exits with code `2` and an
+`[E::bwamem3]` message naming the gap if the host cannot execute the
+binary's compiled-in instructions. This converts what would otherwise
+be an unhelpful SIGILL deep in alignment into a clean abort at startup.
+
+Diagnostic invocations opt out: `bwa-mem3 version`,
+`bwa-mem3 <subcommand> --help`, and `bwa-mem3 <subcommand> -h` always
+succeed regardless of host capability, so operators can introspect a
+binary on a host that cannot run alignment. The `version` command
+prints `SIMD floor:` (the build's required minimum) and
+`SIMD runtime:` (the resolved tier) on stdout; on a too-old host it
+also emits a `[W::bwa-mem3]` warning on stderr.
+
+The `simd_dispatch.cpp` translation unit itself is compiled at
+`-march=x86-64` via an explicit Makefile rule, so the precheck path
+stays SIGILL-safe even when `BASELINE_ARCH=avx2` (or higher) for the
+rest of the binary.
+
+## Per-tier parity validation
+
+`test/regression/all_tiers_parity.sh` runs `bwa-mem3 mem` with
+`BWAMEM3_FORCE_TIER` walking the full ladder
+(`sse41 → sse42 → avx → avx2 → avx512bw`) on the same input and
+diff's the BAM output. The expected result is byte-identical SAM
+across every tier; any divergence is a bug in either a kernel TU or
+the per-kernel factory wiring. CI runs this script on the x86 matrix
+row.
+
+## Trade-offs vs the prior multi-binary launcher
+
+| Property | Pre-PR-#83 (multi-binary `execv`) | Current (single binary, in-process dispatch) |
+|---|---|---|
+| Install size | ~120 MB (5 ISA binaries + launcher) | ~25 MB (one binary) |
+| Build cost | 5 sequential clean rebuilds + launcher | One parallel build |
+| Process model | `bwa-mem3` (launcher) → `execv` → `bwa-mem3.<tier>` | One process, one `main()` |
+| Per-call overhead | Direct call (tier fixed at launch via separate binary) | Indirect call through factory vtable or `extern "C"` wrapper (~0.3 ns / call) |
+| Non-kernel auto-vectorization | At each binary's compile tier | At `BASELINE_ARCH` (default `avx2`); raise via `BASELINE_ARCH=` |
+| Tier override | Run the `.<tier>` binary directly | `BWAMEM3_FORCE_TIER=<tier>` (downgrade-only) |
+| `runsimd.cpp` (220-line launcher + safestringlib) | Required | Removed |
+
+The ~0.3 ns indirect-call cost is amortized across alignment work and
+has not been measurable in any bench cell. The non-kernel
+auto-vectorization at `BASELINE_ARCH` is what closes the gap PR #84
+identified after PR #83 originally regressed by silently hardcoding
+the non-kernel compile to `sse41`.
 
 ## Distribution layout
 
-When packaging or deploying on x86, include all five ISA binaries plus the launcher in the same directory:
+For deployment on any x86 host meeting the build's floor:
 
 ```text
 bin/
-  bwa-mem3           ← launcher
-  bwa-mem3.sse41
-  bwa-mem3.sse42
-  bwa-mem3.avx
-  bwa-mem3.avx2
-  bwa-mem3.avx512bw
+  bwa-mem3       ← single binary, dispatches in-process
 ```
 
-On ARM, only `bwa-mem3` (the symlink) and `bwa-mem3.arm64` are needed.
+For ARM:
+
+```text
+bin/
+  bwa-mem3       ← single binary, NEON kernels only
+```
+
+No `.<tier>`-suffixed companion files are produced or needed. When
+shipping a Docker image intended for a mixed-microarch fleet, build at
+the lowest expected tier (e.g. `BASELINE_ARCH=avx2` for "AVX2 and
+newer") — the runtime dispatcher will still pick AVX-512BW kernels on
+AVX-512 hosts via the per-tier factory tables. See
+[Multi-architecture deployment](../best-practices/multi-arch-deployment.md)
+for the `docker buildx` manifest-list recipe.
 
 ## The `mem` SIMD banner
 
-After selecting and executing a binary, the `mem` subcommand prints a single-line banner to stderr before alignment begins:
+The legacy `Executing in AVX2 mode!!` banner is gone. Use either:
 
-```text
------------------------------
-Executing in AVX2 mode!!
------------------------------
-```
-
-The banner text is set at compile time via `#if __AVX512BW__` / `#elif __AVX2__` / … preprocessor guards in `src/main.cpp`. This confirms at runtime which ISA path is active.
+- `bwa-mem3 version` — prints `SIMD floor:` and `SIMD runtime:` lines
+  on stdout (always available, no alignment required).
+- `BWAMEM3_DEBUG_SIMD=1 bwa-mem3 mem …` — prints a one-line
+  `[I::bwamem3_simd_init_body]` banner on stderr at the start of the
+  run.
 
 ---
 
@@ -85,4 +210,7 @@ The banner text is set at compile time via `#if __AVX512BW__` / `#elif __AVX2__`
 [SIMD dispatch architecture](simd-dispatch.md) ·
 [Apple Silicon / NEON port](neon-port.md) ·
 [Building from source](building.md) ·
-[Performance → SIMD dispatch matrix](../performance/simd-dispatch.md)
+[Performance → SIMD dispatch matrix](../performance/simd-dispatch.md) ·
+[Host requirements](../getting-started/host-requirements.md) ·
+[`BASELINE_ARCH=avx512bw` build flag](../whats-different/avx512-baseline.md) ·
+[Multi-architecture deployment](../best-practices/multi-arch-deployment.md)

--- a/docs/src/developer-guide/neon-port.md
+++ b/docs/src/developer-guide/neon-port.md
@@ -4,7 +4,7 @@ bwa-mem3 supports ARM64 (Apple Silicon and Linux aarch64) as a first-class build
 
 ## Architecture overview
 
-The ARM build compiles a single binary (`bwa-mem3.arm64`) rather than a family of ISA-specific binaries. There is only one NEON instruction-set level on all current ARM64 CPUs, so the multi-binary launcher used on x86 is not needed. `make arm64` builds the binary and creates a symlink `bwa-mem3 -> bwa-mem3.arm64`.
+The ARM build compiles a single binary with a single NEON kernel TU. There is only one NEON instruction-set level on all current ARM64 CPUs, so the per-tier dispatch table used by the x86 single-binary build (see [Single-binary SIMD dispatch (x86)](launcher.md)) collapses to a one-entry switch on aarch64 — there is effectively no dispatch overhead. `make arm64` builds and installs the binary at the bare `bwa-mem3` name.
 
 ### sse2neon shim
 
@@ -47,7 +47,7 @@ The FM-index (`FMI_search.cpp`) is memory-bound with sequential pointer-chasing 
 | Correctness verification | done | — | 200,006 alignments, 0 differences vs. reference |
 | Dynamic L2 cache detection | done | ~0% | 4 MB detected; compile-time `BATCH_SIZE=1024` already optimal |
 | Native NEON `bandedSWA.cpp` | done | ~4% | `vbsl`-based blendv in `simd_compat.h` |
-| Multi-binary launcher | N/A | 0% | Not applicable on ARM (single NEON level) |
+| Per-tier dispatch table | N/A | 0% | Collapses to one entry on ARM (single NEON level) |
 | Accelerate.framework | done | ~0% | Linked; no suitable compute patterns |
 | M1/M2/M3/M4 detection | done | ~0% | P/E-core counts and L2 cache via sysctl |
 | Native NEON `FMI_search.cpp` | N/A | 0% | Memory-bound; SIMD cannot help |

--- a/docs/src/developer-guide/release.md
+++ b/docs/src/developer-guide/release.md
@@ -35,9 +35,115 @@ On an untagged commit the string includes the commit distance and short SHA:
 v0.1.0-12-g3f7ab2e
 ```
 
-## Tagging a release
+## Semver policy
 
-1. Confirm `main` builds cleanly and all tests pass:
+bwa-mem3 follows semver, interpreted for an alignment tool as follows.
+
+**MAJOR (`X.0.0`)** — bump when the change would break a downstream
+consumer that pinned the previous version without checking release
+notes. Concretely:
+
+- An on-disk index file format change (a re-index is required to use
+  the new version).
+- Removal or rename of a CLI flag or subcommand.
+- A SAM/BAM tag is removed, renamed, or its type/value space changes
+  incompatibly (a column-fixed downstream parser would break). Adding
+  a new tag is **not** a major change.
+- A change to the resolved primary alignment that is intentional and
+  affects more than a negligible fraction of reads (e.g. a MAPQ
+  recalibration applied unconditionally). Concordance regressions
+  attributable to bug fixes are not major changes — call them out in
+  the release notes under "Correctness" instead.
+- Dropping support for a previously supported host class
+  (e.g. raising the build's compiled-in `BASELINE_ARCH` floor in a way
+  that excludes hosts the previous release ran on).
+
+**MINOR (`0.X.0`)** — bump for any user-visible new functionality that
+does not break consumers pinned to the previous minor. Examples:
+
+- A new CLI flag or subcommand.
+- A new SAM aux tag emitted on output (e.g. `HN:i` in 0.1.0, the
+  Bismark `XR:Z` / `XG:Z` / `XM:Z` set in 0.2.0).
+- A new operational feature (e.g. `bwa-mem3 shm`, in-process SIMD
+  dispatch).
+- A user-facing default change that is documented in release notes but
+  does not require any consumer action (e.g. `BASELINE_ARCH=avx2` as
+  the build default).
+- New performance characteristics that change wall-time meaningfully.
+
+**PATCH (`0.0.X`)** — bump for bug fixes, doc-only changes, build
+fixes, and internal refactors that have no user-visible behavioral
+delta. Pre-existing-bug fixes that incidentally shift output for a
+small fraction of reads are patch-level when called out in the
+release notes; widespread output shifts (>0.1% of reads on a typical
+WGS bench cell) deserve MINOR or MAJOR depending on the source.
+
+While the project is pre-1.0, the leading `0.` is treated literally —
+`0.2.0` may make breaking changes vs `0.1.0` if called out clearly in
+the release notes. After 1.0, MAJOR bumps are reserved for genuinely
+breaking changes.
+
+## Release-readiness checklist
+
+Run through this list on the commit you intend to tag, before any
+git-tag command. **Every item must pass.**
+
+### Build and test
+
+- [ ] `make clean && make` succeeds at the default `BASELINE_ARCH`
+      (`avx2`) on a Linux x86_64 host.
+- [ ] `make clean && make BASELINE_ARCH=sse41` succeeds on the same
+      host — confirms the portability floor still compiles.
+- [ ] `make clean && make` succeeds on an arm64 host (Apple Silicon
+      or aarch64 Linux).
+- [ ] `make test` passes on both x86_64 and arm64.
+- [ ] `test/regression/all_tiers_parity.sh` produces byte-identical
+      SAM across `BWAMEM3_FORCE_TIER=sse41 → sse42 → avx → avx2 → avx512bw`
+      on an AVX-512BW host. Failures here indicate a per-tier kernel
+      or dispatcher-wiring regression — fix before tagging.
+
+### Bench
+
+- [ ] [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench) run
+      submitted on the candidate SHA via
+      `bwa_mem3_bench.cli submit --fg-labs-sha <sha>` (or the local
+      smoke path for a fast sanity check).
+- [ ] `bench regression --prev <previous-tag-sha>` reports gate `PASS`
+      — concordance ≥ 99.999% on every `vs-baseline.json` cell except
+      methylation (which is expected to drift vs the bwameth
+      baseline; see the methylation carve-out below) and no cell
+      labeled `REGRESSION`.
+- [ ] Methylation cells reviewed for expected-drift consistency: the
+      `meth-twist-emseq-5M` concordance vs the bwameth baseline should
+      sit at ~98.9% post-PR-#90, with the per-class breakdown matching
+      the entry in
+      [`bwa-mem3-bench/docs/expected-divergences.yaml`](https://github.com/fg-labs/bwa-mem3-bench/blob/main/docs/expected-divergences.yaml)
+      (or the entry added in this release — the file is in the bench
+      repo, not in this repo).
+
+### Docs
+
+- [ ] `make docs` builds cleanly with no mdbook warnings.
+- [ ] `NEWS.md` has a top-section entry for the new version with
+      Operational / packaging, Correctness, Performance, and
+      Methylation subheadings as applicable; every user-visible PR in
+      the release window is listed with its number.
+- [ ] `docs/src/whats-different/overview.md` `FG-MAIN-TABLE` is
+      regenerated to cover the new PRs (see
+      [Contributing](contributing.md) for the regeneration command).
+- [ ] `docs/src/whats-different/upstream-prs.md` has rows for every
+      user-visible PR landed since the previous tag.
+- [ ] `docs/src/reference/changelog.md` and `docs/src/cli/version.md`
+      examples reference the new release string.
+- [ ] Spot-check the bwa-mem3-bench reference numbers in
+      `docs/src/performance/overview.md` against the bench's
+      `regression.md` for the tagging SHA.
+
+## Tagging the release
+
+Run these in order; each command depends on the previous one.
+
+1. Pre-flight (confirms the readiness checklist):
 
    ```bash
    make clean && make
@@ -45,15 +151,15 @@ v0.1.0-12-g3f7ab2e
    make docs
    ```
 
-2. Update `NEWS.md` with the release notes for the new version.
+2. Confirm `NEWS.md` is current. The top entry header line must match
+   the tag you are about to create (e.g. `Release 0.2.0 (YYYY-MM-DD)`).
 
-3. Tag the release commit:
+3. Tag the release commit. Prefer a signed tag (`-s`); fall back to an
+   annotated tag (`-a`) only when signing is unavailable:
 
    ```bash
    git tag -s v0.X.Y -m "Release v0.X.Y"
    ```
-
-   Use a signed tag (`-s`) when your GPG key is available. Annotated tags (`-a`) are acceptable when signing is not possible.
 
 4. Push the tag to the `fg-labs` remote:
 
@@ -61,15 +167,26 @@ v0.1.0-12-g3f7ab2e
    git push fg-labs v0.X.Y
    ```
 
-   Read the Docs activates a versioned build at `/v0.X.Y/` automatically when the tag appears on the remote.
+   Read the Docs activates a versioned build at `/v0.X.Y/` automatically
+   when the tag appears on the remote.
 
-5. Create a GitHub release from the tag via `gh`:
+5. Create a GitHub release from the tag via `gh`. The body should be
+   the matching `NEWS.md` section, no preamble:
 
    ```bash
    gh release create v0.X.Y --repo fg-labs/bwa-mem3 \
      --title "bwa-mem3 v0.X.Y" \
-     --notes-file <(sed -n '/^## \[0\.X\.Y\]/,/^## /p' NEWS.md | head -n -1)
+     --notes-file <(awk '/^Release / {p = ($0 ~ /^Release 0\.X\.Y /)} p' NEWS.md)
    ```
+
+   Substitute `0.X.Y` with the exact version literal you are tagging,
+   including any pre-release suffix — e.g. for `v0.2.0-pre` use
+   `/^Release 0\.2\.0-pre /`. The trailing space in the inner pattern
+   anchors the match to a complete version token so that `0.2.0` does
+   not also match `Release 0.2.0-pre (...)`. The awk script prints
+   lines while `p` is true: it flips on at the matching `Release` line
+   and back off at the next `Release` line, which gives a clean
+   section without needing a trailing `sed '$d'`.
 
 > **Note — Tarball builds**
 >
@@ -77,6 +194,31 @@ v0.1.0-12-g3f7ab2e
 > so `git describe` fails and the version falls back to `FG_LABS_VERSION_FALLBACK`.
 > For reproducible tarball builds, set `VERSION_STRING` explicitly on the command line:
 > `make VERSION_STRING=v0.X.Y`.
+
+## Post-release verification
+
+After the tag is pushed and the GitHub release is published:
+
+- Wait ~5 minutes for Read the Docs to build the new version, then
+  open `https://bwa-mem3.readthedocs.io/en/v0.X.Y/` and confirm:
+  - The version selector lists `v0.X.Y`.
+  - The home page renders with no missing-page errors.
+  - `developer-guide/launcher.md`, `performance/overview.md`, and
+    `methylation/tags.md` all render with their mermaid diagrams and
+    tables intact (these are the most diagram-heavy pages).
+- Pull the tag in a clean clone and verify `bwa-mem3 version`
+  reports the bare tag string (no `-N-gSHA` distance suffix):
+
+  ```bash
+  git clone -b v0.X.Y --depth 1 https://github.com/fg-labs/bwa-mem3.git
+  cd bwa-mem3 && make
+  ./bwa-mem3 version | head -1
+  # expect: v0.X.Y
+  ```
+
+- If the docs build failed on RTD or the version string is wrong, do
+  not delete or move the tag. Tags are immutable in practice — open a
+  follow-up `v0.X.(Y+1)` patch release with the fix instead.
 
 ## Branch and tag conventions
 

--- a/docs/src/developer-guide/simd-dispatch.md
+++ b/docs/src/developer-guide/simd-dispatch.md
@@ -1,12 +1,21 @@
 # SIMD dispatch architecture
 
-bwa-mem3 uses two complementary mechanisms to select the best available SIMD code path at run time: a **multi-binary launcher** on x86 (handled separately in [Multi-binary launcher](launcher.md)) and **compile-time conditional compilation** inside each kernel, mediated by `src/simd_compat.h`.
+bwa-mem3 uses two complementary mechanisms to run the best available
+SIMD code path at run time: **in-process tier dispatch** on x86
+(handled separately in
+[Single-binary SIMD dispatch (x86)](launcher.md)) and **compile-time
+conditional compilation** inside each kernel translation unit,
+mediated by `src/simd_compat.h` and `src/kernel_dispatch.h`.
 
-This page covers the compile-time layer: what the macros do, which kernels are vectorised at each ISA level, and how the dispatch decision flows.
+This page covers the compile-time layer: what the macros do, which
+kernels are vectorised at each ISA level, and how the dispatch
+decision flows from `main()` to a tier-specific kernel instruction.
 
 ## The `simd_compat.h` abstraction layer
 
-`src/simd_compat.h` is the single point where platform detection and intrinsic selection occur. It is included by every file that touches SIMD code. The header resolves to one of four paths:
+`src/simd_compat.h` is the single point where platform detection and
+intrinsic selection occur. It is included by every file that touches
+SIMD code. The header resolves to one of four paths:
 
 | Platform | Branch condition | Intrinsic headers |
 |---|---|---|
@@ -15,12 +24,17 @@ This page covers the compile-time layer: what the macros do, which kernels are v
 | x86 AVX2 | `__AVX2__` | `<immintrin.h>` |
 | x86 SSE4.1 / SSE2 | `__SSE4_1__` or `__SSE2__` | `<smmintrin.h>` + `<emmintrin.h>` |
 
-The ARM path defines `APPLE_SILICON 1`, sets `SIMD_WIDTH8 = 16` and `SIMD_WIDTH16 = 8` (128-bit NEON lanes), defines a `posix_memalign`-backed `_mm_malloc` replacement that enforces the 128-byte Apple Silicon cache-line alignment, and provides two optimised NEON helpers that sse2neon does not generate efficiently:
+The ARM path defines `APPLE_SILICON 1`, sets `SIMD_WIDTH8 = 16` and
+`SIMD_WIDTH16 = 8` (128-bit NEON lanes), defines a
+`posix_memalign`-backed `_mm_malloc` replacement that enforces the
+128-byte Apple Silicon cache-line alignment, and provides two
+optimised NEON helpers that sse2neon does not generate efficiently:
 
 - `_mm_movemask_epi16` — extracts the MSB of each 16-bit element using `vshrq_n_u16` + `vmovn_u16` + position-weighted `vaddv_u8`, replacing the `_mm_movemask_epi8(v) & 0xAAAA` pattern used in `bandedSWA.cpp`.
 - `_mm_blendv_epi16_fast` — a bitwise select on 16-bit elements via NEON `vbslq_s16`, replacing the OR/AND/ANDNOT sequence sse2neon emits for `_mm_blendv_epi8`.
 
-`SIMD_WIDTH8` and `SIMD_WIDTH16` control the lane counts in `kswv.cpp` and `bandedSWA.cpp`. On x86 they are set by the architecture-specific header rather than here; the macros differ per ISA level:
+`SIMD_WIDTH8` and `SIMD_WIDTH16` control the lane counts in `kswv.cpp`
+and `bandedSWA.cpp`. The macros differ per ISA level:
 
 | ISA | `SIMD_WIDTH8` | `SIMD_WIDTH16` |
 |---|---|---|
@@ -29,69 +43,131 @@ The ARM path defines `APPLE_SILICON 1`, sets `SIMD_WIDTH8 = 16` and `SIMD_WIDTH1
 | AVX-512BW | 64 | 32 |
 | ARM NEON | 16 | 8 |
 
+## Per-tier compilation and symbol mangling
+
+On x86 the four kernel translation units listed in `KERNEL_SRCS`
+(`bandedSWA.cpp`, `kswv.cpp`, `ksw.cpp`, `sam_encode.cpp`) are
+compiled **five times each** — once per supported tier
+(`sse41` / `sse42` / `avx` / `avx2` / `avx512bw`) — with tier-specific
+`-m...` flags. `src/kernel_dispatch.h` is a preprocessor-only header
+that renames each exported kernel symbol per a
+`KERNEL_VARIANT=_<tier>` macro, so the five tier compiles produce
+non-colliding symbols that all link into one binary.
+
+`bandedSWA.h` adds an abstract `IBandedPairWiseSW` interface;
+`BandedPairWiseSW` is `final` and inherits from it. `kswv.h` mirrors
+this with `Ikswv`. Each per-tier kernel TU exports a C-linkage factory
+function (`make_bsw_kernel_<tier>`, `make_kswv_kernel_<tier>`) that
+returns a `std::unique_ptr<I*>` to the tier-specific concrete class.
+The dispatcher in `src/simd_dispatch.cpp` switches on `g_tier` and
+calls the matching factory; the call sites in `bwamem.cpp` and
+`bwamem_pair.cpp` see only the interface. This separation keeps the
+dispatcher TU free of class-layout knowledge and sidesteps the ODR
+risk that would arise from each tier's compile pulling in a
+differently-laid-out concrete class definition.
+
+The free-function `ksw_*` family (`ksw_extend2`, `ksw_global2`,
+`ksw_extend`, `ksw_global`, `ksw_align2`, `ksw_align`) is dispatched
+through thin `extern "C"` wrappers in `simd_dispatch.cpp` that switch
+on `g_tier` and tail-call the matching mangled per-tier symbol.
+Internal aux helpers in `ksw.cpp` (`ksw_qinit`, `ksw_u8`, `ksw_i16`)
+are forced `static` so the five tier compiles do not multi-define
+them. The SAM seq/qual encoder previously inlined in `bwamem.cpp` was
+lifted into `src/sam_encode.{h,cpp}` so it also participates in
+per-tier compilation.
+
+All non-kernel TUs (`bwamem.cpp`, `bwamem_pair.cpp`, `fastmap.cpp`,
+`FMI_search.cpp`, `bntseq.cpp`, …) compile **once** at the
+`BASELINE_ARCH` tier (default `avx2`, set by the `make` line). They
+call into the dispatcher's tier-agnostic entry points, which fan out
+to the per-tier kernels at run time. See
+[Single-binary SIMD dispatch (x86)](launcher.md) for the runtime
+selection and override semantics, and
+[`BASELINE_ARCH=avx512bw` build flag](../whats-different/avx512-baseline.md)
+for why non-kernel TUs do not auto-vectorize at 512-bit by default.
+
+On arm64 there is one NEON tier and one kernel compile per TU; the
+dispatch tables collapse to single-entry switches and the per-tier
+mangling layer is a no-op.
+
 ## Dispatch diagram
 
-The full dispatch decision, from the shell to a kernel instruction, follows this flow:
+The full dispatch decision, from the shell to a kernel instruction,
+follows this flow:
 
 ```mermaid
 flowchart TD
     A[User runs: bwa-mem3 mem ...] --> B{Platform}
 
-    B -- ARM / Apple Silicon --> C[Single binary\nbwa-mem3.arm64]
-    B -- x86 --> D[Launcher: bwa-mem3\nsrc/runsimd.cpp]
+    B -- ARM / Apple Silicon --> C[bwa-mem3 main, single NEON kernel TU]
+    B -- x86 --> D[bwa-mem3 main, calls bwamem3_simd_init in src/simd_dispatch.cpp]
 
-    D --> E{cpuid: best ISA}
-    E -- AVX-512BW --> F1[exec bwa-mem3.avx512bw]
-    E -- AVX2 --> F2[exec bwa-mem3.avx2]
-    E -- AVX --> F3[exec bwa-mem3.avx]
-    E -- SSE4.2 --> F4[exec bwa-mem3.sse42]
-    E -- SSE4.1 --> F5[exec bwa-mem3.sse41]
+    D --> E{__builtin_cpu_supports + BWAMEM3_FORCE_TIER}
+    E -- AVX-512BW --> F1[g_tier = avx512bw]
+    E -- AVX2 --> F2[g_tier = avx2]
+    E -- AVX --> F3[g_tier = avx]
+    E -- SSE4.2 --> F4[g_tier = sse42]
+    E -- SSE4.1 --> F5[g_tier = sse41]
 
-    F1 & F2 & F3 & F4 & F5 --> G[main.cpp\ncompiled with matching ARCH_FLAGS]
+    F1 & F2 & F3 & F4 & F5 --> G[Non-kernel TUs run\nat BASELINE_ARCH tier]
     C --> G
 
     G --> H{Kernel call}
 
-    H -- kswv\nbatched SW --> I[kswv.cpp\nSIMD_WIDTH8/16 from simd_compat.h]
-    H -- bandedSWA\nmate-rescue --> J[bandedSWA.cpp\nblendv / movemask from simd_compat.h]
-    H -- FM-index\nbackward extension --> K[FMI_search.cpp\n__builtin_popcountl — not SIMD]
-    H -- libsais\nBWT construction --> L[libsais.c\nOpenMP parallel SA-IS]
+    H -- kswv\nbatched SW --> I[per-tier kswv.<tier>.o\nvia make_kswv_kernel_<tier>]
+    H -- bandedSWA\nmate-rescue --> J[per-tier bandedSWA.<tier>.o\nvia make_bsw_kernel_<tier>]
+    H -- ksw_align2 etc.\nfree functions --> K[per-tier ksw.<tier>.o\nvia extern-C wrapper in simd_dispatch.cpp]
+    H -- sam_encode --> L[per-tier sam_encode.<tier>.o]
+    H -- FMI_search\nbackward extension --> M[FMI_search.cpp\n__builtin_popcountl — not SIMD]
+    H -- libsais\nBWT construction --> N[libsais.c\nOpenMP parallel SA-IS]
 
-    I --> M[SIMD instructions\nat ISA level of this binary]
-    J --> M
+    I --> O[SIMD instructions\nat the dispatched tier]
+    J --> O
+    K --> O
+    L --> O
 ```
 
 ## Per-kernel vectorisation status
 
-| Kernel | SSE4.1 | AVX2 | AVX-512BW | ARM NEON |
-|---|---|---|---|---|
-| `kswv` (batched Smith-Waterman) | vectorised | vectorised (2x width) | vectorised (4x width) | native NEON |
-| `bandedSWA` (banded SW / mate-rescue) | vectorised | vectorised | vectorised | native NEON blendv |
-| `FMI_search` (FM-index backward ext.) | scalar | scalar | scalar | scalar |
-| `libsais` (BWT / SA construction) | OpenMP only | OpenMP only | OpenMP only | OpenMP only |
-| `bam_writer` (BAM serialisation) | — | — | — | — |
+| Kernel | SSE4.1 | SSE4.2 | AVX | AVX2 | AVX-512BW | ARM NEON |
+|---|---|---|---|---|---|---|
+| `kswv` (batched Smith-Waterman) | 8-wide int16 | 8-wide int16 | 8-wide int16 | 16-wide int16 | 32-wide int16 | 8-wide int16 (native) |
+| `bandedSWA` (banded SW / mate-rescue) | vectorised | vectorised | vectorised | vectorised | vectorised | native NEON blendv |
+| `ksw_*` free functions (SW extension) | per-tier | per-tier | per-tier | per-tier | per-tier | per-tier (NEON) |
+| `sam_encode` (SAM seq/qual encoder) | per-tier | per-tier | per-tier | per-tier | per-tier | per-tier (NEON) |
+| `FMI_search` (FM-index backward ext.) | scalar | scalar | scalar | scalar | scalar | scalar |
+| `libsais` (BWT / SA construction) | OpenMP only | OpenMP only | OpenMP only | OpenMP only | OpenMP only | OpenMP only |
 
-`FMI_search` is memory-bound with sequential pointer-chasing dependencies; adding SIMD to it produces no measurable speedup. `libsais` benefits from OpenMP-parallel induced sorting but not from SIMD widening within a single thread.
+`FMI_search` is memory-bound with sequential pointer-chasing
+dependencies; adding SIMD to it produces no measurable speedup.
+`libsais` benefits from OpenMP-parallel induced sorting but not from
+SIMD widening within a single thread.
 
 ## Adding a new SIMD kernel
 
 1. Include `simd_compat.h` rather than any platform intrinsic header directly.
 2. Use `SIMD_WIDTH8` / `SIMD_WIDTH16` for lane-count arithmetic so the code compiles correctly across all ISA levels.
-3. For ARM-specific optimisations, gate them with `#ifdef APPLE_SILICON` (or `#if defined(__ARM_NEON)`) and provide a `simd_compat.h`-routed fallback for x86.
-4. Verify correctness on at least SSE4.1 (lowest supported x86 level) and ARM64 using `make test`.
+3. If the kernel needs per-tier compilation:
+   - Add the source to `KERNEL_SRCS` in the Makefile so the per-tier pattern rules (`src/%.<tier>.o`) pick it up.
+   - Use the `KERNEL_VARIANT` rename macros from `src/kernel_dispatch.h` to expose mangled symbols.
+   - Export a C-linkage factory or dispatcher entry point from the per-tier TU and add a switch on `g_tier` in `src/simd_dispatch.cpp`.
+4. For ARM-specific optimisations, gate them with `#ifdef APPLE_SILICON` (or `#if defined(__ARM_NEON)`) and provide a `simd_compat.h`-routed fallback for x86.
+5. Verify correctness on at least SSE4.1 (lowest supported x86 tier) and ARM64 using `make test`, then run `test/regression/all_tiers_parity.sh` to confirm byte-identical SAM across every x86 tier under `BWAMEM3_FORCE_TIER`.
 
 > **Tip — Testing SIMD correctness**
 >
 > The kswv unit tests in `test/unit/test_kswv*.cpp` use synthetic sequence-pair generators
 > that drive edge cases (empty batches, nrow==0, homopolymers) across every SIMD width.
 > Run them with `./test/bwa_mem3_tests_unit --test-suite="unit/kswv"` after modifying
-> any vectorised kernel.
+> any vectorised kernel, then loop `BWAMEM3_FORCE_TIER` over all five tiers in an
+> end-to-end smoke run to catch dispatcher-wiring regressions that the unit tests miss.
 
 ---
 
 **See also:**
-[Multi-binary launcher](launcher.md) ·
+[Single-binary SIMD dispatch (x86)](launcher.md) ·
 [Apple Silicon / NEON port](neon-port.md) ·
 [Building from source](building.md) ·
 [Performance → SIMD dispatch matrix](../performance/simd-dispatch.md) ·
+[`BASELINE_ARCH=avx512bw` build flag](../whats-different/avx512-baseline.md) ·
 [Regression test framework](regression-tests.md)

--- a/docs/src/getting-started/host-requirements.md
+++ b/docs/src/getting-started/host-requirements.md
@@ -13,7 +13,7 @@ bwa-mem3 runs on the hosts in the table below. Verify your host with `bwa-mem3 v
 
 ```text
 $ bwa-mem3 version
-bwa-mem3-0.1.0-pre-12-gabcdef1
+v0.1.0-pre-12-gabcdef1
 SIMD floor: avx2 (x86-64-v3, Haswell 2013+); kernels: sse41 sse42 avx avx2 avx512bw
 SIMD runtime: avx512bw (BWAMEM3_FORCE_TIER unset)
 mimalloc 3.x.x

--- a/docs/src/getting-started/quick-align.md
+++ b/docs/src/getting-started/quick-align.md
@@ -74,9 +74,11 @@ bwa-mem3 emits standard SAM tags plus the `HN:i:` tag introduced by the fork:
 | `AS:i` | int | Alignment score |
 | `XS:i` | int | Suboptimal alignment score |
 | `SA:Z` | string | Supplementary alignment chain |
+| `MC:Z` | string | Mate CIGAR (paired-end) |
+| `MQ:i` | int | Mate mapping quality (paired-end) |
 | `HN:i` | int | Total number of primary alignments (reported and suppressed) found for the read, before the `-h` supplementary cap is applied |
 
-For the methylation-specific tags (`YS:Z`, `YC:Z`, `YD:Z`), see
+For the methylation-specific tags (`XR:Z`, `XG:Z`, `XM:Z`), see
 [Methylation Reference — SAM tags](../methylation/tags.md).
 
 ---

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,8 +25,8 @@ support for things you used to need a wrapper script for.
   NEON/AVX2/AVX-512BW, mem_sam_pe proper-pair flag — every fix tracked
   back to the upstream PR or issue that found it.
 - **Architecture-aware out of the box.** SSE4.1, SSE4.2, AVX, AVX2,
-  AVX-512BW, and ARM64/NEON. A multi-binary launcher picks the right
-  one for your CPU.
+  AVX-512BW, and ARM64/NEON. One binary per platform; the dispatcher
+  picks the right tier for your CPU in process at startup.
 
 ## Get started in 30 seconds
 

--- a/docs/src/methylation/bwameth-mapping.md
+++ b/docs/src/methylation/bwameth-mapping.md
@@ -47,9 +47,10 @@ before handing off to the aligner. `bwa-mem3 --meth` performs the C→T / G→A
 conversion in-memory on each read batch before passing it to the alignment
 kernel. No temporary FASTQ is written and no extra pipe stage is needed.
 
-**Inline BAM post-processing.** Header rewriting, `YD:Z:` tagging, chimera QC,
-and QC-fail propagation all happen inside the same process and the same pass
-over the alignments. There is no separate post-processing step. Output is
+**Inline BAM post-processing.** Header rewriting, Bismark `XR:Z` / `XG:Z` /
+`XM:Z` tag emission, opt-in chimera QC (`--chimera-qc`), and QC-fail
+propagation all happen inside the same process and the same pass over the
+alignments. There is no separate post-processing step. Output is
 written as uncompressed BAM (`wb0`) — a near-zero-cost format that downstream
 `samtools sort` reads natively.
 
@@ -66,17 +67,21 @@ intentionally differs — see below):
 | Field | bwameth.py | bwa-mem3 --meth |
 |-------|-----------|-----------------|
 | `@SQ` headers | One per real chromosome | One per real chromosome |
-| `YS:Z:` | Pre-c2t original sequence | Same |
-| `YC:Z:` | Conversion direction (`CT` or `GA`) | Same |
-| `YD:Z:` | Strand (`f` or `r`) | Same |
+| Methylation aux tags | `YS:Z`, `YC:Z`, `YD:Z` (bwameth) | `XR:Z`, `XG:Z`, `XM:Z` (Bismark-compatible) |
 | `@PG` | `ID:bwameth` | `ID:bwa-mem3-meth` |
-| Chimera QC threshold | Longest M < 44% of read | Same (44%) |
+| Chimera QC threshold | Longest M < 44% of read | Same (44%), opt-in via `--chimera-qc` |
 | Chimera QC flags | `0x200`, clear `0x2`, MAPQ ≤ 1 | Same |
 | SEQ field | Pre-c2t bases (RC-flipped when `is_rev`) | Same |
 
-The `@PG ID:` is intentionally different so provenance is unambiguous. All
-downstream tools that rely on `YS:Z:`, `YC:Z:`, `YD:Z:`, and the QC flags
-behave identically.
+The `@PG ID:` is intentionally different so provenance is unambiguous.
+bwa-mem3 `--meth` emits the **Bismark-compatible** `XR:Z` / `XG:Z` /
+`XM:Z` tag set rather than the bwameth-style `YS:Z` / `YC:Z` / `YD:Z`
+set, which means the output is directly consumable by
+`bismark_methylation_extractor`, methylKit, methtuple, DMRfinder, and
+epialleleR in addition to MethylDackel and biscuit. Downstream tools
+that read `YS:Z` / `YC:Z` / `YD:Z` will not find those tags and must be
+pointed at the corresponding `XR:Z` / `XG:Z` (and the per-base `XM:Z`
+methylation call string) instead.
 
 > **Info — End-to-end regression coverage**
 >
@@ -96,6 +101,6 @@ post-processing path only.
 **See also:**
 [Overview](overview.md) ·
 [Conversion details](conversion.md) ·
-[SAM tags: YS, YC, YD](tags.md) ·
+[SAM tags: XR, XG, XM](tags.md) ·
 [Chimera QC and header rewriting](post-processing.md) ·
 [Related Projects: bwameth.py](../related-projects/bwameth.md)

--- a/docs/src/methylation/conversion.md
+++ b/docs/src/methylation/conversion.md
@@ -28,7 +28,8 @@ two projections of each chromosome:
 
 Converted R1 reads are therefore alignable to `f`-prefixed contigs and
 converted R2 reads to `r`-prefixed contigs. The contig prefix records which
-strand hypothesis was used and feeds the `YD:Z:` tag directly.
+strand hypothesis was used and feeds the Bismark `XG:Z` tag directly
+(`CT` for `f`-prefixed / OT, `GA` for `r`-prefixed / OB).
 
 ## Where conversion happens
 
@@ -44,9 +45,13 @@ comment buffer as:
 YS:Z:<l_seq bases>\tYC:Z:<direction>
 ```
 
-where `<direction>` is `CT` for R1 (C→T) and `GA` for R2 (G→A). These fields
-pass through the alignment kernel untouched and are emitted as SAM aux tags in
-the output BAM. See [SAM tags: YS, YC, YD](tags.md) for the per-tag reference.
+where `<direction>` is `CT` for R1 (C→T) and `GA` for R2 (G→A). These
+fields pass through the alignment kernel untouched and serve two
+internal purposes at BAM-write time: `YS:Z` is the source for SEQ
+restoration (see next section), and `YC:Z` is the source for the
+emitted `XR:Z:` Bismark tag. They are **not** emitted to the output
+BAM — `bam_writer.cpp` suppresses them under `--meth`. See
+[SAM tags: XR, XG, XM](tags.md) for the per-tag output reference.
 
 ## Sequence restoration in the BAM SEQ field
 
@@ -54,8 +59,11 @@ Methylation callers such as MethylDackel identify methylated cytosines by
 examining the BAM SEQ field at each CpG site. They need to see real `C`/`T`
 bases — not the uniformly-converted `T`/`A` bases that were used for alignment.
 
-`meth_mem_aln_to_bam` (in `src/meth_bam.cpp`) restores the original sequence
-from `YS:Z:` before writing the BAM record:
+`meth_mem_aln_to_bam` (in `src/meth_bam.cpp`) restores the original
+sequence from the internal `YS:Z` carrier on `bseq1_t.comment` before
+writing the BAM record (the carrier itself is suppressed at BAM emit
+by `bam_writer.cpp` under `--meth`, so it never reaches the output
+file):
 
 1. The `YS:Z:` payload is located at the start of the `bseq1_t.comment` field
    (offset `+5` past the `YS:Z:` header bytes).
@@ -91,7 +99,7 @@ FASTA can be used interchangeably with either tool across tested versions.
 
 **See also:**
 [Overview](overview.md) ·
-[SAM tags: YS, YC, YD](tags.md) ·
+[SAM tags: XR, XG, XM](tags.md) ·
 [Interop with external bwameth.py c2t](external-c2t.md) ·
 [User Guide → Indexing the reference](../user-guide/indexing.md) ·
 [Best Practices → Methylation defaults](../best-practices/methylation.md)

--- a/docs/src/performance/overview.md
+++ b/docs/src/performance/overview.md
@@ -18,6 +18,18 @@ bwa-mem3 inherits the SIMD-vectorized alignment kernels of bwa-mem2 and adds sev
 
 PR [#58](https://github.com/fg-labs/bwa-mem3/pull/58) and the related lockstep SMEM-batching work ([#33](https://github.com/fg-labs/bwa-mem3/pull/33)) reduced per-read overhead in the main mapping loop beyond what upstream bwa-mem2 carries. The batch `-H` ingestion improvement ([#49](https://github.com/fg-labs/bwa-mem3/pull/49)) further reduces header-processing latency for large sample sets.
 
+## Reference numbers across architectures
+
+Wall-time medians from [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench) at SHA `dc7fcfe` (2026-05-13), 5 reps per cell, t≈16, hg38, paired-end 150 bp:
+
+| sample | c6a (AVX2, Zen3) | c7a (AVX-512, Zen4) | c7i (AVX-512, SPR) | c7g (NEON, Graviton3) | c8g (NEON, Graviton4) |
+|---|---:|---:|---:|---:|---:|
+| wgs-5M | 147.70 s | **101.17 s** | 138.33 s | 178.54 s | 151.23 s |
+| wes-5M | 84.37 s | **61.96 s** | 75.08 s | 84.50 s | 70.90 s |
+| panel-twist-5M | 158.49 s | **106.94 s** | 151.78 s | 194.04 s | 163.38 s |
+
+Concordance vs upstream `bwa-mem2 v2.2.1` on these cells: **100.0000%** across 8.1M–10M reads/cell. NEON-vs-x86 cross-architecture concordance on the same builds is also 100.0000%. Spot-pool noise envelope (rep-to-rep CV): ~1% on c6a / c7a / c7g / c8g, ~8–9% on c7i. See the bench repo for the methodology, the full per-rep table, and noisier instance classes excluded from this summary.
+
 ## Benchmarking responsibly
 
 Alignment throughput is sensitive to read length, error rate, reference size, thread count, CPU architecture, NUMA topology, and whether the index is cold (in-kernel page cache) or warm. The [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench) harness controls for these variables by running standardized workloads on defined instance types. If you need numbers for a procurement or publication decision, run the harness against your target hardware.

--- a/docs/src/performance/pgo.md
+++ b/docs/src/performance/pgo.md
@@ -84,9 +84,9 @@ make pgo-use PGO_ARCH=avx512bw PGO_PROFILE_DIR=pgo_profiles_avx512bw
 >
 > Profile data collected on one microarchitecture is not portable to a different one. An AVX2 profile collected on a Haswell CPU will not improve — and may pessimize — an AVX-512BW build run on a Sapphire Rapids CPU. Always collect profiles on the same hardware class where the optimized binary will run.
 
-## PGO and the multi-binary layout
+## PGO and the single-binary multi-tier build
 
-The PGO targets produce a single optimized binary for a single arch target. They do not rebuild the full `make multi` set. If you want PGO-optimized multi-binary dispatch, build and profile each arch variant separately, place them alongside the launcher, and verify with `./bwa-mem3 version`.
+The PGO targets produce one optimized binary for a single `arch=` target. They do not yet rebuild the default `make single` multi-tier binary's per-tier kernel TUs. If you need PGO across more than one host class, build and profile each `arch=` variant separately and deploy whichever matches the target fleet — `bwa-mem3 version` will report the resolved tier so you can confirm. PGO for the in-process multi-tier dispatch path is tracked as a future enhancement.
 
 ## Relationship to LTO
 

--- a/docs/src/performance/simd-dispatch.md
+++ b/docs/src/performance/simd-dispatch.md
@@ -1,87 +1,131 @@
 # SIMD Dispatch Matrix
 
-bwa-mem3 uses a multi-binary dispatch strategy on x86: the `bwa-mem3` launcher reads the CPU's CPUID bits at startup, then `execv`s the highest-capability variant binary found on disk. On ARM there is only one NEON level, so the launcher execs `bwa-mem3.arm64` directly without any cpuid check.
+bwa-mem3 ships **one binary per platform**. The x86 binary contains
+compiled kernels for every supported SIMD tier
+(`sse41` / `sse42` / `avx` / `avx2` / `avx512bw`) and dispatches in
+process at startup. The arm64 binary contains a single NEON kernel
+path. There are no `bwa-mem3.<tier>` companion files on disk and no
+launcher binary.
 
 ## Dispatch flowchart
 
 ```mermaid
 flowchart TD
-    A[bwa-mem3 launcher starts] --> B{Platform?}
-    B -- ARM / aarch64 --> C[exec bwa-mem3.arm64]
-    B -- x86 --> D[read CPUID via __cpuidex]
-    D --> E{AVX-512BW supported?}
-    E -- yes --> F[exec bwa-mem3.avx512bw]
-    E -- no --> G{AVX2 supported?}
-    G -- yes --> H[exec bwa-mem3.avx2]
-    G -- no --> I{AVX supported?}
-    I -- yes --> J[exec bwa-mem3.avx]
-    I -- no --> K{SSE4.2 supported?}
-    K -- yes --> L[exec bwa-mem3.sse42]
-    K -- no --> M{SSE4.1 supported?}
-    M -- yes --> N[exec bwa-mem3.sse41]
-    M -- no --> O[error: no supported variant found]
+    A[bwa-mem3 mem starts] --> B{Platform?}
+    B -- ARM / aarch64 --> C[NEON kernel TU, no dispatch]
+    B -- x86 --> D[bwamem3_simd_init in src/simd_dispatch.cpp]
+    D --> E[__builtin_cpu_supports]
+    E --> F{Host capability?}
+    F -- AVX-512BW --> G1[g_tier = avx512bw]
+    F -- AVX2 --> G2[g_tier = avx2]
+    F -- AVX --> G3[g_tier = avx]
+    F -- SSE4.2 --> G4[g_tier = sse42]
+    F -- SSE4.1 --> G5[g_tier = sse41]
+    F -- below build floor --> H[exit(2): host below SIMD floor]
+    G1 & G2 & G3 & G4 & G5 --> I[Per-kernel factory selects matching tier]
 ```
 
-The launcher reads CPUID leaf 1 (for SSE flags) and leaf 7 (for AVX2 and AVX-512 flags). It checks in descending capability order and stops at the first variant binary it finds on disk. If no variant binary is executable, it exits with an error.
+Tier detection runs once during `main()`. Subsequent kernel calls pay
+a single indirect-call hop through a factory vtable (or an
+`extern "C"` wrapper for free-function `ksw_*` kernels) — about
+0.3 ns per call after BTB warm-up, well below run-to-run noise on the
+[bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench) corpus.
 
-The ARM path always tries `bwa-mem3.arm64` first, then falls back to the bare `bwa-mem3` name (which on ARM is a symlink to `bwa-mem3.arm64` created by `make arm64`).
+If the host CPU does not meet the build's compile-time SIMD floor
+(`BASELINE_ARCH`, default `avx2` since PR #84), the binary exits with
+code 2 and an `[E::bwamem3]` message naming the gap before any
+alignment work runs. `bwa-mem3 version`, `--help`, and `-h` are
+exempt and always succeed so operators can introspect a binary on a
+host that cannot run alignment. See
+[Host requirements](../getting-started/host-requirements.md).
 
-## Building the variant binaries
-
-`make multi` builds all five x86 variants and the launcher in sequence:
+## Building
 
 ```bash
-make multi
+make                              # single multi-tier x86 binary, BASELINE_ARCH=avx2
+make BASELINE_ARCH=sse41          # lower host SIMD floor / maximize portability (~10–15% slower on AVX2 hosts)
+make BASELINE_ARCH=avx512bw       # AVX-512BW-only fleet (locks the host floor)
+make arm64                        # single NEON binary, no dispatch table
 ```
 
-This produces:
+`BASELINE_ARCH` controls the tier at which non-kernel translation
+units compile. The hand-tuned kernel TUs in `KERNEL_SRCS`
+(`bandedSWA`, `kswv`, `ksw`, `sam_encode`) are always compiled at
+every supported tier and dispatched at runtime, so a build at
+`BASELINE_ARCH=avx2` still uses the AVX-512BW kernels on AVX-512BW
+hosts. The non-kernel TUs are not auto-vectorized above
+`BASELINE_ARCH`, which is the trade-off — see
+[`BASELINE_ARCH=avx512bw` build flag](../whats-different/avx512-baseline.md)
+for the empirical perf characterization.
 
-| Filename | Arch flags | Minimum CPU |
+Supported x86 tiers (minimum CPU for each tier's kernel path):
+
+| Tier | Arch flags | Minimum CPU |
 |---|---|---|
-| `bwa-mem3.sse41` | `-msse4.1` | Penryn (2007) / K10 (2011) |
-| `bwa-mem3.sse42` | `-msse4.2` | Nehalem (2008) / Bulldozer (2011) |
-| `bwa-mem3.avx` | `-mavx` | Sandy Bridge (2011) / Bulldozer (2011) |
-| `bwa-mem3.avx2` | `-mavx2` | Haswell (2013) / Excavator (2015) |
-| `bwa-mem3.avx512bw` | `-mavx512f -mavx512bw` | Skylake-X (2017) / Zen 4 (2022) |
+| `sse41` | `-msse4.1` | Penryn (2007) / K10 (2011) |
+| `sse42` | `-msse4.2` | Nehalem (2008) / Bulldozer (2011) |
+| `avx` | `-mavx` | Sandy Bridge (2011) / Bulldozer (2011) |
+| `avx2` | `-mavx2` | Haswell (2013) / Excavator (2015) |
+| `avx512bw` | `-mavx512f -mavx512bw -mprefer-vector-width=256` | Skylake-X (2017) / Zen 4 (2022) |
 
-For ARM builds, `make arm64` produces a single binary and creates the symlink:
+For arm64 builds:
 
-| Filename | Arch flags | Platform |
+| Binary | Arch flags | Platform |
 |---|---|---|
-| `bwa-mem3.arm64` | `-DAPPLE_SILICON=1` + sse2neon shim | Any aarch64 / Apple Silicon |
-
-To build a single-arch binary for a known target (e.g. for a cluster with uniform hardware):
-
-```bash
-make arch=avx2
-```
-
-The resulting binary is named `bwa-mem3` and contains only AVX2 code. The launcher is not built; it is not needed when the target ISA is fixed.
+| `bwa-mem3` (arm64) | `-DAPPLE_SILICON=1` + native NEON / sse2neon shim | Any aarch64 / Apple Silicon |
 
 ## Kernel vectorization coverage
 
-The table below lists the kernels that have SIMD implementations and which ISA levels they cover.
-
 | Kernel | SSE4.1 | SSE4.2 | AVX | AVX2 | AVX-512BW | NEON (arm64) |
 |---|---|---|---|---|---|---|
-| kswv (vectorized Smith-Waterman) | 8-wide int16 | 8-wide int16 | 8-wide int16 | 16-wide int16 | 32-wide int16 | 8-wide int16 (native) |
-| bandedSWA (banded alignment) | SSE2 baseline | SSE2 baseline | SSE2 baseline | SSE2 baseline | SSE2 baseline | native NEON blendv |
-| FM-index lookup (FMI_search) | SSE popcount | SSE popcount | SSE popcount | SSE popcount | SSE popcount | __builtin_popcountl |
+| `kswv` (vectorized Smith-Waterman) | 8-wide int16 | 8-wide int16 | 8-wide int16 | 16-wide int16 | 32-wide int16 | 8-wide int16 (native) |
+| `bandedSWA` (banded alignment / mate-rescue) | vectorized | vectorized | vectorized | vectorized | vectorized | native NEON blendv |
+| `ksw_*` (SW extension free functions) | per-tier | per-tier | per-tier | per-tier | per-tier | per-tier (NEON) |
+| `sam_encode` (SAM seq/qual encoder) | per-tier | per-tier | per-tier | per-tier | per-tier | per-tier (NEON) |
+| FM-index lookup (`FMI_search`) | scalar popcount | scalar popcount | scalar popcount | scalar popcount | scalar popcount | `__builtin_popcountl` |
 | libsais BWT construction | scalar | scalar | scalar | OpenMP parallel | OpenMP parallel | OpenMP parallel |
 
 > **Note — FM-index is memory-bound**
 >
-> The FM-index backward-extension loop is limited by pointer-chasing through the `cp_occ` arrays, not by computation. Additional SIMD width does not increase throughput here. See the Apple Silicon optimization log in [Developer Guide — Apple Silicon / NEON port](../developer-guide/neon-port.md) for the profiling evidence.
+> The FM-index backward-extension loop is limited by pointer-chasing through the `cp_occ` arrays, not by computation. Additional SIMD width does not increase throughput here. See [Developer Guide — Apple Silicon / NEON port](../developer-guide/neon-port.md) for the profiling evidence.
 
-## Why the launcher uses execv, not a function pointer
+## Runtime overrides
 
-The multi-binary design was inherited from bwa-mem2. Separate compilation units mean the compiler can use the target ISA's full instruction set throughout — not just in hand-vectorized loops but also in auto-vectorized loops, register allocation, and branch heuristics. A single-binary dispatcher that calls ISA-specific function pointers achieves the same for hand-written kernels but leaves the compiler's auto-vectorization gated at the baseline ISA. For a workload with this many scalar loops, the execv approach yields a measurable difference. For the ARM path, all CPUs have the same NEON level so the single-binary approach is fine.
+Two environment variables tune dispatch:
+
+| Variable | Effect |
+|---|---|
+| `BWAMEM3_FORCE_TIER=<tier>` | Forces a specific tier (`sse41` / `sse42` / `avx` / `avx2` / `avx512bw`). Downgrade-only: requests above the host's detected tier (which would SIGILL) and unknown names are rejected with a stderr warning. Used by `test/regression/all_tiers_parity.sh` to confirm byte-identical SAM across all tiers on AVX-512 hosts. |
+| `BWAMEM3_DEBUG_SIMD=1` | Prints a one-line `[I::bwamem3_simd_init_body]` startup banner with the build baseline, the detected host capability, and the resolved tier. Also enables the build-baseline-vs-host gap warning. |
+
+Use `bwa-mem3 version` to read the resolved tier without alignment:
+
+```text
+bwa-mem3 0.1.0-pre
+SIMD floor:   avx2 (x86-64-v3, Haswell 2013+); kernels: sse41 sse42 avx avx2 avx512bw
+SIMD runtime: avx512bw (BWAMEM3_FORCE_TIER unset)
+```
+
+## Why in-process dispatch, not separate binaries
+
+The pre-PR-#83 design shipped six binaries (one launcher plus one
+per ISA tier) and `execv`d the matching tier at startup. That worked
+but cost ~120 MB on disk, required all six binaries to be present in
+the same directory, and made `BWAMEM3_FORCE_TIER` impossible without
+re-exec'ing a different file. The current single-binary design keeps
+the per-tier compile granularity for the hand-tuned kernel TUs while
+collapsing distribution to one file (~25 MB), and adds runtime tier
+override and a clean host-floor precheck. Indirect-call overhead is
+the only trade-off, and it is below the measurement noise floor on
+every architecture in the bench matrix.
 
 ---
 
 **See also:**
 [Performance overview](overview.md) ·
 [PGO build](pgo.md) ·
+[Host requirements](../getting-started/host-requirements.md) ·
 [Developer Guide — SIMD dispatch architecture](../developer-guide/simd-dispatch.md) ·
-[Developer Guide — Multi-binary launcher (x86)](../developer-guide/launcher.md) ·
-[Developer Guide — Apple Silicon / NEON port](../developer-guide/neon-port.md)
+[Developer Guide — Single-binary SIMD dispatch (x86)](../developer-guide/launcher.md) ·
+[Developer Guide — Apple Silicon / NEON port](../developer-guide/neon-port.md) ·
+[`BASELINE_ARCH=avx512bw` build flag](../whats-different/avx512-baseline.md)

--- a/docs/src/performance/tuning.md
+++ b/docs/src/performance/tuning.md
@@ -2,36 +2,35 @@
 
 The items below are ordered by expected impact for most workloads. Work through them in sequence; there is little point optimizing output format before confirming you are running the right binary for your CPU.
 
-## 1. Run the right binary for your CPU
+## 1. Confirm the resolved SIMD tier matches your CPU
 
-If you built with `make multi` (recommended for production x86 deployments), the `bwa-mem3` launcher reads CPUID at startup and execs the highest-capability variant automatically. Verify which variant is running by checking the banner printed to stderr at the start of a `mem` run:
-
-```text
------------------------------
-Executing in AVX512 mode!!
------------------------------
-```
-
-If the banner says SSE4.1 on a machine you believe supports AVX2, the variant binary may be missing from the directory. Confirm with:
+The default `make` produces a single binary that contains every supported
+x86 SIMD tier and selects one in process at startup. Verify which tier
+is running:
 
 ```bash
-ls -1 bwa-mem3.sse41 bwa-mem3.sse42 bwa-mem3.avx bwa-mem3.avx2 bwa-mem3.avx512bw 2>&1
+bwa-mem3 version
+# expect: SIMD floor: <build_floor>; SIMD runtime: <resolved_tier>
 ```
 
-If files are missing, rebuild with `make multi`.
+If the runtime tier is below what your CPU supports, double-check
+whether you accidentally built with a lower `BASELINE_ARCH=` or set
+`BWAMEM3_FORCE_TIER` in the environment. Set `BWAMEM3_DEBUG_SIMD=1` to
+get a startup banner on stderr at the start of a `mem` run.
 
-For ARM / Apple Silicon, there is only one binary level. Confirm it is in use:
+On ARM / Apple Silicon, the binary has one NEON tier; `bwa-mem3 version`
+reports `SIMD runtime: neon`.
 
-```bash
-ls -la bwa-mem3
-# expect: bwa-mem3 -> bwa-mem3.arm64
-```
-
-See [SIMD dispatch matrix](simd-dispatch.md) for the full dispatch logic and the minimum CPU requirements for each variant.
+See [SIMD dispatch matrix](simd-dispatch.md) for the full dispatch
+logic and the minimum CPU requirements for each tier.
 
 > **Tip — Single-arch deployments**
 >
-> On a cluster where all nodes have the same CPU, build with `make arch=avx2` (or the appropriate ISA). The launcher overhead is negligible but removing it simplifies the deployment: only one binary to distribute and no variant-lookup failures.
+> On a cluster where every node has the same CPU, build with
+> `make arch=avx2` (or the appropriate ISA). The runtime dispatch
+> overhead is negligible, but a single-arch build trims the binary
+> and removes any chance of `BWAMEM3_FORCE_TIER` accidentally
+> downgrading throughput in production.
 
 ## 2. Build with PGO if you will run repeatedly
 
@@ -99,7 +98,7 @@ On a 16-core machine, allocating 12 threads to `mem` and 8 to `samtools sort` (w
 
 | Item | Action | Reference |
 |---|---|---|
-| Right binary for CPU | `make multi`; verify banner | [SIMD dispatch matrix](simd-dispatch.md) |
+| Right SIMD tier for CPU | `bwa-mem3 version`; verify `SIMD runtime:` | [SIMD dispatch matrix](simd-dispatch.md) |
 | PGO for production | `pgo-generate` → train → `pgo-use` | [PGO build](pgo.md) |
 | Shared-memory index | `bwa-mem3 shm ref.fa` before batch runs | [Quick start: shm](../getting-started/quick-shm.md) |
 | Emit uncompressed BAM | `--bam=0` | [Best Practices — Output format](../best-practices/output-format.md) |

--- a/docs/src/reference/glossary.md
+++ b/docs/src/reference/glossary.md
@@ -52,8 +52,8 @@ A step in paired-end alignment where, if one mate lacks a confident seed, bwa-me
 **mimalloc**
 A high-performance memory allocator from Microsoft. bwa-mem3 vendors mimalloc and links it into every binary by default. To disable, build with `USE_MIMALLOC=0`. See [Memory allocator (mimalloc)](../user-guide/allocator.md).
 
-**Multi-binary launcher**
-On x86, bwa-mem3 ships a thin launcher binary that detects CPUID features at runtime and execs the appropriate arch-specialized binary (`bwa-mem3.sse41`, `.avx2`, `.avx512bw`, etc.). On ARM64 a single `bwa-mem3.arm64` binary is built. See [Multi-binary launcher (x86)](../developer-guide/launcher.md).
+**Single-binary SIMD dispatch**
+On x86, bwa-mem3 ships one binary that contains compiled kernels for every supported SIMD tier (`sse41` / `sse42` / `avx` / `avx2` / `avx512bw`) and selects one in process at startup via `__builtin_cpu_supports`. There are no per-tier companion binaries. On ARM64 the binary contains a single NEON kernel TU. Replaces the prior multi-binary `execv` launcher (PR #83). See [Single-binary SIMD dispatch (x86)](../developer-guide/launcher.md).
 
 **PGO**
 Profile-Guided Optimization — a two-pass build where the first pass instruments the binary, a representative workload is run to collect profiles, and the second pass uses those profiles to guide inlining and branch layout. Activated via `make pgo-generate` then `make pgo-use`. See [PGO build](../performance/pgo.md).
@@ -68,7 +68,7 @@ SAM flag bit indicating that both mates of a pair are mapped in the expected ori
 Sequence Alignment Map — a tab-delimited text format for read alignments. Each record contains mandatory fields (QNAME, FLAG, RNAME, POS, MAPQ, CIGAR, RNEXT, PNEXT, TLEN, SEQ, QUAL) plus optional tags. See [Output: SAM/BAM, headers, tags](../user-guide/output.md).
 
 **SIMD dispatch**
-Runtime selection of the fastest available SIMD instruction set (SSE4.1, AVX2, AVX-512BW, NEON) for hot alignment kernels. On x86 this is implemented by the multi-binary launcher; on ARM64 a single binary covers NEON. See [SIMD dispatch matrix](../performance/simd-dispatch.md).
+Runtime selection of the fastest available SIMD instruction set (SSE4.1, SSE4.2, AVX, AVX2, AVX-512BW, NEON) for hot alignment kernels. On x86 this is implemented in process by `src/simd_dispatch.cpp` via `__builtin_cpu_supports`; on ARM64 a single NEON tier covers every supported CPU. See [SIMD dispatch matrix](../performance/simd-dispatch.md).
 
 **SMEM**
 Super-Maximal Exact Match — a seed found by extending a read's position in the FM-index as far as possible in both directions. SMEMs form the initial seeds for chaining and extension in the BWA-MEM algorithm. See [Performance improvements](../whats-different/performance.md).

--- a/docs/src/user-guide/indexing.md
+++ b/docs/src/user-guide/indexing.md
@@ -90,9 +90,10 @@ numbers.
 
 ## Arch flags and the index format
 
-The FM-index format is architecture-independent. A single index can be used
-with any bwa-mem3 binary — `bwa-mem3.avx2`, `bwa-mem3.avx512bw`, and the ARM
-single-binary all read the same on-disk layout.
+The FM-index format is architecture-independent. A single index works
+across every SIMD tier and every supported platform: the x86 binary's
+AVX2 / AVX-512BW dispatch paths and the arm64 NEON binary all read the
+same on-disk layout.
 
 ---
 

--- a/docs/src/user-guide/output.md
+++ b/docs/src/user-guide/output.md
@@ -66,8 +66,20 @@ convention of separate-tool pipelines.
 ### Standard tags
 
 bwa-mem3 emits the same standard tags as bwa-mem2 (`NM:i`, `MD:Z`, `AS:i`,
-`XS:i`, `SA:Z`, `RG:Z`, `XA:Z`, etc.). These are documented in the SAM
-specification and are not described further here.
+`XS:i`, `SA:Z`, `RG:Z`, `XA:Z`, `MC:Z`, etc.). These are documented in the
+SAM specification and are not described further here.
+
+bwa-mem3 additionally emits `MQ:i` on paired-end records — the mate's
+mapping quality, set alongside `MC:Z` (the mate's CIGAR) so callers that
+key off the mate's MAPQ don't need to look at the mate record. Both SAM
+and `--bam` output paths emit it. Backported from `lh3/bwa` PR #330 in
+fg-labs PR #35.
+
+The `XA:Z` field set widens from `chr,pos,CIGAR,NM` to
+`chr,pos,CIGAR,NM,score,mapq` when `-u` (a.k.a. the upstream "XB" toggle)
+is passed; the tag name itself remains `XA:Z` for downstream
+compatibility. Tools that parse `XA:Z` need to be aware of the two
+possible field widths.
 
 ### `HN:i` — total alignment hit count
 
@@ -84,14 +96,22 @@ relying solely on MAPQ.
 
 ### Methylation-only tags
 
-The following tags are emitted only when `--meth` is active. See
-[SAM tags: YS, YC, YD](../methylation/tags.md) for the full per-tag reference.
+The following Bismark-compatible tags are emitted only when `--meth` is
+active. See [SAM tags: XR, XG, XM](../methylation/tags.md) for the full
+per-tag reference, including the `XM:Z` character alphabet and the
+`XG:Z` strand-pick semantics.
 
 | Tag | Type | Description |
 |-----|------|-------------|
-| `YS:Z` | string | Original (pre-c2t) read sequence |
-| `YC:Z` | string | Conversion direction: `CT` (R1, C→T) or `GA` (R2, G→A) |
-| `YD:Z` | string | Methylation strand: `f` (forward) or `r` (reverse) |
+| `XR:Z` | string | Read conversion direction: `CT` (R1 / SE) or `GA` (R2) |
+| `XG:Z` | string | Genome strand of the alignment: `CT` (OT) or `GA` (OB) |
+| `XM:Z` | string | Per-base methylation call string (length = `SEQ`) |
+
+The bwameth-style `YS:Z` / `YC:Z` tags exist only as an internal carrier
+on `bseq1_t.comment` for SEQ restoration and `XR:Z` derivation; they
+are suppressed at BAM emit and never appear in output. The bwameth
+`YD:Z` strand tag has been replaced by Bismark `XG:Z` and is not
+emitted.
 
 ## MAPQ semantics
 

--- a/docs/src/user-guide/tips.md
+++ b/docs/src/user-guide/tips.md
@@ -7,9 +7,10 @@ full rationale.
 ## Index once, align many times
 
 Build the FM-index once per reference version. The on-disk index format is
-stable across bwa-mem3 releases and architecture variants — `bwa-mem3.avx2`
-and `bwa-mem3.avx512bw` read the same files. You do not need to re-index when
-upgrading bwa-mem3 unless the release notes say otherwise.
+stable across bwa-mem3 releases and across every SIMD tier inside the
+single binary — the AVX2 and AVX-512BW kernel paths read the same files.
+You do not need to re-index when upgrading bwa-mem3 unless the release
+notes say otherwise.
 
 ```sh
 # Build once
@@ -78,20 +79,24 @@ wait
 See [Threading and resource use](threading.md) for per-machine thread count
 recommendations.
 
-## Use the right binary for your CPU
+## Confirm the binary's SIMD tier matches your CPU
 
-bwa-mem3 ships separate binaries per SIMD level. Using the highest level
-supported by your CPU gives the best performance:
+bwa-mem3 ships **one binary per platform** that contains every supported
+x86 SIMD tier (or the single NEON path on arm64) and picks the right
+tier in process at startup. There are no per-tier companion binaries to
+copy or call directly.
 
-| CPU generation | Recommended binary |
-|---------------|-------------------|
-| Modern Intel/AMD (2018+) | `bwa-mem3.avx512bw` or `bwa-mem3.avx2` |
-| Older x86 | `bwa-mem3.sse42` or `bwa-mem3.sse41` |
-| Apple Silicon / AWS Graviton | `bwa-mem3` (single ARM binary) |
+| CPU generation | Resolved tier |
+|---------------|---------------|
+| Modern Intel/AMD (2018+) | `avx512bw` or `avx2` |
+| Older x86 | `sse42` or `sse41` |
+| Apple Silicon / AWS Graviton | `neon` |
 
-When you run `bwa-mem3` (the launcher), it detects your CPU and execs the
-appropriate variant automatically. If you copy only a single SIMD binary,
-call it directly.
+Verify the resolved tier with `bwa-mem3 version` (prints `SIMD floor:` and
+`SIMD runtime:` lines on stdout) or set `BWAMEM3_DEBUG_SIMD=1` to get a
+startup banner from `bwa-mem3 mem`. If you need to force a lower tier
+for A/B regression testing, set `BWAMEM3_FORCE_TIER=<tier>` — upgrade
+requests above the host's capability are rejected.
 
 See [Performance: SIMD dispatch matrix](../performance/simd-dispatch.md).
 

--- a/docs/src/whats-different/arch-support.md
+++ b/docs/src/whats-different/arch-support.md
@@ -24,26 +24,38 @@ that matches both names. All four architecture-conditional blocks in the
 Makefile are rewritten to use `IS_ARM`: the NEON/sse2neon flag block, the x86
 arch-specific block, the ARM64 single-binary build block, and the `multi`
 target ARM64 short-circuit. The CI workflow is extended to trigger on pushes
-to `fg-main` (the integration branch) and adds an `ubuntu-24.04-arm` matrix
-row so the aarch64 path is exercised on every PR.
+to `fg-main` (the integration branch at the time of PR #1, renamed to `main`
+in the 0.1.0-pre release) and adds an `ubuntu-24.04-arm` matrix row so the
+aarch64 path is exercised on every PR.
 
 ## `arch=avx512bw` explicit build target (PR #16)
 
 The AVX-512 Smith-Waterman kernels in bwa-mem2 are guarded by the
-`__AVX512BW__` preprocessor macro — not `__AVX512F__`. The only way to build
-them before this PR was `arch=avx512`, but `make multi` emitted the dispatch
-binary as `bwa-mem2.avx512bw`. The build selector (`avx512`), the preprocessor
-guard (`__AVX512BW__`), and the dispatcher suffix (`.avx512bw`) disagreed.
+`__AVX512BW__` preprocessor macro — not `__AVX512F__`. The only way to
+build them before this PR was `arch=avx512`, but the (then) `make multi`
+rule emitted the dispatch binary as `bwa-mem2.avx512bw`. The build
+selector (`avx512`), the preprocessor guard (`__AVX512BW__`), and the
+dispatcher suffix (`.avx512bw`) disagreed.
 
-PR #16 adds `arch=avx512bw` as an explicit Makefile target with flags
-`-mavx512f -mavx512bw` and switches `make multi` to invoke `arch=avx512bw`
-when emitting `bwa-mem3.avx512bw`. The legacy `arch=avx512` is preserved as
-an alias with identical flags. No C++ is changed; the fix is 11 insertions and
-2 deletions in the Makefile.
+PR #16 added `arch=avx512bw` as an explicit Makefile target with flags
+`-mavx512f -mavx512bw` and switched the multi-binary `make` path to use
+it. The legacy `arch=avx512` was preserved as an alias with identical
+flags. No C++ was changed; the fix was 11 insertions and 2 deletions in
+the Makefile.
 
-This is a pure build-correctness fix: before PR #16, `arch=avx512bw` and
-`arch=multi` builds on AVX-512BW hardware silently compiled the wrong kernel
-(see [Correctness → AVX-512BW dispatch guard](correctness.md) for the
+PR #83 has since replaced the multi-binary scheme with a single binary
+that compiles each kernel TU at every supported tier and dispatches
+in process; the `avx512bw` tier name and flag set survived the
+transition unchanged, and the `arch=avx512bw` build target remains the
+single-arch fallback for clusters with uniform AVX-512BW hardware. The
+pre-#16 mismatch between selector, guard, and suffix is therefore
+resolved in both the historical multi-binary layout and the current
+single-binary layout.
+
+This is a pure build-correctness fix: before PR #16, `arch=avx512bw`
+and the legacy multi-binary build on AVX-512BW hardware silently
+compiled the wrong kernel (see
+[Correctness → AVX-512BW dispatch guard](correctness.md) for the
 downstream effect).
 
 ## NEON kswv mate-rescue (PR #18)

--- a/docs/src/whats-different/build-infra.md
+++ b/docs/src/whats-different/build-infra.md
@@ -71,12 +71,16 @@ per-arch × per-regime profile capture. See also
 
 ## `CXXFLAGS`/`CPPFLAGS`/`LDFLAGS` forwarding (PR #50)
 
-The Makefile's `multi:` rule compiled `runsimd.cpp` (the x86 multi-binary
-launcher) without honoring `CXXFLAGS`, `CPPFLAGS`, or `LDFLAGS`. The `$(EXE)`
-link honored `CXXFLAGS` and `LDFLAGS` but not `CPPFLAGS`.
+At the time of PR #50, the Makefile's `multi:` rule compiled
+`runsimd.cpp` (the x86 multi-binary launcher) without honoring
+`CXXFLAGS`, `CPPFLAGS`, or `LDFLAGS`. The `$(EXE)` link honored
+`CXXFLAGS` and `LDFLAGS` but not `CPPFLAGS`. PR #83 has since replaced
+the multi-binary scheme with a single binary that builds via the
+`single:` target (the default), and that target inherits the same
+flag-forwarding behavior.
 
-PR #50 mirrors upstream [bwa-mem2#290](https://github.com/bwa-mem2/bwa-mem2/pull/290):
-the `multi:` compile now honors all three variables, and `$(EXE)` link adds
+PR #50 mirrored upstream [bwa-mem2#290](https://github.com/bwa-mem2/bwa-mem2/pull/290):
+the compile rules now honor all three variables, and `$(EXE)` link adds
 `$(CPPFLAGS)`. This allows downstream packagers (Debian, Bioconda) and
 reproducible-build systems to inject hardening flags (`-D_FORTIFY_SOURCE=2`,
 `-fstack-protector-strong`, `-Wl,-z,relro`) through the environment without

--- a/docs/src/whats-different/features.md
+++ b/docs/src/whats-different/features.md
@@ -23,11 +23,16 @@ bwa-mem3 mem --meth ref.fa R1.fq R2.fq | samtools sort -o out.bam
 index that `bwameth.py index-mem2` produces.
 
 `mem --meth` performs inline C→T conversion of R1 and G→A conversion of R2
-before seeding, stashes the original bases in `YS:Z:`, records the conversion
-direction in `YC:Z:`, consolidates the `f`/`r` contig pairs back to one `@SQ`
-per real chromosome, applies a chimera QC heuristic (longest M/=/X run < 44%
-of read length → set `0x200`, clear proper-pair `0x2`, cap MAPQ at 1), copies
-`YS:Z:` back into the SEQ field for CpG-calling tools, and writes a `@PG
+before seeding (stashing the pre-conversion bases on an internal
+`YS:Z` / `YC:Z` carrier in `bseq1_t.comment`; both are suppressed at
+BAM emit), consolidates the `f`/`r` contig pairs back to one `@SQ`
+per real chromosome, emits Bismark-compatible `XR:Z` (read conversion
+direction), `XG:Z` (genome strand), and `XM:Z` (per-base methylation
+call string) auxiliary tags on every record, optionally applies a
+chimera QC heuristic (longest M/=/X run < 44% of read length → set
+`0x200`, clear proper-pair `0x2`, cap MAPQ at 1) when `--chimera-qc`
+is passed, copies the internal pre-conversion sequence back into the
+BAM SEQ field for CpG-calling tools, and writes a `@PG
 ID:bwa-mem3-meth` entry.
 
 On the bwameth.py example fixture (92,684 reads), end-to-end output is

--- a/docs/src/whats-different/overview.md
+++ b/docs/src/whats-different/overview.md
@@ -32,11 +32,99 @@ Each deep-dive page covers one category of change:
 ## Carried on top of upstream
 
 <!-- FG-MAIN-TABLE:start -->
-| Commit    | Topic                                                           | Upstream status |
-|-----------|-----------------------------------------------------------------|-----------------|
-| `ae73227` | Apple Silicon / ARM64 NEON support (PR #288 work)               | [PR #288][pr288] open |
-| `744a9e7` | `ci`: cross-platform build + dwgsim phiX end-to-end test        | fork-only       |
-| `490502b` | `fix`: drop unused global `stat` that shadows libc              | fork-only       |
+
+Auto-generated from `git log --reverse --no-merges master..main` and the conventional-commits scope on each PR-merge title; do not edit by hand. For per-PR upstream disposition (bwa-mem2 PR / issue refs and status), see [Upstream PR status](upstream-prs.md).
+
+| Commit    | Topic                                                                                                      | PR |
+|-----------|------------------------------------------------------------------------------------------------------------|----|
+| `ae73227` | Add Apple Silicon (ARM64/NEON) support with native optimizations | — |
+| `744a9e7` | feat: add CI workflow with cross-platform build and end-to-end test | — |
+| `490502b` | fix: drop unused global `stat` that shadows libc | — |
+| `9364cfc` | ci: pin GitHub Actions to full-length commit SHAs | [#4](https://github.com/fg-labs/bwa-mem3/pull/4) |
+| `b6eaba1` | chore: configure CodeRabbit to review PRs against fg-main | [#2](https://github.com/fg-labs/bwa-mem3/pull/2) |
+| `db5086a` | docs: add FG-MAIN.md documenting the fork's relationship to upstream | [#3](https://github.com/fg-labs/bwa-mem3/pull/3) |
+| `5132582` | feat(arm64): make Linux aarch64 build + CI-test on every fg-main push | [#1](https://github.com/fg-labs/bwa-mem3/pull/1) |
+| `96016a5` | ci: pin dwgsim seed (-z 42) to stop parity-test flakiness | [#10](https://github.com/fg-labs/bwa-mem3/pull/10) |
+| `246b528` | fix(hdr): align bwamem.h declarations with bwamem.cpp definitions | [#5](https://github.com/fg-labs/bwa-mem3/pull/5) |
+| `b27f374` | feat(hdr): export mem_infer_dir for external consumers | [#6](https://github.com/fg-labs/bwa-mem3/pull/6) |
+| `62700b1` | chore: move profiling globals out of main.cpp | [#7](https://github.com/fg-labs/bwa-mem3/pull/7) |
+| `6b76c7b` | feat: expose worker_alloc/worker_free, the core worker_t pre-allocation helpers | [#8](https://github.com/fg-labs/bwa-mem3/pull/8) |
+| `e80765b` | feat: split mem_sam_pe into mem_pair_resolve + thin emission wrapper | [#9](https://github.com/fg-labs/bwa-mem3/pull/9) |
+| `84defc3` | feat: --bam[=LEVEL] output flag for direct BAM emission | [#12](https://github.com/fg-labs/bwa-mem3/pull/12) |
+| `73907d7` | feat: vendor mimalloc v3.3.0 and link by default | [#19](https://github.com/fg-labs/bwa-mem3/pull/19) |
+| `7641ebf` | feat(meth): --meth + `index --meth` — bwameth.py-equivalent bisulfite mode | [#13](https://github.com/fg-labs/bwa-mem3/pull/13) |
+| `0165b6c` | fix: zero bseq1_t in kseq2bseq1 so realloc'd entries don't carry garbage | [#22](https://github.com/fg-labs/bwa-mem3/pull/22) |
+| `e7cb763` | [proto] NEON kswv mate-rescue — correctness + perf harness | [#18](https://github.com/fg-labs/bwa-mem3/pull/18) |
+| `a5aab04` | test(ci): add unit-test harness, fixtures, and ARM build support | [#23](https://github.com/fg-labs/bwa-mem3/pull/23) |
+| `2fddafd` | [proto] AVX2 kswv mate-rescue — stacked on PR 18 | [#20](https://github.com/fg-labs/bwa-mem3/pull/20) |
+| `8944028` | fix: compute no_pairing 0x2 flag from the emitted alignment | [#17](https://github.com/fg-labs/bwa-mem3/pull/17) |
+| `2fd0e96` | fix(kswv): apply NEON score2-scan fixes to AVX-512BW kernel | [#21](https://github.com/fg-labs/bwa-mem3/pull/21) |
+| `68adecd` | ci: expand workflow matrix + add canonical deep-test row | [#24](https://github.com/fg-labs/bwa-mem3/pull/24) |
+| `690914f` | build(make): add explicit arch=avx512bw target | [#16](https://github.com/fg-labs/bwa-mem3/pull/16) |
+| `0bb9402` | fix(kswv): gate AVX2 arch dispatch on !__AVX512BW__ | [#26](https://github.com/fg-labs/bwa-mem3/pull/26) |
+| `43457e8` | fix(kswv): consolidate score2 plateaus per-lane to match scalar ksw_align2 | [#28](https://github.com/fg-labs/bwa-mem3/pull/28) |
+| `2311f11` | fix(kswv): port score2 plateau consolidation to NEON + AVX-512BW | [#29](https://github.com/fg-labs/bwa-mem3/pull/29) |
+| `75c709a` | fix(kswv): apply score2 plateau fix + missing filters to kswv_512_16 | [#30](https://github.com/fg-labs/bwa-mem3/pull/30) |
+| `61813ef` | fix(kswv): rewrite kswv_neon_16 — real SIMD kernel with correct table + score2 | [#31](https://github.com/fg-labs/bwa-mem3/pull/31) |
+| `1f76655` | perf(seed): lockstep SMEM batching across N reads | [#33](https://github.com/fg-labs/bwa-mem3/pull/33) |
+| `93a79ec` | feat(mem): emit HN:i tag with total hit count per primary | [#42](https://github.com/fg-labs/bwa-mem3/pull/42) |
+| `dd3a82c` | chore: port four nh13 lh3/bwa PRs into bwa-mem2 (-z, -u/XB, MQ, @HD order) | [#35](https://github.com/fg-labs/bwa-mem3/pull/35) |
+| `98ba6ab` | build(make): forward user CXXFLAGS/CPPFLAGS/LDFLAGS to final link steps | [#50](https://github.com/fg-labs/bwa-mem3/pull/50) |
+| `e9302a1` | fix(kswv): guard post-loop rowMax store on nrow==0 batches | [#51](https://github.com/fg-labs/bwa-mem3/pull/51) |
+| `9b702ca` | fix(sam): sanitize whitespace in -R when embedding into @PG CL: field | [#54](https://github.com/fg-labs/bwa-mem3/pull/54) |
+| `ed63fad` | perf(header): batch -H ingestion to fix O(n^2) header read (closes #37) | [#49](https://github.com/fg-labs/bwa-mem3/pull/49) |
+| `595d8e5` | feat(mapq): add --supp-rep-hard-cap opt-in supp MAPQ rescoring | [#56](https://github.com/fg-labs/bwa-mem3/pull/56) |
+| `79628c3` | chore(version): stamp PACKAGE_VERSION from git describe at build time | [#52](https://github.com/fg-labs/bwa-mem3/pull/52) |
+| `e22dade` | fix(smem): size SMEM buffers from observed max read length (closes #44) | [#55](https://github.com/fg-labs/bwa-mem3/pull/55) |
+| `03688a0` | chore: normalize CRLF line endings to LF (#43) | [#53](https://github.com/fg-labs/bwa-mem3/pull/53) |
+| `57e21bd` | feat(makefile): parameterize PGO targets by arch + profile dir | [#59](https://github.com/fg-labs/bwa-mem3/pull/59) |
+| `79b90ce` | feat(index): libsais-based memory-bounded FM-index construction | [#57](https://github.com/fg-labs/bwa-mem3/pull/57) |
+| `d8d4a6d` | feat(cli): wire up --help across commands; add -h to top-level and index | [#60](https://github.com/fg-labs/bwa-mem3/pull/60) |
+| `7301762` | perf: consolidated mapping speedups (ksw2, SMEM, SAL, SAM) | [#58](https://github.com/fg-labs/bwa-mem3/pull/58) |
+| `eaf4ed6` | test: doctest-based test framework scaffolding + Codecov | [#34](https://github.com/fg-labs/bwa-mem3/pull/34) |
+| `bbbecd3` | ci(proto-neon-kswv): split into fan-out/fan-in jobs with caching | [#63](https://github.com/fg-labs/bwa-mem3/pull/63) |
+| `20f77e9` | feat(shm): port `bwa shm` from bwa-mem v1 | [#65](https://github.com/fg-labs/bwa-mem3/pull/65) |
+| `c20f61c` | feat(shm): add `bwa-mem2 shm --meth` for symmetric meth UX | [#67](https://github.com/fg-labs/bwa-mem3/pull/67) |
+| `ee18a3b` | refactor: rename bwa_mem2idx to bwa_mem3idx | — |
+| `bb919f2` | feat: rename PG header to bwa-mem3 (ID, PN, usage strings) | — |
+| `7a56f9a` | feat: rename meth PG header to bwa-mem3-meth and drive VN from PACKAGE_VERSION | — |
+| `95c673d` | build: rename binary to bwa-mem3, update version guard and fallback | — |
+| `2d5ad10` | test: rename test binaries from bwa_mem2_tests_* to bwa_mem3_tests_* | — |
+| `31f214a` | chore: sweep bwa-mem2 -> bwa-mem3 in source comments and log messages | — |
+| `ff40f96` | chore: rename BWAMEM2_* header guards to BWAMEM3_* | — |
+| `c2c786a` | test: sweep bwa-mem2 -> bwa-mem3 in test, bench, and scripts | — |
+| `148e431` | ci: update workflows for bwa-mem3 rename and main branch | — |
+| `dddd8dd` | docs: rewrite README for bwa-mem3 (lineage attribution, drop upstream-only sections) | — |
+| `34c8ea3` | docs: rename FG-MAIN.md to docs/whats-different.md | — |
+| `5719617` | docs: update whats-different.md for bwa-mem3 and main branch | — |
+| `bdd67f3` | docs: drop README-ori.md (lineage preserved in README + git history) | — |
+| `924a70f` | docs: add 0.1.0-pre release notes and update status.md | — |
+| `85d3b3b` | ci: drop master from branch filter (master branch removed from remote) | — |
+| `2ea69db` | fix(test/meth): alias bwa-mem2 -> bwa-mem3 on PATH for bwameth.py oracle | [#72](https://github.com/fg-labs/bwa-mem3/pull/72) |
+| `4f805e6` | chore: rename shell vars BWAMEM2/BWA_MEM2[_*] to BWAMEM3/BWA_MEM3[_*] | [#68](https://github.com/fg-labs/bwa-mem3/pull/68) |
+| `8137740` | perf(kswv): add per-strip L1 prefetches to all u8/16 kernels | [#70](https://github.com/fg-labs/bwa-mem3/pull/70) |
+| `41e1f3c` | docs: add comprehensive mdbook on Read the Docs | [#71](https://github.com/fg-labs/bwa-mem3/pull/71) |
+| `442de25` | fix(fmi): parenthesize SA_COMPX_MASK precedence in sampled-SA prefetch | [#73](https://github.com/fg-labs/bwa-mem3/pull/73) |
+| `000c0fd` | perf(fmi): bump SMEM_LOCKSTEP_N from 8 to 16 | [#75](https://github.com/fg-labs/bwa-mem3/pull/75) |
+| `b3a665e` | fix(bntseq): bound .alt parse buffer to prevent stack overflow | [#74](https://github.com/fg-labs/bwa-mem3/pull/74) |
+| `af33cdd` | feat(bns): convert mem_matesw_batch_{pre,post} to bns_fetch_seq_v2 | [#76](https://github.com/fg-labs/bwa-mem3/pull/76) |
+| `9bb277a` | Update index.md | [#79](https://github.com/fg-labs/bwa-mem3/pull/79) |
+| `fdb244d` | perf(libsais_build): skip wasted zero-init on unpack + SA buffers | [#80](https://github.com/fg-labs/bwa-mem3/pull/80) |
+| `ff95a4f` | perf(ksort): replace per-call malloc with on-stack buffer for small n | [#78](https://github.com/fg-labs/bwa-mem3/pull/78) |
+| `7caf77c` | perf(ungapped): closed-form HIT for total_mis == 0 | [#77](https://github.com/fg-labs/bwa-mem3/pull/77) |
+| `e65ceb2` | fix(profiling): clamp display_stats nthreads to LIM_C | [#81](https://github.com/fg-labs/bwa-mem3/pull/81) |
+| `ddfb0da` | feat(shm): serialize /bwactl RMW with a POSIX named semaphore | [#82](https://github.com/fg-labs/bwa-mem3/pull/82) |
+| `b9e0b66` | feat(simd): replace multi-binary execv launcher with single-binary in-process dispatch | [#83](https://github.com/fg-labs/bwa-mem3/pull/83) |
+| `7d27f23` | perf(build): default x86 single-binary baseline to avx2 (was sse41) | [#84](https://github.com/fg-labs/bwa-mem3/pull/84) |
+| `316dba6` | fix(matesw): copy ref slice before ksw_align2 to avoid SIGSEGV on shm-backed ref_string | [#85](https://github.com/fg-labs/bwa-mem3/pull/85) |
+| `427c81c` | perf(fmi): inline backwardExt to recover gcc 12+ wall-clock regression | [#88](https://github.com/fg-labs/bwa-mem3/pull/88) |
+| `c96d31a` | perf(x86): cap avx512bw autovec at 256-bit; bwa_shm /dev/shm preflight | [#86](https://github.com/fg-labs/bwa-mem3/pull/86) |
+| `23f528d` | ci: migrate parity tests from dwgsim/phiX174 to holodeck/chr22 | [#89](https://github.com/fg-labs/bwa-mem3/pull/89) |
+| `ec67b09` | feat(meth): emit Bismark-compatible XR/XG/XM auxiliary tags | [#90](https://github.com/fg-labs/bwa-mem3/pull/90) |
+| `652ce0f` | docs(install): list autoconf/automake/libomp/zlib system prereqs | [#93](https://github.com/fg-labs/bwa-mem3/pull/93) |
+| `296b1b9` | docs(install): fix RHEL/Fedora package name pkgconfig → pkgconf-pkg-config | [#94](https://github.com/fg-labs/bwa-mem3/pull/94) |
+| `dc7fcfe` | feat(simd): add SIMD host-floor precheck for multi-arch deployment | [#95](https://github.com/fg-labs/bwa-mem3/pull/95) |
+
 <!-- FG-MAIN-TABLE:end -->
 
 ### Additional fork-level changes
@@ -60,7 +148,6 @@ Each deep-dive page covers one category of change:
   to stock bwa-mem2. Typical values are 5–20 (lower = more aggressive); the
   upstream #260 repro drops from MAPQ=60 to MAPQ=0 at `--supp-rep-hard-cap 18`.
 
-[pr288]: https://github.com/bwa-mem2/bwa-mem2/pull/288
 
 ## Version stamping
 

--- a/docs/src/whats-different/upstream-prs.md
+++ b/docs/src/whats-different/upstream-prs.md
@@ -5,7 +5,7 @@ corresponding upstream bwa-mem2 PR or issue. "Fork-only" means no upstream PR
 exists; the change may be submitted upstream in the future or may be
 fork-specific by design. "Open" means the upstream PR or issue existed at the
 time of bwa-mem3's implementation but had not been merged. Upstream status is
-current as of the bwa-mem3 0.1.0-pre release.
+current as of the bwa-mem3 0.2.0-pre release.
 
 For prose descriptions of each change, follow the links in the "bwa-mem3 PR"
 column to the relevant deep-dive page section.
@@ -25,6 +25,8 @@ column to the relevant deep-dive page section.
 | NEON 16-bit kernel rewrite | [#31](https://github.com/fg-labs/bwa-mem3/pull/31) | — | fork-only |
 | kseq2bseq1 zero-initialization | [#22](https://github.com/fg-labs/bwa-mem3/pull/22) | — | fork-only |
 | Proper-pair flag from emitted alignment | [#17](https://github.com/fg-labs/bwa-mem3/pull/17) | — | fork-only |
+| `@HD` emitted before `@SQ` per SAM spec | [#35](https://github.com/fg-labs/bwa-mem3/pull/35) | [lh3/bwa#345](https://github.com/lh3/bwa/pull/345) | closed (lh3 only) |
+| `mem_matesw` SIGSEGV on shm-backed `ref_string` | [#85](https://github.com/fg-labs/bwa-mem3/pull/85) | — | fork-only |
 | **Performance** | | | |
 | Lockstep SMEM batching | [#33](https://github.com/fg-labs/bwa-mem3/pull/33) | — | fork-only |
 | Batched `-H` header ingestion (O(n) fix) | [#49](https://github.com/fg-labs/bwa-mem3/pull/49) | [bwa-mem2#204](https://github.com/bwa-mem2/bwa-mem2/pull/204) | open PR |
@@ -38,6 +40,10 @@ column to the relevant deep-dive page section.
 | `--supp-rep-hard-cap` MAPQ rescoring | [#56](https://github.com/fg-labs/bwa-mem3/pull/56) | [bwa-mem2#260](https://github.com/bwa-mem2/bwa-mem2/issues/260) | open issue |
 | `bwa-mem3 shm` shared-memory index | [#65](https://github.com/fg-labs/bwa-mem3/pull/65) | — | fork-only (v1 feature port) |
 | `shm --meth` symmetry | [#67](https://github.com/fg-labs/bwa-mem3/pull/67) | — | fork-only |
+| `-z FLOAT` (XA_drop_ratio CLI knob) | [#35](https://github.com/fg-labs/bwa-mem3/pull/35) | [lh3/bwa#294](https://github.com/lh3/bwa/pull/294) | merged (lh3 only) |
+| `-u` flag — widen `XA:Z` records with `,score,mapq` | [#35](https://github.com/fg-labs/bwa-mem3/pull/35) | [lh3/bwa#293](https://github.com/lh3/bwa/pull/293) | merged (lh3 only) |
+| `MQ:i` mate mapping quality tag | [#35](https://github.com/fg-labs/bwa-mem3/pull/35) | [lh3/bwa#330](https://github.com/lh3/bwa/pull/330) | merged (lh3 only) |
+| Bismark-compatible `XR:Z` / `XG:Z` / `XM:Z` tags | [#90](https://github.com/fg-labs/bwa-mem3/pull/90) | — | fork-only |
 | **Architecture support** | | | |
 | Linux ARM64 / aarch64 build + CI | [#1](https://github.com/fg-labs/bwa-mem3/pull/1) | [bwa-mem2#288](https://github.com/bwa-mem2/bwa-mem2/pull/288) | open PR |
 | `arch=avx512bw` explicit Makefile target | [#16](https://github.com/fg-labs/bwa-mem3/pull/16) | — | fork-only |


### PR DESCRIPTION
## Summary

Comprehensive docs pass to bring the mdBook and `NEWS.md` into alignment with the v0.2.0-pre release surface, plus a stricter release process. No code changes.

- **SIMD dispatch rewrite (PR #83 follow-through).** Rewrites `developer-guide/launcher.md`, `developer-guide/simd-dispatch.md`, and `performance/simd-dispatch.md` to describe the single-binary in-process dispatch architecture. Sweeps every other page that referenced `make multi`, `runsimd.cpp`, the `execv` launcher, or `bwa-mem3.<tier>` companion binaries (`index.md`, `tips.md`, `indexing.md`, `neon-port.md`, `tuning.md`, `building.md`, `best-practices/build.md`, `anti-patterns.md`, `pgo.md`, `arch-support.md`, `build-infra.md`, `glossary.md`, `SUMMARY.md`). Documents `BWAMEM3_FORCE_TIER` and `BWAMEM3_DEBUG_SIMD`.
- **Methylation tag corrections (PR #90 follow-through).** Five pages still described `YS:Z` / `YC:Z` / `YD:Z` as user-visible output tags after PR #90 made them internal-only carriers suppressed in `bam_writer.cpp`. Updates `user-guide/output.md`, `getting-started/quick-align.md`, `methylation/conversion.md`, `methylation/bwameth-mapping.md`, `best-practices/anti-patterns.md`, `best-practices/output-format.md`, and `whats-different/features.md` to describe the emitted Bismark `XR:Z` / `XG:Z` / `XM:Z` set instead.
- **Output behavior audit (PR #35 follow-through).** Documents the `MQ:i` mate-MAPQ tag and the `-u`/XB `XA:Z` field widening in `user-guide/output.md` and `getting-started/quick-align.md` — both were in the codebase but absent from the docs.
- **`upstream-prs.md` cross-reference completed.** Adds rows for the four `lh3/bwa` back-ports from PR #35 (`-z`, `-u`/XB, `MQ:i`, `@HD`-before-`@SQ`), PR #85 (matesw SIGSEGV), and PR #90 (Bismark tags). Bumps the intro stamp from 0.1.0-pre to 0.2.0-pre.
- **Performance reference numbers.** Adds the `dc7fcfe` (2026-05-13) wall-time median table to `performance/overview.md` with 100.0000% concordance numbers vs `bwa-mem2 v2.2.1` and the NEON-vs-x86 cross-arch check.
- **`/dev/shm` preflight (PR #86).** Documents the `statvfs` preflight, the `[E::bwa_shm_stage]` error format, and the AWS remount sizing hint in `cli/shm.md`.
- **`NEWS.md` 0.2.0-pre completeness.** Rewrites the 0.2.0-pre entry to cover PR #83 / #84 / #85 / #86 / #88 / #90 / #95 (previously only #90 was listed). Updates the date stamp to 2026-05-13.
- **CLI `version` banner (PR #95 follow-through).** Updates `cli/version.md` to show the new `SIMD floor:` + `SIMD runtime:` stdout lines, the `[W::bwa-mem3]` stderr warning on too-old hosts, and the exit-0 introspection guarantee.
- **Release process strengthened.** Adds a semver policy section, a release-readiness checklist (build + test + bench gate + docs), and a post-release verification section to `developer-guide/release.md`.

Organised into four logical commits so each piece can be reviewed independently:

1. `docs(simd): rewrite for single-binary in-process dispatch (PR #83)` — 16 files, +552/-253.
2. `docs(meth): align YS/YC/YD references with Bismark XR/XG/XM emission (PR #90)` — 4 files, +45/-26.
3. `docs(output): document MQ:i, XA:Z widening, perf numbers, /dev/shm preflight` — 5 files, +64/-9.
4. `docs(release): populate NEWS.md 0.2.0-pre; strengthen release process` — 3 files, +256/-36.

## Test plan

- [ ] `make docs` builds cleanly with no mdbook warnings
- [ ] Spot-check rendered mermaid diagrams on `developer-guide/launcher.md`, `developer-guide/simd-dispatch.md`, and `performance/simd-dispatch.md`
- [ ] Skim `whats-different/upstream-prs.md` for any missed PR rows
- [ ] Confirm the cited bwa-mem3-bench numbers in `performance/overview.md` match the `dc7fcfe` `regression.md` summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-binary SIMD dispatch on x86 with runtime tier selection
  * Environment vars to force/downgrade tier and enable SIMD debug diagnostics
  * `bwa-mem3 version` shows SIMD floor/runtime info and warns when host is below floor
  * `/dev/shm` capacity preflight for index staging with clearer abort messaging

* **Bug Fixes**
  * Fixed SIGSEGV when aligning against shm-backed read-only reference slices

* **Formatting/Output**
  * Methylation emits Bismark-compatible tags (XR:Z, XG:Z, XM:Z); added MC:Z and MQ:i for mates

* **Documentation**
  * Extensive updates across build, developer, CLI, methylation, and performance docs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/96)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->