### PR TITLE
chore(release): prep v0.2.0 release notes and metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ CPPFLAGS+=	-DENABLE_PREFETCH -DV17=1 -DMATE_SORT=0 -DLIBSAIS_OPENMP
 # `git describe` (e.g. v2.3-30-g61813ef, with -dirty suffix for modified
 # trees) so the stamped version always reflects the actual build. Fall
 # back to a static tag for source-tarball / shallow-clone builds.
-FG_LABS_VERSION_FALLBACK := 0.1.0-pre
+FG_LABS_VERSION_FALLBACK := 0.2.0
 VERSION_STRING := $(shell git describe --tags --dirty 2>/dev/null || echo $(FG_LABS_VERSION_FALLBACK))
 INCLUDES+=   -Isrc -Iext/safestringlib/include -Iext/htslib -Iext/libsais/include
 ifeq ($(USE_MIMALLOC),1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-Release 0.2.0-pre (2026-05-13)
+Release 0.2.0 (2026-05-13)
 ---------------------------------
 
 Operational / packaging
@@ -38,6 +38,11 @@ Operational / packaging
   size, and a `mount -o remount,size=...` hint — replacing the prior
   `[fread] Bad address` failure mode. `statvfs` failures (no `/dev/shm`,
   restricted sandbox) are non-fatal and the stage proceeds.
+* `bwa-mem3 shm` `/bwactl` registry RMW is now serialized via a POSIX
+  named semaphore (#82, closes #66). Concurrent `shm stage` / `shm drop`
+  invocations across processes no longer race when updating the
+  registry; the prior best-effort flock was per-`open` and did not
+  cover the read-modify-write window.
 
 Methylation
 
@@ -58,6 +63,16 @@ Correctness
   `ksw_align2` mutates its reference slice in place; when the slice
   pointed into a read-only shm segment, this faulted. Now copies the
   slice before passing it in.
+* `FMI_search` sampled-SA prefetch: parenthesized `SA_COMPX_MASK`
+  precedence so the masked offset is computed against the correct
+  operand (#73). The unparenthesized form was silently producing
+  wrong-but-harmless prefetch addresses; no alignment output was
+  affected.
+* `bntseq` `.alt` parser bounds the line buffer to prevent a
+  stack-overflow on malicious or malformed `.alt` files (#74).
+* `display_stats` clamps the per-thread bucket count to `LIM_C` so
+  `--profile` with `-t` greater than the compiled-in limit no longer
+  writes past the end of the stats array (#81).
 
 Performance
 
@@ -72,6 +87,12 @@ Performance
   gcc 12+ wall-clock regression (#88). See
   `docs/src/performance/overview.md` for the reference numbers across
   architectures.
+* Smaller contributions in the release window: per-strip L1 prefetches
+  across all `kswv` u8/u16 kernels (#70); `SMEM_LOCKSTEP_N` bumped from
+  8 to 16 (#75); closed-form ungapped HIT path when `total_mis == 0`
+  (#77); `ksort` switched to an on-stack buffer for small `n` to drop
+  a per-call `malloc` (#78); `libsais_build` skips a wasted zero-init
+  pass on its unpack and SA buffers, trimming index-build time (#80).
 
 Release 0.1.0-pre (2026-04-28)
 ---------------------------------

--- a/docs/src/best-practices/multi-arch-deployment.md
+++ b/docs/src/best-practices/multi-arch-deployment.md
@@ -46,7 +46,7 @@ AWS Batch, GCP Batch, Kubernetes, and containerd all read the manifest list and 
 
 ```text
 $ bwa-mem3 version
-bwa-mem3-0.1.0-pre-12-gabcdef1
+v0.2.0-12-gabcdef1
 SIMD floor: avx2 (x86-64-v3, Haswell 2013+); kernels: sse41 sse42 avx avx2 avx512bw
 SIMD runtime: avx512bw (BWAMEM3_FORCE_TIER unset)
 ```

--- a/docs/src/cli/version.md
+++ b/docs/src/cli/version.md
@@ -30,7 +30,7 @@ build prints (mimalloc line on stderr, the rest on stdout — order in a
 merged stream is not guaranteed):
 
 ```text
-v0.2.0-pre-12-gabcdef1
+v0.2.0-12-gabcdef1
 SIMD floor: avx2 (x86-64-v3, Haswell 2013+); kernels: sse41 sse42 avx avx2 avx512bw
 SIMD runtime: avx512bw (BWAMEM3_FORCE_TIER unset)
 mimalloc 3.3.0

--- a/docs/src/developer-guide/release.md
+++ b/docs/src/developer-guide/release.md
@@ -7,7 +7,7 @@ bwa-mem3 follows [semantic versioning](https://semver.org). Releases are driven 
 The Makefile computes the version string at parse time:
 
 ```makefile
-FG_LABS_VERSION_FALLBACK := 0.1.0-pre
+FG_LABS_VERSION_FALLBACK := 0.2.0
 VERSION_STRING := $(shell git describe --tags --dirty 2>/dev/null || echo $(FG_LABS_VERSION_FALLBACK))
 ```
 
@@ -180,10 +180,10 @@ Run these in order; each command depends on the previous one.
    ```
 
    Substitute `0.X.Y` with the exact version literal you are tagging,
-   including any pre-release suffix — e.g. for `v0.2.0-pre` use
-   `/^Release 0\.2\.0-pre /`. The trailing space in the inner pattern
-   anchors the match to a complete version token so that `0.2.0` does
-   not also match `Release 0.2.0-pre (...)`. The awk script prints
+   including any pre-release suffix — e.g. for `v0.3.0-pre` use
+   `/^Release 0\.3\.0-pre /`. The trailing space in the inner pattern
+   anchors the match to a complete version token so that `0.3.0` does
+   not also match `Release 0.3.0-pre (...)`. The awk script prints
    lines while `p` is true: it flips on at the matching `Release` line
    and back off at the next `Release` line, which gives a clean
    section without needing a trailing `sed '$d'`.

--- a/docs/src/getting-started/host-requirements.md
+++ b/docs/src/getting-started/host-requirements.md
@@ -13,7 +13,7 @@ bwa-mem3 runs on the hosts in the table below. Verify your host with `bwa-mem3 v
 
 ```text
 $ bwa-mem3 version
-v0.1.0-pre-12-gabcdef1
+v0.2.0-12-gabcdef1
 SIMD floor: avx2 (x86-64-v3, Haswell 2013+); kernels: sse41 sse42 avx avx2 avx512bw
 SIMD runtime: avx512bw (BWAMEM3_FORCE_TIER unset)
 mimalloc 3.x.x

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -129,7 +129,7 @@ active:
 Expected output (with mimalloc):
 
 ```text
-bwa-mem3-0.1.0-pre-12-gabcdef1
+v0.2.0-12-gabcdef1
 mimalloc 3.x.x
 ```
 

--- a/docs/src/performance/simd-dispatch.md
+++ b/docs/src/performance/simd-dispatch.md
@@ -101,7 +101,7 @@ Two environment variables tune dispatch:
 Use `bwa-mem3 version` to read the resolved tier without alignment:
 
 ```text
-bwa-mem3 0.1.0-pre
+v0.2.0
 SIMD floor:   avx2 (x86-64-v3, Haswell 2013+); kernels: sse41 sse42 avx avx2 avx512bw
 SIMD runtime: avx512bw (BWAMEM3_FORCE_TIER unset)
 ```

--- a/docs/src/whats-different/upstream-prs.md
+++ b/docs/src/whats-different/upstream-prs.md
@@ -5,7 +5,7 @@ corresponding upstream bwa-mem2 PR or issue. "Fork-only" means no upstream PR
 exists; the change may be submitted upstream in the future or may be
 fork-specific by design. "Open" means the upstream PR or issue existed at the
 time of bwa-mem3's implementation but had not been merged. Upstream status is
-current as of the bwa-mem3 0.2.0-pre release.
+current as of the bwa-mem3 0.2.0 release.
 
 For prose descriptions of each change, follow the links in the "bwa-mem3 PR"
 column to the relevant deep-dive page section.
@@ -27,11 +27,21 @@ column to the relevant deep-dive page section.
 | Proper-pair flag from emitted alignment | [#17](https://github.com/fg-labs/bwa-mem3/pull/17) | — | fork-only |
 | `@HD` emitted before `@SQ` per SAM spec | [#35](https://github.com/fg-labs/bwa-mem3/pull/35) | [lh3/bwa#345](https://github.com/lh3/bwa/pull/345) | closed (lh3 only) |
 | `mem_matesw` SIGSEGV on shm-backed `ref_string` | [#85](https://github.com/fg-labs/bwa-mem3/pull/85) | — | fork-only |
+| `SA_COMPX_MASK` precedence in sampled-SA prefetch | [#73](https://github.com/fg-labs/bwa-mem3/pull/73) | — | fork-only |
+| `.alt` parse buffer bounded (stack overflow) | [#74](https://github.com/fg-labs/bwa-mem3/pull/74) | — | fork-only |
+| `display_stats` nthreads clamp to `LIM_C` | [#81](https://github.com/fg-labs/bwa-mem3/pull/81) | — | fork-only |
 | **Performance** | | | |
 | Lockstep SMEM batching | [#33](https://github.com/fg-labs/bwa-mem3/pull/33) | — | fork-only |
 | Batched `-H` header ingestion (O(n) fix) | [#49](https://github.com/fg-labs/bwa-mem3/pull/49) | [bwa-mem2#204](https://github.com/bwa-mem2/bwa-mem2/pull/204) | open PR |
 | libsais FM-index construction | [#57](https://github.com/fg-labs/bwa-mem3/pull/57) | — | fork-only |
 | Consolidated mapping speedups | [#58](https://github.com/fg-labs/bwa-mem3/pull/58) | — | fork-only |
+| kswv per-strip L1 prefetches (all u8/16 kernels) | [#70](https://github.com/fg-labs/bwa-mem3/pull/70) | — | fork-only |
+| `SMEM_LOCKSTEP_N` bumped from 8 to 16 | [#75](https://github.com/fg-labs/bwa-mem3/pull/75) | — | fork-only |
+| Closed-form ungapped HIT when `total_mis == 0` | [#77](https://github.com/fg-labs/bwa-mem3/pull/77) | — | fork-only |
+| `ksort` on-stack buffer for small `n` | [#78](https://github.com/fg-labs/bwa-mem3/pull/78) | — | fork-only |
+| `libsais_build` skip wasted zero-init | [#80](https://github.com/fg-labs/bwa-mem3/pull/80) | — | fork-only |
+| Cap `avx512bw` autovec at 256-bit | [#86](https://github.com/fg-labs/bwa-mem3/pull/86) | — | fork-only |
+| Inline `FMI_search::backwardExt` (recover gcc 12+ regression) | [#88](https://github.com/fg-labs/bwa-mem3/pull/88) | — | fork-only |
 | **Features** | | | |
 | `--bam=LEVEL` direct BAM output | [#12](https://github.com/fg-labs/bwa-mem3/pull/12) | — | fork-only |
 | `--meth` bisulfite alignment mode | [#13](https://github.com/fg-labs/bwa-mem3/pull/13) | — | fork-only |
@@ -44,11 +54,17 @@ column to the relevant deep-dive page section.
 | `-u` flag — widen `XA:Z` records with `,score,mapq` | [#35](https://github.com/fg-labs/bwa-mem3/pull/35) | [lh3/bwa#293](https://github.com/lh3/bwa/pull/293) | merged (lh3 only) |
 | `MQ:i` mate mapping quality tag | [#35](https://github.com/fg-labs/bwa-mem3/pull/35) | [lh3/bwa#330](https://github.com/lh3/bwa/pull/330) | merged (lh3 only) |
 | Bismark-compatible `XR:Z` / `XG:Z` / `XM:Z` tags | [#90](https://github.com/fg-labs/bwa-mem3/pull/90) | — | fork-only |
+| `/bwactl` registry interprocess lock (POSIX named semaphore) | [#82](https://github.com/fg-labs/bwa-mem3/pull/82) | — | fork-only |
+| `bwa-mem3 shm` `/dev/shm` capacity preflight | [#86](https://github.com/fg-labs/bwa-mem3/pull/86) | — | fork-only |
+| Host-floor precheck (`SIMD floor:` / `SIMD runtime:`, exit 2 on under-floor host) | [#95](https://github.com/fg-labs/bwa-mem3/pull/95) | — | fork-only |
 | **Architecture support** | | | |
 | Linux ARM64 / aarch64 build + CI | [#1](https://github.com/fg-labs/bwa-mem3/pull/1) | [bwa-mem2#288](https://github.com/bwa-mem2/bwa-mem2/pull/288) | open PR |
 | `arch=avx512bw` explicit Makefile target | [#16](https://github.com/fg-labs/bwa-mem3/pull/16) | — | fork-only |
 | NEON kswv mate-rescue kernel | [#18](https://github.com/fg-labs/bwa-mem3/pull/18) | — | fork-only |
 | AVX2 kswv mate-rescue kernel | [#20](https://github.com/fg-labs/bwa-mem3/pull/20) | — | fork-only |
+| `bns_fetch_seq_v2` migration of `mem_matesw_batch_{pre,post}` | [#76](https://github.com/fg-labs/bwa-mem3/pull/76) | — | fork-only |
+| Single-binary in-process SIMD dispatch (replaces multi-binary `execv` launcher) | [#83](https://github.com/fg-labs/bwa-mem3/pull/83) | — | fork-only |
+| Default x86 `BASELINE_ARCH=avx2` (was `sse41`) | [#84](https://github.com/fg-labs/bwa-mem3/pull/84) | — | fork-only |
 | **Build & infrastructure** | | | |
 | doctest framework + Codecov | [#34](https://github.com/fg-labs/bwa-mem3/pull/34) | — | fork-only |
 | `PACKAGE_VERSION` from `git describe` | [#52](https://github.com/fg-labs/bwa-mem3/pull/52) | [bwa-mem2#283](https://github.com/bwa-mem2/bwa-mem2/issues/283), [bwa-mem2#284](https://github.com/bwa-mem2/bwa-mem2/pull/284) | open issue + open PR |


### PR DESCRIPTION
## Summary

Release-readiness pass for tagging `v0.2.0`, working through the checklist in `docs/src/developer-guide/release.md`.

- **`Makefile`** — `FG_LABS_VERSION_FALLBACK := 0.1.0-pre` → `0.2.0` so source-tarball / shallow-clone builds report the correct version.
- **`NEWS.md`** — header to `Release 0.2.0 (2026-05-13)`; add #82 (`/bwactl` POSIX named semaphore) under Operational / packaging; expand Correctness with #73 (`SA_COMPX_MASK` precedence), #74 (`.alt` parse buffer bound), #81 (`display_stats` nthreads clamp); cite the smaller perf contributions (#70, #75, #77, #78, #80) in Performance alongside the headline #86/#88 wins.
- **`docs/src/whats-different/upstream-prs.md`** — add rows for every fork-carried PR landed since `v0.1.0-pre` that was previously missing: #70, #73, #74, #75, #76, #77, #78, #80, #81, #82, #83, #84, #86 (×2: perf + shm preflight), #88, #95. Preamble updated to "current as of the 0.2.0 release".
- **Stale literals** — `0.2.0-pre` / `0.1.0-pre` example version strings refreshed to `0.2.0` in `cli/version.md`, `host-requirements.md`, `installation.md`, `multi-arch-deployment.md`, `simd-dispatch.md`. Two of these (`installation.md`, `multi-arch-deployment.md`) also had a `bwa-mem3-<ver>` prefix that did not match the actual `bwa-mem3 version` output (which uses `v<ver>`); corrected.
- **`release.md`** — bump the Makefile snippet to `0.2.0`; rewrite the awk pre-release example to use a hypothetical `v0.3.0-pre` so it does not collide with the version being tagged.

Historical `0.1.0-pre` references in `arch-support.md`, `overview.md` (FG-MAIN-TABLE commit subject), `release.md:227` (`-pre` convention example citing the existing tag), and the previous-release section / baseline cite in `NEWS.md` are intentionally left as-is.

## Test plan

Verified locally on darwin arm64:

- [x] `make` builds clean
- [x] `make docs-cli` is a no-op against the captured snippets (no drift in `docs/_generated/cli/`)
- [x] `make docs` builds with no content warnings (only the pre-existing `mdbook-mermaid` tooling-version-mismatch line)
- [x] `make test` — 38 doctest cases / 2,885,190 assertions PASS; integration, kswv_nrow_zero, shm_section_find, shm_lock_destroy, version_banner all PASS

Still needed before tagging (not in this PR):

- [ ] `make` + `make test` on a Linux x86_64 host (default + `BASELINE_ARCH=sse41`)
- [ ] `test/regression/all_tiers_parity.sh` on an AVX-512BW host (byte-identical SAM across `sse41 → sse42 → avx → avx2 → avx512bw`)
- [ ] `bwa-mem3-bench` regression gate on the merge commit with `--prev v0.1.0-pre`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inter-process semaphore locking for registry access
  * Added shared-memory capacity pre-check
  * Added host SIMD capability validation with diagnostic exit code

* **Bug Fixes**
  * Corrected SIMD prefetch mask precedence, parser bounds handling, and stats overflow/clamping

* **Performance**
  * Small release-window optimizations across dispatch and kernel paths

* **Documentation**
  * Updated examples and release notes to reflect v0.2.0 release

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/97)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->