### PR TITLE
docs: complete whats-different tables for v0.2.0 readiness

### DIFF
--- a/docs/src/whats-different/overview.md
+++ b/docs/src/whats-different/overview.md
@@ -124,6 +124,8 @@ Auto-generated from `git log --reverse --no-merges master..main` and the convent
 | `652ce0f` | docs(install): list autoconf/automake/libomp/zlib system prereqs | [#93](https://github.com/fg-labs/bwa-mem3/pull/93) |
 | `296b1b9` | docs(install): fix RHEL/Fedora package name pkgconfig → pkgconf-pkg-config | [#94](https://github.com/fg-labs/bwa-mem3/pull/94) |
 | `dc7fcfe` | feat(simd): add SIMD host-floor precheck for multi-arch deployment | [#95](https://github.com/fg-labs/bwa-mem3/pull/95) |
+| `3bc64b0` | docs: pre-release documentation pass for v0.2.0-pre | [#96](https://github.com/fg-labs/bwa-mem3/pull/96) |
+| `27a60c9` | chore(release): prep v0.2.0 release notes and metadata | [#97](https://github.com/fg-labs/bwa-mem3/pull/97) |
 
 <!-- FG-MAIN-TABLE:end -->
 

--- a/docs/src/whats-different/upstream-prs.md
+++ b/docs/src/whats-different/upstream-prs.md
@@ -72,6 +72,9 @@ column to the relevant deep-dive page section.
 | `CXXFLAGS`/`CPPFLAGS`/`LDFLAGS` forwarding | [#50](https://github.com/fg-labs/bwa-mem3/pull/50) | [bwa-mem2#290](https://github.com/bwa-mem2/bwa-mem2/pull/290) | open upstream PR |
 | Unit-test harness + ARM CI | [#23](https://github.com/fg-labs/bwa-mem3/pull/23) | — | fork-only |
 | CI matrix expansion (7 rows) | [#24](https://github.com/fg-labs/bwa-mem3/pull/24) | — | fork-only |
+| Shell-var rename `BWAMEM2`/`BWA_MEM2[_*]` → `BWAMEM3`/`BWA_MEM3[_*]` (CI/bench/test scripts) | [#68](https://github.com/fg-labs/bwa-mem3/pull/68) | — | fork-only |
+| Methylation oracle: alias `bwa-mem2` → `bwa-mem3` on `PATH` for `bwameth.py` | [#72](https://github.com/fg-labs/bwa-mem3/pull/72) | — | fork-only |
+| Migrate parity tests from dwgsim/phiX174 to holodeck/chr22 | [#89](https://github.com/fg-labs/bwa-mem3/pull/89) | — | fork-only |
 
 ## Upstream issues tracked but not yet fixed in bwa-mem3
 


### PR DESCRIPTION
## Summary

Closes the docs side of the v0.2.0 release-readiness checklist. The FG-MAIN-TABLE in `whats-different/overview.md` was regenerated through #95 but `main` has since landed #96 and #97; `upstream-prs.md` was also missing three infrastructure rows that the release.md checklist requires.

- **FG-MAIN-TABLE**: append rows for #96 (`docs: pre-release documentation pass for v0.2.0-pre`) and #97 (`chore(release): prep v0.2.0 release notes and metadata`) so the table covers the full `master..main` range at the tagging SHA.
- **upstream-prs.md (Build & infrastructure)**: add the three previously-missing rows for runtime/build/CI-relevant PRs:
  - #68 — Shell-var rename `BWAMEM2`/`BWA_MEM2[_*]` → `BWAMEM3`/`BWA_MEM3[_*]` (CI/bench/test scripts only — no user-facing env-var contract change; the user-facing `BWAMEM3_FORCE_TIER` / `BWAMEM3_DEBUG_SIMD` are covered under #83)
  - #72 — Methylation oracle: alias `bwa-mem2` → `bwa-mem3` on `PATH` for `bwameth.py`
  - #89 — Migrate parity tests from dwgsim/phiX174 to holodeck/chr22

Pure-docs and release-chore PRs (#71, #79, #93, #94, #96, #97) are intentionally omitted from `upstream-prs.md` to match the existing convention of tracking only behavioral / build / CI changes.

## Release-readiness sweep results (against 27a60c9 + this commit)

| Check | Result |
|---|---|
| arm64 build + `make test` (Apple Silicon, macOS) | PASS — 38 cases / 2,885,190 assertions |
| x86_64 avx2 build + `make test` (c7i.4xlarge, AL2023) | PASS — 2,858,911 assertions, standalones OK |
| x86_64 `BASELINE_ARCH=sse41` build (floor compile check) | PASS |
| `test/regression/all_tiers_parity.sh` on AVX-512BW host | PASS — `sse41 sse42 avx avx2 avx512bw` all byte-identical (96,973 B per tier) |
| `make docs` | PASS — no content warnings (only benign mdbook-mermaid version-skew note) |

The bench-gate item (`bwa-mem3-bench submit --fg-labs-sha …` + `bench regression`) is being driven separately and is not gated by this PR.

## Test plan

- [x] `make docs` clean on this branch
- [x] FG-MAIN-TABLE rows render correctly in the built book
- [x] `upstream-prs.md` rows appear under Build & infrastructure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation with release version entries for v0.2.0
  * Added documentation reflecting configuration variable naming updates
  * Updated test framework migration documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/98)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->