### PR TITLE
chore(release): open 0.3.0-pre window

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ CPPFLAGS+=	-DENABLE_PREFETCH -DV17=1 -DMATE_SORT=0 -DLIBSAIS_OPENMP
 # `git describe` (e.g. v2.3-30-g61813ef, with -dirty suffix for modified
 # trees) so the stamped version always reflects the actual build. Fall
 # back to a static tag for source-tarball / shallow-clone builds.
-FG_LABS_VERSION_FALLBACK := 0.2.0
+FG_LABS_VERSION_FALLBACK := 0.3.0-pre
 VERSION_STRING := $(shell git describe --tags --dirty 2>/dev/null || echo $(FG_LABS_VERSION_FALLBACK))
 INCLUDES+=   -Isrc -Iext/safestringlib/include -Iext/htslib -Iext/libsais/include
 ifeq ($(USE_MIMALLOC),1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+Release 0.3.0-pre (TBD)
+---------------------------------
+
+Operational / packaging
+
+Methylation
+
+Correctness
+
+Performance
+
+
 Release 0.2.0 (2026-05-13)
 ---------------------------------
 

--- a/docs/src/developer-guide/release.md
+++ b/docs/src/developer-guide/release.md
@@ -7,7 +7,7 @@ bwa-mem3 follows [semantic versioning](https://semver.org). Releases are driven 
 The Makefile computes the version string at parse time:
 
 ```makefile
-FG_LABS_VERSION_FALLBACK := 0.2.0
+FG_LABS_VERSION_FALLBACK := 0.3.0-pre
 VERSION_STRING := $(shell git describe --tags --dirty 2>/dev/null || echo $(FG_LABS_VERSION_FALLBACK))
 ```
 


### PR DESCRIPTION
## Summary

Open the in-development window for the next release, following the [v0.2.0 tag](https://github.com/fg-labs/bwa-mem3/releases/tag/v0.2.0).

- **Makefile**: `FG_LABS_VERSION_FALLBACK` `0.2.0` → `0.3.0-pre` so source-tarball / shallow-clone builds (where `git describe` fails) report the in-development line instead of the just-shipped tag.
- **`docs/src/developer-guide/release.md`**: bump the same example in the "Version stamping" section to match.
- **NEWS.md**: prepend a `Release 0.3.0-pre (TBD)` skeleton with empty `Operational / packaging`, `Methylation`, `Correctness`, and `Performance` subsections, so PRs landing in this window can append into the right bucket as they go in. The `(TBD)` placeholder will be flipped to the actual release date in the eventual release-prep PR (mirroring how #97 finalised the 0.2.0 section).

Tagged builds and full clones are unaffected — `git describe` continues to report exact tag strings (`v0.2.0`, `v0.2.0-N-gabcdef1`, etc.).

## Test plan

- [x] `git describe` still returns `v0.2.0` on the v0.2.0 tag (fallback is only consulted when `git describe` fails)
- [x] `NEWS.md` 0.2.0 section is unchanged below the new skeleton
- [x] Skeleton subheadings match the structure used in the 0.2.0 section so PR authors have a familiar landing pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Single-binary SIMD dispatch
  * New methylation output tags for enhanced alignment reporting

* **Bug Fixes**
  * Multiple correctness fixes including reference handling and bounds checks

* **Chores**
  * Version updated to 0.3.0-pre
  * Performance improvements included

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/99)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->