### PR TITLE
fix(smem): track enc_qdb byte capacity separately from wsize_mem

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1053,10 +1053,16 @@ int mem_kernel1_core(FMI_search *fmi,
     // `if (tot_len >= wsize_mem)` gate skip the enc_qdb realloc on
     // subsequent batches even when enc_qdb is undersized.
     if (tot_len > mmc->wsize_qdb[tid]) {
+        int64_t tmp = mmc->wsize_qdb[tid];
         mmc->enc_qdb[tid] = (uint8_t *) realloc(mmc->enc_qdb[tid],
                                                 tot_len * sizeof(uint8_t));
         assert(mmc->enc_qdb[tid] != NULL);
         mmc->wsize_qdb[tid] = tot_len;
+        if (bwa_verbose >= 4) {
+            fprintf(stderr, "[%0.4d] Re-allocating enc_qdb: "
+                    "%" PRId64 " -> %" PRId64 "\n",
+                    tid, tmp, mmc->wsize_qdb[tid]);
+        }
     }
     // tot_len *= N_SMEM_KERNEL;
     // fprintf(stderr, "wsize: %d, tot_len: %d\n", mmc->wsize_mem[tid], tot_len);

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1045,15 +1045,29 @@ int mem_kernel1_core(FMI_search *fmi,
             kv_init(chain_ar[l]);
         return 1;
     }
+    // enc_qdb is sized in *bytes* (= tot_len). Track its capacity via the
+    // dedicated wsize_qdb so it stays correct independent of wsize_mem,
+    // which mem_collect_smem grows in *SMEM-entry* units. On short-read
+    // workloads (≤50 bp aDNA), the post-mem_collect_smem wsize_mem in SMEM
+    // units can exceed tot_len in bytes, which would make the legacy
+    // `if (tot_len >= wsize_mem)` gate skip the enc_qdb realloc on
+    // subsequent batches even when enc_qdb is undersized.
+    if (tot_len > mmc->wsize_qdb[tid]) {
+        mmc->enc_qdb[tid] = (uint8_t *) realloc(mmc->enc_qdb[tid],
+                                                tot_len * sizeof(uint8_t));
+        assert(mmc->enc_qdb[tid] != NULL);
+        mmc->wsize_qdb[tid] = tot_len;
+    }
     // tot_len *= N_SMEM_KERNEL;
     // fprintf(stderr, "wsize: %d, tot_len: %d\n", mmc->wsize_mem[tid], tot_len);
-    // This covers enc_qdb/SMEM reallocs
+    // This covers matchArray and the per-read int arrays. enc_qdb is grown
+    // separately above (wsize_qdb).
     if (tot_len >= mmc->wsize_mem[tid])
     {
         int64_t tmp = mmc->wsize_mem[tid];
         mmc->wsize_mem[tid] = tot_len;
         if (bwa_verbose >= 4) {
-            fprintf(stderr, "[%0.4d] Re-allocating SMEM scratch (enc_qdb): "
+            fprintf(stderr, "[%0.4d] Re-allocating SMEM scratch: "
                     "%" PRId64 " -> %" PRId64 "\n",
                     tid, tmp, mmc->wsize_mem[tid]);
         }
@@ -1066,8 +1080,6 @@ int mem_kernel1_core(FMI_search *fmi,
                                                      mmc->wsize_mem[tid] *  sizeof(int32_t));
         mmc->query_pos_ar[tid] = (int16_t *) realloc(mmc->query_pos_ar[tid],
                                                      mmc->wsize_mem[tid] *  sizeof(int16_t));
-        mmc->enc_qdb[tid]      = (uint8_t *) realloc(mmc->enc_qdb[tid],
-                                                      mmc->wsize_mem[tid] * sizeof(uint8_t));
         mmc->rid[tid]          = (int32_t *) realloc(mmc->rid[tid],
                                                       mmc->wsize_mem[tid] * sizeof(int32_t));
         // w.mmc.lim[l]        = (int32_t *) _mm_malloc((BATCH_SIZE + 32) * sizeof(int32_t), 64);

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -219,6 +219,12 @@ typedef struct
     int64_t wsize_mem[MAX_THREADS];
     int64_t wsize_mem_s[MAX_THREADS];
     int64_t wsize_mem_r[MAX_THREADS];
+    // enc_qdb byte-size tracker. Separate from wsize_mem because
+    // mem_collect_smem repurposes wsize_mem as an SMEM-entry count, which
+    // breaks the byte-count invariant for enc_qdb on short-read workloads
+    // (≤50 bp aDNA), where SMEM count >> tot_len bytes can leave enc_qdb
+    // silently undersized between batches.
+    int64_t wsize_qdb[MAX_THREADS];
 
     // Lockstep SMEM batching per-slot state. One pair of contiguous SMEM
     // buffers per thread, each of size SMEM_LOCKSTEP_N * lockstep_buf_cap[tid].

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -267,6 +267,7 @@ void worker_alloc(const mem_opt_t *opt, worker_t &w, int32_t nreads, int32_t nth
         w.mmc.wsize_mem[l]     = 0;
         w.mmc.wsize_mem_s[l]   = 0;
         w.mmc.wsize_mem_r[l]   = 0;
+        w.mmc.wsize_qdb[l]     = 0;
         w.mmc.matchArray[l]    = NULL;
         w.mmc.min_intv_ar[l]   = NULL;
         w.mmc.query_pos_ar[l]  = NULL;


### PR DESCRIPTION
`mmc->wsize_mem[tid]` is overloaded: `mem_kernel1_core` sets it to a byte count (= `tot_len`) to size `enc_qdb`, while `mem_collect_smem` later repurposes it as an SMEM-entry count to size `matchArray`. Once the SMEM-count value is in place, the gate at
`mem_kernel1_core: if (tot_len >= mmc->wsize_mem[tid])` compares bytes against SMEM entries on subsequent batches.

On short-read workloads (≤50 bp aDNA reads) the SMEM density per base is high enough that the SMEM-entry count can exceed `tot_len` in bytes. The gate then evaluates FALSE even when `enc_qdb` is undersized, the realloc is skipped, and the next `memcpy(enc_qdb + offset, ..., l_seq)` in `mem_collect_smem` overruns the buffer. The OOB write corrupts mimalloc's adjacent free-list metadata, and the next allocator call (typically `mem_chain_seeds` -> `_mm_malloc`) SIGSEGVs inside `_mi_page_malloc_zero`. Under `-p` the corruption surfaces earlier as the `c->seqid == l` assertion in `mem_chain2aln_across_reads_V2`.

AddressSanitizer pinpoints the OOB write at `src/bwamem.cpp:802` (`memcpy(enc_qdb + offset, seq_[l].seq, l_seq)`), with the buffer allocated by `realloc` at `src/bwamem.cpp:1069` (mem_kernel1_core). Long-read workloads (≥150 bp) hide the bug because the SMEM count stays below `tot_len`; PR #55's `max_readlength`-based sizing covers matchArray but not this enc_qdb/wsize_mem semantic mismatch.

Fix: add `wsize_qdb[MAX_THREADS]` to `mem_cache`, initialize to 0 in `fastmap.cpp:worker_alloc`, and gate the `enc_qdb` realloc on it exclusively. The four other arrays (`matchArray`, `min_intv_ar`, `query_pos_ar`, `rid`) keep using `wsize_mem` -- they're indexed by entry count and were never the source of the corruption.

Reproducer (45M merged single-end aDNA reads, 40-50 bp, hs37d5): unpatched v0.2.0 SIGSEGV at first worker_bwt batch; patched build runs clean, flagstat byte-identical to bwa-mem2 2.2.1 (45,806,401 records, 80.31% mapped). Verified clean under ASAN on a 1M-read subset.

Tested on:
  CPU:      AMD Ryzen 9 9950X (Zen 5, 16C/32T)
  OS:       Ubuntu 26.04 LTS (kernel 7.0.0-15-generic)
  Compiler: gcc 15.2.0
  Build:    `make` (single-binary, USE_MIMALLOC=1, BASELINE_ARCH=avx2)

CI environment for context: matrix uses g++ on ubuntu-latest (gcc 13.x at time of writing) plus one clang++ row, on what appears to be Zen 4 hardware. This reporter is on Zen 5 + gcc 15 (defaults to -std=gnu23), which is a newer toolchain than CI exercises -- but the bug reproduces on AVX2, AVX-512BW, and an SMEM_LOCKSTEP_N=1 rebuild on the same host, so it is not codegen-, SIMD-, or microarchitecture-specific. CI just doesn't exercise the input regime: every fixture under `test/fixtures/` has reads ≥300 bp. A short-read fixture (≤50 bp) added to the regression suite would catch this class of bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an allocation-tracking bug that could leave an encoder buffer undersized on longer reads, improving processing reliability and stability.
* **Chores**
  * Added per-thread size tracking and ensured it’s initialized correctly to prevent future undersizing across batches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/100)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->