### PR TITLE
fix(mapq): propagate SMEM SA-count to seed n_hits so --supp-rep-hard-…

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -943,6 +943,8 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
 
                 s.qbeg = p->m;
                 s.score= s.len = slen;
+                // Propagate SMEM SA-count so chain_n_hits gates --supp-rep-hard-cap.
+                s.n_hits = static_cast<int32_t>(p->s);
                 if (s.rbeg < 0 || s.len < 0)
                     fprintf(stderr, "rbeg: %ld, slen: %d, cnt: %d, n: %d, m: %d, num_smem: %ld\n",
                             s.rbeg, s.len, cnt-1, p->n, p->m, num_smem);


### PR DESCRIPTION
…cap works

`mem_seed_t::n_hits` is the per-seed SA-occurrence count of the SMEM that produced it. It is *read* at `src/bwamem.cpp:2651` to compute `chain_max_n_hits`, which is then assigned to `chain_n_hits` at line 2717 and gates the supp-MAPQ rescoring at
`if (opt->supp_rep_hard_cap > 0 && ... && p->chain_n_hits >= cap)` (`bwamem.cpp:1760`; analogous sites in `bwamem_pair.cpp`).

But `n_hits` is never *assigned* during the SMEM-to-seed conversion loop at `src/bwamem.cpp:944-948`. The seed is stack-allocated as `mem_seed_t s;` and gets `n_hits = 1` from the `abc()` default constructor in `bwamem.h:124`. `s.qbeg`, `s.score`, `s.len` are populated from the SMEM, but `s.n_hits` is left at the default.

Consequently every seed has `n_hits == 1`, every chain has `chain_max_n_hits == 1`, and the gate `chain_n_hits >= cap` evaluates FALSE for any `cap >= 2`. The `--supp-rep-hard-cap N` flag parses correctly, propagates to `mem_opt_t`, and reaches the rescoring sites -- but the data feeding the gate is never populated, so the option ships as documented and does literally nothing.

The "1 = no repetitive seed" comment on `chain_n_hits` at `bwamem.h:163` documents the intent, not the implementation.

Fix: one line in the SMEM->seed materialization loop -- `s.n_hits = p->s;`. `p->s` is the SMEM's SA-count and is already in scope.

Verification (45M merged single-end aDNA reads, 40-50 bp, hs37d5; sambamba markdup; samtools mpileup -B -q 30 -Q 30 -l v42.4.1240K.pos; pileupCaller --randomHaploid --seed 42):

                 supps at MAPQ=0        geno sites differ vs cap=0
                 -----------------      --------------------------
  cap=0          903,503                (baseline)
  cap=5          924,843  (+21,340)     467
  cap=10         916,705  (+13,202)     1
  cap=20         905,199  (+1,696)      0

Before this fix all four caps produced an identical SAM (cap=0 supp-MAPQ=0 count for every value of N). After the fix the cap acts as advertised.

This is the data dependency that PR #56 needed but didn't add; upstream issue #46 ("track(correctness): investigate unreliable supplementary-alignment MAPQ (upstream #260)") therefore remained effectively unresolved at v0.2.0 despite the cap option shipping.

CI gap: PR #56 added a working call site against an unwritten data dependency. No integration test in `test/` exercises the flag against a workload with repetitive seeds, so this slipped past the matrix. A fixture-based test asserting non-equality of supp MAPQ histograms between `--supp-rep-hard-cap 0` and `--supp-rep-hard-cap 5` on a known-repetitive region would catch this class of regression.

Tested on:
  CPU:      AMD Ryzen 9 9950X (Zen 5, 16C/32T)
  OS:       Ubuntu 26.04 LTS (kernel 7.0.0-15-generic)
  Compiler: gcc 15.2.0
  Build:    `make` (single-binary, USE_MIMALLOC=1, BASELINE_ARCH=avx2)

CI environment for context: matrix uses g++ on ubuntu-latest (gcc 13.x at time of writing) plus one clang++ row, on what appears to be Zen 4 hardware. This is a logic bug independent of compiler or microarch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Seed occurrence counts now reflect actual match repetitiveness during alignment, improving accuracy when handling repetitive genomic regions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/101)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->