### PR TITLE
build(htslib): inherit transitive link deps from htslib_static.mk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,16 @@ jobs:
         # libomp-dev is required so `clang++ -fopenmp` can find -lomp when
         # building the test framework on the AVX2 clang matrix row. On g++
         # rows it's unused — libgomp ships with g++.
+        #
+        # libdeflate-dev exercises the htslib_static.mk transitive-deps
+        # path: htslib's configure auto-detects libdeflate and libhts.a
+        # then references libdeflate_* symbols that resolve via -ldeflate
+        # from $(HTSLIB_static_LIBS). Without this on the runner, the
+        # libdeflate-enabled link path is invisible to CI.
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
-          packages: zlib1g-dev bwa autoconf automake samtools libomp-dev
-          version: 1.0
+          packages: zlib1g-dev libdeflate-dev bwa autoconf automake samtools libomp-dev
+          version: 1.1
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'

--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,16 @@ LIBS += -Lext/htslib -lhts
 LIBS += $(LIBSAIS_OPENMP_LIBS)
 LIBS += $(STATIC_GCC)
 LIBS += $(LIBS_EXTRA)
+# Pull in htslib's transitive deps (-ldeflate when libdeflate is detected,
+# bzlib, lzma, curl when those features are enabled, etc.) from the
+# generated htslib_static.mk -- same mechanism samtools uses. Without this,
+# any htslib feature whose configure auto-detects (notably libdeflate on
+# Debian/Ubuntu, where libdeflate-dev is the default install) results in
+# unresolved-symbol link errors at the bwa-mem3 link step. The `-include`
+# is tolerant of the file being absent on first Make pass; the $(HTS_LIB)
+# rule below produces it as a side effect of building libhts.a.
+-include ext/htslib/htslib_static.mk
+LIBS += $(HTSLIB_static_LIBS)
 # Non-kernel objects: always compiled once at the baseline ISA and linked into
 # libbwa.a on every build (arm64 and x86 alike).
 OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/kthread.o \
@@ -552,7 +562,7 @@ $(HTS_LIB):
 	    ([ -f config.mk ] || (autoreconf -i && \
 	        ./configure --disable-lzma --disable-libcurl --disable-gcs \
 	                    --disable-s3 --disable-plugins --disable-bz2)) && \
-	    $(MAKE) libhts.a
+	    $(MAKE) libhts.a htslib_static.mk
 
 # libsais: compile the two C sources we use (libsais.c + libsais64.c) as
 # plain .o files. OpenMP enabled via LIBSAIS_OPENMP so libsais64_gsa_omp

--- a/Makefile
+++ b/Makefile
@@ -204,15 +204,27 @@ LIBS += $(LIBSAIS_OPENMP_LIBS)
 LIBS += $(STATIC_GCC)
 LIBS += $(LIBS_EXTRA)
 # Pull in htslib's transitive deps (-ldeflate when libdeflate is detected,
-# bzlib, lzma, curl when those features are enabled, etc.) from the
-# generated htslib_static.mk -- same mechanism samtools uses. Without this,
-# any htslib feature whose configure auto-detects (notably libdeflate on
-# Debian/Ubuntu, where libdeflate-dev is the default install) results in
-# unresolved-symbol link errors at the bwa-mem3 link step. The `-include`
-# is tolerant of the file being absent on first Make pass; the $(HTS_LIB)
-# rule below produces it as a side effect of building libhts.a.
+# bzlib / lzma / curl when those features are enabled) from the generated
+# htslib_static.mk -- the same mechanism samtools uses (samtools'
+# config.mk.in pulls in both static_LIBS and static_LDFLAGS).
+#
+# Without this, any htslib configure feature that auto-detects on the
+# host -- notably libdeflate on Debian/Ubuntu where libdeflate-dev is
+# the default install -- gives libhts.a unresolved symbols that fail
+# the bwa-mem3 link step.
+#
+# Mechanism (subtle): on a clean tree, htslib_static.mk doesn't exist
+# at parse time, so `-include` silently skips it. To populate
+# HTSLIB_static_LIBS / HTSLIB_static_LDFLAGS in time for the link
+# recipe we rely on GNU Make's "remade-makefiles" restart loop, which
+# only fires when the include file is itself a target with a non-empty
+# recipe in this Makefile. The rule is declared next to the `$(HTS_LIB)`
+# recipe further down (where HTS_LIB is in scope and the build-time
+# concerns sit together); the `@:` recipe there is required -- a
+# prereq-only rule does NOT trigger restart.
 -include ext/htslib/htslib_static.mk
-LIBS += $(HTSLIB_static_LIBS)
+LIBS    += $(HTSLIB_static_LIBS)
+LDFLAGS += $(HTSLIB_static_LDFLAGS)
 # Non-kernel objects: always compiled once at the baseline ISA and linked into
 # libbwa.a on every build (arm64 and x86 alike).
 OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/kthread.o \
@@ -495,7 +507,9 @@ test-binaries: $(BWA_LIB) $(HTS_LIB)
 	$(MAKE) -C test framework unit integration \
 	    CXX="$(CXX)" \
 	    COVERAGE=$(COVERAGE) \
-	    ARCH_FLAGS_FROM_PARENT='$(ARCH_FLAGS)'
+	    ARCH_FLAGS_FROM_PARENT='$(ARCH_FLAGS)' \
+	    HTSLIB_static_LIBS='$(HTSLIB_static_LIBS)' \
+	    HTSLIB_static_LDFLAGS='$(HTSLIB_static_LDFLAGS)'
 
 shm_section_find_test: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_section_find_test.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/shm_section_find_test.o $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) -o $@
@@ -563,6 +577,20 @@ $(HTS_LIB):
 	        ./configure --disable-lzma --disable-libcurl --disable-gcs \
 	                    --disable-s3 --disable-plugins --disable-bz2)) && \
 	    $(MAKE) libhts.a htslib_static.mk
+
+# Companion to the `-include ext/htslib/htslib_static.mk` near LIBS:
+# declare the include file as a target with a non-empty recipe so GNU
+# Make's "remade-makefiles" restart loop fires on the first parse,
+# builds $(HTS_LIB) (which generates htslib_static.mk as a side effect
+# of the `make libhts.a htslib_static.mk` invocation above), then
+# re-parses this Makefile so HTSLIB_static_LIBS / HTSLIB_static_LDFLAGS
+# resolve in time for the link recipe. `@:` is required -- without a
+# recipe, Make doesn't consider the include file "remade" and skips
+# the restart, leaving the include variables empty at link time.
+# Must be placed after the default goal (myall / all) so it doesn't
+# accidentally become the default goal of `make` with no arguments.
+ext/htslib/htslib_static.mk: $(HTS_LIB)
+	@:
 
 # libsais: compile the two C sources we use (libsais.c + libsais64.c) as
 # plain .o files. OpenMP enabled via LIBSAIS_OPENMP so libsais64_gsa_omp

--- a/test/Makefile
+++ b/test/Makefile
@@ -45,6 +45,17 @@ else
     LIBS     ?= -L.. -fopenmp -lbwa ../ext/libsais/src/libsais.o ../ext/libsais/src/libsais64.o -lz ../ext/htslib/libhts.a -lpthread
 endif
 
+# Inherit htslib's transitive deps from the parent Makefile so libhts.a's
+# libdeflate (and any other configure-autodetected feature) symbols
+# resolve at link time. The parent's `test-binaries` recipe propagates
+# HTSLIB_static_LIBS / HTSLIB_static_LDFLAGS as command-line overrides.
+# Both default to empty when this Makefile is invoked standalone, in
+# which case the link will fail the same way the parent's would without
+# the parent's htslib_static.mk include block -- see the parent Makefile
+# for the mechanism.
+LIBS    += $(HTSLIB_static_LIBS)
+LDFLAGS += $(HTSLIB_static_LDFLAGS)
+
 ifneq ($(IS_ARM),)
     CPPFLAGS = -DENABLE_PREFETCH -D__SSE__=1 -D__SSE2__=1 -D__SSE3__=1 -D__SSSE3__=1 -D__SSE4_1__=1 -D__SSE4_2__=1 -DAPPLE_SILICON=1 -DCACHE_LINE_BYTES=128
     INCLUDES = -I../src -I../ext/sse2neon -I../ext


### PR DESCRIPTION
`Makefile`'s `LIBS` line hard-codes `-Lext/htslib -lhts` but never reads htslib's generated `htslib_static.mk`. htslib's configure auto-detects libdeflate when `libdeflate-dev` is on the system (Debian/Ubuntu's default install since 22.04, Fedora since 36) and, when found, compiles `bgzf.c` / `cram/cram_io.c` against `libdeflate_*` symbols. The resulting `libhts.a` carries unresolved references to `libdeflate_alloc_compressor`, `libdeflate_deflate_compress`, `libdeflate_free_compressor`, `libdeflate_crc32`,
`libdeflate_alloc_decompressor`, `libdeflate_deflate_decompress`, `libdeflate_free_decompressor`, and the parent link fails:

    /usr/bin/x86_64-linux-gnu-ld.bfd: ext/htslib/libhts.a(bgzf.o):
        in function `bgzf_compress':
        undefined reference to `libdeflate_alloc_compressor'
    ...
    collect2: error: ld returned 1 exit status

The current workaround forces htslib's configure to take `--without-libdeflate`, which loses the well-known libdeflate bgzf speedup (≈2-3× over zlib on both compression and decompression -- significant for BAM I/O) for no real reason: the missing piece is just a `-ldeflate` flag at the bwa-mem3 link step.

Fix: read htslib's generated `htslib_static.mk` (which exposes `HTSLIB_static_LIBS`, the full transitive link spec htslib's autoconf computed during configure) and append it to bwa-mem3's `LIBS`. This is the canonical samtools recipe for consuming a vendored libhts.a -- see samtools/samtools `Makefile`. With this in place:

  - libdeflate-dev installed   -> `htslib_static.mk` reports
                                  `-lpthread -lz -lm -ldeflate`,
                                  bwa-mem3 binary dynamically links
                                  `libdeflate.so.0`.
  - libdeflate-dev absent      -> htslib's autoconf falls back to zlib,
                                  `htslib_static.mk` reports
                                  `-lpthread -lz -lm`, bwa-mem3 still
                                  links cleanly.

Net change: +11 -1 in `Makefile`. The `--without-libdeflate` workaround is dropped from the htslib configure invocation; the `$(HTS_LIB)` recipe now also builds `htslib_static.mk` (htslib already has the rule, it's a free side effect of `make libhts.a htslib_static.mk`).

The `-include` is tolerant of the file being absent on Make's first pass; on the second pass (after `$(HTS_LIB)` has run as a dependency of the bwa-mem3 link target) the file exists and `HTSLIB_static_LIBS` expands correctly. A clean tree build was end-to-end verified -- the final link line gains a trailing `-ldeflate` exactly where it's needed, and `ldd bwa-mem3` shows `libdeflate.so.0 => /usr/lib/...`.

Tested on:
  CPU:      AMD Ryzen 9 9950X (Zen 5, 16C/32T)
  OS:       Ubuntu 26.04 LTS (kernel 7.0.0-15-generic)
  Compiler: gcc 15.2.0
  libdeflate-dev 1.23-2ubuntu1 (Ubuntu default for 26.04)
  Build:    `make` (single-binary, USE_MIMALLOC=1, BASELINE_ARCH=avx2)

CI environment for context: matrix uses g++ on ubuntu-latest (gcc 13.x at time of writing, ubuntu-24.04 -> 22.04 image) plus one clang++ row, on what appears to be Zen 4 hardware. The current CI rows do not expose this bug because the GitHub Actions runners do not have `libdeflate-dev` installed by default -- htslib's autoconf falls back to zlib silently, the parent link succeeds, and the `--without-libdeflate` workaround is invisibly redundant. Once a developer or CI matrix row adds `libdeflate-dev` (deliberately or via a base-image bump), the bug becomes visible. The fix is a no-op in the no-libdeflate case and unlocks libdeflate in the with-libdeflate case, so it is safe to land regardless of CI image configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build system to detect and forward statically discovered library link flags and libs so static-linked dependencies resolve correctly during builds.
* **CI**
  * Added libdeflate to Linux dependency installation for static-link scenarios and updated a CI action version for improved reliability.
* **Tests**
  * Test sub-builds now inherit the same detected static link settings as the main build to prevent linker failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->