### PR TITLE
ci: partition kswv-x86 ccache by MAKE_ARCH to fix -march=native flake

### DIFF
--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -452,10 +452,23 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ env.CCACHE_DIR }}
-          # Share with run-mem-${arch}: same restore-keys prefix.
-          key: ccache-${{ runner.arch }}-kswv-${{ github.sha }}
+          # Include MAKE_ARCH in the key/restore-keys so cache entries
+          # don't leak across x86 microarch boundaries. The
+          # `kswv_nrow_zero_test` target compiles src/kswv.cpp at
+          # -march=native to exercise the host's native-ISA kswv class
+          # (see parent Makefile's src/kswv.native.o rule). ccache hashes
+          # the literal command line, NOT host CPUID -- so an
+          # AVX-512-built kswv.native.o was previously served to runners
+          # that lacked AVX-512 (via the `ccache-${{ runner.arch }}-`
+          # prefix matching across microarchs) and the test would SIGILL
+          # on its first kswv operation. Partitioning by MAKE_ARCH
+          # (avx2 / avx512bw / arm64) keeps the cache microarch-aware.
+          # This drops the historical sharing with run-mem-${arch} jobs,
+          # which is fine -- run-mem-x86 builds with explicit -m flags
+          # tied to MAKE_ARCH anyway, not -march=native.
+          key: ccache-${{ runner.arch }}-${{ env.MAKE_ARCH }}-kswv-${{ github.sha }}
           restore-keys: |
-            ccache-${{ runner.arch }}-
+            ccache-${{ runner.arch }}-${{ env.MAKE_ARCH }}-
 
       - name: Build + run kswv unit test
         # Builds the doctest-based test/bwa_mem3_tests_unit binary via the
@@ -491,26 +504,5 @@ jobs:
         run: |
           make clean
           make ASAN=1 arch="$MAKE_ARCH" CXX="ccache g++" CC="ccache gcc" kswv_nrow_zero_test
-          # DIAGNOSTIC (temporary, to be removed once root cause is fixed):
-          # Verify the hypothesis that ccache + -march=native + heterogeneous
-          # GHA runners cause SIGILL when an AVX-512-built kswv.native.o is
-          # restored to a runner that lacks AVX-512. If `runner avx-512 flags`
-          # is empty AND `kswv.native.o avx-512 insn count` > 0, the cached
-          # .o has instructions the runner can't execute.
-          if [ "${{ matrix.arch }}" = "x86" ]; then
-            echo "::group::diagnostic: runner avx-512 features + cached kswv.native.o ISA"
-            echo "--- /proc/cpuinfo avx-512 flags ---"
-            grep -m1 -oE '\bavx512[a-z_]*\b' /proc/cpuinfo | sort -u || echo "(none)"
-            echo "--- src/kswv.native.o AVX-512 instruction count ---"
-            objdump -d src/kswv.native.o 2>/dev/null \
-              | grep -coE '%(zmm[0-9]+|k[0-7])\b|\bvmovdqu64\b|\bvp[a-z]+512[bwdq]?\b' \
-              || echo "0"
-            echo "--- src/kswv.native.o first 10 AVX-512 instructions (if any) ---"
-            objdump -d src/kswv.native.o 2>/dev/null \
-              | grep -E '%(zmm[0-9]+|k[0-7])\b|\bvmovdqu64\b|\bvp[a-z]+512[bwdq]?\b' \
-              | head -10 \
-              || echo "(none)"
-            echo "::endgroup::"
-          fi
           ./kswv_nrow_zero_test
           ccache --show-stats | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -491,5 +491,26 @@ jobs:
         run: |
           make clean
           make ASAN=1 arch="$MAKE_ARCH" CXX="ccache g++" CC="ccache gcc" kswv_nrow_zero_test
+          # DIAGNOSTIC (temporary, to be removed once root cause is fixed):
+          # Verify the hypothesis that ccache + -march=native + heterogeneous
+          # GHA runners cause SIGILL when an AVX-512-built kswv.native.o is
+          # restored to a runner that lacks AVX-512. If `runner avx-512 flags`
+          # is empty AND `kswv.native.o avx-512 insn count` > 0, the cached
+          # .o has instructions the runner can't execute.
+          if [ "${{ matrix.arch }}" = "x86" ]; then
+            echo "::group::diagnostic: runner avx-512 features + cached kswv.native.o ISA"
+            echo "--- /proc/cpuinfo avx-512 flags ---"
+            grep -m1 -oE '\bavx512[a-z_]*\b' /proc/cpuinfo | sort -u || echo "(none)"
+            echo "--- src/kswv.native.o AVX-512 instruction count ---"
+            objdump -d src/kswv.native.o 2>/dev/null \
+              | grep -coE '%(zmm[0-9]+|k[0-7])\b|\bvmovdqu64\b|\bvp[a-z]+512[bwdq]?\b' \
+              || echo "0"
+            echo "--- src/kswv.native.o first 10 AVX-512 instructions (if any) ---"
+            objdump -d src/kswv.native.o 2>/dev/null \
+              | grep -E '%(zmm[0-9]+|k[0-7])\b|\bvmovdqu64\b|\bvp[a-z]+512[bwdq]?\b' \
+              | head -10 \
+              || echo "(none)"
+            echo "::endgroup::"
+          fi
           ./kswv_nrow_zero_test
           ccache --show-stats | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Fixes a latent CI flake in the `kswv-x86` job of `proto-neon-kswv.yml`. The job's `kswv_nrow_zero_test` step compiles `src/kswv.cpp` at `-march=native` so the test exercises the host's native-ISA `kswv` class (see [parent `Makefile`](../blob/main/Makefile)'s `src/kswv.native.o` recipe). ccache hashes the literal compile command line — it does NOT include host CPUID — so the `-march=native` `.o` is content-keyed only by the source + flags, not by which microarch built it.

The cache step's `restore-keys` was the bare prefix `ccache-${{ runner.arch }}-`, which prefix-matches across all x86_64 runners regardless of microarch. Result: an AVX-512-built `kswv.native.o` saved by a job on Intel Sapphire Rapids / AMD Genoa hardware could be served to a later job on AMD Milan / Skylake-class hardware that lacks AVX-512. The test then SIGILLs on its first `kswv` operation:

```
[nrow-zero-test] 8-bit numPairs=1 phase=0 ...
Illegal instruction     (core dumped) ./kswv_nrow_zero_test
```

This was the failure mode hit on fg-labs/bwa-mem3#108 across three consecutive reruns — each landed on a `MAKE_ARCH=avx2` runner and each restored a different stale cache key whose contents came from AVX-512 hosts.

## Diagnosis (commit 9d0dae6 — temporary, reverted in commit f17a093)

The first commit on this branch added an `objdump` diagnostic between the build and the test run, printing the runner's `/proc/cpuinfo` AVX-512 features and the AVX-512 instruction count in `src/kswv.native.o`. On the clean-cache + AVX-2 runner case, the diagnostic showed:

- `/proc/cpuinfo` AVX-512 flags: *(none)*
- `kswv.native.o` AVX-512 instruction count: `0`
- Test: PASSES

By symmetry, the only path to SIGILL on an AVX-2 runner is when the cached `.o` has AVX-512 instructions — exactly the cross-microarch cache leak this PR fixes.

## Fix (commit f17a093)

Include `MAKE_ARCH` (the value detected by the existing `Detect x86 ISA` / `Set arm make arch` steps — `avx2`, `avx512bw`, or `arm64`) in both the cache primary key and the `restore-keys` prefix. Cache entries no longer leak across microarch boundaries:

```yaml
key: ccache-${{ runner.arch }}-${{ env.MAKE_ARCH }}-kswv-${{ github.sha }}
restore-keys: |
  ccache-${{ runner.arch }}-${{ env.MAKE_ARCH }}-
```

## Tradeoff

This drops the historical cache sharing between the `kswv-*` and `run-mem-*` jobs (they previously shared the bare `ccache-${{ runner.arch }}-` prefix per the existing comment). That's fine: `run-mem-x86` builds with explicit `-m` flags tied to `MAKE_ARCH` (`make arch="$MAKE_ARCH" ...` — no `-march=native`), so its cache content is already microarch-determined. The cross-job sharing was buying nothing safe — only the `-march=native` path is microarch-sensitive, and that only exists in `kswv_nrow_zero_test`.

## Test plan

- [ ] CI run on this branch passes `kswv-x86` (was failing on fg-labs/bwa-mem3#108 with the same SIGILL).
- [ ] Verify other jobs in `proto-neon-kswv.yml` (`kswv-arm`, `run-mem-*`, `report`) still pass — they don't touch the cache key changed here.
- [ ] No code-build behavior change; only CI cache scoping.