### PR TITLE
fix(changelog): strip preamble so release-please owns the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,1 @@
 # Changelog
-
-All notable changes from v0.3.0 onward are documented here. Entries are generated automatically by [release-please](https://github.com/googleapis/release-please) from [Conventional Commits](https://www.conventionalcommits.org/).
-
-For the v0.2.0 release notes, see [`NEWS.md`](./NEWS.md).


### PR DESCRIPTION
## Summary

- Reduce `CHANGELOG.md` to a bare `# Changelog` heading.
- Removes the two preamble paragraphs that release-please mishandles.

## Problem

The first release-please run produced a malformed CHANGELOG layout in #107:

```
# Changelog
## [0.2.1] (2026-05-16)
### Bug Fixes / Documentation
* ...
## Changelog                              <-- redundant H2
All notable changes from v0.3.0 onward... <-- orphaned preamble
For the v0.2.0 release notes, see NEWS.md.
```

`release-please-action` (with `release-type: simple`) inserts new release notes immediately after the `# Changelog` H1 and treats anything below as "prior content". When that prior content does not begin with a `## [version]` marker, the action emits its own `## Changelog` separator before re-appending it. Our preamble paragraphs trip that path on every release. CodeRabbit also flagged the duplicate H2 inline on #107, but deleting only the H2 leaves the preamble orphaned below the release entries — this PR fixes the root cause.

## Fix

Drop the preamble entirely. The "see NEWS.md for v0.2.0" pointer is already redundant — NEWS.md's opening paragraph points back to CHANGELOG.md for v0.3.0+, so the historical context is one click away from either file. The "generated by release-please" sentence is self-evident from the file's contents.

After this lands, release-please will regenerate #107 with a clean file: H1, version section, entries. No orphaned preamble, no duplicate header.

## Test plan

- [ ] Merge to `main`.
- [ ] Confirm release-please re-runs and rewrites #107 with a clean `# Changelog` + `## [0.2.1]` layout (no `## Changelog` H2, no orphaned preamble).
- [ ] Spot-check the resulting CHANGELOG.md on the regenerated branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined changelog documentation by removing explanatory text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->