### PR TITLE
ci(release): read bwa-mem3 version from stdout only in smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,11 @@ jobs:
           tar -xzf Source_code_including_submodules.tar.gz -C /tmp
           cd "/tmp/bwa-mem3-${VERSION}"
           make -j"$(nproc)" CC=cc CXX=c++
-          got=$(./bwa-mem3 version 2>&1 | head -1)
+          # Read stdout only -- bwa-mem3 prints its version string to
+          # stdout, while mimalloc emits a startup banner ("mimalloc
+          # 3.3.x") to stderr. With `2>&1` the banner can flush first
+          # and `head -1` then captures the wrong line.
+          got=$(./bwa-mem3 version 2>/dev/null | head -1)
           case "$got" in
             "$VERSION"|"$VERSION"-*)
               echo "bwa-mem3 version OK: $got"


### PR DESCRIPTION
## Why

After PR #113 unblocked the v0.2.1 release tarball build, the smoke test now reaches the version-assertion step — and immediately fails:

```
##[error]bwa-mem3 reports 'mimalloc 3.3.0', expected '0.2.1' or '0.2.1-<suffix>' (Makefile / scripts/version.sh drifted from version.txt)
```

`bwa-mem3 version` prints its version to **stdout**, while mimalloc emits a one-line startup banner (`mimalloc 3.3.x`) to **stderr**. The current smoke test does `bwa-mem3 version 2>&1 | head -1`, merging both streams; whichever line flushes first wins. On the GitHub-hosted runner that's the stderr banner, so the assertion compares against the wrong line and fails.

Verified locally on `aarch64-apple-darwin`:

```
$ ./bwa-mem3 version 2>/dev/null
0.2.1
SIMD floor: neon (aarch64 baseline); kernels: neon
SIMD runtime: neon (BWAMEM3_FORCE_TIER unset)

$ ./bwa-mem3 version 2>&1 >/dev/null
mimalloc 3.3.0
```

The smoke test's job is to assert bwa-mem3's reported version, not mimalloc's. The fix is to read stdout only.

## What

Drop `2>&1` from the smoke test's version capture. Add a comment explaining the stderr-banner gotcha so future readers don't "fix" this back to `2>&1`.

## Why this was latent

PR #102 added the smoke test, but until PR #113 fixed the htscodecs `version.h` bug, the build always died before reaching this assertion. v0.2.1 is the first release whose tarball build runs to completion, exposing the masked bug.

## Verification plan

After this lands, re-run the `Release` workflow via `workflow_dispatch` for `v0.2.1` to produce the missing `Source_code_including_submodules.tar.gz` asset.