### PR TITLE
test(regression): add ASAN short-read fixture (closes #103)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,32 @@ jobs:
           BWAMETH_DIR: ${{ github.workspace }}/bwa-meth-oracle
         run: bash test/regression/meth_oracle.sh
 
+      - name: Short-read SE smoke (chr22, ASAN, dense+variable-length)
+        if: matrix.canonical == true
+        # Guards the wsize_mem byte-vs-entry capacity-tracker class of bug
+        # fixed in PR #100. The fixture simulates 25-50 bp variable-length
+        # reads from chr22:14M-20M (pericentromeric, repeat-rich) at 5-10%
+        # error so SMEM density per base exceeds tot_len bytes across
+        # successive batches with mismatched byte totals — exactly the
+        # regime that inverts the `if (tot_len >= wsize_mem)` gate.
+        # Builds with ASAN=1 (forces USE_MIMALLOC=0; mimalloc and asan
+        # can't coexist) so the heap-buffer-overflow in mem_collect_smem
+        # surfaces as a non-zero exit independent of allocator behavior.
+        # Placed last in the canonical row because `make clean && make
+        # ASAN=1` replaces $GITHUB_WORKSPACE/bwa-mem3; nothing after this
+        # step uses the binary. Canonical-only because PR #100 confirmed
+        # the bug is input-regime-specific, not codegen-/SIMD-specific
+        # (reproduces on AVX2, AVX-512BW, SMEM_LOCKSTEP_N=1).
+        run: |
+          make clean
+          make -j"$(nproc)" arch=${{ matrix.arch_flag }} \
+            CXX=${{ matrix.cxx || 'g++' }} ASAN=1
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          CHR22_FA=/tmp/chr22/chr22.fa \
+          CHR22_SIM_DIR=/tmp/chr22-sim-dense \
+          PIXI_MANIFEST="$GITHUB_WORKSPACE/test/holodeck/pixi.toml" \
+          bash test/regression/short_read_smoke.sh
+
   coverage:
     name: Coverage (Linux AVX2, gcov → Codecov)
     runs-on: ubuntu-latest

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -12,6 +12,7 @@ matrix row; the rest run on the canonical AVX2 row only. Each script:
 | `chr22_parity.sh`            | bwa vs bwa-mem3 SAM parity on ~50k PE holodeck reads (chr22)          | "Compare chr22 bwa vs bwa-mem3 (parity)"            |
 | `thread_determinism.sh`      | `-t 1` == `-t 4` output after sort on chr22                           | "Thread-determinism smoke (chr22, -t 1 vs -t 4)"    |
 | `bam_roundtrip.sh`           | `--bam=6` BAM decodes and has same record count as SAM (chr22)        | "--bam=6 roundtrip smoke (chr22)"                   |
+| `short_read_smoke.sh`        | ASAN SE on 25-50 bp variable-length dense-chr22 reads (PR #100 fix)   | "Short-read SE smoke (chr22, ASAN, dense+variable-length)" |
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
 
 Each script reads its inputs from environment variables — see the comment

--- a/test/regression/short_read_smoke.sh
+++ b/test/regression/short_read_smoke.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# test/regression/short_read_smoke.sh
+#
+# Regression: ASAN-instrumented bwa-mem3 mem on short, variable-length
+# reads from a repeat-dense region of chr22 must complete cleanly,
+# guarding the wsize_mem byte-vs-entry capacity-tracker class of bug
+# fixed in PR #100.
+#
+# Bug recap. mmc->wsize_mem is set in *bytes* by mem_kernel1_core to
+# size enc_qdb (= tot_len), then repurposed by mem_collect_smem as an
+# *SMEM-entry count* to size matchArray. On subsequent batches the gate
+# `if (tot_len >= wsize_mem)` compares bytes vs SMEM entries. Whenever
+# the carried-over SMEM count exceeds the next batch's byte total,
+# enc_qdb is left undersized and the next
+# `memcpy(enc_qdb + offset, seq, l_seq)` in mem_collect_smem overflows
+# its buffer.
+#
+# Two ingredients are required to surface the bug on CI-scale inputs:
+#   1. High SMEM density per base — short reads with non-trivial error,
+#      aligned to a repeat-rich slice (pericentromeric chr22:14M-20M).
+#   2. Variable per-batch byte totals — variable read length (25-50 bp)
+#      across the FASTQ so successive batches have very different
+#      tot_len, letting one batch's stale wsize_mem (SMEM count) exceed
+#      the next batch's tot_len (bytes).
+#
+# Uniform-length short reads from a low-error chr22 sim do NOT trigger
+# the bug: every batch has the same tot_len, so the gate compares
+# wsize_mem-as-bytes against tot_len-as-bytes correctly, and the
+# misuse downstream in mem_collect_smem never lands on an undersized
+# enc_qdb. The fixture was discovered the hard way; do not "simplify"
+# it back to a single-length truncate of the canonical chr22 sim.
+#
+# Detection: build with `make ASAN=1` (forces USE_MIMALLOC=0 — mimalloc
+# and asan can't coexist) so the heap-buffer-overflow in
+# mem_collect_smem is caught directly. An un-instrumented build merely
+# undersizes enc_qdb and the corruption-to-SIGSEGV translation depends
+# on the allocator's adjacent-metadata layout, which is fragile across
+# libcs and not portable enough for CI.
+#
+# Inputs (env vars):
+#   BWA_MEM3       — path to the ASAN-instrumented bwa-mem3 binary
+#   CHR22_FA       — path to chr22.fa (pre-indexed with bwa-mem3 by caller)
+#   CHR22_SIM_DIR  — directory for fixture-private intermediates
+#   PIXI_MANIFEST  — path to test/holodeck/pixi.toml (holodeck + samtools)
+
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+: "${CHR22_FA:?CHR22_FA must be set}"
+: "${CHR22_SIM_DIR:?CHR22_SIM_DIR must be set}"
+: "${PIXI_MANIFEST:?PIXI_MANIFEST must be set}"
+
+mkdir -p "$CHR22_SIM_DIR"
+
+# Surface the bwa-mem3 stderr log on any error. Without this, a non-zero
+# exit from bwa-mem3 (the exact failure mode this fixture exists to
+# catch) is killed by `set -e` before the ASAN report is echoed,
+# leaving CI with only "exit 134" and no backtrace.
+short_log="$CHR22_SIM_DIR/short_dense_var.log"
+trap 'rc=$?; if [ $rc -ne 0 ] && [ -f "$short_log" ]; then
+        echo "--- bwa-mem3 stderr ($short_log) ---" >&2
+        tail -n 200 "$short_log" >&2
+      fi; exit $rc' ERR
+
+# Pericentromeric chr22:14M-20M is ~23% Ns interleaved with repeat-rich
+# sequence; reads simulated from here hit many short SMEMs per base.
+bed="$CHR22_SIM_DIR/chr22_dense.bed"
+printf 'chr22\t14000000\t20000000\n' > "$bed"
+
+# 1x coverage of 6 Mb at 45 bp = ~133k reads. The bug fires across
+# successive 1024-read SMEM batches within a single mem_kernel1_core
+# call, so coverage well below the "real workload" (45M reads in PR
+# #100's reproducer) still produces plenty of inner batches per thread.
+# 5-10% error rate keeps SMEMs short and numerous; --max-n-frac is
+# loosened because the dense region is N-rich; --single-end emits R1
+# only.
+pixi run --frozen --manifest-path "$PIXI_MANIFEST" -- \
+  holodeck simulate \
+    -r "$CHR22_FA" \
+    -b "$bed" \
+    -o "$CHR22_SIM_DIR/short_dense" \
+    --coverage 1 \
+    --read-length 45 \
+    --fragment-mean 45 --fragment-stddev 5 --min-fragment-length 30 \
+    --seed 42 \
+    --simple-names \
+    --single-end \
+    --min-error-rate 0.05 --max-error-rate 0.10 \
+    --max-n-frac 0.5
+
+# Truncate per-read to a deterministic length in [25, 50]. Variable
+# lengths across the FASTQ are the second ingredient: a batch carrying
+# wsize_mem from a long-batch tail can leave enc_qdb undersized for the
+# next batch whose tot_len byte total is smaller but whose SMEM count
+# has not yet shrunk below the carried-over value. Output is left
+# uncompressed (bwa-mem3 is the sole consumer and decompresses anyway);
+# mawk's END block writes the record count to a sidecar so we don't
+# pay a second pass over the file just to count.
+short_fq="$CHR22_SIM_DIR/short_dense_var.fq"
+short_count="$CHR22_SIM_DIR/short_dense_var.count"
+gunzip -c "$CHR22_SIM_DIR/short_dense.r1.fastq.gz" \
+  | mawk -v count_out="$short_count" 'BEGIN{srand(42)}
+      NR%4==1 { cur_len = 25 + int(26*rand()); print; next }
+      NR%4==2 || NR%4==0 { print substr($0, 1, cur_len); next }
+      { print }
+      END { print NR/4 > count_out }' \
+  > "$short_fq"
+
+short_records=$(cat "$short_count")
+echo "short-read fastq: $short_records records (25-50bp, pericentromeric)"
+
+# Refuse to silently "pass" if holodeck produced essentially nothing —
+# without this, an empty/near-empty FASTQ would let bwa-mem3 exit 0 on
+# zero input and the >= record-count check below would trivially hold.
+# Threshold is two orders of magnitude below the expected ~133k.
+if [ "$short_records" -lt 1000 ]; then
+    echo "FAIL: short-read fastq has $short_records records, expected ~133k (holodeck regression?)" >&2
+    exit 1
+fi
+
+# Fail fast on the first ASAN report so the trap's tail of $short_log
+# captures the actual overflow rather than downstream cascade noise.
+# detect_leaks=0 because LSan (bundled with ASan on Linux, off on
+# macOS) finds pre-existing leaks in FMI_search's lockstep SMEM path
+# that are orthogonal to the wsize_mem class of bug this fixture
+# guards. Conflating the two would block every PR on an unrelated
+# bug; the leaks should be addressed in their own change.
+short_sam="$CHR22_SIM_DIR/short_dense_var.sam"
+ASAN_OPTIONS=abort_on_error=1:halt_on_error=1:detect_leaks=0 \
+"$BWA_MEM3" mem -t 4 "$CHR22_FA" "$short_fq" \
+    > "$short_sam" 2>"$short_log"
+
+# `|| true` because grep -c returns 1 on zero matches (a header-only SAM
+# with set -e would die here instead of at the explicit FAIL below).
+sam_records=$(grep -cv '^@' "$short_sam" || true)
+echo "short-read SAM:   $sam_records records"
+
+# Every input read must produce at least one primary record. The
+# pre-fix corruption truncates the SAM mid-stream (un-instrumented
+# builds) or aborts (ASAN builds), so the equality is a load-bearing
+# check, not a tautology. Tolerate >= because secondary/supplementary
+# alignments add extra lines on the chr22 pericentromere.
+if [ "$sam_records" -lt "$short_records" ]; then
+    echo "FAIL: short-read SE produced $sam_records SAM records, expected >= $short_records" >&2
+    exit 1
+fi
+
+echo "PASS: short-read SE smoke ($sam_records records, 25-50bp pericentromeric)"


### PR DESCRIPTION
## Summary

Closes the CI coverage gap that let the wsize_mem byte-vs-entry capacity tracker bug (PR #100) ship undetected: every fixture under `test/fixtures/` was ≥300 bp, so the gate inversion the bug needs never fired.

The fixture is a regression test, not a unit-test reproducer: it simulates 25-50 bp variable-length single-end reads from pericentromeric `chr22:14M-20M` (repeat-rich, ~23% Ns) at 5-10% error, runs ASAN-instrumented `bwa-mem3 mem`, and asserts a clean exit with full record count. ASAN catches the `mem_collect_smem` heap-buffer-overflow at `bwamem.cpp:676` directly so the signal doesn't depend on allocator-specific corruption-to-SIGSEGV translation.

Two ingredients are required and the first design attempt (a naive 45 bp truncate of the existing chr22 sim) failed to reproduce the bug even under ASAN. The script header documents why and warns future readers not to "simplify" it back. Both ingredients confirmed empirically against an `ab922b6`-reverted local build: exit 134 with `heap-buffer-overflow` in `mem_collect_smem` pre-fix, exit 0 with 133,334/133,334 records post-fix.

## Deviations from the issue text (intentional, documented in commit body)

- **Read count 133k, not "a few thousand."** The bug needs ≥40k reads to produce multiple variable-byte-total inner SMEM batches across 4 threads; 133k is the conservative-safe floor and adds ~15-20s vs. a flakiness-prone smaller count.
- **Reference is the suite's existing chr22, not one of the `test/fixtures/` small slices.** No regression script uses the synthetic 1 Mb or PhiX fixtures; the suite's de-facto reference is the UCSC chr22 downloaded once per CI matrix row. We scope holodeck's *input* region with a 6 Mb BED rather than introducing a new reference.
- **Canonical row + ASAN only, not the full matrix.** PR #100 confirmed the bug is input-regime-specific, not SIMD-/codegen-specific (reproduces on AVX2, AVX-512BW, `SMEM_LOCKSTEP_N=1`). Adding it to every matrix row would cost ~25 min CI per PR for zero marginal coverage.
- **Assertion is ASAN abort + record-count floor, not a bwa-mem2 SAM oracle.** Pre-fix builds crash under ASAN before producing a comparable SAM; ASAN catching the OOB directly is more reliable than allocator-dependent corruption-to-SIGSEGV plus a downstream diff.

## LSan note (`ASAN_OPTIONS=detect_leaks=0`)

The first CI run surfaced pre-existing leaks in `FMI_search.cpp:952`/`:954` (`static thread_local` SMEM caches never freed at thread exit) — orthogonal to the wsize_mem class of bug this fixture guards. Filed as #116. The fixture disables LSan (`detect_leaks=0`) so it stays scoped to its intended bug class; the `detect_leaks` toggle should be removed once #116 is resolved.

## Test plan

- [ ] CI: canonical-row "Short-read SE smoke (chr22, ASAN, dense+variable-length)" step passes.
- [ ] CI: wall-time of the new step is acceptable (first run measured ~4m10s total — ~3.5min `make clean && make ASAN=1` rebuild + ~25s holodeck sim + ~11s `bwa-mem3 mem` real time; build dominates as predicted).
- [ ] CI: no regression of any other matrix row or step.
- [ ] Reviewer confirms the four deviations above are acceptable trade-offs.
- [ ] Reviewer confirms `detect_leaks=0` is the right call (alternative: block on #116).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added a regression test to detect heap-buffer-overflow issues in short variable-length read alignment.

* **Chores**
  * Enhanced CI pipeline with memory sanitization testing for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->