### PR TITLE
fix(smem): free lockstep SMEM caches at thread exit (closes #116)

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -565,6 +565,22 @@ enum LockstepPhase : uint8_t {
     PH_DONE     = 3   // slot finished; match_buf ready for flush
 };
 
+// Per-thread cache for the lockstep SMEM driver's prev[]/match_buf[]
+// buffers. RAII wrapper exists so the buffers are released at thread
+// exit instead of leaking until process exit (LSan complaint, issue
+// #116). Holding the cache as `static thread_local LockstepSmemCache`
+// inside getSMEMsOnePosOneThread_lockstep keeps the per-call reuse
+// behavior unchanged; only the cleanup point moves.
+struct LockstepSmemCache {
+    SMEM  *prev     = nullptr;
+    SMEM  *match    = nullptr;
+    size_t per_slot = 0;
+    ~LockstepSmemCache() {
+        if (prev  != nullptr) _mm_free(prev);
+        if (match != nullptr) _mm_free(match);
+    }
+};
+
 // LISA trick #4: hybrid SoA. The per-slot "hot" state stays compact
 // (~80 bytes) so cross-slot access (e.g. T1 prefetch lookahead against
 // slots[(s+N/2)%N]) hits a tight L1-resident array instead of jumping
@@ -933,31 +949,28 @@ void FMI_search::getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
     // TODO(memory): the cache only grows. For mixed-length workloads (e.g.
     // a single ONT-class read with max_readlength≈1e6 mid-stream — sized
     // to ~640 MB per thread, ~10 GB across 16 OMP workers — followed by
-    // short reads), the high-water mark is held until thread/process exit.
+    // short reads), the high-water mark is held until thread exit.
     // Acceptable for the smoke1M Illumina PE150 benchmark (max_readlength≈
     // 150 → ~38 KB/thread). Revisit if a streaming aligner or long-running
     // service pipeline appears: gate the realloc on a configured upper
-    // bound (e.g. MAX_SMEM_PER_SLOT) or shrink when cached_per_slot greatly
-    // exceeds the current batch. Also flagged by leak-sanitizer/Valgrind
-    // because the buffers are released only at process exit.
+    // bound (e.g. MAX_SMEM_PER_SLOT) or shrink when cache.per_slot greatly
+    // exceeds the current batch.
     BatchSlot slots[SMEM_LOCKSTEP_N] = {};
-    static thread_local SMEM   *cached_prev  = NULL;
-    static thread_local SMEM   *cached_match = NULL;
-    static thread_local size_t  cached_per_slot = 0;
+    static thread_local LockstepSmemCache cache;
     const size_t per_slot_smems = (size_t)max_readlength;
-    if (per_slot_smems > cached_per_slot) {
-        if (cached_prev  != NULL) _mm_free(cached_prev);
-        if (cached_match != NULL) _mm_free(cached_match);
+    if (per_slot_smems > cache.per_slot) {
+        if (cache.prev  != nullptr) _mm_free(cache.prev);
+        if (cache.match != nullptr) _mm_free(cache.match);
         const size_t total_slot_bytes = (size_t)N * per_slot_smems * sizeof(SMEM);
-        cached_prev  = (SMEM *)_mm_malloc(total_slot_bytes, 64);
-        assert_not_null(cached_prev, total_slot_bytes, total_slot_bytes);
-        cached_match = (SMEM *)_mm_malloc(total_slot_bytes, 64);
-        assert_not_null(cached_match, total_slot_bytes, (size_t)2 * total_slot_bytes);
-        cached_per_slot = per_slot_smems;
+        cache.prev  = (SMEM *)_mm_malloc(total_slot_bytes, 64);
+        assert_not_null(cache.prev, total_slot_bytes, total_slot_bytes);
+        cache.match = (SMEM *)_mm_malloc(total_slot_bytes, 64);
+        assert_not_null(cache.match, total_slot_bytes, (size_t)2 * total_slot_bytes);
+        cache.per_slot = per_slot_smems;
     }
     for (int32_t s = 0; s < N; s++) {
-        slots[s].prev      = cached_prev  + (size_t)s * cached_per_slot;
-        slots[s].match_buf = cached_match + (size_t)s * cached_per_slot;
+        slots[s].prev      = cache.prev  + (size_t)s * cache.per_slot;
+        slots[s].match_buf = cache.match + (size_t)s * cache.per_slot;
     }
 
     // Seed the first min(N, numReads) slots.
@@ -1043,9 +1056,10 @@ void FMI_search::getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
     }
 
     *__numTotalSmem = numTotalSmem;
-    /* prev/match buffers are owned by thread_local caches above; intentionally
+    /* prev/match buffers are owned by the thread_local cache above; intentionally
      * not freed here so the next call (same thread) reuses them without a
-     * round-trip through the allocator. The caches leak at thread/process exit. */
+     * round-trip through the allocator. They are released by
+     * LockstepSmemCache's destructor at thread exit. */
 }
 
 int64_t FMI_search::bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,

--- a/test/regression/short_read_smoke.sh
+++ b/test/regression/short_read_smoke.sh
@@ -118,15 +118,13 @@ if [ "$short_records" -lt 1000 ]; then
     exit 1
 fi
 
-# Fail fast on the first ASAN report so the trap's tail of $short_log
-# captures the actual overflow rather than downstream cascade noise.
-# detect_leaks=0 because LSan (bundled with ASan on Linux, off on
-# macOS) finds pre-existing leaks in FMI_search's lockstep SMEM path
-# that are orthogonal to the wsize_mem class of bug this fixture
-# guards. Conflating the two would block every PR on an unrelated
-# bug; the leaks should be addressed in their own change.
+# Fail fast on the first ASAN/LSan report so the trap's tail of
+# $short_log captures the actual overflow rather than downstream
+# cascade noise. LSan (bundled with ASan on Linux) is left on its
+# default so the fixture also catches per-thread leak regressions
+# (e.g. the FMI_search lockstep SMEM caches fixed in #116).
 short_sam="$CHR22_SIM_DIR/short_dense_var.sam"
-ASAN_OPTIONS=abort_on_error=1:halt_on_error=1:detect_leaks=0 \
+ASAN_OPTIONS=abort_on_error=1:halt_on_error=1 \
 "$BWA_MEM3" mem -t 4 "$CHR22_FA" "$short_fq" \
     > "$short_sam" 2>"$short_log"
 


### PR DESCRIPTION
## Summary

`FMI_search::getSMEMsOnePosOneThread_lockstep` caches its `prev[]` and `match_buf[]` buffers per-thread via three `static thread_local` raw pointers, grown on demand and never freed. LSan (bundled with `make ASAN=1` on Linux) reports them as leaked at process exit. The existing comment block at the call site already flagged this as `TODO(memory)` / "flagged by leak-sanitizer/Valgrind because the buffers are released only at process exit".

Discovered when PR #115's first CI run aborted on the LSan report rather than catching the `wsize_mem`-class bug it's actually testing for.

## Fix

Wrap the three statics in a small RAII struct (`LockstepSmemCache`) and hold the cache as `static thread_local LockstepSmemCache cache`. C++11 thread-local destructors run on thread exit (via `__cxa_thread_atexit` on glibc), so the buffers are released deterministically when each worker thread finishes. Per-call reuse pattern is unchanged — only the cleanup point moves from "never" to "thread exit".

Minimum-diff fix. The broader monotonic-growth concern (a single ONT-class read sizing the cache to ~640 MB/thread, held until thread exit) is unchanged and should be addressed separately if a streaming/service pipeline appears.

## Stacked on #115

Base is `test/issue-103-short-read-fixture` (PR #115). Two commits:

1. `fix(smem): free thread-local lockstep SMEM caches at thread exit` — the actual fix in `src/FMI_search.cpp`.
2. `test(regression): re-enable LSan in short-read smoke now that #116 is fixed` — removes `detect_leaks=0` from the short-read fixture #115 introduced, so the same fixture now catches per-thread SMEM leak regressions going forward.

After #115 merges to main, this PR's base will need to be re-targeted to main and rebased. The two commits are orthogonal in terms of files touched (`src/FMI_search.cpp` vs. `test/regression/short_read_smoke.sh`).

## Test plan

- [ ] CI: canonical-row "Short-read SE smoke (chr22, ASAN, dense+variable-length)" passes with LSan default-on (the `detect_leaks=0` flag is removed).
- [ ] CI: no regression of any other matrix row, including the existing chr22 parity/thread-determinism/meth steps.
- [ ] Local LSan verification not possible on macOS (`detect_leaks is not supported on this platform`); relying on Linux CI.
- [ ] Reviewer confirms `static thread_local LockstepSmemCache` with a non-trivial destructor is the right primitive vs. moving the cache into `worker_t` / `mem_cache` (Option 2 in #116).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management in search operations so per-thread buffers are cleaned up reliably at thread exit, reducing resource retention and improving stability.

* **Tests**
  * Strengthened regression tests to enable leak detection at thread level, catching per-thread memory regressions earlier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->