### PR TITLE
test(mapq): regression for --supp-rep-hard-cap on repetitive workload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,14 @@ jobs:
           CHR22_SIM_DIR=/tmp/chr22-sim \
           bash test/regression/thread_determinism.sh
 
+      - name: --supp-rep-hard-cap repetitive-seed regression
+        if: matrix.canonical == true
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          SUPP_REP_FIXTURE_AWK="$GITHUB_WORKSPACE/test/fixtures/supp_rep/build_fixture.awk" \
+          SUPP_REP_PHIX_FA="$GITHUB_WORKSPACE/test/fixtures/phix.fa" \
+          bash test/regression/supp_rep_hard_cap.sh
+
       - name: SE alignment smoke (chr22)
         if: matrix.canonical == true
         run: |

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -14,6 +14,8 @@ All four SMEM/seed tests share `phix.fa` (phiX174, NC_001422.1, 5386 bp) as the 
 
 `synthetic_1mb.fa` is a 1 Mbp ACGT-only FASTA used by the libsais byte-diff, determinism, and memory-budget tests; the matching `.0123` and `.bwt.2bit.64` baselines under `baselines/` are derived from it and only stay reproducible when both source and baselines are committed together.
 
+`supp_rep/build_fixture.awk` is a generator (no committed data) used by `test/regression/supp_rep_hard_cap.sh`. It emits a deterministic engineered reference + SE reads exercising `--supp-rep-hard-cap` against a chain with a high-SA-count SMEM but a uniquely-disambiguated extension; see comments at the top of the awk script.
+
 ## Regenerating the fixtures
 
 Fixtures are derived from `phix.fa` (committed). To regenerate after a format change:

--- a/test/fixtures/supp_rep/build_fixture.awk
+++ b/test/fixtures/supp_rep/build_fixture.awk
@@ -1,0 +1,96 @@
+# Deterministically construct an engineered reference + SE reads that
+# trigger --supp-rep-hard-cap. All bases are sliced from committed
+# phix.fa so the generated fixture is byte-identical across awk
+# implementations (mawk version drift, gawk, BSD awk) — no PRNG.
+#
+# Run as:
+#   mawk -v MODE=ref   -f build_fixture.awk test/fixtures/phix.fa > ref.fa
+#   mawk -v MODE=reads -f build_fixture.awk test/fixtures/phix.fa > reads.fq
+#
+# Phix slice allocations (positions 0-based, half-open; phix.fa is 5386 bp):
+#   [   0,  400)  UNIQUE_A   (400 bp, 1 copy in ref)
+#   [ 400,  600)  UNIQUE_C   (200 bp, 1 copy in ref; disambiguates supp chain)
+#   [ 600,  660)  MOTIF      ( 60 bp, 8 copies in ref; high SA-count seed)
+#   [ 700, 4100)  filler bank — see allocations below
+#
+# Filler slot allocations (all from phix, each used exactly once):
+#   F_pre        (100 bp, phix[ 700, 800))   — between ref start and UNIQUE_A
+#   F_post       (200 bp, phix[ 800,1000))   — between UNIQUE_A and MOTIF copy 0
+#   F_inter[k]   (500 bp, phix[1000+500*k, 1500+500*k)) — between adjacent
+#                                                          MOTIF copies (6 slots)
+#   F_tail       (100 bp, phix[4000,4100))   — after the last MOTIF copy
+#
+# Ref layout (each | separates one concatenated piece):
+#   F_pre | UA | F_post | M | F_i0 | M | F_i1 | M | F_i2 | M | F_i3 | M | UC
+#                                                            \-- DISAMBIG (5th M)
+#         | M | F_i4 | M | F_i5 | M | F_tail
+#
+# Eight MOTIF copies total; the fifth (0-indexed DISAMBIG=4) is followed
+# immediately by UNIQUE_C, so the 260 bp string MOTIF+UNIQUE_C appears
+# uniquely once in the ref while MOTIF alone appears eight times. The
+# 500 bp inter-repeat gap is large enough that bwa-mem2 emits each MOTIF
+# copy as a separate chain seed (SA-count 8 → n_hits=8); too small a gap
+# can let chain merging collapse the eight ref hits into a single chain
+# without propagating the per-seed n_hits=8 to chain_n_hits.
+#
+# Read structure: UNIQUE_A + MOTIF + UNIQUE_C = 660 bp.
+#   primary chain → UNIQUE_A   (chain_n_hits = 1, MAPQ = 60)
+#   supp chain    → MOTIF + UNIQUE_C at DISAMBIG  (chain_n_hits = 8 from the
+#                                                  MOTIF seed; natural MAPQ
+#                                                  high because UNIQUE_C
+#                                                  disambiguates the chain)
+# With cap = 0 the supp keeps its natural MAPQ. With cap >= 2 (and <= 8) the
+# supp goes to MAPQ = 0.
+
+# Accumulate phix bases (concatenate every non-header line).
+/^>/ { next }
+     { phix = phix $0 }
+
+END {
+    if (length(phix) < 4100) {
+        print "ERROR: phix body too short (" length(phix) " < 4100 bp)" > "/dev/stderr"
+        exit 1
+    }
+
+    # 1-based substr offsets. Phix position k (0-based) is substr(phix, k+1).
+    unique_a = substr(phix, 1,   400)        # phix[0,   400)
+    unique_c = substr(phix, 401, 200)        # phix[400, 600)
+    motif    = substr(phix, 601,  60)        # phix[600, 660)
+
+    f_pre    = substr(phix, 701, 100)        # phix[ 700,  800)
+    f_post   = substr(phix, 801, 200)        # phix[ 800, 1000)
+    f_tail   = substr(phix, 4001, 100)       # phix[4000, 4100)
+    for (k = 0; k < 6; k++) {
+        f_inter[k] = substr(phix, 1001 + k * 500, 500)  # phix[1000 + 500k, 1500 + 500k)
+    }
+
+    N_COPIES      = 8
+    DISAMBIG_COPY = 4   # 0-indexed copy after which UNIQUE_C is inserted
+
+    ref = f_pre unique_a f_post
+    inter_idx = 0
+    for (i = 0; i < N_COPIES; i++) {
+        ref = ref motif
+        if (i == DISAMBIG_COPY)    ref = ref unique_c
+        else if (i < N_COPIES - 1) { ref = ref f_inter[inter_idx]; inter_idx++ }
+    }
+    ref = ref f_tail
+    L = length(ref)
+
+    if (MODE == "ref") {
+        print ">supp_rep_engineered"
+        for (i = 1; i <= L; i += 70) print substr(ref, i, 70)
+        exit
+    }
+    if (MODE == "reads") {
+        # 30 SE reads, identical body so the cap effect is uniform; distinct
+        # read names so SAM record counts are stable.
+        read = unique_a motif unique_c
+        qual = ""
+        for (q = 0; q < length(read); q++) qual = qual "I"
+        for (n = 0; n < 30; n++) printf "@r%02d\n%s\n+\n%s\n", n, read, qual
+        exit
+    }
+    print "ERROR: MODE must be ref or reads" > "/dev/stderr"
+    exit 1
+}

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -13,6 +13,7 @@ matrix row; the rest run on the canonical AVX2 row only. Each script:
 | `thread_determinism.sh`      | `-t 1` == `-t 4` output after sort on chr22                           | "Thread-determinism smoke (chr22, -t 1 vs -t 4)"    |
 | `bam_roundtrip.sh`           | `--bam=6` BAM decodes and has same record count as SAM (chr22)        | "--bam=6 roundtrip smoke (chr22)"                   |
 | `short_read_smoke.sh`        | ASAN SE on 25-50 bp variable-length dense-chr22 reads (PR #100 fix)   | "Short-read SE smoke (chr22, ASAN, dense+variable-length)" |
+| `supp_rep_hard_cap.sh`       | `--supp-rep-hard-cap` forces MAPQ=0 on repetitive-seed supps (#101)   | "--supp-rep-hard-cap repetitive-seed regression"    |
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
 
 Each script reads its inputs from environment variables — see the comment

--- a/test/regression/supp_rep_hard_cap.sh
+++ b/test/regression/supp_rep_hard_cap.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# test/regression/supp_rep_hard_cap.sh
+#
+# Regression: --supp-rep-hard-cap N must force MAPQ=0 on supplementary
+# alignments whose chain originates from a repetitive seed.
+#
+# Before #101, the SMEM->seed materialization loop in bwamem.cpp left
+# s.n_hits at its default constructor value (1), so chain_n_hits was
+# always 1, the gate `chain_n_hits >= cap` never fired, and the option
+# shipped as a silent no-op. No test in test/ exercised the flag against
+# a workload with repetitive seeds, which is how the regression slipped
+# past CI. This script closes that gap.
+#
+# Fixture (deterministic, regenerated each run from build_fixture.awk;
+# bytes are sliced from committed phix.fa so the output is byte-identical
+# across awk implementations — no PRNG):
+#   - reference with a 60 bp motif duplicated 8x; one copy is flanked by
+#     a 200 bp UNIQUE_C that disambiguates the chain extension
+#   - 30 SE reads = [400 bp UNIQUE_A][60 bp MOTIF][200 bp UNIQUE_C]
+#   - primary chain anchors on UNIQUE_A (chain_n_hits=1, MAPQ=60)
+#   - supp chain spans MOTIF+UNIQUE_C: high natural MAPQ from local score
+#     margin, but chain_n_hits=8 from the re-seeded sub-MEM within the
+#     MOTIF+UNIQUE_C SMEM (the MOTIF alone has SA-count 8)
+#
+# With --supp-rep-hard-cap 0 every supp keeps its natural MAPQ (60).
+# With --supp-rep-hard-cap 3 the gate fires and every supp goes to MAPQ=0.
+# Pre-#101 the two SAMs are identical because chain_n_hits is stuck at 1.
+#
+# Inputs:
+#   BWA_MEM3              — path to bwa-mem3 binary under test
+#   SUPP_REP_FIXTURE_AWK  — path to test/fixtures/supp_rep/build_fixture.awk
+#   SUPP_REP_PHIX_FA      — path to test/fixtures/phix.fa (the fixture source)
+#
+# Asserts both directions of the gate so a future regression in either
+# branch (cap=0 silently zeroing supps, or cap>0 failing to fire) shows up.
+
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+: "${SUPP_REP_FIXTURE_AWK:?SUPP_REP_FIXTURE_AWK must be set}"
+: "${SUPP_REP_PHIX_FA:?SUPP_REP_PHIX_FA must be set}"
+
+OUT_DIR="$(mktemp -d -t bwamem3-supprep-XXXXXX)"
+trap 'rm -rf "$OUT_DIR"' EXIT
+
+REF="$OUT_DIR/supp_rep_ref.fa"
+READS="$OUT_DIR/supp_rep_reads.fq"
+CAP0_SAM="$OUT_DIR/cap0.sam"
+CAP_N_SAM="$OUT_DIR/cap_n.sam"
+# Cap value: must lie in (1, N_COPIES] where N_COPIES=8 in the fixture.
+# 3 leaves a comfortable margin and matches the value documented in #104.
+CAP=3
+# Slack for any future seed-strategy or chain-merge tweaks that legitimately
+# split one of the 30 reads into a non-supp shape. Set well below 30 so the
+# test still fails loudly if PR #101's one-liner is reverted (which would
+# drop all 30 cap=N MAPQ=0 supps to 0).
+MIN_SUPP=20
+
+mawk -v MODE=ref   -f "$SUPP_REP_FIXTURE_AWK" "$SUPP_REP_PHIX_FA" > "$REF"
+mawk -v MODE=reads -f "$SUPP_REP_FIXTURE_AWK" "$SUPP_REP_PHIX_FA" > "$READS"
+
+"$BWA_MEM3" index "$REF" > "$OUT_DIR/index.log" 2>&1
+
+"$BWA_MEM3" mem -t 1 "$REF" "$READS" \
+    > "$CAP0_SAM" 2>"$OUT_DIR/cap0.log"
+"$BWA_MEM3" mem -t 1 --supp-rep-hard-cap "$CAP" "$REF" "$READS" \
+    > "$CAP_N_SAM" 2>"$OUT_DIR/cap_n.log"
+
+# Count supplementary alignments (SAM flag bit 0x800 / 2048) and split each
+# count by MAPQ==0 vs MAPQ>0.
+count_supps()        { samtools view -c -f 2048 "$1"; }
+count_supps_mapq0()  { samtools view    -f 2048 "$1" | mawk '$5 == 0' | wc -l | tr -d ' '; }
+count_supps_mapqpos(){ samtools view    -f 2048 "$1" | mawk '$5 >  0' | wc -l | tr -d ' '; }
+
+cap0_supps=$(count_supps        "$CAP0_SAM")
+cap0_mapq0=$(count_supps_mapq0  "$CAP0_SAM")
+cap0_mapqp=$(count_supps_mapqpos "$CAP0_SAM")
+capn_supps=$(count_supps        "$CAP_N_SAM")
+capn_mapq0=$(count_supps_mapq0  "$CAP_N_SAM")
+capn_mapqp=$(count_supps_mapqpos "$CAP_N_SAM")
+
+echo "cap=0:      $cap0_supps supps ($cap0_mapqp at MAPQ>0, $cap0_mapq0 at MAPQ=0)"
+echo "cap=$CAP:      $capn_supps supps ($capn_mapqp at MAPQ>0, $capn_mapq0 at MAPQ=0)"
+
+# Sanity: the workload must actually produce supplementaries. If it doesn't,
+# the rest of the assertions trivially "pass" with zero counts. A fixture
+# regression (e.g. read-length tweak that stops splitting the read) shows
+# up here, not as a misleading silent pass.
+if [ "$cap0_supps" -lt "$MIN_SUPP" ]; then
+    echo "FAIL: cap=0 produced $cap0_supps supplementary records, expected >= $MIN_SUPP" >&2
+    echo "      fixture or aligner behavior changed in a way that breaks the test setup" >&2
+    exit 1
+fi
+
+# Direction 1: with cap disabled, the natural MAPQ on the supp chain is
+# high (UNIQUE_C disambiguates the chain to one position). If supps come
+# back at MAPQ=0 here, either the fixture stopped triggering the
+# disambiguation or supp MAPQ computation regressed unrelatedly.
+if [ "$cap0_mapq0" -gt 0 ]; then
+    echo "FAIL: cap=0 produced $cap0_mapq0 supps at MAPQ=0 (expected 0; fixture should yield high natural MAPQ)" >&2
+    exit 1
+fi
+
+# Direction 2: with cap=N, every supp goes to MAPQ=0. This is the assertion
+# that fails when PR #101's one-line fix is reverted — without it,
+# chain_n_hits stays at 1 and the gate never fires.
+if [ "$capn_mapq0" -lt "$MIN_SUPP" ]; then
+    echo "FAIL: cap=$CAP produced only $capn_mapq0 supps at MAPQ=0 (expected >= $MIN_SUPP)" >&2
+    echo "      probable cause: chain_n_hits is not being propagated from SMEM SA-count" >&2
+    echo "      (this is the failure mode #101 fixed at src/bwamem.cpp:944-948)" >&2
+    exit 1
+fi
+
+# Belt-and-suspenders: the supp count should be the same with and without
+# the cap. The gate only changes MAPQ; it should not add or drop records.
+if [ "$cap0_supps" != "$capn_supps" ]; then
+    echo "FAIL: supp record count differs cap=0 ($cap0_supps) vs cap=$CAP ($capn_supps)" >&2
+    exit 1
+fi
+
+echo "PASS: --supp-rep-hard-cap forces supp MAPQ=0 on repetitive-seed chains ($capn_mapq0 of $capn_supps flipped)"


### PR DESCRIPTION
## Summary

- Adds a deterministic fixture-based regression test for `--supp-rep-hard-cap`. The flag shipped as a silent no-op from v0.2.0 until #101's one-line fix because no test exercised it against a workload with repetitive seeds.
- New mawk generator (`test/fixtures/supp_rep/build_fixture.awk`) emits a ~12 kb engineered reference (60 bp motif × 8 copies, one copy uniquely flanked) and 30 SE reads that produce one primary chain on a unique anchor (chain_n_hits=1) and one supplementary chain whose SMEM has SA-count 8 but whose extension is locally unambiguous — exactly the regime where the cap gate diverges from a no-op.
- New driver script (`test/regression/supp_rep_hard_cap.sh`) runs `bwa-mem3 mem` with `--supp-rep-hard-cap 0` and `--supp-rep-hard-cap 3` and asserts both directions of the gate plus supp-record-count invariance. Wired into ci.yml on the canonical matrix row.

The PE rescoring sites at `src/bwamem_pair.cpp:576,975` only fire with ALT contigs (`!p->is_alt`) so they're out of scope for this fixture — the SE gate at `src/bwamem.cpp:1622` is what the production data in #101's verification table exercises.

Closes #104.

## Test plan

- [x] Script PASSes on `main` with #101's fix in place: `PASS: --supp-rep-hard-cap forces supp MAPQ=0 on repetitive-seed chains (30 of 30 flipped)`
- [x] Script FAILs when PR #101's one-liner (`s.n_hits = static_cast<int32_t>(p->s);` at `src/bwamem.cpp:946`) is commented out: `FAIL: cap=3 produced only 0 supps at MAPQ=0 (expected >= 20)` with stderr pointing at `src/bwamem.cpp:944-948`
- [x] `git diff src/` is clean after the revert/restore cycle
- [ ] CI passes on the canonical matrix row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a deterministic regression that verifies how the --supp-rep-hard-cap option affects supplementary alignment MAPQ distribution while preserving total supplementary counts.
* **Documentation**
  * Documented the new deterministic fixture generator and updated regression docs to describe the new test and its intent.
* **Chores (CI)**
  * CI now runs the new canonical-only regression step for the chr22 workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fg-labs/bwa-mem3/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->