### PR TITLE
docs: correct stale concordance claims + document supplementary-alignment divergence

### DIFF
--- a/docs/src/performance/overview.md
+++ b/docs/src/performance/overview.md
@@ -20,15 +20,15 @@ PR [#58](https://github.com/fg-labs/bwa-mem3/pull/58) and the related lockstep S
 
 ## Reference numbers across architectures
 
-Wall-time medians from [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench) at SHA `dc7fcfe` (2026-05-13), 5 reps per cell, t≈16, hg38, paired-end 150 bp:
+Wall-time medians from [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench) at SHA `bffae5a` (2026-06-07), 5 reps per cell, t≈16, hg38, paired-end 150 bp:
 
 | sample | c6a (AVX2, Zen3) | c7a (AVX-512, Zen4) | c7i (AVX-512, SPR) | c7g (NEON, Graviton3) | c8g (NEON, Graviton4) |
 |---|---:|---:|---:|---:|---:|
-| wgs-5M | 147.70 s | **101.17 s** | 138.33 s | 178.54 s | 151.23 s |
-| wes-5M | 84.37 s | **61.96 s** | 75.08 s | 84.50 s | 70.90 s |
-| panel-twist-5M | 158.49 s | **106.94 s** | 151.78 s | 194.04 s | 163.38 s |
+| wgs-5M | 142.88 s | **97.94 s** | 147.83 s | 176.49 s | 150.76 s |
+| wes-5M | 78.87 s | **59.81 s** | 79.25 s | 81.81 s | 67.47 s |
+| panel-twist-5M | 157.12 s | **105.99 s** | 166.15 s | 192.53 s | 164.16 s |
 
-Concordance vs upstream `bwa-mem2 v2.2.1` on these cells: **100.0000%** across 8.1M–10M reads/cell. NEON-vs-x86 cross-architecture concordance on the same builds is also 100.0000%. Spot-pool noise envelope (rep-to-rep CV): ~1% on c6a / c7a / c7g / c8g, ~8–9% on c7i. See the bench repo for the methodology, the full per-rep table, and noisier instance classes excluded from this summary.
+Concordance vs upstream `bwa-mem2 v2.2.1` on these cells, measured over primary-alignment records: **wgs-5M 99.9893%, wes-5M 99.9996%, panel-twist-5M 99.9414%**. bwa-mem3 is intentionally **not** byte-identical to bwa-mem2 — the residual differences are additive SAM tags, per-architecture SIMD `score2`/`MAPQ` convergence, deterministic tie-breaks, and a small number of additional supplementary alignments; see [Equivalence with bwa-mem2](../whats-different/equivalence.md) for the full audited breakdown. NEON-vs-x86 cross-architecture concordance on the same builds remains **100.0000%** (the ARM and x86 fg-labs builds produce identical records). Spot-pool noise envelope (rep-to-rep CV): ~1% on c6a / c7a / c7g / c8g, ~8–9% on c7i. See the bench repo for the methodology, the full per-rep table, and noisier instance classes excluded from this summary.
 
 ## Benchmarking responsibly
 

--- a/docs/src/whats-different/equivalence.md
+++ b/docs/src/whats-different/equivalence.md
@@ -2,26 +2,25 @@
 
 bwa-mem3 is **not** byte-identical to bwa-mem2, and that is intentional. Upstream bwa-mem2 advertises exact equivalence with the original `bwa` — "produces alignment identical to bwa" and "exact same output as bwa-mem(2)" — and that guarantee was the right bar for a project whose sole charter was to reproduce `bwa mem` faster. bwa-mem3 has a broader charter: it adds informative SAM tags, fixes crashes and undefined behavior, corrects SIMD scoring kernels, and makes tie resolution deterministic. Several of those changes necessarily move output away from a byte-for-byte match. We have consciously stepped below the bit-identity bar, and this page records exactly where, and gives an auditable trail back to every merged pull request so a reader can decide for themselves whether each divergence matters for their workflow.
 
-The short version: on the data we have tested, the **core alignment** — where each read maps and how — is preserved. The **SAM byte stream** is not, because bwa-mem3 emits additional auxiliary tags that upstream never wrote. Beyond the additive tags, other divergences exist in the code but are latent, opt-in, or per-architecture; they are described under "What differs" below and in more depth on the [Correctness fixes](correctness.md), [Performance improvements](performance.md), and [Features](features.md) pages.
+The short version: on the data we have tested, the **core alignment** — where each read maps and how — is preserved on essentially every read. The **SAM byte stream** is not, primarily because bwa-mem3 emits additional auxiliary tags that upstream never wrote, and secondarily because it adds a handful of supplementary alignments and shifts MAPQ/CIGAR on a small per-architecture fraction of reads. Beyond the additive tags, the remaining divergences are latent, opt-in, or per-architecture; they are described under "What differs" below and in more depth on the [Correctness fixes](correctness.md), [Performance improvements](performance.md), and [Features](features.md) pages.
 
 ## What is preserved
 
-We ran an empirical concordance check on sample `smoke-1M` (1M paired-end 150 bp reads), aligned on an AVX2 host (AWS `c6a`), comparing current `main` (commit `c6240a74`) against upstream `bwa-mem2` v2.2.1 over all 64,763 SAM records. The following fields were **identical on every record — zero differences**:
+We ran an empirical concordance check with [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench) at commit `bffae5a` (current `main`), comparing bwa-mem3 against upstream `bwa-mem2` v2.2.1 on x86 hosts across whole-genome, whole-exome, and panel workloads. **Primary-alignment concordance** — reference name, position, CIGAR, MAPQ, and placement flags compared per read end — is:
 
-- Reference name and mapping position (`RNAME`, `POS`)
-- `CIGAR`
-- Mapping quality (column 5, `MAPQ`)
-- The full bitwise `FLAG`, including the `0x2` proper-pair bit
-- The `AS:i` alignment score
-- The `NM:i` edit distance, `MD:Z` mismatch string, `MC:Z` mate CIGAR, and `XS:i` suboptimal score
+| sample | primary concordance | primary records |
+|---|---:|---:|
+| wes-5M | 99.9996% | 10,051,170 |
+| wgs-5M | 99.9893% | 9,980,872 |
+| panel-twist-5M | 99.9414% | 7,913,324 |
 
-In other words, on this workload, where each read maps, how it is aligned, how confidently, and how its mate relates to it are all unchanged from upstream.
+Where each read maps is preserved on essentially every read. The well-under-0.1% of primary records that differ do so in `MAPQ`, `CIGAR`, or position, and are accounted for by the per-architecture SIMD `score2`/`MAPQ` convergence and the deterministic tie-break change described under "What differs" below and on the [Correctness fixes](correctness.md) page. (On the 1M-read `smoke-1M` cell the figure is 99.946%; the larger exome and genome cells above are more representative.) Cross-architecture, the NEON (ARM) and x86 builds are byte-identical to each other — 100.0000% concordance over all records, supplementary alignments included.
 
 ## What differs
 
-### Additive SAM tags (observed on the tested data)
+### Additive SAM tags
 
-The only differences observed on `smoke-1M` are two **additive** auxiliary tags that bwa-mem3 emits and upstream does not:
+The most pervasive difference is two **additive** auxiliary tags that bwa-mem3 emits and upstream does not:
 
 - `MQ:i` — mate mapping quality, present on ~100% of bwa-mem3 records and absent from upstream output.
 - `HN:i` — total hit count per primary, present on 54,188 of the 64,763 bwa-mem3 records and on 0 upstream records.
@@ -42,9 +41,13 @@ Same alignment, same scores — two extra tags. Because these tags are inserted 
 
 Separately, the `@PG` header line reports `ID:bwa-mem3` / `PN:bwa-mem3` rather than `bwa-mem2`, which is also a byte-level header difference by design.
 
+### Additional supplementary alignments
+
+On the default build, with no special flags, bwa-mem3 emits a small number of **additional supplementary (chimeric/split) alignments** that upstream `bwa-mem2` v2.2.1 does not. On `wes-5M` (5,025,585 read pairs) bwa-mem3 emits 5,123 supplementary records versus upstream's 5,118 — five extra split alignments, on five templates (0.0001%). The **primary** alignment of every affected pair is unchanged; only an extra supplementary record is added. This is measured by bwa-mem3-bench's `compare-bams`, which reports per-template supplementary count-mismatch and position-unmatched rates alongside primary concordance. These additions are default-on behavior — they occur with no special flags — and are *not* a product of the opt-in `--supp-rep-hard-cap` rescoring, which only lowers MAPQ and never adds records. Pinning them to a specific upstream-divergence PR is tracked as follow-up.
+
 ### Divergences that are latent, opt-in, or per-architecture
 
-The following changes can move alignments, scores, or MAPQ relative to upstream, but did **not** surface on the tested `smoke-1M` / AVX2 cell because they are gated, latent, or only active on other inputs or architectures:
+The following changes can move alignments, scores, or MAPQ relative to upstream, but did **not** surface as primary-alignment differences on the measured cells because they are gated, latent, or only active on other inputs or architectures:
 
 - **Proper-pair `FLAG` recompute ([#17](https://github.com/fg-labs/bwa-mem3/pull/17), default-on).** bwa-mem3 computes the `0x2` bit from the alignment actually emitted rather than from the below-threshold primary. This only changes the flag in the rare case where the primary's score is under `opt->T` but an ALT hit clears it; on `smoke-1M` no record hit that path, so the full `FLAG` matched upstream exactly. See [Correctness fixes → Proper-pair flag](correctness.md).
 - **SIMD scoring-kernel fixes ([#21](https://github.com/fg-labs/bwa-mem3/pull/21), [#26](https://github.com/fg-labs/bwa-mem3/pull/26), [#28](https://github.com/fg-labs/bwa-mem3/pull/28), [#29](https://github.com/fg-labs/bwa-mem3/pull/29), [#30](https://github.com/fg-labs/bwa-mem3/pull/30), [#31](https://github.com/fg-labs/bwa-mem3/pull/31)).** These correct the batched mate-rescue `kswv` kernels so the suboptimal score (`score2` → `XS:i`/`MAPQ`) converges toward the scalar `ksw_align2` reference. They move `XS`/`MAPQ` on the minority of reads where the SIMD kernel previously diverged, and the affected reads differ by architecture (AVX2 vs NEON vs AVX-512BW). See [Correctness fixes → kswv score2 plateau series](correctness.md).


### PR DESCRIPTION
Two doc pages made claims that are now false or stale; this refreshes both against [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench) numbers at commit `bffae5a`.

## What was wrong

- `performance/overview.md` asserted **100.0000%** concordance vs upstream `bwa-mem2` v2.2.1. That is false: bwa-mem3 is intentionally not byte-identical to bwa-mem2. The fresh primary-alignment concordance is wgs-5M 99.9893%, wes-5M 99.9996%, panel-twist-5M 99.9414%.
- `whats-different/equivalence.md` claimed **zero differences** on `smoke-1M` at the older commit `c6240a74`. That predated PR #123 (deterministic tie-breaks), which landed afterward and moved output. The page also never documented that bwa-mem3 emits extra supplementary alignments.

## What changed

- Refreshed the perf table and concordance statement in `performance/overview.md` to `bffae5a` (5 reps/cell, hg38, PE 150 bp), and replaced the false 100% claim with per-sample primary-alignment concordance plus a pointer to the equivalence page for the audited breakdown.
- Rewrote the "What is preserved" section of `equivalence.md` to report primary-alignment concordance across wes/wgs/panel cells instead of the stale "zero differences on smoke-1M" claim.
- Added a new **Additional supplementary alignments** subsection: on the default build (no flags), bwa-mem3 emits a small number of extra supplementary records (wes-5M: 5,123 vs upstream 5,118 — +5 on 5 of 5,025,585 templates, 0.0001%); primary alignments of affected pairs are unchanged.
- Generalized the additive-SAM-tags wording so it no longer reads as smoke-1M-specific.

NEON-vs-x86 cross-architecture concordance is still **100.0000%** (all records, supplementaries included) and that claim is retained.

All numbers come from a bwa-mem3-bench full run (all archs x samples x 5 reps) at `bffae5a`. `mdbook build` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated performance benchmark results with latest bwa-mem3 data across instance types.
  * Clarified equivalence narrative between bwa-mem3 and bwa-mem2, explaining core alignment preservation while documenting SAM format differences.
  * Expanded documentation on supplementary alignments and minor MAPQ/CIGAR variations between versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->