### PR TITLE
docs(bench): inject generated divergence catalog + per-release concordance table

### DIFF
--- a/docs/src/related-projects/bwa-mem3-bench.md
+++ b/docs/src/related-projects/bwa-mem3-bench.md
@@ -29,6 +29,35 @@ bwa-mem3-bench runs collected after the relevant PR was merged. The suite also
 validates that bwa-mem3 does not regress relative to bwa-mem2 on any supported
 architecture before a new release is tagged.
 
+## Per-release concordance history
+
+Per-(release, sample) primary-alignment concordance against upstream bwa-mem2 v2.2.1, with supplementary-alignment counts, across released bwa-mem3 versions. Concordance is the minimum vs-baseline value over reps and x86 architectures (deterministic per sample); `supp_query`/`supp_baseline` are total supplementary records emitted by bwa-mem3 and bwa-mem2, and `count_mismatch` is the number of templates whose supplementary count differs. The [divergence catalog](../whats-different/equivalence.md#declared-divergence-catalog) explains what each kind of drift is and its budget.
+
+This table and the divergence catalog are both generated from the benchmark database — do not edit them by hand. Regenerate after a new release is collected with `pixi run python -m bwa_mem3_bench.cli bench docs --releases v0.2.0=<sha>,v0.2.1=<sha>,...` (in the bwa-mem3-bench repo), then replace the content between the `FG-DIVERGENCE-CATALOG` / `FG-RELEASE-TABLE` markers with the emitted `runs/docs/{divergence-catalog.md,release-table.md}` (the `inject_between_markers` helper in `bwa_mem3_bench.report.docs` does exactly this splice).
+
+<!-- FG-RELEASE-TABLE:start -->
+| release | sample | concordance_% | supp_query | supp_baseline | count_mismatch |
+| --- | --- | --- | --- | --- | --- |
+| v0.2.0 | meth-twist-emseq-5M | 98.8852 | 0 | 0 | 0 |
+| v0.2.0 | panel-twist-5M | 100.0000 | 186946 | 186946 | 0 |
+| v0.2.0 | smoke-1M | 100.0000 | 1455 | 1455 | 0 |
+| v0.2.0 | smoke-meth | 98.8573 | 0 | 0 | 0 |
+| v0.2.0 | wes-5M | 100.0000 | 5118 | 5118 | 0 |
+| v0.2.0 | wgs-5M | 100.0000 | 49686 | 49686 | 0 |
+| v0.2.1 | meth-twist-emseq-5M | 98.8852 | 0 | 0 | 0 |
+| v0.2.1 | panel-twist-5M | 100.0000 | 186946 | 186946 | 0 |
+| v0.2.1 | smoke-1M | 100.0000 | 1455 | 1455 | 0 |
+| v0.2.1 | smoke-meth | 98.8573 | 0 | 0 | 0 |
+| v0.2.1 | wes-5M | 100.0000 | 5118 | 5118 | 0 |
+| v0.2.1 | wgs-5M | 100.0000 | 49686 | 49686 | 0 |
+| v0.2.2 | meth-twist-emseq-5M | 98.8773 | 0 | 0 | 0 |
+| v0.2.2 | panel-twist-5M | 99.9414 | 187039 | 186946 | 199 |
+| v0.2.2 | smoke-1M | 99.9460 | 0 | 0 | 0 |
+| v0.2.2 | smoke-meth | 98.8429 | 0 | 0 | 0 |
+| v0.2.2 | wes-5M | 99.9996 | 5123 | 5118 | 5 |
+| v0.2.2 | wgs-5M | 99.9893 | 49926 | 49686 | 256 |
+<!-- FG-RELEASE-TABLE:end -->
+
 ## Links
 
 - GitHub: <https://github.com/fg-labs/bwa-mem3-bench>

--- a/docs/src/whats-different/equivalence.md
+++ b/docs/src/whats-different/equivalence.md
@@ -43,7 +43,7 @@ Separately, the `@PG` header line reports `ID:bwa-mem3` / `PN:bwa-mem3` rather t
 
 ### Additional supplementary alignments
 
-On the default build, with no special flags, bwa-mem3 emits a small number of **additional supplementary (chimeric/split) alignments** that upstream `bwa-mem2` v2.2.1 does not. On `wes-5M` (5,025,585 read pairs) bwa-mem3 emits 5,123 supplementary records versus upstream's 5,118 — five extra split alignments, on five templates (0.0001%). The **primary** alignment of every affected pair is unchanged; only an extra supplementary record is added. This is measured by bwa-mem3-bench's `compare-bams`, which reports per-template supplementary count-mismatch and position-unmatched rates alongside primary concordance. These additions are default-on behavior — they occur with no special flags — and are *not* a product of the opt-in `--supp-rep-hard-cap` rescoring, which only lowers MAPQ and never adds records. Pinning them to a specific upstream-divergence PR is tracked as follow-up.
+On the default build, with no special flags, bwa-mem3 emits a small number of **additional supplementary (chimeric/split) alignments** that upstream `bwa-mem2` v2.2.1 does not. On `wes-5M` (5,025,585 read pairs) bwa-mem3 emits 5,123 supplementary records versus upstream's 5,118 — five extra split alignments, on five templates (0.0001%). The **primary** alignment of every affected pair is unchanged; only an extra supplementary record is added. This is measured by bwa-mem3-bench's `compare-bams`, which reports per-template supplementary count-mismatch and position-unmatched rates alongside primary concordance. These additions are default-on behavior — they occur with no special flags — and are *not* a product of the opt-in `--supp-rep-hard-cap` rescoring, which only lowers MAPQ and never adds records. Pinning them to a specific upstream-divergence PR is tracked as follow-up ([#127](https://github.com/fg-labs/bwa-mem3/issues/127)).
 
 ### Divergences that are latent, opt-in, or per-architecture
 
@@ -54,6 +54,18 @@ The following changes can move alignments, scores, or MAPQ relative to upstream,
 - **Seeding correctness fixes ([#55](https://github.com/fg-labs/bwa-mem3/pull/55), [#73](https://github.com/fg-labs/bwa-mem3/pull/73), [#100](https://github.com/fg-labs/bwa-mem3/pull/100)).** These fix buffer sizing and a prefetch-mask precedence bug. They change alignments only where the old bug actually triggered (e.g. reads longer than 151 bp for [#55](https://github.com/fg-labs/bwa-mem3/pull/55); [#73](https://github.com/fg-labs/bwa-mem3/pull/73) is a prefetch hint with no semantic change).
 - **Opt-in MAPQ rescoring ([#56](https://github.com/fg-labs/bwa-mem3/pull/56), [#101](https://github.com/fg-labs/bwa-mem3/pull/101), [#118](https://github.com/fg-labs/bwa-mem3/pull/118), default-off).** `--supp-rep-hard-cap INT` forces MAPQ=0 on supplementary alignments anchored in repetitive seeds. With no flag the output is unchanged; [#101](https://github.com/fg-labs/bwa-mem3/pull/101) makes the flag actually take effect (it shipped as a silent no-op before), and [#118](https://github.com/fg-labs/bwa-mem3/pull/118) is its regression test. See [Features → `--supp-rep-hard-cap`](features.md).
 - **Tie-break determinism ([#123](https://github.com/fg-labs/bwa-mem3/pull/123)).** Makes secondary-alignment ordering deterministic across runs; can reorder equal-scoring ties relative to upstream's order.
+
+## Declared divergence catalog
+
+The divergences described above are tracked as a structured registry in [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench) (`docs/expected-divergences.yaml`). Each carries a per-sample concordance-drift budget that the benchmark gates against on every run — a new bwa-mem3 build that drifts beyond its budget fails CI rather than silently shipping a regression. The table below is generated from that registry; do not edit it by hand (see [bwa-mem3-bench → Per-release concordance history](../related-projects/bwa-mem3-bench.md) for how it is regenerated).
+
+<!-- FG-DIVERGENCE-CATALOG:start -->
+| id | pr | affected | samples | budget_% | summary |
+| --- | --- | --- | --- | --- | --- |
+| FG-PRIMARY-DRIFT | fg-labs/bwa-mem3#123 | primary_alignment | wgs-5M, wes-5M, panel-twist-5M, smoke-1M | 0.1000 | Per-architecture SIMD score2/MAPQ convergence (#21, #26, #28-#31) and deterministic tie-break ordering (#123) shift MAPQ, CIGAR, or position on a small fraction of primary alignments relative to bwa-mem2 v2.2.1. Where each read maps is preserved; the affected reads differ in placement detail, and the set varies by SIMD architecture. |
+| FG-METH-DIVERGENCE | fg-labs/bwa-mem3#90 | meth_alignment | meth-twist-emseq-5M, smoke-meth | 1.5000 | Bisulfite (--meth) mode against the bwameth.py baseline diverges beyond the ignored YD/XM/XG tag set (Bismark-compatible XR/XG/XM tags and C->T/G->A conversion handling), giving a larger but still-bounded concordance drift on methylation workloads. |
+| FG-SUPP-ADDITIONS | TBD | supplementary_alignment | all | 0.0000 | bwa-mem3 emits a small number of additional supplementary (split/chimeric) alignments vs bwa-mem2 v2.2.1 on the default build (e.g. wes-5M: 5123 vs 5118). Primary alignments are unchanged. Tracked as a supplementary-count metric (compare-bams supp_count_mismatch / supp_unmatched); it does not affect the primary-concordance drift budget, hence 0.0 here. |
+<!-- FG-DIVERGENCE-CATALOG:end -->
 
 ## Auditable PR list
 


### PR DESCRIPTION
Wires the benchmark evidence into the mdbook as marker-delimited, auto-generated blocks, so it can't silently go stale the way the concordance claims did before #125. Both blocks are produced by `bwa_mem3_bench bench docs` from the divergence registry and the benchmark database, and spliced between `<!-- NAME:start -->` / `<!-- NAME:end -->` markers the same way the existing `FG-MAIN-TABLE` block works.

## What's added

**`whats-different/equivalence.md` → "Declared divergence catalog"** — a `FG-DIVERGENCE-CATALOG` block rendered from bwa-mem3-bench's `expected-divergences.yaml`. It lists each declared divergence class (primary-alignment drift, methylation divergence, supplementary additions), its affected samples, and the per-sample concordance-drift **budget** the benchmark gates against on every run — a build that drifts past its budget fails CI rather than silently shipping a regression.

**`related-projects/bwa-mem3-bench.md` → "Per-release concordance history"** — a `FG-RELEASE-TABLE` block: per-(release, sample) primary-alignment concordance against upstream bwa-mem2 v2.2.1, plus supplementary-record counts and per-template count-mismatch, across v0.2.0 / v0.2.1 / v0.2.2. v0.2.0 and v0.2.1 are 100% non-meth with exact supplementary parity; v0.2.2 introduces the small bounded drift (wes 99.9996%, wgs 99.9893%, panel 99.9414%) already described in prose on the equivalence page — the table row matches that prose exactly.

## Regeneration

Both blocks carry a "do not edit by hand" note pointing at `bwa_mem3_bench.cli bench docs --releases <label=sha,...>`, whose `runs/docs/{divergence-catalog.md,release-table.md}` output is spliced between the markers (the `inject_between_markers` helper in `bwa_mem3_bench.report.docs` does the splice). After a new release is benchmarked and collected, regenerate and re-splice.

## Notes

- PR references inside the generated catalog (e.g. `fg-labs/bwa-mem3#123`) are emitted as plain text rather than markdown links, to keep the generator output stable; mdbook renders them verbatim. Linkifying them is a follow-up on the generator side if desired.
- `mdbook build` is clean (only the pre-existing mdbook-mermaid version-skew warning).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added detailed per-release concordance history documentation comparing primary-alignment concordance metrics and supplementary alignment results with upstream bwa-mem2 v2.2.1, including mismatch measurements across releases and samples.
* Introduced a structured divergence catalog documenting specific alignment divergences, affected categories, sample sets, and associated drift budgets for transparency and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->