### PR TITLE
feat(reader): content-detecting FASTQ reader fast path (libdeflate BGZF)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install bwa autoconf automake libomp
+        run: brew install bwa autoconf automake libomp libdeflate
 
       - name: Verify CMake is available
         run: cmake --version
@@ -474,7 +474,7 @@ jobs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
-          packages: zlib1g-dev autoconf automake gcovr
+          packages: zlib1g-dev libdeflate-dev autoconf automake gcovr
           version: 1.0
 
       - name: Build libbwa.a with coverage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential cmake zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev
+            build-essential cmake zlib1g-dev libdeflate-dev libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev
 
       - name: Cache cargo bin (mdbook + plugins)
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -197,7 +197,7 @@ jobs:
           submodules: recursive
 
       - name: Install apt dependencies
-        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev samtools libomp-dev ccache
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev libdeflate-dev samtools libomp-dev ccache
 
       - name: Detect x86 ISA (avx2 / avx512bw)
         if: matrix.arch == 'x86'
@@ -433,7 +433,7 @@ jobs:
           submodules: recursive
 
       - name: Install apt dependencies
-        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev libomp-dev ccache
+        run: sudo apt-get update && sudo apt-get install -y zlib1g-dev libdeflate-dev libomp-dev ccache
 
       - name: Detect x86 ISA
         if: matrix.arch == 'x86'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
         # / requirements.host.
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
-          packages: zlib1g-dev autoconf automake
+          packages: zlib1g-dev libdeflate-dev autoconf automake
           version: 1.0
 
       - name: Install git-archive-all

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,17 @@ ifeq ($(USE_MIMALLOC),1)
     INCLUDES += -Iext/mimalloc/include
 endif
 
+# libdeflate: used directly by src/fast_reader.c for BGZF block decode (the
+# vanilla-gzip path stays on zlib). htslib already links -ldeflate
+# transitively; we add the <libdeflate.h> include path here. On macOS it
+# lives under the Homebrew prefix, resolved dynamically (mirrors the libomp
+# prefix detection below) so the build works on both Apple Silicon
+# (/opt/homebrew) and Intel (/usr/local) hosts rather than hardcoding one.
+ifeq ($(UNAME_S),Darwin)
+    LIBDEFLATE_PREFIX ?= $(shell brew --prefix libdeflate 2>/dev/null)
+    INCLUDES += -I$(LIBDEFLATE_PREFIX)/include
+endif
+
 # libsais (pinned in ext/libsais; see submodule SHA): linear-time suffix
 # array / BWT construction via SA-IS. Compiled with OpenMP so
 # libsais_gsa_omp can run parallel induced-sorting. libomp is already a
@@ -203,6 +214,12 @@ LIBS += -Lext/htslib -lhts
 LIBS += $(LIBSAIS_OPENMP_LIBS)
 LIBS += $(STATIC_GCC)
 LIBS += $(LIBS_EXTRA)
+# libdeflate is a direct dependency of src/fast_reader.c (BGZF block decode).
+ifeq ($(UNAME_S),Darwin)
+    LIBS += -L$(LIBDEFLATE_PREFIX)/lib -ldeflate
+else
+    LIBS += -ldeflate
+endif
 # Pull in htslib's transitive deps (-ldeflate when libdeflate is detected,
 # bzlib / lzma / curl when those features are enabled) from the generated
 # htslib_static.mk -- the same mechanism samtools uses (samtools'
@@ -234,7 +251,8 @@ OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/kthread.o \
 			src/meth_orig_ref.o src/meth_xm.o \
 			src/packed_text.o src/fm_index_writer.o src/index_prelude.o \
 			src/system.o src/libsais_build.o \
-			src/bwa_shm.o src/simd_dispatch.o
+			src/bwa_shm.o src/simd_dispatch.o \
+			src/fast_reader.o src/fast_reader_bseq.o
 
 # Kernel TUs (bandedSWA, kswv, ksw, sam_encode) are compiled per-tier on x86
 # and linked directly via KERNEL_TIER_OBJS_LINK. The dispatch wrappers in
@@ -519,6 +537,25 @@ shm_pack_round_trip_test: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_pack_ro
 
 shm_lock_destroy_test: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_lock_destroy_test.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/shm_lock_destroy_test.o $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) -o $@
+
+# fast_reader is C (not C++); the implicit .c rule omits $(INCLUDES), so give
+# these objects explicit rules carrying the project include paths (incl.
+# libdeflate) and preprocessor defines.
+src/fast_reader.o: src/fast_reader.c src/fast_reader.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDES) -c -o $@ $<
+
+src/fast_reader_bseq.o: src/fast_reader_bseq.c src/fast_reader_bseq.h src/fast_reader.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDES) -c -o $@ $<
+
+# Standalone fast_reader correctness self-test (plain/gzip/multi-member/BGZF
+# round-trips). Links only zlib + libdeflate, so it needs no bwa-mem3 build.
+FAST_READER_TEST_INC = -Isrc
+ifeq ($(UNAME_S),Darwin)
+    FAST_READER_TEST_INC += -I$(LIBDEFLATE_PREFIX)/include
+    FAST_READER_TEST_LIB = -L$(LIBDEFLATE_PREFIX)/lib
+endif
+fast_reader_selftest: src/fast_reader.c test/fast_reader_selftest.c
+	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fast_reader_selftest.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -ldeflate -o $@
 
 test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
 

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -60,6 +60,10 @@ Supplementary MAPQ rescoring (fg-labs extension):
                  with >=INT genome occurrences (i.e. the supp region is repetitive on its
                  own). 0 disables (default). Typical values 5-20; lower = more aggressive.
                  Primary MAPQ is unaffected.
+Input reader:
+   --legacy-reader
+                 use the legacy gzFile/kseq input reader instead of the default
+                 content-detecting fast reader (escape hatch / A-B baseline).
 Help:
    --help        print this help message and exit
 Note: Please read the man page for detailed description of the command line and options.

--- a/src/fast_reader.c
+++ b/src/fast_reader.c
@@ -1,0 +1,285 @@
+#include "fast_reader.h"
+
+#include <zlib.h>
+#include <libdeflate.h>
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define FR_CIN_CAP   (1u << 18)   /* 256 KiB compressed/raw input buffer      */
+#define FR_BOUT_CAP  (1u << 16)   /* 64 KiB: max BGZF block uncompressed size */
+#define FR_HDR_PEEK  18           /* bytes needed to reach BGZF BSIZE         */
+
+struct fast_reader {
+    int          fd;
+    fr_format_t  fmt;
+
+    /* Compressed/raw input buffer; [cin_pos, cin_len) is valid, unconsumed. */
+    unsigned char *cin;
+    size_t         cin_len, cin_pos, cin_cap;
+    int            eof_in;
+
+    /* gzip */
+    z_stream zs;
+    int      zs_active;
+
+    /* bgzf */
+    struct libdeflate_decompressor *ld;
+    unsigned char *bout;                 /* one decompressed block */
+    size_t         bout_len, bout_pos, bout_cap;
+    int            done;                 /* bgzf stream exhausted */
+};
+
+/* --------------------------------------------------------------------- */
+
+fr_format_t fr_detect(const unsigned char *h, size_t n)
+{
+    if (n < 2) return FR_PLAIN;                      /* empty / tiny -> plain */
+    if (h[0] == 0x1f && h[1] == 0x8b) {              /* gzip family */
+        if (n >= FR_HDR_PEEK && h[2] == 0x08 && (h[3] & 0x04)) {  /* deflate + FEXTRA */
+            unsigned xlen = (unsigned)h[10] | ((unsigned)h[11] << 8);
+            /* BGZF: BC subfield (htslib always writes it first, at offset 12) */
+            if (xlen >= 6 && h[12] == 'B' && h[13] == 'C') return FR_BGZF;
+        }
+        return FR_GZIP;
+    }
+    if (h[0] == 0x42 && h[1] == 0x5a) return FR_UNSUPPORTED;        /* bzip2 "BZ" */
+    if (n >= 4 && h[0] == 0x28 && h[1] == 0xb5 && h[2] == 0x2f && h[3] == 0xfd)
+        return FR_UNSUPPORTED;                                     /* zstd */
+    if (n >= 6 && h[0] == 0xfd && h[1] == 0x37 && h[2] == 0x7a && h[3] == 0x58 && h[4] == 0x5a)
+        return FR_UNSUPPORTED;                                     /* xz */
+    return FR_PLAIN;
+}
+
+/* Refill the input buffer from fd, preserving unconsumed bytes at the front.
+ * Returns 0 on success, -1 on read error. */
+static int fr_fill(fast_reader_t *fr)
+{
+    if (fr->cin_pos > 0) {
+        size_t keep = fr->cin_len - fr->cin_pos;
+        if (keep > 0) memmove(fr->cin, fr->cin + fr->cin_pos, keep);
+        fr->cin_len = keep;
+        fr->cin_pos = 0;
+    }
+    while (fr->cin_len < fr->cin_cap && !fr->eof_in) {
+        ssize_t r = read(fr->fd, fr->cin + fr->cin_len, fr->cin_cap - fr->cin_len);
+        if (r < 0) { if (errno == EINTR) continue; return -1; }
+        if (r == 0) { fr->eof_in = 1; break; }
+        fr->cin_len += (size_t)r;
+    }
+    return 0;
+}
+
+/* --------------------------------------------------------------------- */
+
+fast_reader_t *fast_reader_dopen(int fd, const char **err)
+{
+    /* Ownership of fd transfers to the reader at open time (see fast_reader.h),
+     * so every error path must close it -- otherwise non-legacy callers leak the
+     * descriptor when open fails. */
+#define FR_DOPEN_FAIL(msg) do { if (err) *err = (msg); if (fd >= 0) close(fd); return NULL; } while (0)
+    unsigned char hdr[FR_HDR_PEEK];
+    size_t got = 0;
+    while (got < sizeof hdr) {
+        ssize_t r = read(fd, hdr + got, sizeof hdr - got);
+        if (r < 0) { if (errno == EINTR) continue; FR_DOPEN_FAIL("read failed"); }
+        if (r == 0) break;
+        got += (size_t)r;
+    }
+
+    fr_format_t fmt = fr_detect(hdr, got);
+    if (fmt == FR_UNSUPPORTED) {
+        FR_DOPEN_FAIL("unsupported compression format; bwa-mem3 supports plain, gzip, and bgzip");
+    }
+
+    fast_reader_t *fr = (fast_reader_t *)calloc(1, sizeof *fr);
+    if (!fr) FR_DOPEN_FAIL("out of memory");
+    fr->fd = fd;
+    fr->fmt = fmt;
+    fr->cin_cap = FR_CIN_CAP;
+    fr->cin = (unsigned char *)malloc(fr->cin_cap);
+    if (!fr->cin) { free(fr); FR_DOPEN_FAIL("out of memory"); }
+
+    /* Prime the sniffed header bytes so nothing is lost on non-seekable fds. */
+    memcpy(fr->cin, hdr, got);
+    fr->cin_len = got;
+    fr->cin_pos = 0;
+
+    if (fmt == FR_GZIP) {
+        fr->zs.zalloc = Z_NULL; fr->zs.zfree = Z_NULL; fr->zs.opaque = Z_NULL;
+        fr->zs.next_in = Z_NULL; fr->zs.avail_in = 0;
+        if (inflateInit2(&fr->zs, 15 + 16) != Z_OK) {   /* 15+16 = gzip wrapper */
+            free(fr->cin); free(fr); FR_DOPEN_FAIL("inflateInit2 failed");
+        }
+        fr->zs_active = 1;
+    } else if (fmt == FR_BGZF) {
+        fr->ld = libdeflate_alloc_decompressor();
+        fr->bout_cap = FR_BOUT_CAP;
+        fr->bout = (unsigned char *)malloc(fr->bout_cap);
+        if (!fr->ld || !fr->bout) {
+            if (fr->ld) libdeflate_free_decompressor(fr->ld);
+            free(fr->bout); free(fr->cin); free(fr);
+            FR_DOPEN_FAIL("out of memory");
+        }
+    }
+#undef FR_DOPEN_FAIL
+    return fr;
+}
+
+/* --------------------------------------------------------------------- */
+
+static int fr_read_plain(fast_reader_t *fr, unsigned char *buf, int len)
+{
+    int out = 0;
+    if (fr->cin_pos < fr->cin_len) {              /* serve primed/buffered bytes */
+        size_t avail = fr->cin_len - fr->cin_pos;
+        int take = avail < (size_t)len ? (int)avail : len;
+        memcpy(buf, fr->cin + fr->cin_pos, (size_t)take);
+        fr->cin_pos += (size_t)take;
+        out += take;
+    }
+    while (out < len && !fr->eof_in) {
+        ssize_t r = read(fr->fd, buf + out, len - out);
+        if (r < 0) { if (errno == EINTR) continue; return -1; }
+        if (r == 0) { fr->eof_in = 1; break; }
+        out += (int)r;
+    }
+    return out;
+}
+
+static int fr_read_gzip(fast_reader_t *fr, unsigned char *buf, int len)
+{
+    fr->zs.next_out = buf;
+    fr->zs.avail_out = (uInt)len;
+    while (fr->zs.avail_out > 0) {
+        if (fr->zs.avail_in == 0) {
+            if (fr_fill(fr) < 0) return -1;
+            if (fr->cin_len - fr->cin_pos == 0) break;     /* no more input */
+            fr->zs.next_in = fr->cin + fr->cin_pos;
+            fr->zs.avail_in = (uInt)(fr->cin_len - fr->cin_pos);
+        }
+        int ret = inflate(&fr->zs, Z_NO_FLUSH);
+        fr->cin_pos = fr->cin_len - fr->zs.avail_in;       /* track consumed */
+        if (ret == Z_STREAM_END) {                          /* member done */
+            if (inflateReset(&fr->zs) != Z_OK) return -1;
+            if (fr->zs.avail_in == 0 && fr->eof_in) break;  /* nothing follows */
+            continue;                                       /* next member */
+        }
+        if (ret == Z_BUF_ERROR) {                           /* needs more input */
+            if (fr->eof_in && fr->zs.avail_in == 0) break;
+            continue;
+        }
+        if (ret != Z_OK) return -1;                         /* hard error */
+    }
+    return len - (int)fr->zs.avail_out;
+}
+
+/* Decode the next BGZF block into fr->bout, skipping empty (EOF-marker) blocks
+ * and stopping at clean EOF. Returns 0 on success/EOF (fr->done set on EOF),
+ * -1 on a decode/format error. */
+static int fr_next_bgzf_block(fast_reader_t *fr)
+{
+    for (;;) {
+        fr->bout_len = fr->bout_pos = 0;
+        if (fr_fill(fr) < 0) return -1;
+        size_t avail = fr->cin_len - fr->cin_pos;
+        if (avail == 0) { fr->done = 1; return 0; }         /* clean EOF */
+        if (avail < FR_HDR_PEEK) return -1;                  /* truncated header */
+
+        const unsigned char *p = fr->cin + fr->cin_pos;
+        if (!(p[0] == 0x1f && p[1] == 0x8b && p[2] == 0x08 && (p[3] & 0x04))) return -1;
+
+        unsigned xlen = (unsigned)p[10] | ((unsigned)p[11] << 8);
+        unsigned end = 12 + xlen;
+        /* xlen is attacker-controlled (up to 65535); the extra field must lie
+         * entirely within the bytes actually read, or the scan below could
+         * over-read past `avail` into uninitialized / out-of-bounds memory. */
+        if (end > avail) return -1;                          /* extra field overruns input */
+        unsigned bsize = 0; int found = 0;
+        unsigned off = 12;
+        while (off + 4 <= end) {                             /* scan extra for BC */
+            unsigned slen = (unsigned)p[off + 2] | ((unsigned)p[off + 3] << 8);
+            /* The BC subfield carries a 2-byte payload at p[off+4..off+5];
+             * confirm those bytes are within the extra field before reading. */
+            if (p[off] == 'B' && p[off + 1] == 'C' && slen == 2 && off + 6 <= end) {
+                bsize = (unsigned)p[off + 4] | ((unsigned)p[off + 5] << 8);
+                found = 1; break;
+            }
+            off += 4 + slen;
+        }
+        if (!found) return -1;
+
+        size_t block_len = (size_t)bsize + 1;
+        if (block_len < (size_t)(12 + xlen + 8)) return -1;  /* malformed */
+        if (avail < block_len) return -1;                    /* truncated block */
+
+        size_t cdata_off = 12 + xlen;
+        size_t cdata_len = block_len - cdata_off - 8;
+        uint32_t crc = (uint32_t)p[block_len - 8]        | ((uint32_t)p[block_len - 7] << 8) |
+                       ((uint32_t)p[block_len - 6] << 16) | ((uint32_t)p[block_len - 5] << 24);
+        uint32_t isize = (uint32_t)p[block_len - 4]        | ((uint32_t)p[block_len - 3] << 8) |
+                         ((uint32_t)p[block_len - 2] << 16) | ((uint32_t)p[block_len - 1] << 24);
+
+        fr->cin_pos += block_len;                            /* consume the block */
+
+        if (isize == 0) continue;                            /* EOF marker / empty block */
+        if (isize > fr->bout_cap) return -1;                 /* >64 KiB: not BGZF */
+
+        size_t actual = 0;
+        enum libdeflate_result r =
+            libdeflate_deflate_decompress(fr->ld, p + cdata_off, cdata_len,
+                                          fr->bout, isize, &actual);
+        if (r != LIBDEFLATE_SUCCESS || actual != isize) return -1;
+        if (libdeflate_crc32(0, fr->bout, isize) != crc) return -1;
+
+        fr->bout_len = isize;
+        fr->bout_pos = 0;
+        return 0;
+    }
+}
+
+static int fr_read_bgzf(fast_reader_t *fr, unsigned char *buf, int len)
+{
+    int out = 0;
+    while (out < len) {
+        if (fr->bout_pos < fr->bout_len) {
+            size_t avail = fr->bout_len - fr->bout_pos;
+            int take = avail < (size_t)(len - out) ? (int)avail : (len - out);
+            memcpy(buf + out, fr->bout + fr->bout_pos, (size_t)take);
+            fr->bout_pos += (size_t)take;
+            out += take;
+            continue;
+        }
+        if (fr->done) break;
+        if (fr_next_bgzf_block(fr) < 0) return -1;
+        if (fr->bout_len == 0 && fr->done) break;
+    }
+    return out;
+}
+
+int fast_reader_read(fast_reader_t *fr, void *buf, int len)
+{
+    if (len <= 0) return 0;
+    switch (fr->fmt) {
+        case FR_PLAIN: return fr_read_plain(fr, (unsigned char *)buf, len);
+        case FR_GZIP:  return fr_read_gzip(fr, (unsigned char *)buf, len);
+        case FR_BGZF:  return fr_read_bgzf(fr, (unsigned char *)buf, len);
+        default:       return -1;
+    }
+}
+
+fr_format_t fast_reader_format(const fast_reader_t *fr) { return fr->fmt; }
+
+void fast_reader_close(fast_reader_t *fr)
+{
+    if (!fr) return;
+    if (fr->zs_active) inflateEnd(&fr->zs);
+    if (fr->ld) libdeflate_free_decompressor(fr->ld);
+    free(fr->bout);
+    free(fr->cin);
+    if (fr->fd >= 0) close(fr->fd);
+    free(fr);
+}

--- a/src/fast_reader.h
+++ b/src/fast_reader.h
@@ -1,0 +1,58 @@
+/* fast_reader: content-detecting, gzread-compatible FASTQ byte source.
+ *
+ * Sniffs the input codec by magic bytes and serves decompressed bytes via a
+ * gzread-style API, so the existing kseq parser can sit on top unchanged:
+ *
+ *   - plain  : raw passthrough
+ *   - gzip   : zlib streaming inflate, spanning concatenated members
+ *   - bgzf   : libdeflate, one block at a time (the parallel-ready seam)
+ *
+ * libdeflate's decompress API is one-shot (no streaming), so it is used only
+ * for the bounded <=64 KB BGZF blocks; vanilla gzip stays on zlib's streaming
+ * inflate. See docs/design for the rationale and the per-arch measurements.
+ */
+#ifndef FAST_READER_H
+#define FAST_READER_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    FR_PLAIN       =  0,
+    FR_GZIP        =  1,
+    FR_BGZF        =  2,
+    FR_UNSUPPORTED = -1  /* recognized but unsupported: bzip2 / xz / zstd */
+} fr_format_t;
+
+/* Classify an input by its leading bytes. Up to 18 bytes are needed to
+ * distinguish BGZF from plain gzip (the BC extra subfield carrying BSIZE);
+ * fewer bytes is fine and short/empty input classifies as FR_PLAIN. */
+fr_format_t fr_detect(const unsigned char *hdr, size_t n);
+
+typedef struct fast_reader fast_reader_t;
+
+/* Open a reader over an already-open file descriptor. Takes ownership of fd
+ * (closed by fast_reader_close). Sniffs the codec and primes the consumed
+ * header bytes internally, so non-seekable inputs (pipes/stdin) work without
+ * seeking. On error returns NULL and, if err != NULL, sets *err to a static
+ * message (e.g. an unsupported codec). */
+fast_reader_t *fast_reader_dopen(int fd, const char **err);
+
+/* gzread-compatible: read up to len decompressed bytes into buf. Returns the
+ * number of bytes produced (0 at clean EOF) or -1 on a decode error.
+ * Transparently spans concatenated gzip members and BGZF blocks. */
+int fast_reader_read(fast_reader_t *fr, void *buf, int len);
+
+fr_format_t fast_reader_format(const fast_reader_t *fr);
+
+/* Close the reader and the underlying fd, and free all buffers. */
+void fast_reader_close(fast_reader_t *fr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FAST_READER_H */

--- a/src/fast_reader_bseq.c
+++ b/src/fast_reader_bseq.c
@@ -1,0 +1,82 @@
+#include "fast_reader_bseq.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "kstring.h"
+#include "kseq.h"
+#include "utils.h"   /* err_fatal */
+
+/* kseq instantiated over the fast_reader byte source. This is the only TU that
+ * uses this handle type, so there is no kseq_t name collision with the gzFile
+ * instantiation used elsewhere. */
+KSEQ_INIT(fast_reader_t *, fast_reader_read)
+
+/* trim_readno / kseq2bseq1 mirror the static helpers in bwa.cpp exactly:
+ * strip a trailing /<digit> for any digit; per-field strdup; qual==NULL when
+ * empty; zero the struct first (the output loop free()s every field). */
+static inline void fr_trim_readno(kstring_t *s)
+{
+    if (s->l > 2 && s->s[s->l - 2] == '/' && isdigit((unsigned char)s->s[s->l - 1]))
+        s->l -= 2, s->s[s->l] = 0;
+}
+
+static inline void fr_kseq2bseq1(const kseq_t *ks, bseq1_t *s)
+{
+    memset(s, 0, sizeof(*s));
+    s->name    = strdup(ks->name.s);
+    s->comment = ks->comment.l ? strdup(ks->comment.s) : 0;
+    s->seq     = strdup(ks->seq.s);
+    s->qual    = ks->qual.l ? strdup(ks->qual.s) : 0;
+    s->l_seq   = strlen(s->seq);
+}
+
+void *fast_kseq_init(fast_reader_t *fr) { return kseq_init(fr); }
+
+void fast_kseq_destroy(void *ks) { if (ks) kseq_destroy((kseq_t *)ks); }
+
+bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s)
+{
+    kseq_t *ks = (kseq_t *)ks1_, *ks2 = (kseq_t *)ks2_;
+    int64_t size = 0, m, n;
+    bseq1_t *seqs;
+    m = n = 0; seqs = 0;
+    while (kseq_read(ks) >= 0) {
+        if (ks2 && kseq_read(ks2) < 0) {                 /* 2nd file has fewer */
+            fprintf(stderr, "[W::%s] the 2nd file has fewer sequences.\n", __func__);
+            break;
+        }
+        if (n >= m) {
+            m = m ? m << 1 : 256;
+            /* Grow via a temp so a failed realloc doesn't leak the old buffer
+             * (cppcheck memleakOnRealloc). Abort loudly on OOM rather than
+             * returning a short batch: the pipeline reads n_seqs==0 as clean
+             * EOF and would silently truncate the alignment. Matches bwa-mem3's
+             * house style of aborting on allocation failure. */
+            bseq1_t *tmp = (bseq1_t *)realloc(seqs, m * sizeof(bseq1_t));
+            if (tmp == NULL)
+                err_fatal(__func__, "failed to grow read buffer to %ld records", (long)m);
+            seqs = tmp;
+        }
+        fr_trim_readno(&ks->name);
+        fr_kseq2bseq1(ks, &seqs[n]);
+        seqs[n].id = n;
+        size += seqs[n++].l_seq;
+        if (ks2) {
+            fr_trim_readno(&ks2->name);
+            fr_kseq2bseq1(ks2, &seqs[n]);
+            seqs[n].id = n;
+            size += seqs[n++].l_seq;
+        }
+        if (size >= chunk_size && (n & 1) == 0) break;   /* even-parity cut, all modes */
+    }
+    if (size == 0) {                                      /* 1st file has fewer */
+        if (ks2 && kseq_read(ks2) >= 0)
+            fprintf(stderr, "[W::%s] the 1st file has fewer sequences.\n", __func__);
+    }
+    *n_ = n;
+    *s = size;
+    return seqs;
+}

--- a/src/fast_reader_bseq.h
+++ b/src/fast_reader_bseq.h
@@ -1,0 +1,42 @@
+/* Adapter: kseq parser over a fast_reader, producing bseq1_t chunks with the
+ * exact contract of bseq_read_orig (same chunking, parity, trim, per-field
+ * allocation). Kept in its own translation unit because kseq.h can only be
+ * instantiated for one handle type per TU. */
+#ifndef FAST_READER_BSEQ_H
+#define FAST_READER_BSEQ_H
+
+#include "bwa.h"
+#include "fast_reader.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Create a kseq bound to an already-open fast_reader, returned as an opaque
+ * kseq_t*. `fr` must be non-NULL and outlive the returned handle (the kseq
+ * borrows it; it does not take ownership and fast_kseq_destroy does NOT close
+ * the underlying fast_reader). Returns the handle; never returns NULL on the
+ * caller-visible path (the underlying kseq_init allocates with calloc and the
+ * fast_reader is assumed valid). */
+void *fast_kseq_init(fast_reader_t *fr);
+
+/* Destroy a handle from fast_kseq_init. `ks` may be NULL (no-op). Frees only
+ * the kseq buffers; the caller still owns and must close the fast_reader the
+ * handle was bound to. */
+void  fast_kseq_destroy(void *ks);
+
+/* Mirror of bseq_read_orig, reading from fast_reader-backed kseq handles.
+ * Reads up to ~chunk_size bytes of sequence (cut on an even record boundary)
+ * and returns a malloc'd bseq1_t array of *n_ records; the caller owns the
+ * array and every per-record string field (name/comment/seq/qual). `ks1_` is
+ * required; `ks2_` is the second mate handle and may be NULL for single-end /
+ * interleaved input. At EOF the function sets *n_ = 0 and *s = 0; the returned
+ * pointer is then NULL (no records were allocated). Mismatched record counts
+ * between the two files are reported to stderr and truncate the batch. */
+bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FAST_READER_BSEQ_H */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -44,6 +44,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "meth_bam.h"
 #include "meth_orig_ref.h"
 #include "bwa_shm.h"
+#include "fast_reader_bseq.h"
 
 #if AFF && (__linux__)
 #include <sys/sysinfo.h>
@@ -348,10 +349,9 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
 
         /* Read "reads" from input file (fread) */
         int64_t sz = 0;
-        ret->seqs = bseq_read_orig(aux->task_size,
-                                   &ret->n_seqs,
-                                   aux->ks, aux->ks2,
-                                   &sz);
+        ret->seqs = aux->legacy_reader
+            ? bseq_read_orig(aux->task_size, &ret->n_seqs, aux->ks, aux->ks2, &sz)
+            : bseq_read_fast(aux->task_size, &ret->n_seqs, aux->frks, aux->frks2, &sz);
 
         tprof[READ_IO][0] += __rdtsc() - tim;
 
@@ -901,6 +901,10 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                 with >=INT genome occurrences (i.e. the supp region is repetitive on its\n");
     fprintf(stderr, "                 own). 0 disables (default). Typical values 5-20; lower = more aggressive.\n");
     fprintf(stderr, "                 Primary MAPQ is unaffected.\n");
+    fprintf(stderr, "Input reader:\n");
+    fprintf(stderr, "   --legacy-reader\n");
+    fprintf(stderr, "                 use the legacy gzFile/kseq input reader instead of the default\n");
+    fprintf(stderr, "                 content-detecting fast reader (escape hatch / A-B baseline).\n");
     fprintf(stderr, "Help:\n");
     fprintf(stderr, "   --help        print this help message and exit\n");
     fprintf(stderr, "Note: Please read the man page for detailed description of the command line and options.\n");
@@ -979,7 +983,7 @@ int main_mem(int argc, char *argv[])
     const char  *mode                      = 0;
 
     mem_opt_t    *opt, opt0;
-    gzFile        fp, fp2 = 0;
+    gzFile        fp = 0, fp2 = 0;
     void         *ko = 0, *ko2 = 0;
     int           fd, fd2;
     mem_pestat_t  pes[4];
@@ -1013,6 +1017,7 @@ int main_mem(int argc, char *argv[])
         OPT_METH_SET_AS_FAILED,
         OPT_METH_CHIMERA_QC,
         OPT_SUPP_REP_HARD_CAP,
+        OPT_LEGACY_READER,
         OPT_HELP,
     };
     static struct option long_opts[] = {
@@ -1021,6 +1026,7 @@ int main_mem(int argc, char *argv[])
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
         {"chimera-qc",               no_argument,       0, OPT_METH_CHIMERA_QC},
         {"supp-rep-hard-cap",        required_argument, 0, OPT_SUPP_REP_HARD_CAP},
+        {"legacy-reader",            no_argument,       0, OPT_LEGACY_READER},
         {"help",                     no_argument,       0, OPT_HELP},
         {0, 0, 0, 0}
     };
@@ -1175,6 +1181,7 @@ int main_mem(int argc, char *argv[])
             }
             opt->supp_rep_hard_cap = (int)v;
         }
+        else if (c == OPT_LEGACY_READER) aux.legacy_reader = 1;
         else if (c == OPT_HELP) {
             usage(opt);
             free(opt);
@@ -1351,8 +1358,22 @@ int main_mem(int argc, char *argv[])
         return 1;
     }
     // fp = gzopen(argv[optind + 1], "r");
-    fp = gzdopen(fd, "r");
-    aux.ks = kseq_init(fp);
+    if (aux.legacy_reader) {
+        fp = gzdopen(fd, "r");
+        aux.ks = kseq_init(fp);
+    } else {
+        const char *fr_err = NULL;
+        aux.fr1 = fast_reader_dopen(fd, &fr_err);
+        if (aux.fr1 == NULL) {
+            fprintf(stderr, "[E::%s] %s\n", __func__, fr_err ? fr_err : "failed to open input");
+            free(opt);
+            if (out_opened) fclose(aux.fp);
+            delete aux.fmi;
+            kclose(ko);
+            return 1;
+        }
+        aux.frks = fast_kseq_init(aux.fr1);
+    }
 
     // PAIRED_END
     /* Handling Paired-end reads */
@@ -1369,8 +1390,8 @@ int main_mem(int argc, char *argv[])
                 fprintf(stderr, "[E::%s] failed to open file `%s'.\n", __func__, argv[optind + 2]);
                 free(opt);
                 free(ko);
-                err_gzclose(fp);
-                kseq_destroy(aux.ks);
+                if (aux.legacy_reader) { err_gzclose(fp); kseq_destroy(aux.ks); }
+                else { fast_kseq_destroy(aux.frks); fast_reader_close(aux.fr1); }
                 if (out_opened)
                     fclose(aux.fp);
                 delete aux.fmi;
@@ -1378,11 +1399,24 @@ int main_mem(int argc, char *argv[])
                 // kclose(ko2);
                 return 1;
             }
-            // fp2 = gzopen(argv[optind + 2], "r");
-            fp2 = gzdopen(fd2, "r");
-            aux.ks2 = kseq_init(fp2);
+            if (aux.legacy_reader) {
+                fp2 = gzdopen(fd2, "r");
+                aux.ks2 = kseq_init(fp2);
+                assert(aux.ks2 != 0);
+            } else {
+                const char *fr_err2 = NULL;
+                aux.fr2 = fast_reader_dopen(fd2, &fr_err2);
+                if (aux.fr2 == NULL) {
+                    fprintf(stderr, "[E::%s] %s\n", __func__, fr_err2 ? fr_err2 : "failed to open input");
+                    free(opt);
+                    fast_kseq_destroy(aux.frks); fast_reader_close(aux.fr1);
+                    if (out_opened) fclose(aux.fp);
+                    delete aux.fmi; kclose(ko); kclose(ko2);
+                    return 1;
+                }
+                aux.frks2 = fast_kseq_init(aux.fr2);
+            }
             opt->flag |= MEM_F_PE;
-            assert(aux.ks2 != 0);
         }
     }
 
@@ -1530,13 +1564,15 @@ int main_mem(int argc, char *argv[])
     free(hdr_line);
     free(idx_hdr_lines);
     free(opt);
-    kseq_destroy(aux.ks);
-    err_gzclose(fp); kclose(ko);
+    if (aux.legacy_reader) { kseq_destroy(aux.ks); err_gzclose(fp); }
+    else { fast_kseq_destroy(aux.frks); fast_reader_close(aux.fr1); }
+    kclose(ko);
 
     // PAIRED_END
-    if (aux.ks2) {
-        kseq_destroy(aux.ks2);
-        err_gzclose(fp2); kclose(ko2);
+    if (aux.ks2 || aux.fr2) {
+        if (aux.legacy_reader) { kseq_destroy(aux.ks2); err_gzclose(fp2); }
+        else { fast_kseq_destroy(aux.frks2); fast_reader_close(aux.fr2); }
+        kclose(ko2);
     }
 
     /* BGZF flush + EOF marker errors surface only on close. Propagate to the

--- a/src/fastmap.h
+++ b/src/fastmap.h
@@ -55,8 +55,15 @@ KSEQ_DECLARE(gzFile)
 /* Forward-declared — keeps htslib out of this header. */
 struct bam_writer_s;
 
+#include "fast_reader.h"
+
 typedef struct {
 	kseq_t *ks, *ks2;
+	/* Fast-path reader (default). When legacy_reader is set, the gzFile/kseq
+	 * path (ks, ks2, fp) is used; otherwise the fast_reader path below. */
+	int legacy_reader;
+	fast_reader_t *fr1, *fr2;
+	void *frks, *frks2;   /* kseq_t* over fast_reader; opaque in this header */
 	mem_opt_t *opt;
 	mem_pestat_t *pes0;
 	int64_t n_processed;

--- a/test/fast_reader_selftest.c
+++ b/test/fast_reader_selftest.c
@@ -1,0 +1,208 @@
+/* Standalone correctness self-test for fast_reader.
+ *
+ * Generates plain, gzip, multi-member gzip, and BGZF encodings of a known
+ * payload (programmatically — no committed fixtures), reads each back through
+ * fast_reader, and asserts the decoded bytes equal the original. Also checks
+ * fr_detect classification and the unsupported-codec path.
+ *
+ * Build (standalone, no bwa-mem3 link needed):
+ *   cc -I src -I/opt/homebrew/include test/fast_reader_selftest.c src/fast_reader.c \
+ *      -L/opt/homebrew/lib -lz -ldeflate -o fast_reader_selftest
+ */
+#include "fast_reader.h"
+
+#include <zlib.h>
+#include <libdeflate.h>
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int g_fail = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", (msg)); g_fail = 1; } \
+    else         { fprintf(stderr, "ok:   %s\n", (msg)); } \
+} while (0)
+
+/* Allocate or abort the self-test: every buffer is dereferenced immediately, so
+ * an unchecked malloc would crash on OOM instead of failing controllably. */
+#define XMALLOC(ptr, n) do { (ptr) = malloc((n)); assert((ptr) != NULL); } while (0)
+
+/* Build a multi-record FASTQ-ish payload large enough to span buffer refills. */
+static unsigned char *make_payload(size_t *out_n)
+{
+    size_t cap = 4u << 20;          /* 4 MiB */
+    unsigned char *buf;
+    XMALLOC(buf, cap);
+    size_t n = 0;
+    for (int i = 0; n + 256 < cap; i++) {
+        n += (size_t)snprintf((char *)buf + n, cap - n,
+            "@read%d/1 some comment %d\n"
+            "ACGTACGTNNNNacgtACGT%d\n"
+            "+\n"
+            "IIIIIIIIIIIIIIIIIIII\n", i, i, i);
+    }
+    *out_n = n;
+    return buf;
+}
+
+static void write_file(const char *path, const unsigned char *p, size_t n)
+{
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    assert(fd >= 0);
+    size_t off = 0;
+    while (off < n) { ssize_t w = write(fd, p + off, n - off); assert(w > 0); off += (size_t)w; }
+    close(fd);
+}
+
+/* One-member gzip via zlib. Returns compressed length. */
+static size_t gz_member(const unsigned char *in, size_t n, unsigned char *out, size_t cap)
+{
+    z_stream zs; memset(&zs, 0, sizeof zs);
+    deflateInit2(&zs, 6, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+    zs.next_in = (Bytef *)in; zs.avail_in = (uInt)n;
+    zs.next_out = out; zs.avail_out = (uInt)cap;
+    int r = deflate(&zs, Z_FINISH); assert(r == Z_STREAM_END);
+    size_t len = cap - zs.avail_out;
+    deflateEnd(&zs);
+    return len;
+}
+
+/* One BGZF block (n <= 65536). Returns block length written to out. */
+static size_t bgzf_block(struct libdeflate_compressor *c,
+                         const unsigned char *in, size_t n, unsigned char *out)
+{
+    size_t bound = libdeflate_deflate_compress_bound(c, n);
+    unsigned char *cbuf;
+    XMALLOC(cbuf, bound);
+    size_t clen = libdeflate_deflate_compress(c, in, n, cbuf, bound);
+    assert(clen > 0 || n == 0);
+    if (clen == 0) {                 /* empty input: emit an empty stored block */
+        cbuf[0] = 0x03; cbuf[1] = 0x00; clen = 2;
+    }
+    size_t block_len = 12 + 6 + clen + 8;
+    uint16_t bsize = (uint16_t)(block_len - 1);
+    unsigned char *p = out;
+    p[0]=0x1f; p[1]=0x8b; p[2]=0x08; p[3]=0x04;
+    p[4]=p[5]=p[6]=p[7]=0; p[8]=0; p[9]=0xff;
+    p[10]=6; p[11]=0;                          /* XLEN = 6 */
+    p[12]='B'; p[13]='C'; p[14]=2; p[15]=0;
+    p[16]=bsize & 0xff; p[17]=(bsize >> 8) & 0xff;
+    memcpy(p + 18, cbuf, clen);
+    uint32_t crc = libdeflate_crc32(0, in, n);
+    uint32_t isize = (uint32_t)n;
+    unsigned char *t = p + 18 + clen;
+    t[0]=crc&0xff; t[1]=(crc>>8)&0xff; t[2]=(crc>>16)&0xff; t[3]=(crc>>24)&0xff;
+    t[4]=isize&0xff; t[5]=(isize>>8)&0xff; t[6]=(isize>>16)&0xff; t[7]=(isize>>24)&0xff;
+    free(cbuf);
+    return block_len;
+}
+
+/* Read a whole file through fast_reader and compare to expected. */
+static int roundtrip(const char *path, const unsigned char *expect, size_t n,
+                     fr_format_t expect_fmt)
+{
+    int fd = open(path, O_RDONLY); assert(fd >= 0);
+    const char *err = NULL;
+    fast_reader_t *fr = fast_reader_dopen(fd, &err);
+    if (!fr) { fprintf(stderr, "  dopen failed: %s\n", err ? err : "?"); return 0; }
+    if (fast_reader_format(fr) != expect_fmt) { fprintf(stderr, "  wrong format\n"); fast_reader_close(fr); return 0; }
+    /* Each fast_reader_read may write up to 65536 bytes at got + total before
+     * the overrun guard runs, so the buffer must hold n plus one full chunk
+     * of slack past the expected length (otherwise a final over-length read
+     * heap-overflows before the guard can catch it). */
+    unsigned char *got;
+    XMALLOC(got, n + 65536);
+    size_t total = 0; int ok = 1;
+    for (;;) {
+        int r = fast_reader_read(fr, got + total, 65536);
+        if (r < 0) { fprintf(stderr, "  read error\n"); ok = 0; break; }
+        if (r == 0) break;
+        total += (size_t)r;
+        if (total > n + 65536) { fprintf(stderr, "  overrun\n"); ok = 0; break; }
+    }
+    if (ok && (total != n || memcmp(got, expect, n) != 0)) {
+        fprintf(stderr, "  mismatch: got %zu vs %zu bytes\n", total, n);
+        ok = 0;
+    }
+    free(got);
+    fast_reader_close(fr);
+    return ok;
+}
+
+int main(void)
+{
+    /* --- fr_detect --- */
+    unsigned char gz[18]  = {0x1f,0x8b,0x08,0x00};
+    unsigned char bg[18]  = {0x1f,0x8b,0x08,0x04,0,0,0,0,0,0xff,6,0,'B','C',2,0,0x12,0};
+    unsigned char bz[2]   = {0x42,0x5a};
+    unsigned char zs4[4]  = {0x28,0xb5,0x2f,0xfd};
+    CHECK(fr_detect((unsigned char*)"",0) == FR_PLAIN,        "fr_detect: empty -> plain");
+    CHECK(fr_detect((unsigned char*)"@SEQ",4) == FR_PLAIN,    "fr_detect: text -> plain");
+    CHECK(fr_detect(gz,18) == FR_GZIP,                        "fr_detect: gzip");
+    CHECK(fr_detect(bg,18) == FR_BGZF,                        "fr_detect: bgzf");
+    CHECK(fr_detect(bz,2) == FR_UNSUPPORTED,                  "fr_detect: bzip2 -> unsupported");
+    CHECK(fr_detect(zs4,4) == FR_UNSUPPORTED,                 "fr_detect: zstd -> unsupported");
+
+    size_t n; unsigned char *pay = make_payload(&n);
+    fprintf(stderr, "payload: %zu bytes\n", n);
+
+    /* --- plain --- */
+    write_file("/tmp/fr_plain.fq", pay, n);
+    CHECK(roundtrip("/tmp/fr_plain.fq", pay, n, FR_PLAIN), "roundtrip: plain");
+
+    /* --- single-member gzip --- */
+    {
+        size_t cap = n + (n >> 1) + 4096;
+        unsigned char *gzb;
+        XMALLOC(gzb, cap);
+        size_t gl = gz_member(pay, n, gzb, cap);
+        write_file("/tmp/fr_one.fq.gz", gzb, gl);
+        CHECK(roundtrip("/tmp/fr_one.fq.gz", pay, n, FR_GZIP), "roundtrip: single-member gzip");
+        free(gzb);
+    }
+
+    /* --- multi-member gzip (cat a.gz b.gz) --- */
+    {
+        size_t half = n / 2;
+        size_t cap = n + (n >> 1) + 8192;
+        unsigned char *a, *b;
+        XMALLOC(a, cap);
+        XMALLOC(b, cap);
+        size_t la = gz_member(pay, half, a, cap);
+        size_t lb = gz_member(pay + half, n - half, b, cap);
+        unsigned char *cat;
+        XMALLOC(cat, la + lb);
+        memcpy(cat, a, la); memcpy(cat + la, b, lb);
+        write_file("/tmp/fr_multi.fq.gz", cat, la + lb);
+        CHECK(roundtrip("/tmp/fr_multi.fq.gz", pay, n, FR_GZIP), "roundtrip: multi-member gzip");
+        free(a); free(b); free(cat);
+    }
+
+    /* --- BGZF (multiple blocks + EOF marker) --- */
+    {
+        struct libdeflate_compressor *c = libdeflate_alloc_compressor(6);
+        size_t cap = n + (n >> 1) + 65536;
+        unsigned char *bgz;
+        XMALLOC(bgz, cap);
+        size_t off = 0, src = 0;
+        while (src < n) {
+            size_t chunk = n - src; if (chunk > 60000) chunk = 60000;   /* < 64 KiB */
+            off += bgzf_block(c, pay + src, chunk, bgz + off);
+            src += chunk;
+        }
+        off += bgzf_block(c, NULL, 0, bgz + off);                       /* EOF marker */
+        write_file("/tmp/fr_bgzf.fq.gz", bgz, off);
+        CHECK(roundtrip("/tmp/fr_bgzf.fq.gz", pay, n, FR_BGZF), "roundtrip: bgzf");
+        libdeflate_free_compressor(c);
+        free(bgz);
+    }
+
+    free(pay);
+    fprintf(stderr, g_fail ? "\nSELFTEST FAILED\n" : "\nSELFTEST PASSED\n");
+    return g_fail;
+}


### PR DESCRIPTION
## Summary

Implements a content-detecting FASTQ reader fast path. `fast_reader` (`src/fast_reader.{c,h}`) is a `gzread`-compatible byte source that sniffs the input codec by magic bytes and serves decompressed bytes for three modes:

- **plain** — passthrough
- **gzip** — zlib streaming inflate, spanning concatenated (multi-member) streams
- **BGZF** — libdeflate, one ≤64 KB block at a time, with CRC32/ISIZE verification (the parallel-ready seam)

The existing **kseq** parser sits on top of the byte source unchanged, so record boundary / whitespace / read-number-trim / `qual==NULL` semantics match the legacy reader exactly — no parser re-implementation, no divergence risk.

## Why this engine split

libdeflate's decompress API is **one-shot** (no streaming state), so it cannot stream a multi-GB single-member gzip; it is used only for the bounded BGZF blocks. Vanilla gzip stays on **zlib** because a local inflate microbench on arm64 (the core arch) found no streaming inflater beats it there: zlib-ng 0.67×, ISA-L 0.47×; libdeflate 1.2× but one-shot. So vanilla gzip gets no codec change (no regression); the differentiated win is the BGZF path and the seam it lays for a future parallel reader.

## Integration

Wired into `kt_pipeline` step 0 behind `--legacy-reader`: the fast path is the **default**; `--legacy-reader` restores the `gzFile`/kseq path as an escape hatch and A/B baseline. `bseq_read_fast` mirrors `bseq_read_orig`'s contract exactly (even-parity chunk cut, PE interleave, `trim_readno` on any digit, per-field `malloc` matching `kseq2bseq1` since the pipeline frees fields individually).

## Verification

- **Standalone self-test** (`make fast_reader_selftest`): generates plain / gzip / multi-member gzip / BGZF encodings programmatically and asserts `fast_reader` reproduces the payload byte-for-byte; also checks `fr_detect` classification and the unsupported-codec path. **Passes.**
- **Compiles** in-project: `src/fast_reader.o`, `src/fast_reader_bseq.o`, and `src/fastmap.o` (the integration) all build against real headers.
- Full-binary build + end-to-end fast-vs-`--legacy-reader` SAM diff: in progress.

## Status

Draft. Honest scope: on arm64 the vanilla-gzip common case is ~unchanged (zlib retained); the measurable wins are BGZF input and the parallel-reader seam. Next: the per-arch thread-scaling + x86 inflate bench, and the parallel-BGZF follow-on. The SIMD record-scan and any per-arch gzip-codec swap are deferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a unified content-detecting reader for plain, gzip, and BGZF (bgzip) compressed FASTQ/FASTA inputs via a new reader API.
  * Introduced an optional `--legacy-reader` mode to keep the previous gz/kseq-based ingestion path.

* **Tests**
  * Added a standalone `fast_reader_selftest` to validate detection and round-trip decoding for supported/unsupported formats.

* **Chores**
  * Updated CI and build dependencies to include `libdeflate`/`libdeflate-dev`, and enhanced the build to support the new reader components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->