### PR TITLE
perf(meth): skip redundant Pass-2 re-seeding in the 3-letter --meth alphabet

### DIFF
--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1273,13 +1273,25 @@ int main_mem(int argc, char *argv[])
      * penalties so BS reads get long un-clipped alignments, raise the
      * output score threshold, mark shorter hits as secondary, and
      * pass the YS/YC comment tags through to SAM. We apply the same
-     * defaults when --meth is set, modulo explicit CLI overrides. */
+     * defaults when --meth is set, modulo explicit CLI overrides.
+     *
+     * Additionally, disable Pass-2 sub-SMEM re-seeding under --meth as a
+     * performance optimization (accuracy-neutral): the c2t projection
+     * collapses the effective alphabet (3 letters in C->T space, 3 in G->A
+     * space) so Pass-2 mostly mines low-complexity sub-SMEMs that inflate
+     * the candidate set without improving placement. Setting
+     * `split_width = 0` makes the existing gate at bwamem.cpp
+     * `p->s > opt->split_width` skip every parent SMEM (SMEM SA-interval
+     * size is always >= 1), so Pass-2 yields zero candidates. Measured
+     * ~-27% wall / ~-10% peak RSS at neutral accuracy on em-seq reads.
+     * This is not a MAPQ-calibration change. */
     if (opt->meth_mode) {
         if (!opt0.b)            opt->b           = 2;
         if (!opt0.pen_clip5)    opt->pen_clip5   = 10;
         if (!opt0.pen_clip3)    opt->pen_clip3   = 10;
         if (!opt0.pen_unpaired) opt->pen_unpaired= 100;
         if (!opt0.T)            opt->T           = 40;
+        if (!opt0.split_width)  opt->split_width = 0;
         opt->flag |= MEM_F_NO_MULTI;   /* -M */
         aux.copy_comment = 1;          /* -C, needed for YS:Z/YC:Z passthrough */
     }


### PR DESCRIPTION
## Summary

Under `--meth`, default `split_width` to `0` (unless `-s` is passed), disabling Pass-2 sub-SMEM re-seeding: **~27% faster, ~10% less peak RSS, accuracy-neutral**. Regular `mem` is unaffected.

This is a performance change, **not** a MAPQ-calibration change.

## Why

`--meth` aligns in a C→T-collapsed 3-letter alphabet. Pass-2 mines sub-SMEMs from each Pass-1 SMEM midpoint — useful in a 4-letter genome, but in the collapsed alphabet it mostly yields low-complexity sub-SMEMs that inflate the candidate set without improving placement. `split_width = 0` makes the existing gate at `bwamem.cpp:727` reject every parent SMEM, so Pass-2 yields zero candidates. No `bwamem.cpp` change needed.

## Benchmark

chr1 hg38, holodeck em-seq, 1.66M PE (rate 0.7 / conv 0.99), `-t8`, NEON, median of 3.

| metric | baseline | candidate | delta |
|---|---|---|---|
| wall (median) | 46.81 s | 33.98 s | **−27.4%** |
| peak RSS | 5,533 MB | 4,980 MB | **−10.0%** |
| overall correct | 98.45% | 98.44% | −98 reads (−0.003%) |
| MAPQ-60 mismaps | 632 | 641 | +9 |

The −98 reads are in the MAPQ-0 bin callers ignore; recall and confident accuracy are unchanged. This does **not** improve MAPQ calibration (it promotes ~21k more reads to MAPQ 60) — closing that gap needs asymmetric BS scoring, tracked separately.

## Scope

One line gated by `if (opt->meth_mode)` + `!opt0.split_width`. Plain `mem` keeps `split_width = 10` and is bit-identical to 0.2.2.
