### PR TITLE
perf: lower default max_matesw 50 → 10

### DIFF
--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -13,7 +13,7 @@ Options:
     -c INT        skip seeds with more than INT occurrences [500]
     -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [0.50]
     -W INT        discard a chain if seeded bases shorter than INT [0]
-    -m INT        perform at most INT rounds of mate rescues for each read [50]
+    -m INT        perform at most INT rounds of mate rescues for each read [10]
     -S            skip mate rescue
     -P            skip pairing; mate rescue performed unless -S also in use
 Scoring options:

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -176,7 +176,7 @@ reference is short and inference may be inaccurate.
 #### `-m INT` — mate rescue rounds
 
 Maximum number of mate-rescue attempts per read. Reduce to speed up alignment
-on data where the default (50) wastes time on unrescuable pairs.
+on data where the default (10) wastes time on unrescuable pairs.
 
 #### `-S` — skip mate rescue
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -166,7 +166,7 @@ mem_opt_t *mem_opt_init()
     o->n_threads = 1;
     o->max_XA_hits = 5;
     o->max_XA_hits_alt = 200;
-    o->max_matesw = 50;
+    o->max_matesw = 10;
     o->mask_level_redun = 0.95;
     o->min_chain_weight = 0;
     o->max_chain_extend = 1<<30;

--- a/test/regression/chr22_parity.sh
+++ b/test/regression/chr22_parity.sh
@@ -27,7 +27,8 @@ bwa mem -t 4 "$BWA_CHR22_FA" \
     "$CHR22_SIM_DIR/reads.r2.fastq.gz" \
     > "$CHR22_SIM_DIR/bwa.sam" 2>"$CHR22_SIM_DIR/bwa.log"
 
-"$BWA_MEM3" mem -t 4 "$CHR22_FA" \
+# pin to bwa's default max_matesw so parity is independent of bwa-mem3's lowered default
+"$BWA_MEM3" mem -t 4 -m 50 "$CHR22_FA" \
     "$CHR22_SIM_DIR/reads.r1.fastq.gz" \
     "$CHR22_SIM_DIR/reads.r2.fastq.gz" \
     > "$CHR22_SIM_DIR/bwamem3.sam" 2>"$CHR22_SIM_DIR/bwamem3.log"


### PR DESCRIPTION
Draft — **benched on real data via bwa-mem3-bench; see results below.**

## What
Lower the default `max_matesw` (mate-rescue depth, the `-m` flag) from 50 → 10. The `-m` flag still accepts any value; only the default changes. Also regenerates the CLI docs and pins the chr22 parity test to `-m 50` so it stays comparable to stock `bwa` (which defaults to 50).

## Why
Mate rescue runs Smith-Waterman for up to `max_matesw` near-best candidates per read. Volume instrumentation showed bwa-mem3 dispatches ~7× more rescue SW than minimap2-lineage aligners; candidates beyond ~10 add deep rescue almost entirely in repetitive, low-MAPQ loci. 10 matches minimap2/minibwa's `max_rescue=10`.

## Real-data benchmark (PR `6095b61` vs main `92d1bcf`, 5M pairs each)
Full write-up in [this comment](https://github.com/fg-labs/bwa-mem3/pull/130#issuecomment-4704452788).

**Speed (median):**

| dataset / arch | wall Δ | CPU Δ | peak-RSS Δ |
|---|---:|---:|---:|
| panel-twist-5M / c8g | −21.3% | −21.9% | −0.5% |
| wgs-5M / c8g | −18.7% | −19.3% | 0.0% |
| wes-5M / c8g | −13.9% | −18.4% | −0.8% |
| meth-twist-emseq-5M / m7i | −8.7% | −11.0% | −0.4% |

Faster on every dataset, RSS flat; largest on high-depth panel — exactly where the cap binds.

**Accuracy (samtools flagstat; deterministic):**

| dataset | mapped% Δ | proper-pair% Δ |
|---|---:|---:|
| wgs-5M | −0.01 pp | −0.02 pp |
| wes-5M | −0.01 pp | −0.02 pp |
| panel-twist-5M | −0.12 pp | −0.12 pp |
| meth-twist-emseq-5M | −0.07 pp | −0.19 pp |

**Near-neutral, not strictly zero.** A small, consistent, *directional* reduction (≤0.12 pp mapped, ≤0.19 pp proper-pair), confined to the deep mate-rescue tail — the change only ever *removes* rescued alignments (`mapped_only_query ≈ 0`), never adds mismaps. Immaterial for WGS/WES; largest on amplicon/panel.

## Status / open
Draft. Before flipping the universal default, recommend one **truth-set sensitivity spot-check** (simulated or GIAB) confirming the dropped deep-rescues (≤9k/5M on panel, ≤600 on WGS) are low-confidence repetitive placements, not real recall — converting "near-neutral" to "confirmed-neutral". (Read-level holodeck check pending.)

_Methodology note: use a template/order-independent BAM comparator for cross-build concordance — strict positional `fgumi compare --mode content` desyncs when supplementary-record counts differ and over-reports._
