### PR TITLE
docs: settings profiles (bwa drop-in vs recommended)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ shared-memory index, mimalloc allocator) maintained by [Fulcrum Genomics](https:
 
 bwa-mem3 is **not** byte-identical to bwa-mem2 — it adds SAM tags, fixes crashes, and changes tie resolution. The core alignment is preserved on the data we have tested, but the SAM byte stream is not. See [Equivalence with bwa-mem2](https://bwa-mem3.readthedocs.io/en/latest/whats-different/equivalence.html) for a field-by-field comparison and a full per-PR audit.
 
+By default bwa-mem3 keeps bwa-mem2's command-line defaults, so it drops into an existing pipeline unchanged. For the fastest configuration — and what each recommended deviation from the bwa defaults trades for speed — see [Settings profiles: bwa drop-in vs recommended](https://bwa-mem3.readthedocs.io/en/latest/best-practices/settings-profiles.html).
+
 **Full documentation:** <https://bwa-mem3.readthedocs.io>
 
 ## Install

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -28,6 +28,7 @@
 
 # Best Practices
 
+- [Settings profiles: bwa drop-in vs recommended](best-practices/settings-profiles.md)
 - [Build](best-practices/build.md)
 - [Output format](best-practices/output-format.md)
 - [Multi-sample workflows](best-practices/multi-sample.md)

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -1,0 +1,105 @@
+# Settings profiles: bwa drop-in vs recommended
+
+bwa-mem3's **defaults are chosen to track bwa-mem / bwa-mem2 behavior** — it is meant to be a
+faster drop-in for an existing bwa-mem2 pipeline. Some defaults that the bwa lineage inherited are,
+however, more conservative than necessary. This page defines two profiles:
+
+- a **drop-in profile** that keeps the bwa-mem/bwa-mem2 defaults, for migrations and parity checks;
+- a **recommended profile** that deviates from those defaults where we have benchmarked the change
+  to be near-neutral on accuracy and clearly faster.
+
+The defaults ship as the drop-in profile. The recommended profile is **opt-in** — you turn it on
+with explicit flags — so upgrading bwa-mem3 never silently changes your alignments.
+
+> bwa-mem3 is already, by design, *not* byte-identical to bwa-mem2 even at default settings
+> (additive SAM tags, per-architecture SIMD `score2`/MAPQ convergence, deterministic tie-breaks, a
+> few extra supplementary alignments) — it is 99.94%–99.9996% concordant on primary records
+> (panel-twist to WES). See
+> [Equivalence with bwa-mem2](../whats-different/equivalence.md). "Drop-in" therefore means *as close
+> to bwa-mem2 as bwa-mem3 gets*; the recommended profile is a further, documented deviation.
+
+## Drop-in profile (default)
+
+```bash
+bwa-mem3 mem -t <N> ref.fa R1.fq R2.fq > out.sam
+```
+
+No extra flags. Use this when you are:
+
+- reproducing or validating against bwa-mem / bwa-mem2 output, or
+- migrating an existing bwa-mem2 pipeline and want to change one variable (the aligner binary) at a
+  time before tuning anything else.
+
+## Recommended profile
+
+```bash
+bwa-mem3 mem -t <N> -m 10 ref.fa R1.fq R2.fq > out.sam
+```
+
+Use this for new pipelines, or once a drop-in migration is validated and you want bwa-mem3's best
+speed/accuracy trade-off. Current recommended deviations:
+
+| flag | default (drop-in) | recommended | effect |
+|---|---|---|---|
+| `-m` (mate-rescue depth) | 50 | **10** | ~11–22% less alignment CPU; near-neutral accuracy (see below) |
+
+This table will grow as we benchmark additional tunings; each entry is gated on the same
+"measurably faster, near-neutral accuracy" bar.
+
+## Why we recommend `-m 10`
+
+`-m` caps how many near-best candidate loci per read get a mate-rescue Smith–Waterman pass. bwa-mem
+and bwa-mem2 both default to **50**; we measured the marginal value of that depth directly —
+end-to-end and at the read level against simulated golden truth.
+
+**The depth beyond ~10 is a measured wash.** Mate rescue earns its keep on the first few candidates,
+but candidates 11–50 only ever engage on reads with many near-best loci — repetitive and
+cross-contig placements — and on truth data deep rescue places about **as many of those reads
+correctly as it mis-places**. Lowering `-m` 50 → 10 changes which low-confidence reads win, but the
+**net true-recall cost is ≈ 0.003–0.004%** (≈200 reads in 5.4 M), on both methylation and
+non-methylation data, and the accuracy-vs-depth curve is flat (no depth between 10 and 50 is
+meaningfully better). Disabling rescue entirely (`-S`, or `-m 0`) *is* a real regression — so rescue
+matters, just not 50-deep.
+
+**In exchange you get a real speed-up**, largest exactly where deep rescue binds (high-depth
+amplicon/panel and repetitive regions):
+
+| dataset | alignment CPU | wall |
+|---|---:|---:|
+| panel-twist (high depth) | **−22%** | −21% |
+| wgs | −19% | −19% |
+| wes | −18% | −14% |
+| meth (em-seq) | −11% | −9% |
+
+Aggregate `samtools flagstat` impact is a uniform, directional sub-0.2 pp reduction in
+mapped%/proper-pair% (≤0.02 pp on WGS/WES; ≤0.12–0.19 pp on amplicon/meth), entirely in the
+low-MAPQ deep-rescue tail: the mapped count only ever *decreases* (it never newly maps a
+previously-unmapped read), and the handful of reads whose placement does change net to ≈0 recall
+against golden truth.
+
+Numbers are from [bwa-mem3-bench](../related-projects/bwa-mem3-bench.md) on 5 M-read real datasets
+plus a multi-contig holodeck golden-truth ablation; consult the bench for methodology and current
+figures.
+
+## Speed: drop-in and recommended
+
+When comparing bwa-mem3 to a stock bwa-mem2 baseline, report both layers:
+
+1. **Drop-in speed-up** — bwa-mem3 vs bwa-mem2 at *identical* settings, from its vectorized kernels,
+   lockstep SMEM batching, libsais indexing, and mimalloc. See
+   [Performance Overview](../performance/overview.md) and
+   [What's Different — Performance](../whats-different/performance.md).
+2. **Recommended-profile speed-up** — the additional ~11–22% alignment-CPU reduction from `-m 10`,
+   *on top of* the drop-in gain.
+
+A benchmark that quotes only default-vs-default settings understates the throughput available to a
+caller who has adopted the recommended profile; quote both so readers can pick the comparison that
+matches their deployment.
+
+---
+
+**See also:**
+[Tuning checklist](../performance/tuning.md) ·
+[Performance Overview](../performance/overview.md) ·
+[Equivalence with bwa-mem2](../whats-different/equivalence.md) ·
+[CLI Reference — `mem`](../cli/mem.md)

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -176,7 +176,9 @@ reference is short and inference may be inaccurate.
 #### `-m INT` — mate rescue rounds
 
 Maximum number of mate-rescue attempts per read. Reduce to speed up alignment
-on data where the default (50) wastes time on unrescuable pairs.
+on data where the default (50) wastes time on unrescuable pairs. See
+[Settings profiles](../best-practices/settings-profiles.md) for the benchmarked
+`-m 10` recommendation.
 
 #### `-S` — skip mate rescue
 


### PR DESCRIPTION
Documents two settings profiles — a **bwa-mem/bwa-mem2 drop-in** profile (the defaults, unchanged) and a **recommended** profile — instead of changing any default. Supersedes #130 (decision: keep the bwa-compatible default, document the recommendation).

## What
- New Best Practices page `best-practices/settings-profiles.md` (added to the mdbook TOC):
  - **Drop-in profile** (default, no flags) — as close to bwa-mem2 as bwa-mem3 gets.
  - **Recommended profile** — `-m 10` (table built to grow), with the benchmarked rationale.
- README pointer to the page.
- **No code or default change.**

## Why `-m 10` is recommended (not defaulted)
bwa-mem and bwa-mem2 both default mate-rescue depth to `-m 50`; bwa-mem3 keeps 50 for drop-in parity. Benchmarks (full bench write-up on #130) show depth beyond ~10 is a measured accuracy wash:
- **Speed:** −11% to −22% alignment CPU (largest on high-depth panel/amplicon).
- **Accuracy:** flat depth curve; `-m 50`→`-m 10` net true-recall cost ≈ **−0.003% (meth) / −0.0036% (non-meth)** vs multi-contig holodeck golden truth — all in the low-MAPQ cross-contig deep-rescue tail (offsetting churn). `-m 0` is a real regression, so rescue matters, just not 50-deep.

The page also instructs reporting speed for **both** profiles (drop-in gain vs bwa-mem2, plus the additional `-m 10` gain).

Draft pending mdbook render review (and an optional GIAB variant-sensitivity pass before recommending `-m 10` for variant-calling callers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive settings profiles documentation including default drop-in configuration, optimized variant, comparative performance tables, and CLI usage examples
  * Updated README to reference settings profiles for configuration options and compatibility information
  * Enhanced mate-rescue flag documentation with performance recommendations and cross-reference to settings profiles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->