### PR TITLE
fix(test): make meth layer-2 FAIL diagnostics reachable under set -e

### DIFF
--- a/test/meth/test.sh
+++ b/test/meth/test.sh
@@ -194,16 +194,19 @@ norm() {
 # once we consolidate f*/r* to one output contig the information IS
 # available, so we compute a real TLEN. Diff QNAME..MPOS (cols 1-8) to
 # assert structural parity without re-enforcing bwameth.py's TLEN=0 quirk.
+# `|| true`: under `set -euo pipefail` a non-zero `diff` exit (files differ) inside
+# a command substitution aborts the script *before* the FAIL branch below runs,
+# turning a real structural mismatch into a silent `exit 1` with no diagnostic.
 ONE="$(diff <(norm /tmp/meth_mine.sam | cut -f1-8) \
-             <(norm /tmp/meth_oracle_records.sam | cut -f1-8) | wc -l | tr -d ' ')"
+             <(norm /tmp/meth_oracle_records.sam | cut -f1-8) | wc -l | tr -d ' ' || true)"
 if [[ "$ONE" != "0" ]]; then
     echo "FAIL layer 2: structural diff in cols 1-8 ($ONE lines)"
-    diff <(norm /tmp/meth_mine.sam | cut -f1-8) <(norm /tmp/meth_oracle_records.sam | cut -f1-8) | head -20
+    diff <(norm /tmp/meth_mine.sam | cut -f1-8) <(norm /tmp/meth_oracle_records.sam | cut -f1-8) | head -20 || true
     exit 1
 fi
 
 TWO="$(diff <(norm /tmp/meth_mine.sam | cut -f6) \
-             <(norm /tmp/meth_oracle_records.sam | cut -f6) | wc -l | tr -d ' ')"
+             <(norm /tmp/meth_oracle_records.sam | cut -f6) | wc -l | tr -d ' ' || true)"
 if [[ "$TWO" != "0" ]]; then echo "FAIL layer 2: CIGAR diff ($TWO lines)"; exit 1; fi
 
 MINE_N="$(wc -l < /tmp/meth_mine.sam | tr -d ' ')"


### PR DESCRIPTION
## Problem
`test/meth/test.sh` layer 2 captures structural-diff and CIGAR-diff counts via command substitution:

```bash
ONE="$(diff <(...) <(...) | wc -l | tr -d ' ')"
if [[ "$ONE" != "0" ]]; then echo "FAIL layer 2: structural diff ..."; ... ; exit 1; fi
```

Under `set -euo pipefail`, when the files differ `diff` exits non-zero, so (with `pipefail`) the whole substitution exits non-zero and **`set -e` aborts the script at the assignment — before the `if` FAIL branch runs**. A real structural mismatch therefore surfaces as a bare `exit 1` with **no diagnostic**: the run dies right after `OK layer 1 ...` with no `FAIL layer 2:` line and no diff. (Found while debugging a meth seeding change — the silent exit made the failure look mysterious when it was just the structural diff firing.)

## Fix
Append `|| true` to the two diff-counting substitutions (and the diagnostic `diff | head`) so a differing `diff` is captured as a count instead of aborting the script. The intended `FAIL layer 2: ...` message and the truncated line-diff now print.

## Verification
- `bash -n` passes.
- Minimal repro confirms the behavior change under `set -euo pipefail`: `X="$(diff <(echo a) <(echo b) | wc -l || true)"` continues (X=1); without `|| true` the script aborts before the next line.
- Sibling audit: layer 3 (`test_bismark_tags.sh`) compares via `mawk` (exits 0 on mismatch), so it is unaffected; the record-count checks use `wc -l < file` (cannot fail). No other instances.

No behavior change on passing runs (identical files → `diff` exits 0 → unchanged); this only restores the diagnostic on the failing path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Layer 2 structural-diff test reliability to prevent unexpected script termination and provide clearer diagnostic output when check mismatches occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->