### PR TITLE
docs: situational --supp-rep-hard-cap 20 for SV-aware pipelines

### DIFF
--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -96,6 +96,25 @@ A benchmark that quotes only default-vs-default settings understates the through
 caller who has adopted the recommended profile; quote both so readers can pick the comparison that
 matches their deployment.
 
+## Situational: `--supp-rep-hard-cap` for SV-aware pipelines
+
+This is **not** part of the recommended profile — it is a situational knob, not a free speed-up, and
+the default (`0`, off) is correct for plain alignment.
+
+If you run structural-variant or breakpoint detection downstream (e.g. `fgsv SvPileup`),
+`--supp-rep-hard-cap 20` suppresses repeat-induced *spurious* supplementary breakpoints — split
+alignments anchored in repeats whose mapping quality is overestimated — at no measured cost to real
+SV breakpoints. On GIAB HG002 CMRG (GRCh38, 2×250) it stripped repeat artifacts while preserving
+every credible real-SV breakpoint, including ones in moderately-repetitive regions.
+
+Do **not** use more aggressive values: `--supp-rep-hard-cap` ≤ 10 began suppressing *real* GIAB SV
+breakpoints (a verified insertion at chr3:45890256 and deletion at chr18:79739776) whose supporting
+split reads happen to land in repetitive regions.
+
+Caveats: this was measured on a single repeat-enriched truth set at the breakpoint level (not
+end-to-end SV calls), so treat `20` as a sensible starting point for SV workflows rather than a
+universal recommendation. It has no effect on primary-alignment MAPQ or on non-SV pipelines.
+
 ---
 
 **See also:**


### PR DESCRIPTION
Stacked on #131 (adds a section to the same `settings-profiles.md` page; base is `docs/nh_settings-profiles` so the diff is just the new section — it will retarget to `main` automatically when #131 merges).

Adds a *situational* note documenting `--supp-rep-hard-cap 20` for downstream structural-variant / breakpoint workflows. It is deliberately **not** part of the recommended profile: it is a precision/sensitivity trade for SV pipelines, not a universal speed-up, and the default (`0`, off) stays correct for plain alignment.

Backed by a GIAB HG002 CMRG (GRCh38, 2×250) breakpoint-level validation via `fgsv SvPileup`: cap 20 stripped repeat-induced spurious supplementary breakpoints while preserving every credible real-SV breakpoint, whereas values ≤10 suppressed verified real SVs (a `SIMPLEINS` at chr3:45890256 and a `SIMPLEDEL` at chr18:79739776) whose supporting split reads sit in moderately-repetitive regions.

Caveats are stated inline: single repeat-enriched truth set, breakpoint-level not end-to-end SV calling, so `20` is a sensible starting point for SV workflows rather than a universal recommendation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new best practices guide for the `--supp-rep-hard-cap` setting, explaining how it suppresses spurious supplementary breakpoints in SV-aware pipelines with configuration recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->