### PR TITLE
fix(meth): emit -R read group as @RG header in --meth mode

### DIFF
--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1489,6 +1489,14 @@ int main_mem(int argc, char *argv[])
                 "(%d chrom(s)).\n", g_meth_cmap->n_output);
         const char *meth_out_path = is_o ? out_path : "-";
         extern char *bwa_pg;
+        /* idx_hdr_lines is intentionally NOT passed to the meth writer: in
+         * --meth mode ref_prefix points at the ".bwameth.c2t" index, so its
+         * .hdr/.dict sidecar describes the doubled f/r converted contigs, not
+         * the user's reference. The consolidated @SQ from g_meth_cmap is
+         * authoritative. Carrying real reference metadata (@SQ M5/UR, @CO/@PG)
+         * into --meth output would require loading the *original* reference's
+         * sidecar and merging by SN -- a follow-up, not this fix. See the
+         * matching note in meth_bam_writer_open (meth_bam.cpp). */
         g_meth_bam_writer = meth_bam_writer_open(meth_out_path, g_meth_cmap, bwa_pg, NULL,
                                                  hdr_line, opt->bam_level);
         if (g_meth_bam_writer == NULL) {

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1490,7 +1490,7 @@ int main_mem(int argc, char *argv[])
         const char *meth_out_path = is_o ? out_path : "-";
         extern char *bwa_pg;
         g_meth_bam_writer = meth_bam_writer_open(meth_out_path, g_meth_cmap, bwa_pg, NULL,
-                                                 opt->bam_level);
+                                                 hdr_line, opt->bam_level);
         if (g_meth_bam_writer == NULL) {
             fprintf(stderr, "ERROR: meth: failed to open BAM writer for '%s'\n", meth_out_path);
             meth_orig_ref_free(g_meth_orig_ref); g_meth_orig_ref = NULL;

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -164,7 +164,19 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
      * (stamped from bwa_rg_id below) actually reference. The consolidated
      * @SQ above is authoritative for --meth, so a user -H that re-supplies
      * @SQ for an already-emitted contig will make htslib reject the add and
-     * the open fails loudly rather than emitting duplicate references. */
+     * the open fails loudly rather than emitting duplicate references.
+     *
+     * Note: unlike bam_writer_open (the default path), the index's .hdr/.dict
+     * sidecar records (idx_hdr_lines) are deliberately NOT forwarded here. In
+     * --meth mode the index prefix is the c2t-converted reference (fastmap.cpp
+     * rewrites ref_prefix to ".bwameth.c2t" before loading the sidecar), so
+     * that sidecar describes the doubled f/r converted contigs: its @SQ is
+     * unusable and its @CO/@PG describe the internal conversion artifact, not
+     * the user's reference. The correct way to carry real reference metadata
+     * (@SQ M5/UR tags, @CO/@PG) into --meth output is to load the *original*
+     * (pre-c2t) reference's sidecar and merge it by SN into the consolidated
+     * @SQ -- left as a follow-up; see the matching note at the call site in
+     * main_mem (fastmap.cpp). */
     if (hdr_line != NULL && hdr_line[0] != '\0' &&
         sam_hdr_add_lines(w->hdr, hdr_line, 0) < 0) goto fail;
 

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -105,10 +105,27 @@ static void sanitize_cl(char *s)
     for (; *s; ++s) if (*s == '\t') *s = ' ';
 }
 
+/* True if the SAM header text `s` contains a line whose type is `tag4`
+ * (e.g. "@HD\t"): either as the first line or following a newline. Used to
+ * avoid emitting a default @HD when the user's -H already supplies one —
+ * htslib's sam_hdr_add_lines does not de-dup @HD records, so two would be
+ * written. Mirrors the same guard in bam_writer.cpp's default path. */
+static int hdr_text_has_type(const char *s, const char *tag4)
+{
+    if (s == NULL || s[0] == '\0') return 0;
+    size_t n = strlen(tag4);
+    if (strncmp(s, tag4, n) == 0) return 1;
+    char needle[8] = "\n";
+    /* tag4 is always 4 chars ("@XX\t"); "\n" + tag4 fits in 8. */
+    strncpy(needle + 1, tag4, sizeof(needle) - 2);
+    return strstr(s, needle) != NULL;
+}
+
 meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
                                         meth_chrom_map_t *cmap,
                                         const char *bwa_pg,
                                         const char *meth_pg_cl,
+                                        const char *hdr_line,
                                         int compression_level)
 {
     if (path_or_dash == NULL || cmap == NULL) return NULL;
@@ -126,8 +143,10 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
     w->hdr = sam_hdr_init();
     if (w->hdr == NULL) { hts_close(w->fp); free(w); return NULL; }
 
-    /* @HD */
-    if (sam_hdr_add_line(w->hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL) < 0) goto fail;
+    /* @HD — skip the default when the user's -H already supplies one, else
+     * htslib would write two @HD lines (it does not de-dup @HD). */
+    if (!hdr_text_has_type(hdr_line, "@HD\t") &&
+        sam_hdr_add_line(w->hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL) < 0) goto fail;
 
     /* @SQ from consolidated chrom map */
     for (int i = 0; i < cmap->n_output; ++i) {
@@ -138,6 +157,16 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
                              "LN", len_buf,
                              NULL) < 0) goto fail;
     }
+
+    /* User header text (-R read group, -H lines). Emitted after @SQ and
+     * before the @PG lines, matching the default writer's precedence so a
+     * -R read group becomes an @RG header that the per-record RG:Z tags
+     * (stamped from bwa_rg_id below) actually reference. The consolidated
+     * @SQ above is authoritative for --meth, so a user -H that re-supplies
+     * @SQ for an already-emitted contig will make htslib reject the add and
+     * the open fails loudly rather than emitting duplicate references. */
+    if (hdr_line != NULL && hdr_line[0] != '\0' &&
+        sam_hdr_add_lines(w->hdr, hdr_line, 0) < 0) goto fail;
 
     /* Original bwa-mem3 @PG */
     if (bwa_pg != NULL && bwa_pg[0] != '\0') {

--- a/src/meth_bam.h
+++ b/src/meth_bam.h
@@ -48,12 +48,16 @@ extern meth_chrom_map_t *g_meth_cmap;
 extern meth_bam_writer_t *g_meth_bam_writer;
 
 /* Open a BAM writer at path ("-" for stdout). `compression_level` is the
- * BGZF deflate level: 0 = uncompressed, 1..9 = deflate. Returns NULL on
- * failure. */
+ * BGZF deflate level: 0 = uncompressed, 1..9 = deflate. `hdr_line` is the
+ * assembled user header text (-R read group and/or -H lines, '\n'-joined,
+ * no trailing newline), or NULL — emitted verbatim after the @SQ block so a
+ * -R read group lands as an @RG header, matching the default (non-meth)
+ * writer. Returns NULL on failure. */
 meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
                                         meth_chrom_map_t *cmap,
                                         const char *bwa_pg,
                                         const char *meth_pg_cl,
+                                        const char *hdr_line,
                                         int compression_level);
 
 /* Write one bam1_t. Returns 0 on success, -1 on error. */

--- a/test/meth_rg_header_test.sh
+++ b/test/meth_rg_header_test.sh
@@ -102,8 +102,13 @@ if ! command -v samtools >/dev/null 2>&1; then
     exit 0
 fi
 
-# --meth requires a c2t-converted index built with `index --meth`.
-if [[ ! -s "$ref.bwameth.c2t.bwt.2bit.64" ]]; then
+# --meth requires a c2t-converted index built with `index --meth`. Check the
+# full artifact set (converted FASTA + the five FMI files), not just one, so a
+# partial index left by an interrupted run is rebuilt rather than skipped —
+# matching the non-meth block above.
+if [[ ! -s "$ref.bwameth.c2t"            || ! -s "$ref.bwameth.c2t.bwt.2bit.64" \
+      || ! -s "$ref.bwameth.c2t.0123"    || ! -s "$ref.bwameth.c2t.amb"        \
+      || ! -s "$ref.bwameth.c2t.ann"     || ! -s "$ref.bwameth.c2t.pac" ]]; then
     "$bin" index --meth "$ref" >/dev/null 2>&1 \
         || { echo "FAIL: bwa-mem3 index --meth on phix.fa failed" >&2; exit 1; }
 fi

--- a/test/meth_rg_header_test.sh
+++ b/test/meth_rg_header_test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# test/meth_rg_header_test.sh
+#
+# Asserts that a `-R '@RG\t...'` read group supplied on the command line is
+# emitted as an @RG header line in BOTH the default path and `--meth` mode.
+#
+# Bug: `mem --meth` stamps every record with the RG:Z tag derived from the
+# user's -R argument (via the global bwa_rg_id), but the meth BAM writer
+# (meth_bam_writer_open) never received the assembled hdr_line, so no @RG
+# header line was written. The result is a malformed BAM whose records
+# reference a read group ID that the header never declares — strict
+# validators (Picard, noodles) reject it. The default (non-meth) path
+# threads hdr_line into its writer and was always correct; this test pins
+# both so the two modes can never diverge again.
+#
+# The assertion is the SAM invariant "every RG:Z tag value must be declared
+# by an @RG ID: in the header":
+#   * the @RG header line is present and carries ID:<rg>,
+#   * every alignment record carries RG:Z:<rg>, and
+#   * the RG:Z value matches the declared @RG ID.
+#
+# --meth output is BAM, so reading its header back needs samtools. When
+# samtools is absent (minimal dev boxes) the --meth half is skipped with a
+# warning rather than failing; CI always has samtools, so the regression
+# stays enforced there.
+#
+# Usage: test/meth_rg_header_test.sh <bwa-mem3-binary> <fixtures-dir>
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <bwa-mem3-binary> <fixtures-dir>" >&2
+    exit 2
+fi
+
+bin="$1"
+fixtures="$2"
+ref="$fixtures/phix.fa"
+reads="$fixtures/reads.fa"
+
+[[ -x "$bin" ]]   || { echo "FAIL: bwa-mem3 binary not executable at $bin" >&2; exit 1; }
+[[ -s "$ref" ]]   || { echo "FAIL: phix.fa missing at $ref" >&2; exit 1; }
+[[ -s "$reads" ]] || { echo "FAIL: reads.fa missing at $reads" >&2; exit 1; }
+
+# A read group whose ID is distinct from every other token so a stray match
+# can't accidentally satisfy the assertions.
+RG_ID="rg_meth_test"
+RG=$'@RG\tID:'"$RG_ID"$'\tSM:sample1\tPL:ILLUMINA'
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# assert_rg_consistent <label> <header-text-file> <records-text-file>
+# Verifies the SAM invariant: an @RG ID:<RG_ID> line exists, every record
+# carries RG:Z:<RG_ID>, and there is at least one record to check.
+assert_rg_consistent() {
+    local label="$1" hdr="$2" recs="$3"
+
+    # ID:<RG_ID> is always followed by a tab here (SM: trails it in $RG).
+    if ! grep -q $'^@RG\t' "$hdr" || ! grep -q $'\tID:'"$RG_ID"$'\t' "$hdr"; then
+        echo "FAIL [$label]: no '@RG ... ID:$RG_ID' header line" >&2
+        echo "---- header (@RG lines, tabs as <TAB>) ----" >&2
+        grep '^@RG' "$hdr" | sed $'s/\t/<TAB>/g' >&2 || echo "(none)" >&2
+        echo "-------------------------------------------" >&2
+        exit 1
+    fi
+
+    local n_recs n_tagged
+    n_recs="$(wc -l < "$recs" | tr -d ' ')"
+    [[ "$n_recs" -ge 1 ]] || { echo "FAIL [$label]: no alignment records emitted" >&2; exit 1; }
+
+    # RG:Z:<RG_ID> may be the last tag on a record (no trailing tab) — match
+    # a tab-or-end boundary so a record ending in RG:Z still counts.
+    n_tagged="$(grep -cE $'\tRG:Z:'"$RG_ID"$'(\t|$)' "$recs" || true)"
+    if [[ "$n_tagged" -ne "$n_recs" ]]; then
+        echo "FAIL [$label]: $n_tagged/$n_recs records carry RG:Z:$RG_ID" >&2
+        exit 1
+    fi
+
+    echo "OK:   [$label] @RG ID:$RG_ID declared and all $n_recs records tagged"
+}
+
+# --- default (non-meth) path: SAM output -----------------------------------
+# This path was always correct; it is the control that proves --meth must
+# match it.
+if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.0123" || ! -s "$ref.amb" \
+      || ! -s "$ref.ann"       || ! -s "$ref.pac" ]]; then
+    "$bin" index "$ref" >/dev/null 2>&1 || { echo "FAIL: bwa-mem3 index on phix.fa failed" >&2; exit 1; }
+fi
+
+"$bin" mem -R "$RG" "$ref" "$reads" >"$tmp/plain.sam" 2>"$tmp/plain.err" || {
+    echo "FAIL: bwa-mem3 mem (non-meth) exited non-zero" >&2; cat "$tmp/plain.err" >&2; exit 1
+}
+grep '^@'  "$tmp/plain.sam" >"$tmp/plain.hdr" || true
+grep -v '^@' "$tmp/plain.sam" >"$tmp/plain.recs" || true
+assert_rg_consistent "non-meth" "$tmp/plain.hdr" "$tmp/plain.recs"
+
+# --- --meth path: BAM output (needs samtools to read the header) -----------
+if ! command -v samtools >/dev/null 2>&1; then
+    echo "SKIP: samtools not found; --meth half not checked" >&2
+    echo "PASS: @RG header emitted in non-meth mode (--meth skipped)"
+    exit 0
+fi
+
+# --meth requires a c2t-converted index built with `index --meth`.
+if [[ ! -s "$ref.bwameth.c2t.bwt.2bit.64" ]]; then
+    "$bin" index --meth "$ref" >/dev/null 2>&1 \
+        || { echo "FAIL: bwa-mem3 index --meth on phix.fa failed" >&2; exit 1; }
+fi
+
+"$bin" mem --meth -R "$RG" "$ref" "$reads" >"$tmp/meth.bam" 2>"$tmp/meth.err" || {
+    echo "FAIL: bwa-mem3 mem --meth exited non-zero" >&2; cat "$tmp/meth.err" >&2; exit 1
+}
+samtools view -H "$tmp/meth.bam" >"$tmp/meth.hdr" 2>/dev/null \
+    || { echo "FAIL: samtools could not read --meth BAM header" >&2; exit 1; }
+samtools view    "$tmp/meth.bam" >"$tmp/meth.recs" 2>/dev/null \
+    || { echo "FAIL: samtools could not read --meth BAM records" >&2; exit 1; }
+assert_rg_consistent "--meth" "$tmp/meth.hdr" "$tmp/meth.recs"
+
+echo "PASS: -R read group emitted as @RG header in both default and --meth modes"

--- a/test/meth_rg_header_test.sh
+++ b/test/meth_rg_header_test.sh
@@ -122,4 +122,35 @@ samtools view    "$tmp/meth.bam" >"$tmp/meth.recs" 2>/dev/null \
     || { echo "FAIL: samtools could not read --meth BAM records" >&2; exit 1; }
 assert_rg_consistent "--meth" "$tmp/meth.hdr" "$tmp/meth.recs"
 
+# --- --meth @HD de-dup: a user -H @HD must suppress the default @HD ---------
+# meth_bam_writer_open emits a default "@HD VN:1.6 SO:unsorted" UNLESS the
+# user's -H already supplies an @HD (the hdr_text_has_type() guard). Without
+# that guard htslib would write two @HD lines (it does not de-dup @HD). Pass a
+# DISTINCT @HD (SO:coordinate) alongside -R and assert the output carries
+# exactly one @HD line and it is the user's — proving the default was
+# suppressed and the user's line survived. This pins the guard that the -R
+# assertions above never exercise (an @RG line carries no @HD).
+USER_HD=$'@HD\tVN:1.6\tSO:coordinate'
+"$bin" mem --meth -R "$RG" -H "$USER_HD" "$ref" "$reads" \
+    >"$tmp/meth_hd.bam" 2>"$tmp/meth_hd.err" || {
+    echo "FAIL: bwa-mem3 mem --meth -H @HD exited non-zero" >&2; cat "$tmp/meth_hd.err" >&2; exit 1
+}
+samtools view -H "$tmp/meth_hd.bam" >"$tmp/meth_hd.hdr" 2>/dev/null \
+    || { echo "FAIL: samtools could not read --meth -H @HD BAM header" >&2; exit 1; }
+
+n_hd="$(grep -c $'^@HD\t' "$tmp/meth_hd.hdr" || true)"
+if [[ "$n_hd" -ne 1 ]]; then
+    echo "FAIL [--meth @HD dedup]: expected exactly 1 @HD line, got $n_hd" >&2
+    echo "---- header @HD lines (tabs as <TAB>) ----" >&2
+    grep '^@HD' "$tmp/meth_hd.hdr" | sed $'s/\t/<TAB>/g' >&2 || echo "(none)" >&2
+    echo "------------------------------------------" >&2
+    exit 1
+fi
+if ! grep -qE $'^@HD\t.*\tSO:coordinate(\t|$)' "$tmp/meth_hd.hdr"; then
+    echo "FAIL [--meth @HD dedup]: the surviving @HD is not the user's (SO:coordinate)" >&2
+    grep '^@HD' "$tmp/meth_hd.hdr" | sed $'s/\t/<TAB>/g' >&2
+    exit 1
+fi
+echo "OK:   [--meth @HD dedup] exactly one @HD line, user's SO:coordinate preserved"
+
 echo "PASS: -R read group emitted as @RG header in both default and --meth modes"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -88,6 +88,14 @@ ok "xeonbsw ($LINES pair scores emitted)"
 "$HERE/pg_cl_escape_test.sh" "$BWAMEM3" "$FIXTURES" || fail "pg_cl_escape_test failed"
 ok "pg_cl_escape_test"
 
+# --- meth_rg_header_test --------------------------------------------------
+# A `-R` read group must be emitted as an @RG header line in --meth mode,
+# not just stamped as RG:Z on records (the default path always was). Guards
+# the malformed-BAM regression where --meth records referenced an undeclared
+# read group ID.
+"$HERE/meth_rg_header_test.sh" "$BWAMEM3" "$FIXTURES" || fail "meth_rg_header_test failed"
+ok "meth_rg_header_test"
+
 # --- help_prescan_test ----------------------------------------------------
 # `mem --help` pre-scan must not match `--help` when it is the value of
 # an option that takes an argument (-R, -o, --set-as-failed, ...).


### PR DESCRIPTION
## Problem

`bwa-mem3 mem --meth` stamps every record with an `RG:Z` tag (from the global `bwa_rg_id`, set by `-R`) but its BAM writer never received the assembled `hdr_line`, so **no `@RG` header line was written**. The output BAM declares no read group yet every record references one — malformed per the SAM spec and rejected by strict validators (Picard, noodles). The default (non-meth) path threads `hdr_line` into `bam_writer_open` and was always correct; only `--meth` diverged.

### Reproduction (before fix)

```
$ bwa-mem3 mem --meth -R $'@RG\tID:rg\tSM:s' ref.fa reads.fq | samtools view -H -
@HD     VN:1.6  SO:unsorted
@SQ     SN:chr1 LN:400
@PG     ...                 # <- no @RG line
$ bwa-mem3 mem --meth -R $'@RG\tID:rg\tSM:s' ref.fa reads.fq | samtools view - | grep -o RG:Z:rg
RG:Z:rg                     # <- but records carry RG:Z:rg
```

The non-meth path (`mem -R ...`) emits the `@RG` line correctly; only `--meth` dropped it.

## Fix

Thread `hdr_line` into `meth_bam_writer_open` and emit it **after the `@SQ` block and before the `@PG` lines**, mirroring `bam_writer_open`'s precedence (user header > index > default). Also suppress the default `@HD` when the user's `-H` supplies one, since htslib's `sam_hdr_add_lines` does not de-dup `@HD`.

The consolidated `@SQ` remains authoritative for `--meth`: a user `-H` that re-supplies an already-emitted contig now fails the open loudly (duplicate-SN error) rather than emitting duplicate references — out of scope to merge here, and a loud failure is preferable to silent corruption.

### After fix

```
@HD     VN:1.6  SO:unsorted
@SQ     SN:chr1 LN:400
@RG     ID:rg   SM:s          # <- now present, between @SQ and @PG
@PG     ID:bwa-mem3 ...
@PG     ID:bwa-mem3-meth ...
```

## Test

Adds `test/meth_rg_header_test.sh` (wired into `run_unit_tests.sh` next to `pg_cl_escape_test`). It runs `mem` and `mem --meth` with the same `-R` and asserts the SAM invariant that **every `RG:Z` value is declared by an `@RG ID` in the header**. The first commit adds the test (RED on `--meth`); the second commit applies the fix (GREEN). The test drives the stable `-R` CLI rather than the C signature, so it survives refactors. The `--meth` half skips with a warning when `samtools` is absent.

Verified locally: full `test/run_unit_tests.sh` passes, including the new test, and an `-H` `@HD`/`@CO` + `-R` edge case produces exactly one `@HD` with correct ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User-supplied SAM header text (via `-R`/`-H`) is now properly preserved in `--meth` BAM output, with correct ordering.
  * Read group (`-R `@RG` ...`) headers are applied consistently to all alignment records in both SAM and `--meth` BAM paths.
  * Prevents duplicate `@HD` entries when a header already provides one.

* **Tests**
  * Added `meth_rg_header_test` regression coverage for `@RG`/`RG:Z` consistency across SAM and `--meth` BAM, integrated into the unit test runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->