### PR TITLE
feat(meth): carry original-reference @SQ M5/UR and @CO/@PG into --meth headers

### DIFF
--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1300,6 +1300,11 @@ int main_mem(int argc, char *argv[])
      * invocation) already passed the ".bwameth.c2t" path directly, use
      * it as-is rather than double-appending. */
     char c2t_ref[PATH_MAX];
+    char orig_ref_buf[PATH_MAX];
+    /* In --meth, the original (pre-c2t) reference prefix, used to load that
+     * reference's .hdr/.dict sidecar for @SQ M5/UR enrichment and @CO/@PG/@RG
+     * pass-through. NULL outside --meth. */
+    const char *meth_orig_ref_prefix = NULL;
     const char *ref_prefix = argv[optind];
     if (opt->meth_mode) {
         const char *suffix = ".bwameth.c2t";
@@ -1314,6 +1319,25 @@ int main_mem(int argc, char *argv[])
                 exit(EXIT_FAILURE);
             }
             ref_prefix = c2t_ref;
+            meth_orig_ref_prefix = argv[optind];
+        } else {
+            /* User passed the ".bwameth.c2t" path directly; recover the
+             * original reference prefix by stripping the suffix so its
+             * sidecar (not the c2t index's) supplies @SQ identity tags. */
+            size_t base = alen - slen;
+            if (base < sizeof(orig_ref_buf)) {
+                memcpy(orig_ref_buf, argv[optind], base);
+                orig_ref_buf[base] = '\0';
+                meth_orig_ref_prefix = orig_ref_buf;
+            } else {
+                /* Degenerate: the prefix doesn't fit. The original sidecar is
+                 * optional (the c2t index alone aligns), so warn and continue
+                 * without @SQ M5/UR enrichment rather than aborting. */
+                fprintf(stderr,
+                        "[bwa-mem3:--meth] WARNING: reference path too long to "
+                        "derive the original prefix; @SQ M5/UR enrichment "
+                        "skipped.\n");
+            }
         }
     }
 
@@ -1426,6 +1450,12 @@ int main_mem(int argc, char *argv[])
      * the --bam path forwards them to htslib's sam_hdr_add_lines so the
      * rich @SQ (AS/M5/SP/AH/…) also makes it into the BAM header. */
     char *idx_hdr_lines = bwa_load_hdr_from_index(ref_prefix);
+    /* --meth only: the original (pre-c2t) reference's .hdr/.dict sidecar, for
+     * @SQ M5/UR enrichment and @CO/@PG/@RG pass-through in meth_bam_writer_open.
+     * NULL outside --meth or when the original has no sidecar. */
+    char *meth_orig_hdr_lines = (meth_orig_ref_prefix != NULL)
+                                ? bwa_load_hdr_from_index(meth_orig_ref_prefix)
+                                : NULL;
 
     /* Output path:
      *  - --meth: open meth_bam_writer with strand-consolidated SQ headers.
@@ -1465,6 +1495,7 @@ int main_mem(int argc, char *argv[])
     (void)is_o;
     (void)hdr_line;
     (void)idx_hdr_lines;
+    (void)meth_orig_hdr_lines;
     (void)out_path;
 #else
     if (opt->meth_mode) {
@@ -1489,16 +1520,15 @@ int main_mem(int argc, char *argv[])
                 "(%d chrom(s)).\n", g_meth_cmap->n_output);
         const char *meth_out_path = is_o ? out_path : "-";
         extern char *bwa_pg;
-        /* idx_hdr_lines is intentionally NOT passed to the meth writer: in
-         * --meth mode ref_prefix points at the ".bwameth.c2t" index, so its
-         * .hdr/.dict sidecar describes the doubled f/r converted contigs, not
-         * the user's reference. The consolidated @SQ from g_meth_cmap is
-         * authoritative. Carrying real reference metadata (@SQ M5/UR, @CO/@PG)
-         * into --meth output would require loading the *original* reference's
-         * sidecar and merging by SN -- a follow-up, not this fix. See the
-         * matching note in meth_bam_writer_open (meth_bam.cpp). */
+        /* The c2t index's own sidecar (idx_hdr_lines) is NOT passed: in --meth
+         * mode ref_prefix points at the ".bwameth.c2t" index, whose sidecar
+         * describes the doubled f/r converted contigs. Instead pass
+         * meth_orig_hdr_lines — the *original* reference's sidecar — so the
+         * writer can enrich the consolidated @SQ with real M5/UR tags and
+         * forward @CO/@PG/@RG provenance. */
         g_meth_bam_writer = meth_bam_writer_open(meth_out_path, g_meth_cmap, bwa_pg, NULL,
-                                                 hdr_line, opt->bam_level);
+                                                 hdr_line, meth_orig_hdr_lines,
+                                                 opt->bam_level);
         if (g_meth_bam_writer == NULL) {
             fprintf(stderr, "ERROR: meth: failed to open BAM writer for '%s'\n", meth_out_path);
             meth_orig_ref_free(g_meth_orig_ref); g_meth_orig_ref = NULL;
@@ -1571,6 +1601,7 @@ int main_mem(int argc, char *argv[])
      * process; the kernel reclaims the mapping at process exit. */
     free(hdr_line);
     free(idx_hdr_lines);
+    free(meth_orig_hdr_lines);
     free(opt);
     if (aux.legacy_reader) { kseq_destroy(aux.ks); err_gzclose(fp); }
     else { fast_kseq_destroy(aux.frks); fast_reader_close(aux.fr1); }

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -121,11 +121,109 @@ static int hdr_text_has_type(const char *s, const char *tag4)
     return strstr(s, needle) != NULL;
 }
 
+/* True if the tab-delimited @SQ `line` (length `line_len`) carries a token
+ * exactly equal to `key``val` (whole token, not a prefix) — e.g. key="SN:"
+ * val="<name>", or key="LN:" val="<decimal>". */
+static int sq_line_has_kv(const char *line, size_t line_len,
+                          const char *key, size_t key_len,
+                          const char *val, size_t val_len)
+{
+    const char *end = line + line_len;
+    const char *p = line + 3;                 /* "@SQ" -> first '\t' */
+    while (p < end) {
+        const char *tok = p + 1;              /* skip the '\t' */
+        const char *tok_end = (const char *)memchr(tok, '\t', (size_t)(end - tok));
+        if (tok_end == NULL) tok_end = end;
+        if ((size_t)(tok_end - tok) == key_len + val_len &&
+            strncmp(tok, key, key_len) == 0 &&
+            strncmp(tok + key_len, val, val_len) == 0)
+            return 1;
+        p = tok_end;
+    }
+    return 0;
+}
+
+/* Append to `out` the reference-identity tags (M5/UR/AS/SP) found on the @SQ
+ * line of `hdr_text` whose SN equals `sn`, each as "\t<TAG>:<value>". Used to
+ * enrich the consolidated --meth @SQ with identity tags from the *original*
+ * (pre-c2t) reference's .hdr/.dict sidecar, matched by SN. Enrichment is gated
+ * on the sidecar line's LN also equalling `expected_len` (the chrom-map
+ * length): a SN match with a differing LN means a stale or foreign sidecar
+ * whose M5/UR would misidentify the sequence, so nothing is appended in that
+ * case. Appends nothing if `hdr_text` is NULL/empty or has no matching @SQ.
+ * SN is unique in a valid header, so the first match wins. */
+static void meth_append_sq_extra_tags(const char *hdr_text, const char *sn,
+                                      int64_t expected_len, kstring_t *out)
+{
+    if (hdr_text == NULL || hdr_text[0] == '\0' || sn == NULL) return;
+    static const char *const WANT[] = { "M5:", "UR:", "AS:", "SP:" };
+    const int n_want = (int)(sizeof(WANT) / sizeof(WANT[0]));
+    const size_t sn_len = strlen(sn);
+    char ln_buf[32];
+    int ln_len = snprintf(ln_buf, sizeof(ln_buf), "%lld", (long long)expected_len);
+    if (ln_len <= 0 || (size_t)ln_len >= sizeof(ln_buf)) return;
+
+    const char *line = hdr_text;
+    while (*line != '\0') {
+        const char *eol = strchr(line, '\n');
+        size_t line_len = eol ? (size_t)(eol - line) : strlen(line);
+        if (line_len >= 4 && strncmp(line, "@SQ\t", 4) == 0 &&
+            sq_line_has_kv(line, line_len, "SN:", 3, sn, sn_len)) {
+            /* SN matched: only enrich when LN agrees, else the sidecar is
+             * stale/foreign and its identity tags can't be trusted. */
+            if (!sq_line_has_kv(line, line_len, "LN:", 3, ln_buf, (size_t)ln_len))
+                return;
+            const char *end = line + line_len;
+            const char *p = line + 3;
+            while (p < end) {
+                const char *tok = p + 1;
+                const char *tok_end = (const char *)memchr(tok, '\t', (size_t)(end - tok));
+                if (tok_end == NULL) tok_end = end;
+                for (int i = 0; i < n_want; ++i) {
+                    if ((size_t)(tok_end - tok) > 3 && strncmp(tok, WANT[i], 3) == 0) {
+                        kputc('\t', out);
+                        kputsn(tok, (int)(tok_end - tok), out);
+                        break;
+                    }
+                }
+                p = tok_end;
+            }
+            return;                           /* SN is unique; first match wins */
+        }
+        if (eol == NULL) break;
+        line = eol + 1;
+    }
+}
+
+/* Append to `out` every record line of `hdr_text` that is NOT @HD or @SQ
+ * (i.e. @CO/@PG/@RG and any others), each terminated by '\n'. @SQ is skipped
+ * because the consolidated @SQ block is authoritative (its identity tags are
+ * merged separately by meth_append_sq_extra_tags); @HD is skipped because the
+ * writer emits its own. */
+static void meth_append_passthrough_records(const char *hdr_text, kstring_t *out)
+{
+    if (hdr_text == NULL) return;
+    const char *line = hdr_text;
+    while (*line != '\0') {
+        const char *eol = strchr(line, '\n');
+        size_t line_len = eol ? (size_t)(eol - line) : strlen(line);
+        int skip = (line_len >= 4 && (strncmp(line, "@HD\t", 4) == 0 ||
+                                      strncmp(line, "@SQ\t", 4) == 0));
+        if (!skip && line_len > 0) {
+            kputsn(line, (int)line_len, out);
+            kputc('\n', out);
+        }
+        if (eol == NULL) break;
+        line = eol + 1;
+    }
+}
+
 meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
                                         meth_chrom_map_t *cmap,
                                         const char *bwa_pg,
                                         const char *meth_pg_cl,
                                         const char *hdr_line,
+                                        const char *orig_idx_hdr_lines,
                                         int compression_level)
 {
     if (path_or_dash == NULL || cmap == NULL) return NULL;
@@ -148,35 +246,48 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
     if (!hdr_text_has_type(hdr_line, "@HD\t") &&
         sam_hdr_add_line(w->hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL) < 0) goto fail;
 
-    /* @SQ from consolidated chrom map */
+    /* @SQ from the consolidated chrom map, enriched by SN with the original
+     * reference's identity tags (M5/UR/AS/SP) from its .hdr/.dict sidecar when
+     * available. SN/LN come from the cmap (authoritative for --meth); the
+     * extra tags are appended verbatim. The consolidated output SN/LN equal
+     * the original reference's contig SN/LN (the c2t build only doubles into
+     * f/r-prefixed contigs and C->T conversion is length-preserving), so the
+     * original sidecar's @SQ matches by SN. */
     for (int i = 0; i < cmap->n_output; ++i) {
-        char len_buf[32];
-        snprintf(len_buf, sizeof(len_buf), "%lld", (long long)cmap->output_lens[i]);
-        if (sam_hdr_add_line(w->hdr, "SQ",
-                             "SN", cmap->output_names[i],
-                             "LN", len_buf,
-                             NULL) < 0) goto fail;
+        kstring_t sq = {0, 0, NULL};
+        ksprintf(&sq, "@SQ\tSN:%s\tLN:%lld",
+                 cmap->output_names[i], (long long)cmap->output_lens[i]);
+        meth_append_sq_extra_tags(orig_idx_hdr_lines, cmap->output_names[i],
+                                  cmap->output_lens[i], &sq);
+        int rc = (sq.s != NULL) ? sam_hdr_add_lines(w->hdr, sq.s, sq.l) : -1;
+        free(sq.s);
+        if (rc < 0) goto fail;
     }
 
-    /* User header text (-R read group, -H lines). Emitted after @SQ and
-     * before the @PG lines, matching the default writer's precedence so a
-     * -R read group becomes an @RG header that the per-record RG:Z tags
-     * (stamped from bwa_rg_id below) actually reference. The consolidated
-     * @SQ above is authoritative for --meth, so a user -H that re-supplies
-     * @SQ for an already-emitted contig will make htslib reject the add and
-     * the open fails loudly rather than emitting duplicate references.
-     *
-     * Note: unlike bam_writer_open (the default path), the index's .hdr/.dict
-     * sidecar records (idx_hdr_lines) are deliberately NOT forwarded here. In
-     * --meth mode the index prefix is the c2t-converted reference (fastmap.cpp
-     * rewrites ref_prefix to ".bwameth.c2t" before loading the sidecar), so
-     * that sidecar describes the doubled f/r converted contigs: its @SQ is
-     * unusable and its @CO/@PG describe the internal conversion artifact, not
-     * the user's reference. The correct way to carry real reference metadata
-     * (@SQ M5/UR tags, @CO/@PG) into --meth output is to load the *original*
-     * (pre-c2t) reference's sidecar and merge it by SN into the consolidated
-     * @SQ -- left as a follow-up; see the matching note at the call site in
-     * main_mem (fastmap.cpp). */
+    /* Original reference's non-@HD/@SQ sidecar records (@CO/@PG/@RG),
+     * forwarded after @SQ and before the user header — mirroring the index
+     * tier of bam_writer_open's precedence (index > default, below user). Its
+     * @SQ is consumed into the enriched consolidated block above and its @HD
+     * is the writer's own, so both are dropped here. `orig_idx_hdr_lines` is
+     * loaded from the *original* (pre-c2t) reference prefix by main_mem; the
+     * c2t index's own sidecar (which describes the doubled f/r converted
+     * contigs) is never consulted. */
+    if (orig_idx_hdr_lines != NULL && orig_idx_hdr_lines[0] != '\0') {
+        kstring_t pt = {0, 0, NULL};
+        meth_append_passthrough_records(orig_idx_hdr_lines, &pt);
+        int rc = (pt.l > 0) ? sam_hdr_add_lines(w->hdr, pt.s, pt.l) : 0;
+        free(pt.s);
+        if (rc < 0) goto fail;
+    }
+
+    /* User header text (-R read group, -H lines). Emitted after @SQ and the
+     * forwarded sidecar records, before the @PG lines, matching the default
+     * writer's precedence (user > index > default) so a -R read group becomes
+     * an @RG header that the per-record RG:Z tags (stamped from bwa_rg_id
+     * below) actually reference. The consolidated @SQ above is authoritative
+     * for --meth, so a user -H that re-supplies @SQ for an already-emitted
+     * contig will make htslib reject the add and the open fails loudly rather
+     * than emitting duplicate references. */
     if (hdr_line != NULL && hdr_line[0] != '\0' &&
         sam_hdr_add_lines(w->hdr, hdr_line, 0) < 0) goto fail;
 

--- a/src/meth_bam.h
+++ b/src/meth_bam.h
@@ -52,12 +52,18 @@ extern meth_bam_writer_t *g_meth_bam_writer;
  * assembled user header text (-R read group and/or -H lines, '\n'-joined,
  * no trailing newline), or NULL — emitted verbatim after the @SQ block so a
  * -R read group lands as an @RG header, matching the default (non-meth)
- * writer. Returns NULL on failure. */
+ * writer. `orig_idx_hdr_lines` is the *original* (pre-c2t) reference's
+ * .hdr/.dict sidecar text, or NULL: its @SQ identity tags (M5/UR/AS/SP) are
+ * merged into the consolidated @SQ for each contig whose SN and LN both match
+ * (an LN mismatch means a stale/foreign sidecar and is skipped), and its
+ * @CO/@PG/@RG records are forwarded after @SQ; its @HD and @SQ lines are
+ * dropped. Returns NULL on failure. */
 meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
                                         meth_chrom_map_t *cmap,
                                         const char *bwa_pg,
                                         const char *meth_pg_cl,
                                         const char *hdr_line,
+                                        const char *orig_idx_hdr_lines,
                                         int compression_level);
 
 /* Write one bam1_t. Returns 0 on success, -1 on error. */

--- a/test/meth_sidecar_enrich_test.sh
+++ b/test/meth_sidecar_enrich_test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# test/meth_sidecar_enrich_test.sh
+#
+# Asserts that `mem --meth` enriches its consolidated @SQ block with the
+# identity tags (M5/UR/AS/SP) of the *original* (pre-c2t) reference, read from
+# that reference's .hdr/.dict sidecar and matched by SN, and forwards the
+# sidecar's @CO/@PG/@RG provenance — while NEVER consulting the c2t index's
+# own sidecar (which describes the doubled f/r converted contigs).
+#
+# Why this matters: the default (--bam) and SAM paths forward the index
+# sidecar, so their @SQ carries M5/UR that strict validators (GATK, Picard)
+# use to bind a BAM to its reference. --meth builds a consolidated @SQ from
+# the chrom map (SN/LN only); without this enrichment that provenance is lost.
+#
+# The test is isolated: it copies phix.fa to a temp dir and builds the c2t
+# index there, so the shared fixtures (and other tests' meth headers) are
+# untouched.
+#
+# Usage: test/meth_sidecar_enrich_test.sh <bwa-mem3-binary> <fixtures-dir>
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <bwa-mem3-binary> <fixtures-dir>" >&2
+    exit 2
+fi
+
+bin="$1"
+fixtures="$2"
+src_ref="$fixtures/phix.fa"
+reads="$fixtures/reads.fa"
+
+[[ -x "$bin" ]]     || { echo "FAIL: bwa-mem3 binary not executable at $bin" >&2; exit 1; }
+[[ -s "$src_ref" ]] || { echo "FAIL: phix.fa missing at $src_ref" >&2; exit 1; }
+[[ -s "$reads" ]]   || { echo "FAIL: reads.fa missing at $reads" >&2; exit 1; }
+
+fail() { echo "FAIL [meth sidecar]: $*" >&2; exit 1; }
+
+# Reading the BAM header back needs samtools; skip cleanly without it (CI has
+# it, so the regression stays enforced there).
+if ! command -v samtools >/dev/null 2>&1; then
+    echo "SKIP: samtools not found; --meth @SQ enrichment not checked" >&2
+    echo "PASS: (skipped, no samtools)"
+    exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+ref="$tmp/phix.fa"
+cp "$src_ref" "$ref"
+
+SN="NC_001422.1"                                  # phiX contig name
+M5="0123456789abcdef0123456789abcdef"             # distinctive, not the real md5
+UR="file:/refs/original/phix.fa"
+AS="phiX-test-asm"
+SP="Enterobacteria phage phiX174"
+CO="provenance: original-reference sidecar"
+PG_ID="orig-sidecar"                              # @PG provenance to forward
+RG_ID="orig-rg"                                   # @RG provenance to forward
+RG_SM="orig-sample"
+
+LN="5386"                                         # phiX length (= chrom-map LN)
+
+# Build the c2t index once (this is what `mem --meth` actually aligns against).
+"$bin" index --meth "$ref" >/dev/null 2>&1 \
+    || fail "bwa-mem3 index --meth on phix.fa failed"
+
+# DECOY sidecar on the c2t index. This is the exact path the *wrong* code
+# (loading the sidecar from the c2t prefix) would read: "<c2t-prefix>.hdr". It
+# carries converted-contig SN and bogus identity tags; if any of it reaches the
+# output header, the writer consulted the c2t sidecar — a bug.
+printf '%s\n' \
+    $'@HD\tVN:1.6\tSO:unsorted' \
+    $'@SQ\tSN:fNC_001422.1\tLN:5386\tM5:ffffffffffffffffffffffffffffffff\tUR:file:/WRONG/c2t.fa' \
+    $'@CO\tDECOY c2t sidecar must not be forwarded' \
+    > "$ref.bwameth.c2t.hdr"
+
+# sq_for_sn <header-file> -> the @SQ line for $SN (robust to field order: SN
+# may be the last field, so match a tab-or-end boundary).
+sq_for_sn() { grep $'^@SQ\t' "$1" | grep -E $'\tSN:'"$SN"$'(\t|$)' || true; }
+
+# run_meth <dict-LN> -> writes the --meth BAM header for a phix.dict whose @SQ
+# carries the given LN. bwa_load_hdr_from_index("$tmp/phix.fa") resolves to
+# "$tmp/phix.dict" (it strips the .fa suffix when no .hdr is present).
+run_meth() {
+    printf '%s\n' \
+        $'@HD\tVN:1.6\tSO:unsorted' \
+        "@SQ"$'\t'"SN:$SN"$'\t'"LN:$1"$'\t'"M5:$M5"$'\t'"UR:$UR"$'\t'"AS:$AS"$'\t'"SP:$SP" \
+        "@CO"$'\t'"$CO" \
+        "@PG"$'\t'"ID:$PG_ID"$'\t'"PN:$PG_ID"$'\t'"VN:1.0" \
+        "@RG"$'\t'"ID:$RG_ID"$'\t'"SM:$RG_SM" \
+        > "$tmp/phix.dict"
+    "$bin" mem --meth "$ref" "$reads" >"$tmp/out.bam" 2>"$tmp/err" \
+        || { echo "FAIL [meth sidecar]: mem --meth exited non-zero" >&2; cat "$tmp/err" >&2; exit 1; }
+    samtools view -H "$tmp/out.bam" >"$tmp/hdr" 2>/dev/null \
+        || fail "samtools could not read --meth BAM header"
+}
+
+# === positive: sidecar LN matches the chrom map -> @SQ is enriched ==========
+run_meth "$LN"
+sq="$(sq_for_sn "$tmp/hdr")"
+[[ -n "$sq" ]] || { echo "FAIL [meth sidecar]: no @SQ for SN:$SN" >&2
+                    grep '^@SQ' "$tmp/hdr" | sed $'s/\t/<TAB>/g' >&2; exit 1; }
+
+want_tag() {
+    grep -qF -- "$1" <<<"$sq" \
+        || { echo "FAIL [meth sidecar]: @SQ missing '$1'" >&2
+             echo "$sq" | sed $'s/\t/<TAB>/g' >&2; exit 1; }
+}
+want_tag $'\tM5:'"$M5"
+want_tag $'\tUR:'"$UR"
+want_tag $'\tAS:'"$AS"
+want_tag $'\tSP:'"$SP"
+grep -qE $'\tLN:'"$LN"$'(\t|$)' <<<"$sq" || fail "@SQ LN is not $LN (chrom map); got: $(sed $'s/\t/<TAB>/g' <<<"$sq")"
+
+# @CO/@PG/@RG provenance from the original sidecar is forwarded (the writer
+# passes through every non-@HD/non-@SQ record, not just @CO).
+grep -qF -- "$(printf '@CO\t%s' "$CO")" "$tmp/hdr" || fail "forwarded @CO provenance missing"
+grep -qE $'^@PG\t.*\tID:'"$PG_ID"$'(\t|$)' "$tmp/hdr" \
+    || grep -qE $'^@PG\tID:'"$PG_ID"$'(\t|$)' "$tmp/hdr" \
+    || fail "forwarded @PG provenance (ID:$PG_ID) missing"
+grep -qE $'^@RG\t.*ID:'"$RG_ID"$'(\t|$)' "$tmp/hdr" || fail "forwarded @RG provenance (ID:$RG_ID) missing"
+grep -qE $'^@RG\t.*SM:'"$RG_SM"$'(\t|$)' "$tmp/hdr" || fail "forwarded @RG SM:$RG_SM missing"
+
+# the c2t decoy sidecar must NOT have been consulted
+if grep -q "M5:ffffffffffffffffffffffffffffffff" "$tmp/hdr"; then fail "c2t decoy M5 leaked into output"; fi
+if grep -q "file:/WRONG/c2t.fa"                  "$tmp/hdr"; then fail "c2t decoy UR leaked into output"; fi
+if grep -q "SN:fNC_001422.1"                     "$tmp/hdr"; then fail "c2t converted contig name leaked into output"; fi
+if grep -q "DECOY"                               "$tmp/hdr"; then fail "c2t decoy @CO leaked into output"; fi
+echo "OK:   [meth sidecar] @SQ enriched with M5/UR/AS/SP from the original reference; @CO forwarded; c2t sidecar ignored"
+
+# === negative: sidecar LN disagrees -> identity tags are NOT trusted ========
+# A stale/foreign sidecar (SN matches, LN does not) must not have its M5/UR
+# attached to a sequence they no longer identify. @CO pass-through is
+# length-independent and still forwarded; the @SQ keeps the chrom-map LN.
+run_meth 9999
+sq="$(sq_for_sn "$tmp/hdr")"
+[[ -n "$sq" ]] || fail "no @SQ for SN:$SN in LN-mismatch case"
+grep -qE $'\tLN:'"$LN"$'(\t|$)' <<<"$sq" || fail "@SQ LN is not $LN (chrom map) in LN-mismatch case"
+if grep -qF $'\tM5:'"$M5" <<<"$sq"; then fail "M5 carried despite sidecar LN mismatch (should be skipped)"; fi
+if grep -qF $'\tUR:'"$UR" <<<"$sq"; then fail "UR carried despite sidecar LN mismatch (should be skipped)"; fi
+echo "OK:   [meth sidecar] LN mismatch skips @SQ identity-tag enrichment"
+
+echo "PASS: --meth carries original-reference @SQ identity tags (SN+LN matched) and @CO provenance"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -96,6 +96,14 @@ ok "pg_cl_escape_test"
 "$HERE/meth_rg_header_test.sh" "$BWAMEM3" "$FIXTURES" || fail "meth_rg_header_test failed"
 ok "meth_rg_header_test"
 
+# --- meth_sidecar_enrich_test ---------------------------------------------
+# --meth must enrich its consolidated @SQ with the original reference's
+# identity tags (M5/UR/AS/SP) from that reference's .hdr/.dict sidecar
+# (matched by SN) and forward its @CO/@PG/@RG provenance, while never
+# consulting the c2t index's own sidecar.
+"$HERE/meth_sidecar_enrich_test.sh" "$BWAMEM3" "$FIXTURES" || fail "meth_sidecar_enrich_test failed"
+ok "meth_sidecar_enrich_test"
+
 # --- help_prescan_test ----------------------------------------------------
 # `mem --help` pre-scan must not match `--help` when it is the value of
 # an option that takes an argument (-R, -o, --set-as-failed, ...).


### PR DESCRIPTION
## What

In `--meth` mode the consolidated `@SQ` block is built from the chrom map with only `SN`/`LN`, and the index sidecar was not forwarded (it is keyed to the `.bwameth.c2t` index, whose `@SQ` describes the doubled `f`/`r` converted contigs). As a result `--meth` output dropped the `@SQ` `M5`/`UR` identity tags that strict validators (GATK, Picard) use to bind a BAM to its reference, plus any `@CO`/`@PG` provenance in the reference sidecar — metadata the default (`--bam`) and SAM paths preserve.

This loads the **original** (pre-c2t) reference's `.hdr/.dict` sidecar in `main_mem` (recovering the original prefix before the `.bwameth.c2t` rewrite) and threads it into `meth_bam_writer_open`. The writer:

- enriches each consolidated `@SQ` with the original sidecar's `M5`/`UR`/`AS`/`SP` tags, matched by **both `SN` and `LN`** (`SN`/`LN` stay from the chrom map — they equal the original contig's, since the c2t build only doubles into `f`/`r` contigs and C→T conversion is length-preserving; an `LN` mismatch means a stale/foreign sidecar and is skipped so a wrong `M5` is never attached), and
- forwards the sidecar's `@CO`/`@PG`/`@RG` records after `@SQ` and before the user header, mirroring `bam_writer_open`'s index tier (`user > index > default`); its `@HD` and `@SQ` are dropped.

The c2t index's own sidecar is never consulted.

Closes #138.

## Stacking

This is **stacked on #137** (the `-R`/`@RG` fix), which adds the `hdr_line` threading and `meth_rg_header_test.sh` this builds on. Until #137 merges, the diff here also shows #137's four commits; once #137 lands I'll rebase onto `main` and this reduces to the single `feat(meth): …` commit. Merge after #137.

## Testing

- New `test/meth_sidecar_enrich_test.sh` (wired into `run_unit_tests.sh`), isolated in a temp dir so shared fixtures are untouched:
  - **positive** — sidecar `SN`+`LN` match: `@SQ` carries `M5`/`UR`/`AS`/`SP`, `LN` from the chrom map, `@CO` forwarded;
  - **negative** — sidecar `LN` mismatch: identity tags are *not* attached;
  - **decoy** — a `<prefix>.bwameth.c2t.hdr` with converted-contig `SN` and bogus tags must not leak in (proves the c2t sidecar is never read).
- `meth_rg_header_test.sh` (from #137) still passes — no regression to the `-R`/`@RG`/`@HD` behavior.
- Local `make` clean; reviewed locally with the CodeRabbit CLI and a CodeRabbit-style self-review, findings addressed (path-too-long now warns instead of silently skipping; `@SQ` enrichment gated on `LN`; test `SN` match made field-order-robust).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In methylation mode (`--meth`), output BAM headers are now enriched with identity metadata tags (M5, UR, AS, SP) from the original reference sidecar when `SN` and `LN` match, improving metadata completeness and traceability.

* **Bug Fixes**
  * Header construction now correctly uses the original reference sidecar for identity enrichment and forwards original provenance (`@CO`, along with related `@PG`/`@RG`) into the final header.

* **Tests**
  * Added a new regression test (`meth_sidecar_enrich_test`) covering both matching and non-matching `LN` scenarios, and integrated it into the unit test suite (`run_unit_tests.sh`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->