### PR TITLE
feat(bsw): recover the 8-bit banded Smith–Waterman path for reads ≥128 bp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,20 @@ jobs:
           CHR22_SIM_DIR=/tmp/chr22-sim \
           bash test/regression/chr22_parity.sh
 
+      - name: Long-read PE 8-bit/16-bit parity (chr22, 400bp)
+        if: matrix.canonical == true
+        # Exercises the recovered >=128bp 8-bit banded-SW path end-to-end: the
+        # script self-simulates 400bp PE reads and diffs `bwa-mem3 mem` with the
+        # 8-bit path enabled (default) vs BWAMEM3_DISABLE_BSW8=1 (forced 16-bit).
+        # The two must be byte-identical -- guards the unsigned [0,255] recurrence
+        # + routing gate against regression. Self-contained A/B (one binary).
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          CHR22_FA=/tmp/chr22/chr22.fa \
+          CHR22_SIM_DIR=/tmp/chr22-sim-longread \
+          PIXI_MANIFEST="$GITHUB_WORKSPACE/test/holodeck/pixi.toml" \
+          bash test/regression/longread_pe_parity.sh
+
       - name: Run unit-test harness
         if: matrix.canonical == true || matrix.arch_flag == 'sse41'
         run: |

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -429,19 +429,25 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
 
 #define MAIN_CODE8_CORE(sbt11, h00, h11, e11, f11, f21, zero256, e_ins256, oe_ins256, e_del256, oe_del256) \
     {                                                                   \
-        __m256i m11 = _mm256_add_epi8(h00, sbt11);                      \
+        /* M = max(0, h00 + sbt) computed in UNSIGNED-saturating form so a    \
+         * legitimate score in [128,255] is kept (the old signed add_epi8 +   \
+         * signed max_epi8 floor wrapped/mis-read >127 as negative). Split    \
+         * the signed substitution score into its +bonus and -penalty parts:  \
+         * adds_epu8 (no wrap past 255) then subs_epu8 (floors at 0). Mirrors  \
+         * the validated NEON smithWaterman128_8 recurrence. */                \
+        __m256i sbt_pos = _mm256_max_epi8(sbt11, zero256);              \
+        __m256i sbt_neg = _mm256_max_epi8(_mm256_sub_epi8(zero256, sbt11), zero256); \
+        __m256i m11 = _mm256_subs_epu8(_mm256_adds_epu8(h00, sbt_pos), sbt_neg); \
         __m256i cmp11 = _mm256_cmpeq_epi8(h00, zero256);                \
-        m11 = _mm256_blendv_epi8(m11, zero256, cmp11);                  \
-        h11 = _mm256_max_epi8(m11, e11);                                \
-        h11 = _mm256_max_epi8(h11, f11);                                \
-        __m256i temp256 = _mm256_sub_epi8(m11, oe_ins256);              \
-        __m256i val256  = _mm256_max_epi8(temp256, zero256);            \
-        e11 = _mm256_sub_epi8(e11, e_ins256);                           \
-        e11 = _mm256_max_epi8(val256, e11);                             \
-        temp256 = _mm256_sub_epi8(m11, oe_del256);                      \
-        val256  = _mm256_max_epi8(temp256, zero256);                    \
-        f21 = _mm256_sub_epi8(f11, e_del256);                           \
-        f21 = _mm256_max_epi8(val256, f21);                             \
+        m11 = _mm256_blendv_epi8(m11, zero256, cmp11);  /* h00==0 -> local restart */ \
+        h11 = _mm256_max_epu8(m11, e11);                                \
+        h11 = _mm256_max_epu8(h11, f11);                                \
+        __m256i temp256 = _mm256_subs_epu8(m11, oe_ins256);            \
+        e11 = _mm256_subs_epu8(e11, e_ins256);                          \
+        e11 = _mm256_max_epu8(temp256, e11);                            \
+        temp256 = _mm256_subs_epu8(m11, oe_del256);                    \
+        f21 = _mm256_subs_epu8(f11, e_del256);                          \
+        f21 = _mm256_max_epu8(temp256, f21);                            \
     }
 
 #define SBT_PREPASS16(s1, s2, sbt11_out, mismatch256, match256, w_ambig_256) \
@@ -671,6 +677,12 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         // so the two agree on B0; smithWaterman256_8 recomputes B0 via
         // bsw8_initial_floor(p[].h0, zdrop).
         const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
+        // The h0-prefix column/row seed below uses SIGNED int8 ops, so the seeded
+        // byte min(h0, REBASE_KEEP_W) must stay <= 127 (signed-positive). The
+        // routing gate (bsw8_envelope_ok) enforces zdrop <= 126; assert for any
+        // direct caller that bypasses the gate.
+        assert(REBASE_KEEP_W <= 127 &&
+               "8-bit h0-prefix seed is signed int8; REBASE_KEEP>127 (zdrop>126) -> route to 16-bit");
 
         int nstart = 0, nend = numPairs;
 
@@ -927,40 +939,39 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     // every carried score buffer/register for that lane, then add B back when
     // reconstructing the absolute result.
     //
-    // SAFETY: subtracting delta saturates cells whose rebaselined value < delta
-    // to 0, i.e. cells that were >= (REBASE_HI - delta) = REBASE_KEEP below the
-    // row max. With REBASE_KEEP > zdrop, any such cell is already beyond the
-    // z-drop horizon (the alignment through it has already z-dropped) and cannot
-    // lead to the optimum, so clamping it to 0 is sound. The per-row max can
-    // climb by at most w_match between two row-end checks (H(i,j) <= H(i-1,j-1)
-    // + w_match), so REBASE_HI must leave >= w_match headroom below 255.
+    // Scores live in the UNSIGNED byte range [0,255]. The DP recurrence computes
+    // M = max(0, h00 + sbt) with unsigned-saturating arithmetic (adds_epu8 then
+    // subs_epu8) and the row/global-max trackers (maxRS1, maxScore256) compare
+    // with UNSIGNED order (== after _mm256_max_epu8), so the full [0,255] is usable.
     //
-    // NB: scores must stay in the SIGNED-positive byte range [0,127]. The DP
-    // recurrence floors cells with `m11 & (m11 > 0)` (signed _mm256_cmpgt_epi8) and
-    // the row/global-max trackers (maxRS1, maxScore256) compare scores
-    // with SIGNED _mm256_cmpgt_epi8 — all of which mis-read a byte >= 128 as
-    // negative. So we re-baseline within [0,127], not [0,255].
-    //
-    // Re-baseline window derived from this kernel's scoring + z-drop, so the
-    // 8-bit score path is correct for ANY valid scoring (not just bench defaults):
-    //   REBASE_KEEP > zdrop      => any cell clamped on re-baseline (>= REBASE_KEEP
-    //                               below the row max) is already past the z-drop
-    //                               horizon, so clamping it to 0 is lossless.
-    //   REBASE_HI + maxStep<=127 => a not-yet-triggered row carries max < REBASE_HI
-    //                               and grows by <= maxStep, so the score byte never
-    //                               exceeds signed-int8 +127 (the floor/max-trackers
-    //                               use signed _mm256_cmpgt_epi8; a byte >=128 would be
-    //                               misread as negative and killed).
-    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window exists) is equivalent
-    // to zdrop + maxStep <= 125; the 8-bit routing gate (bwamem.cpp, separate task)
-    // MUST ensure this, else the pair belongs on the 16-bit path.
+    // CORRECTNESS depends on re-baselining NEVER firing for a pair admitted to
+    // this kernel. The saturating-subtract is NOT generally lossless: it can zero
+    // a still-positive off-diagonal cell (a cell may sit > zdrop below the ROW max
+    // yet still lie on the eventual optimum — z-drop is a row-level early-exit, not
+    // a per-cell guarantee), and a zeroed cell is then misread as the h00==0
+    // local-restart sentinel, spuriously truncating a valid alignment. So we do
+    // NOT rely on re-baseline being lossless; instead it is held inert:
+    //   REBASE_HI = 255 - maxStep: a row whose max has not reached REBASE_HI grows
+    //     by <= maxStep per row (H(i,j) <= H(i-1,j-1) + maxStep), so its bytes stay
+    //     <= 255 with no rebase needed.
+    //   The bwamem.cpp routing gate admits a pair only when its MAX ATTAINABLE
+    //     score stays < REBASE_HI and h0 <= REBASE_KEEP (so B0 == 0). Under that
+    //     gate the row max never reaches REBASE_HI: B stays 0, stored bytes equal
+    //     absolute scores, and the kernel is a plain exact unsigned [0,255] SW.
+    // The re-baseline machinery below is retained only as a safety net; pairs that
+    // could exceed the envelope take the 16-bit path.
+    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window) holds for
+    // zdrop + maxStep <= 253; the routing gate enforces the tighter
+    // zdrop + maxStep <= 127 because the h0-prefix column/row seed (wrapper setup
+    // below) uses SIGNED int8 ops, so the seeded byte min(h0, REBASE_KEEP) must
+    // stay <= 127 (signed-positive).
     int maxStep = (int)this->w_match;
     if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
     if (maxStep < 1) maxStep = 1;
     const int REBASE_KEEP = zdrop + 1;
-    const int REBASE_HI   = 127 - maxStep;
+    const int REBASE_HI   = 255 - maxStep;
     assert(REBASE_HI > REBASE_KEEP &&
-           "8-bit SW re-baseline: zdrop+maxStep>125, scoring outside safe envelope (route to 16-bit)");
+           "8-bit SW re-baseline: zdrop+maxStep>253, scoring outside safe envelope (route to 16-bit)");
     int32_t B[SIMD_WIDTH8];        // per-lane wide score floor (stored = abs - B)
     int32_t best_abs[SIMD_WIDTH8]; // running best score in ABSOLUTE units
     int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end) in ABSOLUTE units
@@ -1189,8 +1200,11 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
             f21 = _mm256_blendv_epi8(f21, zero256, cmp1);
 
             __m256i bmaxRS = maxRS1;
-            maxRS1 =_mm256_max_epi8(maxRS1, h11);
-            __m256i cmpA = _mm256_cmpgt_epi8(maxRS1, bmaxRS);
+            maxRS1 =_mm256_max_epu8(maxRS1, h11);
+            // UNSIGNED >: maxRS1 = max_epu8(.,h11) >= bmaxRS always, so
+            // (maxRS1 >u bmaxRS) == (maxRS1 != bmaxRS). Signed cmpgt_epi8 here
+            // mis-read scores >127 (long reads) as negative.
+            __m256i cmpA = _mm256_xor_si256(_mm256_cmpeq_epi8(maxRS1, bmaxRS), ff256);
             __m256i cmpB =_mm256_cmpeq_epi8(maxRS1, h11);
             cmpA = _mm256_or_si256(cmpA, cmpB);
             cmp1 = _mm256_cmpgt_epi8(j256, tail256);
@@ -1239,10 +1253,12 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
 
         exit0 = _mm256_blendv_epi8(exit0, zero256,  tmp);
 
-        __m256i score256 = _mm256_max_epi8(maxScore256, maxRS1);
+        __m256i score256 = _mm256_max_epu8(maxScore256, maxRS1);
         maxScore256 = _mm256_blendv_epi8(maxScore256, score256, exit0);
 
-        __m256i cmp = _mm256_cmpgt_epi8(maxScore256, bmaxScore256);
+        // UNSIGNED >: maxScore256 (post-update) >= bmaxScore256, so (>u) == (!=).
+        // Signed cmpgt_epi8 mis-read scores >127.
+        __m256i cmp = _mm256_xor_si256(_mm256_cmpeq_epi8(maxScore256, bmaxScore256), ff256);
         // y256 (best col) stays a diagonal offset captured in the best row's
         // frame; the best row itself moves to the wide xrow[] side channel.
         y256 = _mm256_blendv_epi8(y256, y1_256, cmp);
@@ -1254,7 +1270,7 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         __m256i y1_minus1 = _mm256_sub_epi8(y1_256, one256);
         tmp = _mm256_abs_epi8(y1_minus1);                    // |y1_off - 1|
         __m256i bmax_off256 = max_off256;
-        tmp = _mm256_max_epi8(max_off256, tmp);
+        tmp = _mm256_max_epu8(max_off256, tmp);
         max_off256 = _mm256_blendv_epi8(bmax_off256, tmp, cmp);
 
         // Per-lane wide updates (O(rows)): best-score row (xrow), best-gscore
@@ -2322,19 +2338,25 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
 
 #define MAIN_CODE8_CORE(sbt11, h00, h11, e11, f11, f21, zero512, e_ins512, oe_ins512, e_del512, oe_del512) \
     {                                                                   \
-        __m512i m11 = _mm512_add_epi8(h00, sbt11);                      \
+        /* M = max(0, h00 + sbt) in UNSIGNED-saturating form so a legitimate  \
+         * score in [128,255] is kept (the old signed add_epi8 + signed       \
+         * max_epi8 floor wrapped/mis-read >127 as negative). Split the signed \
+         * substitution score into +bonus and -penalty parts: adds_epu8 (no   \
+         * wrap past 255) then subs_epu8 (floors at 0). Mirrors the validated  \
+         * NEON smithWaterman128_8 recurrence. */                              \
+        __m512i sbt_pos = _mm512_max_epi8(sbt11, zero512);              \
+        __m512i sbt_neg = _mm512_max_epi8(_mm512_sub_epi8(zero512, sbt11), zero512); \
+        __m512i m11 = _mm512_subs_epu8(_mm512_adds_epu8(h00, sbt_pos), sbt_neg); \
         __mmask64 cmp11 = _mm512_cmpeq_epi8_mask(h00, zero512);         \
-        m11 = _mm512_mask_blend_epi8(cmp11, m11, zero512);              \
-        h11 = _mm512_max_epi8(m11, e11);                                \
-        h11 = _mm512_max_epi8(h11, f11);                                \
-        __m512i temp512 = _mm512_sub_epi8(m11, oe_ins512);              \
-        __m512i val512  = _mm512_max_epi8(temp512, zero512);            \
-        e11 = _mm512_sub_epi8(e11, e_ins512);                           \
-        e11 = _mm512_max_epi8(val512, e11);                             \
-        temp512 = _mm512_sub_epi8(m11, oe_del512);                      \
-        val512  = _mm512_max_epi8(temp512, zero512);                    \
-        f21 = _mm512_sub_epi8(f11, e_del512);                           \
-        f21 = _mm512_max_epi8(val512, f21);                             \
+        m11 = _mm512_mask_blend_epi8(cmp11, m11, zero512);  /* h00==0 -> local restart */ \
+        h11 = _mm512_max_epu8(m11, e11);                                \
+        h11 = _mm512_max_epu8(h11, f11);                                \
+        __m512i temp512 = _mm512_subs_epu8(m11, oe_ins512);            \
+        e11 = _mm512_subs_epu8(e11, e_ins512);                          \
+        e11 = _mm512_max_epu8(temp512, e11);                            \
+        temp512 = _mm512_subs_epu8(m11, oe_del512);                    \
+        f21 = _mm512_subs_epu8(f11, e_del512);                          \
+        f21 = _mm512_max_epu8(temp512, f21);                            \
     }
 
 #define SBT_PREPASS16(s1, s2, sbt11_out, mismatch512, match512, w_ambig_512) \
@@ -2557,6 +2579,12 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         // so the two agree on B0; smithWaterman512_8 recomputes B0 via
         // bsw8_initial_floor(p[].h0, zdrop).
         const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
+        // The h0-prefix column/row seed below uses SIGNED int8 ops, so the seeded
+        // byte min(h0, REBASE_KEEP_W) must stay <= 127 (signed-positive). The
+        // routing gate (bsw8_envelope_ok) enforces zdrop <= 126; assert for any
+        // direct caller that bypasses the gate.
+        assert(REBASE_KEEP_W <= 127 &&
+               "8-bit h0-prefix seed is signed int8; REBASE_KEEP>127 (zdrop>126) -> route to 16-bit");
 
         int nstart = 0, nend = numPairs;
 
@@ -2815,40 +2843,39 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
     // every carried score buffer/register for that lane, then add B back when
     // reconstructing the absolute result.
     //
-    // SAFETY: subtracting delta saturates cells whose rebaselined value < delta
-    // to 0, i.e. cells that were >= (REBASE_HI - delta) = REBASE_KEEP below the
-    // row max. With REBASE_KEEP > zdrop, any such cell is already beyond the
-    // z-drop horizon (the alignment through it has already z-dropped) and cannot
-    // lead to the optimum, so clamping it to 0 is sound. The per-row max can
-    // climb by at most w_match between two row-end checks (H(i,j) <= H(i-1,j-1)
-    // + w_match), so REBASE_HI must leave >= w_match headroom below 255.
+    // Scores live in the UNSIGNED byte range [0,255]. The DP recurrence computes
+    // M = max(0, h00 + sbt) with unsigned-saturating arithmetic (adds_epu8 then
+    // subs_epu8) and the row/global-max trackers (maxRS1, maxScore512) compare
+    // with UNSIGNED order (_mm512_cmpgt_epu8_mask), so the full [0,255] is usable.
     //
-    // NB: scores must stay in the SIGNED-positive byte range [0,127]. The DP
-    // recurrence floors cells with cmpeq(h00,0) and the row/global-max trackers
-    // (maxRS1, maxScore512) compare scores with SIGNED
-    // _mm512_cmpgt_epi8_mask — all of which mis-read a byte >= 128 as negative.
-    // So we re-baseline within [0,127], not [0,255].
-    //
-    // Re-baseline window derived from this kernel's scoring + z-drop, so the
-    // 8-bit score path is correct for ANY valid scoring (not just bench defaults):
-    //   REBASE_KEEP > zdrop      => any cell clamped on re-baseline (>= REBASE_KEEP
-    //                               below the row max) is already past the z-drop
-    //                               horizon, so clamping it to 0 is lossless.
-    //   REBASE_HI + maxStep<=127 => a not-yet-triggered row carries max < REBASE_HI
-    //                               and grows by <= maxStep, so the score byte never
-    //                               exceeds signed-int8 +127 (the floor/max-trackers
-    //                               use signed _mm512_cmpgt_epi8_mask; a byte >=128
-    //                               would be misread as negative and killed).
-    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window exists) is equivalent
-    // to zdrop + maxStep <= 125; the 8-bit routing gate (bwamem.cpp, separate task)
-    // MUST ensure this, else the pair belongs on the 16-bit path.
+    // CORRECTNESS depends on re-baselining NEVER firing for a pair admitted to
+    // this kernel. The saturating-subtract is NOT generally lossless: it can zero
+    // a still-positive off-diagonal cell (a cell may sit > zdrop below the ROW max
+    // yet still lie on the eventual optimum — z-drop is a row-level early-exit, not
+    // a per-cell guarantee), and a zeroed cell is then misread as the h00==0
+    // local-restart sentinel, spuriously truncating a valid alignment. So we do
+    // NOT rely on re-baseline being lossless; instead it is held inert:
+    //   REBASE_HI = 255 - maxStep: a row whose max has not reached REBASE_HI grows
+    //     by <= maxStep per row (H(i,j) <= H(i-1,j-1) + maxStep), so its bytes stay
+    //     <= 255 with no rebase needed.
+    //   The bwamem.cpp routing gate admits a pair only when its MAX ATTAINABLE
+    //     score stays < REBASE_HI and h0 <= REBASE_KEEP (so B0 == 0). Under that
+    //     gate the row max never reaches REBASE_HI: B stays 0, stored bytes equal
+    //     absolute scores, and the kernel is a plain exact unsigned [0,255] SW.
+    // The re-baseline machinery below is retained only as a safety net; pairs that
+    // could exceed the envelope take the 16-bit path.
+    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window) holds for
+    // zdrop + maxStep <= 253; the routing gate enforces the tighter
+    // zdrop + maxStep <= 127 because the h0-prefix column/row seed (wrapper setup
+    // below) uses SIGNED int8 ops, so the seeded byte min(h0, REBASE_KEEP) must
+    // stay <= 127 (signed-positive).
     int maxStep = (int)this->w_match;
     if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
     if (maxStep < 1) maxStep = 1;
     const int REBASE_KEEP = zdrop + 1;
-    const int REBASE_HI   = 127 - maxStep;
+    const int REBASE_HI   = 255 - maxStep;
     assert(REBASE_HI > REBASE_KEEP &&
-           "8-bit SW re-baseline: zdrop+maxStep>125, scoring outside safe envelope (route to 16-bit)");
+           "8-bit SW re-baseline: zdrop+maxStep>253, scoring outside safe envelope (route to 16-bit)");
     int32_t B[SIMD_WIDTH8];        // per-lane wide score floor (stored = abs - B)
     int32_t best_abs[SIMD_WIDTH8]; // running best score in ABSOLUTE units
     int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end) in ABSOLUTE units
@@ -3071,9 +3098,10 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
             f21 = _mm512_mask_blend_epi8(cmp1, f21, zero512);
             
             /* Part of main code MAIN_CODE */
-            __m512i bmaxRS = maxRS1, blend512;                                      
-            maxRS1 =_mm512_max_epi8(maxRS1, h11);                           
-            __mmask64 cmpA = _mm512_cmpgt_epi8_mask(maxRS1, bmaxRS);                    
+            __m512i bmaxRS = maxRS1, blend512;
+            maxRS1 =_mm512_max_epu8(maxRS1, h11);
+            // UNSIGNED >: signed cmpgt_epi8 mis-read scores >127 (long reads).
+            __mmask64 cmpA = _mm512_cmpgt_epu8_mask(maxRS1, bmaxRS);
             __mmask64 cmpB =_mm512_cmpeq_epi8_mask(maxRS1, h11);                    
             cmpA = cmpA | cmpB;
             cmp1 = _mm512_cmpgt_epi8_mask(j512, tail512);
@@ -3117,12 +3145,13 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
 
         exit0 = _mm512_mask_blend_epi8(tmp, exit0, zero512);
 
-        __m512i score512 = _mm512_max_epi8(maxScore512, maxRS1);
+        __m512i score512 = _mm512_max_epu8(maxScore512, maxRS1);
         // exit0: 0xFF=alive; movepi8_mask high-bit => mask bit=1 where alive.
         __mmask64 mex0 = _mm512_movepi8_mask(exit0);
         maxScore512 = _mm512_mask_blend_epi8(mex0, maxScore512, score512);
 
-        __mmask64 cmp = _mm512_cmpgt_epi8_mask(maxScore512, bmaxScore512);
+        // UNSIGNED >: signed cmpgt_epi8 mis-read scores >127 (long reads).
+        __mmask64 cmp = _mm512_cmpgt_epu8_mask(maxScore512, bmaxScore512);
         // y512 (best col) stays a diagonal offset captured in the best row's
         // frame; the best row itself moves to the wide xrow[] side channel.
         y512 = _mm512_mask_blend_epi8(cmp, y512, y1_512);
@@ -3134,7 +3163,7 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         __m512i y1_minus1 = _mm512_sub_epi8(y1_512, one512);
         __m512i ind512 = _mm512_abs_epi8(y1_minus1);          // |y1_off - 1|
         __m512i bmax_off512 = max_off512;
-        ind512 = _mm512_max_epi8(max_off512, ind512);
+        ind512 = _mm512_max_epu8(max_off512, ind512);
         max_off512 = _mm512_mask_blend_epi8(cmp, bmax_off512, ind512);
 
         // Per-lane wide updates (O(rows)): best-score row (xrow), best-gscore
@@ -5003,10 +5032,16 @@ static inline __m128i _mm_blendv_epi8 (__m128i x, __m128i y, __m128i mask)
 // pre-computed score vector `sbt11` from SBT_PREPASS8.
 #define MAIN_CODE8_CORE(sbt11, h00, h11, e11, f11, f21, zero128, e_ins128, oe_ins128, e_del128, oe_del128) \
     {                                                                   \
-        __m128i m11 = _mm_add_epi8(h00, sbt11);                         \
+        /* M = max(0, h00 + sbt) computed in UNSIGNED-saturating form so a    \
+         * legitimate score in [128,255] is kept (the old signed `m11 &       \
+         * (m11 > 0)` floor mis-read >127 as negative and zeroed it). Split   \
+         * the signed substitution score into its +bonus and -penalty parts:  \
+         * adds_epu8 (no wrap past 255) then subs_epu8 (floors at 0). */       \
+        __m128i sbt_pos = _mm_max_epi8(sbt11, zero128);                 \
+        __m128i sbt_neg = _mm_max_epi8(_mm_sub_epi8(zero128, sbt11), zero128); \
+        __m128i m11 = _mm_subs_epu8(_mm_adds_epu8(h00, sbt_pos), sbt_neg); \
         __m128i cmp11 = _mm_cmpeq_epi8(h00, zero128);                   \
-        m11 = _mm_blendv_epi8(m11, zero128, cmp11);                     \
-        m11 = _mm_and_si128(m11, _mm_cmpgt_epi8(m11, zero128));         \
+        m11 = _mm_blendv_epi8(m11, zero128, cmp11);  /* h00==0 -> local restart */ \
         h11 = _mm_max_epu8(m11, e11);                                   \
         h11 = _mm_max_epu8(h11, f11);                                   \
         __m128i temp128 = _mm_subs_epu8(m11, oe_ins128);                \
@@ -5150,6 +5185,12 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         // so the two agree on B0; smithWaterman128_8 recomputes B0 via
         // bsw8_initial_floor(p[].h0, zdrop).
         const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
+        // The h0-prefix column/row seed below uses SIGNED int8 ops, so the seeded
+        // byte min(h0, REBASE_KEEP_W) must stay <= 127 (signed-positive). The
+        // routing gate (bsw8_envelope_ok) enforces zdrop <= 126; assert for any
+        // direct caller that bypasses the gate.
+        assert(REBASE_KEEP_W <= 127 &&
+               "8-bit h0-prefix seed is signed int8; REBASE_KEEP>127 (zdrop>126) -> route to 16-bit");
 
         int nstart = 0, nend = numPairs;
         
@@ -5398,40 +5439,39 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     // every carried score buffer/register for that lane, then add B back when
     // reconstructing the absolute result.
     //
-    // SAFETY: subtracting delta saturates cells whose rebaselined value < delta
-    // to 0, i.e. cells that were >= (REBASE_HI - delta) = REBASE_KEEP below the
-    // row max. With REBASE_KEEP > zdrop, any such cell is already beyond the
-    // z-drop horizon (the alignment through it has already z-dropped) and cannot
-    // lead to the optimum, so clamping it to 0 is sound. The per-row max can
-    // climb by at most w_match between two row-end checks (H(i,j) <= H(i-1,j-1)
-    // + w_match), so REBASE_HI must leave >= w_match headroom below 255.
+    // Scores live in the UNSIGNED byte range [0,255]. The DP recurrence computes
+    // M = max(0, h00 + sbt) with unsigned-saturating arithmetic (adds_epu8 then
+    // subs_epu8) and the row/global-max trackers (maxRS1, maxScore128) compare
+    // with UNSIGNED order (== after _mm_max_epu8), so the full [0,255] is usable.
     //
-    // NB: scores must stay in the SIGNED-positive byte range [0,127]. The DP
-    // recurrence floors cells with `m11 & (m11 > 0)` (signed _mm_cmpgt_epi8) and
-    // the row/global-max trackers (maxRS1, maxScore128) compare scores
-    // with SIGNED _mm_cmpgt_epi8 — all of which mis-read a byte >= 128 as
-    // negative. So we re-baseline within [0,127], not [0,255].
-    //
-    // Re-baseline window derived from this kernel's scoring + z-drop, so the
-    // 8-bit score path is correct for ANY valid scoring (not just bench defaults):
-    //   REBASE_KEEP > zdrop      => any cell clamped on re-baseline (>= REBASE_KEEP
-    //                               below the row max) is already past the z-drop
-    //                               horizon, so clamping it to 0 is lossless.
-    //   REBASE_HI + maxStep<=127 => a not-yet-triggered row carries max < REBASE_HI
-    //                               and grows by <= maxStep, so the score byte never
-    //                               exceeds signed-int8 +127 (the floor/max-trackers
-    //                               use signed _mm_cmpgt_epi8; a byte >=128 would be
-    //                               misread as negative and killed).
-    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window exists) is equivalent
-    // to zdrop + maxStep <= 125; the 8-bit routing gate (bwamem.cpp, separate task)
-    // MUST ensure this, else the pair belongs on the 16-bit path.
+    // CORRECTNESS depends on re-baselining NEVER firing for a pair admitted to
+    // this kernel. The saturating-subtract is NOT generally lossless: it can zero
+    // a still-positive off-diagonal cell (a cell may sit > zdrop below the ROW max
+    // yet still lie on the eventual optimum — z-drop is a row-level early-exit, not
+    // a per-cell guarantee), and a zeroed cell is then misread as the h00==0
+    // local-restart sentinel, spuriously truncating a valid alignment. So we do
+    // NOT rely on re-baseline being lossless; instead it is held inert:
+    //   REBASE_HI = 255 - maxStep: a row whose max has not reached REBASE_HI grows
+    //     by <= maxStep per row (H(i,j) <= H(i-1,j-1) + maxStep), so its bytes stay
+    //     <= 255 with no rebase needed.
+    //   The bwamem.cpp routing gate admits a pair only when its MAX ATTAINABLE
+    //     score stays < REBASE_HI and h0 <= REBASE_KEEP (so B0 == 0). Under that
+    //     gate the row max never reaches REBASE_HI: B stays 0, stored bytes equal
+    //     absolute scores, and the kernel is a plain exact unsigned [0,255] SW.
+    // The re-baseline machinery below is retained only as a safety net; pairs that
+    // could exceed the envelope take the 16-bit path.
+    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window) holds for
+    // zdrop + maxStep <= 253; the routing gate enforces the tighter
+    // zdrop + maxStep <= 127 because the h0-prefix column/row seed (wrapper setup
+    // below) uses SIGNED int8 ops, so the seeded byte min(h0, REBASE_KEEP) must
+    // stay <= 127 (signed-positive).
     int maxStep = (int)this->w_match;
     if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
     if (maxStep < 1) maxStep = 1;
     const int REBASE_KEEP = zdrop + 1;
-    const int REBASE_HI   = 127 - maxStep;
+    const int REBASE_HI   = 255 - maxStep;
     assert(REBASE_HI > REBASE_KEEP &&
-           "8-bit SW re-baseline: zdrop+maxStep>125, scoring outside safe envelope (route to 16-bit)");
+           "8-bit SW re-baseline: zdrop+maxStep>253, scoring outside safe envelope (route to 16-bit)");
     int32_t B[SIMD_WIDTH8];        // per-lane wide score floor (stored = abs - B)
     int32_t best_abs[SIMD_WIDTH8]; // running best score in ABSOLUTE units
     int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end) in ABSOLUTE units
@@ -5668,9 +5708,12 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             f21 = _mm_blendv_epi8(f21, zero128, cmp1);
             
             // got this block out of MAIN_CODE
-            __m128i bmaxRS = maxRS1;                                        
+            __m128i bmaxRS = maxRS1;
             maxRS1 =_mm_max_epu8(maxRS1, h11);   // modif
-            __m128i cmpA = _mm_cmpgt_epi8(maxRS1, bmaxRS);                  
+            // UNSIGNED >: maxRS1 = max_epu8(.,h11) >= bmaxRS always, so
+            // (maxRS1 >u bmaxRS) == (maxRS1 != bmaxRS). Signed cmpgt_epi8 here
+            // mis-read scores >127 (long reads) as negative.
+            __m128i cmpA = _mm_xor_si128(_mm_cmpeq_epi8(maxRS1, bmaxRS), ff128);
             __m128i cmpB =_mm_cmpeq_epi8(maxRS1, h11);                  
             cmpA = _mm_or_si128(cmpA, cmpB);
             cmp1 = _mm_cmpgt_epi8(j128, tail128);
@@ -5734,7 +5777,10 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         __m128i score128 = _mm_max_epu8(maxScore128, maxRS1);   // epi8 not present, modif
         maxScore128 = _mm_blendv_epi8(maxScore128, score128, exit0);
 
-        __m128i cmp = _mm_cmpgt_epi8(maxScore128, bmaxScore128);
+        // UNSIGNED >: maxScore128 (post-update, = max_epu8 of old & maxRS1 on
+        // alive lanes, else unchanged) is >= bmaxScore128, so (>u) == (!=).
+        // Signed cmpgt_epi8 mis-read scores >127.
+        __m128i cmp = _mm_xor_si128(_mm_cmpeq_epi8(maxScore128, bmaxScore128), ff128);
         // y128 (best col) stays a diagonal offset captured in the best row's
         // frame; the best row itself moves to the wide xrow[] side channel.
         y128 = _mm_blendv_epi8(y128, y1_128, cmp);

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -71,6 +71,22 @@ static inline void build_pmat16(int8_t out[16],
 template <typename T>
 static inline T effective_threads(T n) { return n < 1 ? T(1) : n; }
 
+// ---------------------------------------------------------------------------
+// 8-bit re-baseline floor helpers (shared by wrapper + every SIMD kernel tier)
+//
+// Initial 8-bit score floor: keep the seed score h0 inside the re-baseline
+// keep-window so the stored byte (= H_abs - B) never overflows signed int8.
+// Clamping prefixes >REBASE_KEEP below h0 is lossless (REBASE_KEEP=zdrop+1 >
+// zdrop => already past the z-drop horizon). MUST be used by every SIMD tier.
+// Defined at file scope (before any tier #if block) so every kernel variant
+// (AVX2, AVX-512BW, SSE2/NEON) sees the same definition.
+static inline int bsw8_rebase_keep(int zdrop)            { return zdrop + 1; }
+static inline int bsw8_initial_floor(int h0, int zdrop) {
+    int b0 = h0 - bsw8_rebase_keep(zdrop);
+    return b0 > 0 ? b0 : 0;
+}
+// ---------------------------------------------------------------------------
+
 //-----------------------------------------------------------------------------------
 // constructor
 BandedPairWiseSW::BandedPairWiseSW(const int o_del, const int e_del, const int o_ins,
@@ -316,6 +332,8 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
 //------------------------------------------------------------------------------
 // MACROs
 // ------------------------ vec-8 ---------------------------------------------
+// ZSCORE8 is unused in smithWaterman256_8 (z-drop replaced by wide scalar);
+// retained here in case a future 256-bit tier reinstates it.
 #define ZSCORE8(i4_256, y4_256)                                         \
     {                                                                   \
         __m256i tmpi = _mm256_sub_epi8(i4_256, x256);                   \
@@ -639,28 +657,48 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         __m256i e_del256  = _mm256_set1_epi8(e_del);
         __m256i eb_ins256 = _mm256_set1_epi8(eb - o_ins);
         __m256i eb_del256 = _mm256_set1_epi8(eb - o_del);
-        
+
         int8_t max = 0;
         if (max < w_match) max = w_match;
         if (max < w_mismatch) max = w_mismatch;
         if (max < w_ambig) max = w_ambig;
-        
+
+        // Initial per-lane score floor B0 = max(0, h0 - REBASE_KEEP_W) (long-read
+        // 8-bit, seed score h0 >= 128). Seeding the H bytes from raw h0 overflows
+        // the signed-int8 score state on row 0, so we seed from the rebaselined
+        // h0' = min(h0, REBASE_KEEP_W) instead (see the per-lane h0 init below).
+        // REBASE_KEEP_W MUST equal the kernel's REBASE_KEEP (bsw8_rebase_keep)
+        // so the two agree on B0; smithWaterman256_8 recomputes B0 via
+        // bsw8_initial_floor(p[].h0, zdrop).
+        const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
+
         int nstart = 0, nend = numPairs;
 
-        
+
 //#pragma omp for schedule(dynamic, 128)
         for(i = nstart; i < nend; i+=SIMD_WIDTH8)
         {
             int32_t j, k;
-            uint8_t maxLen1 = 0;
-            uint8_t maxLen2 = 0;
+            int maxLen1 = 0;
+            int maxLen2 = 0;
             bsize = w;
             
             uint64_t tim;
             for(j = 0; j < SIMD_WIDTH8; j++)
             {
                 SeqPair sp = pairArray[i + j];
-                h0[j] = sp.h0;
+                // Re-baseline the seed score into the int8 byte frame: seed the H
+                // arrays from h0' = h0 - B0 = min(h0, REBASE_KEEP_W) (clamped >= 0)
+                // so the initial bytes fit signed-int8 even when the true seed h0
+                // is several hundred (long-read). smithWaterman256_8 recomputes the
+                // matching B0 = max(0, h0 - REBASE_KEEP) from p[].h0 + zdrop and
+                // starts that lane's floor B there, so byte == H_absolute - B.
+                {
+                    int h0p = sp.h0;
+                    if (h0p > REBASE_KEEP_W) h0p = REBASE_KEEP_W;
+                    if (h0p < 0) h0p = 0;
+                    h0[j] = (uint8_t) h0p;
+                }
                 seq1 = seqBufRef + (int64_t)sp.idr;
 
                 for(k = 0; k < sp.len1; k++)
@@ -820,17 +858,17 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 
 void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
                                           uint8_t seq2SoA[],
-                                          uint8_t nrow,
-                                          uint8_t ncol,
+                                          int nrow,
+                                          int ncol,
                                           SeqPair *p,
                                           uint8_t h0[],
                                           uint16_t tid,
                                           int32_t numPairs,
                                           int zdrop,
                                           int32_t w,
-                                          uint8_t qlen[],
+                                          uint8_t qlen[],   // dead parameter (overwritten immediately); remove with call site in a later task
                                           uint8_t myband[])
-{   
+{
     __m256i match256     = _mm256_set1_epi8(this->w_match);
     __m256i mismatch256  = _mm256_set1_epi8(this->w_mismatch);
     __m256i gapOpen256   = _mm256_set1_epi8(this->w_open);
@@ -855,63 +893,152 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     int8_t  *H_h    = H8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
     int8_t  *H_v = H8__ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
 
-    int lane;
+    int i, j;
 
-    int8_t i, j;
-
-    uint8_t tlen[SIMD_WIDTH8];
     uint8_t tail[SIMD_WIDTH8] __attribute((aligned(64)));
     uint8_t head[SIMD_WIDTH8] __attribute((aligned(64)));
 
     // PR 17: per-row score-vector scratch for fission. Thread-local view
     // into sbt8_ (slab-backed; see constructor) — too large for the stack.
     int8_t *sbt_buf = sbt8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
-    
+
+    // --- DIAGONAL-OFFSET POSITION ENCODING (long-read 8-bit, w<=127) ---
+    // Every per-cell COLUMN position is tracked as the diagonal offset
+    //   d = col - i  in [-w, +w+1]  (fits signed int8 for w <= ~126).
+    // ROW quantities (best row, best-gscore row, qlen, tlen, mlen) exceed
+    // int8 for long reads, so they live in WIDE per-lane int32 side channels
+    // updated O(rows) in the per-row epilogue, not O(cells). Absolute end
+    // coordinates are reconstructed at the result store from the wide row.
+    // Persistent column-offset state (head256/tail256) is shifted by -1 each
+    // row (frame follows i) so the same absolute edge keeps its offset.
+    int32_t tlenw[SIMD_WIDTH8];   // raw target length (rows), wide
+    int32_t qlenw[SIMD_WIDTH8];   // raw query length (cols), wide
+    int32_t mbandw[SIMD_WIDTH8];  // per-lane band width, wide
+    int32_t mlenw[SIMD_WIDTH8];   // min(qlen+myband, tlen), wide row bound
+    int32_t xrow[SIMD_WIDTH8];    // best row for score (== i+1 at capture)
+    int32_t ierow[SIMD_WIDTH8];   // best row for gscore (== i+1 at capture)
+
+    // --- PER-LANE SCORE RE-BASELINING (long-read 8-bit, scores > 127) ---
+    // H/F/E and the score maxima are unsigned 8-bit [0,255], but a 1 kb
+    // alignment scores ~900. To keep the kernel 32-lane (8-bit) we carry a
+    // wide per-lane running FLOOR B[l]: every stored 8-bit score represents
+    // (H_absolute - B[l]). When a lane's row-max climbs toward 255 we raise
+    // B[l] by `delta` and subtract `delta` (saturating, _mm256_subs_epu8) from
+    // every carried score buffer/register for that lane, then add B back when
+    // reconstructing the absolute result.
+    //
+    // SAFETY: subtracting delta saturates cells whose rebaselined value < delta
+    // to 0, i.e. cells that were >= (REBASE_HI - delta) = REBASE_KEEP below the
+    // row max. With REBASE_KEEP > zdrop, any such cell is already beyond the
+    // z-drop horizon (the alignment through it has already z-dropped) and cannot
+    // lead to the optimum, so clamping it to 0 is sound. The per-row max can
+    // climb by at most w_match between two row-end checks (H(i,j) <= H(i-1,j-1)
+    // + w_match), so REBASE_HI must leave >= w_match headroom below 255.
+    //
+    // NB: scores must stay in the SIGNED-positive byte range [0,127]. The DP
+    // recurrence floors cells with `m11 & (m11 > 0)` (signed _mm256_cmpgt_epi8) and
+    // the row/global-max trackers (maxRS1, maxScore256, gscore) compare scores
+    // with SIGNED _mm256_cmpgt_epi8 — all of which mis-read a byte >= 128 as
+    // negative. So we re-baseline within [0,127], not [0,255].
+    //
+    // Re-baseline window derived from this kernel's scoring + z-drop, so the
+    // 8-bit score path is correct for ANY valid scoring (not just bench defaults):
+    //   REBASE_KEEP > zdrop      => any cell clamped on re-baseline (>= REBASE_KEEP
+    //                               below the row max) is already past the z-drop
+    //                               horizon, so clamping it to 0 is lossless.
+    //   REBASE_HI + maxStep<=127 => a not-yet-triggered row carries max < REBASE_HI
+    //                               and grows by <= maxStep, so the score byte never
+    //                               exceeds signed-int8 +127 (the floor/max-trackers
+    //                               use signed _mm256_cmpgt_epi8; a byte >=128 would be
+    //                               misread as negative and killed).
+    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window exists) is equivalent
+    // to zdrop + maxStep <= 125; the 8-bit routing gate (bwamem.cpp, separate task)
+    // MUST ensure this, else the pair belongs on the 16-bit path.
+    int maxStep = (int)this->w_match;
+    if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
+    if (maxStep < 1) maxStep = 1;
+    const int REBASE_KEEP = zdrop + 1;
+    const int REBASE_HI   = 127 - maxStep;
+    assert(REBASE_HI > REBASE_KEEP &&
+           "8-bit SW re-baseline: zdrop+maxStep>125, scoring outside safe envelope (route to 16-bit)");
+    int32_t B[SIMD_WIDTH8];        // per-lane wide score floor (stored = abs - B)
+    int32_t best_abs[SIMD_WIDTH8]; // running best score in ABSOLUTE units
+    int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end) in ABSOLUTE units
+
+    // --- INITIAL SCORE FLOOR B0 (long-read 8-bit, seed score h0 >= 128) ---
+    // The H arrays are seeded from the seed score h0 (H_v[0]=h0, then gap-
+    // decremented down column 0 and across row 0). For a long-read seed h0 can
+    // be several hundred, which immediately overflows the signed-int8 byte
+    // state before any re-baseline event can fire. So we start each lane's
+    // running floor at B0[l] = max(0, h0 - REBASE_KEEP) instead of 0: the
+    // wrapper seeds the H bytes from h0' = h0 - B0 = min(h0, REBASE_KEEP)
+    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 127), and
+    // here we set B[l] = B0[l] so the stored bytes still mean (H_absolute - B).
+    //
+    // SAFETY (identical argument to the mid-DP re-baseline): the gap-prefix
+    // cells in column 0 / row 0 that fall more than REBASE_KEEP below h0 are
+    // saturated to byte 0 by the wrapper's unsigned-saturating seed. Because
+    // REBASE_KEEP = zdrop+1 > zdrop, any such prefix cell is already beyond the
+    // z-drop horizon below the seed, so an alignment routed through it has
+    // already z-dropped and cannot be optimal -- clamping it to the floor is
+    // lossless. This is the SAME situation that arises mid-DP whenever B>0 after
+    // a re-baseline (byte 0 then means H_absolute == B, not 0), which the
+    // h00==0 local-restart test in MAIN_CODE8_CORE already handles correctly; B0
+    // simply makes B>0 from row 0 instead of from the first re-baseline event.
+    int32_t B0[SIMD_WIDTH8];
+    for (int l=0; l<SIMD_WIDTH8; l++) {
+        B0[l] = bsw8_initial_floor((int)p[l].h0, zdrop);
+    }
+
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH8; l++) {
-        tlen[l] = p[l].len1;
-        qlen[l] = p[l].len2;
+        tlenw[l]  = p[l].len1;
+        qlenw[l]  = p[l].len2;
+        mbandw[l] = myband[l];
+        int ml = qlenw[l] + mbandw[l];
+        if (ml > tlenw[l]) ml = tlenw[l];
+        mlenw[l]  = ml;
+        xrow[l]   = 0;
+        ierow[l]  = 0;
+        B[l]        = B0[l];   // start the floor at B0 so byte state = abs - B0
+        best_abs[l] = p[l].h0; // maxScore256 inits to the h0 seed; record the
+                               // ABSOLUTE seed score (wide), not the rebaselined byte
+        gbest_abs[l]= -1;      // matches the int8 gscore init (-1) in absolute units
         if (p[l].len2 < minq) minq = p[l].len2;
     }
     minq -= 1; // for gscore
 
-    __m256i tlen256 = _mm256_load_si256((__m256i *) tlen);
-    __m256i qlen256 = _mm256_load_si256((__m256i *) qlen);
     __m256i myband256 = _mm256_load_si256((__m256i *) myband);
     __m256i zero256 = _mm256_setzero_si256();
     __m256i one256  = _mm256_set1_epi8(1);
     __m256i two256  = _mm256_set1_epi8(2);
-    __m256i max_ie256 = zero256;
     __m256i ff256 = _mm256_set1_epi8(0xFF);
-        
-    __m256i tail256 = qlen256, head256 = zero256;
+
+    // gscore best-row marker lane: 1 == "this row updated gscore", 0 == earlier
+    // (the actual earlier row is carried in the wide ierow[] side channel).
+    __m256i max_ie256 = zero256;
+
+    // Offset-frame band edges. head_off starts at 0 (col 0 - row 0); tail_off
+    // starts saturated-high (+127) and is immediately clamped by the band-grow
+    // min() against (1+myband) and (qlen-i) on the first row.
+    __m256i head256 = zero256;
+    __m256i tail256 = _mm256_set1_epi8(127);
     _mm256_store_si256((__m256i *) head, head256);
     _mm256_store_si256((__m256i *) tail, tail256);
-    //__m256i ib256 = _mm256_add_epi8(qlen256, qlen256);
-    // ib256 = _mm256_sub_epi8(ib256, one256);
 
-    __m256i mlen256 = _mm256_add_epi8(qlen256, myband256);
-    mlen256 = _mm256_min_epu8(mlen256, tlen256);
-
-    uint8_t temp[SIMD_WIDTH8]  __attribute((aligned(64)));
-    uint8_t temp1[SIMD_WIDTH8]  __attribute((aligned(64)));
-    
-    __m256i s00  = _mm256_load_si256((__m256i *)(seq1SoA));
     __m256i hval = _mm256_load_si256((__m256i *)(H_v));
     __mmask32 dmask = 0xFFFFFFFF;
-    
+
     __m256i maxScore256 = hval;
     for(j = 0; j < ncol; j++)
         _mm256_store_si256((__m256i *)(F + j * SIMD_WIDTH8), zero256);
-    
-    __m256i x256 = zero256;
-    __m256i y256 = zero256;
-    __m256i i256 = zero256;
+
+    __m256i y256 = zero256;   // best col as diagonal offset: col - i_at_capture (i_at_capture = xrow[l]-1)
     __m256i gscore = _mm256_set1_epi8(-1);
     __m256i max_off256 = zero256;
     __m256i exit0 = _mm256_set1_epi8(0xFF);
     __m256i zdrop256 = _mm256_set1_epi8(zdrop);
-    
+
     int beg = 0, end = ncol;
     int nbeg = beg, nend = end;
     
@@ -920,101 +1047,126 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
 #endif
     
     for(i = 0; i < nrow; i++)
-    {       
+    {
         __m256i e11 = zero256;
         __m256i h00, h11, h10;
         __m256i s10 = _mm256_load_si256((__m256i *)(seq1SoA + (i + 0) * SIMD_WIDTH8));
-        
+
         beg = nbeg; end = nend;
-        int pbeg = beg;
+        // Banding
         if (beg < i - w) beg = i - w;
         if (end > i + w + 1) end = i + w + 1;
         if (end > ncol) end = ncol;
-        
+
         h10 = zero256;
         if (beg == 0)
             h10 = _mm256_load_si256((__m256i *)(H_v + (i+1) * SIMD_WIDTH8));
-        
+
         __m256i j256 = zero256;
-        __m256i maxRS1;
-        maxRS1 = zero256;
-        
-        __m256i i1_256 = _mm256_set1_epi8(i+1);
-        __m256i y1_256 = zero256;
-        
-#if RDT 
+        __m256i maxRS1 = zero256;
+
+        __m256i y1_256 = zero256;   // row-max column as diagonal offset (col - i)
+
+        // gscore best-row marker resets each row (the carried best row lives in
+        // the wide ierow[] side channel; this lane only flags "updated this row").
+        max_ie256 = zero256;
+
+        // Per-row diagonal-offset of the query end: qlen_off = qlen - i. Built
+        // wide then saturated to int8, with a validity mask so an out-of-band
+        // qlen-i (which would wrap and spuriously alias an in-band col offset)
+        // never triggers a false gscore/clamp. qlen_off_valid is true only when
+        // qlen-i lies within the representable band window [-w, w+1].
+        int8_t qlen_off_a[SIMD_WIDTH8]   __attribute((aligned(32)));
+        int8_t qlen_valid_a[SIMD_WIDTH8] __attribute((aligned(32)));
+        int8_t cmpim_a[SIMD_WIDTH8]      __attribute((aligned(32)));
+        for (int l=0; l<SIMD_WIDTH8; l++) {
+            int qoff = qlenw[l] - i;                 // wide
+            int qoff_sat = qoff;                     // saturate to int8 range
+            if (qoff_sat >  127) qoff_sat =  127;
+            if (qoff_sat < -128) qoff_sat = -128;
+            qlen_off_a[l]   = (int8_t) qoff_sat;
+            qlen_valid_a[l] = (qoff >= -w && qoff <= w + 1) ? (int8_t)0xFF : 0;
+            // exit when row i+1 has passed the per-lane effective length bound.
+            cmpim_a[l]      = ((i + 1) > mlenw[l]) ? (int8_t)0xFF : 0;
+        }
+        __m256i qlen_off256   = _mm256_load_si256((__m256i *) qlen_off_a);
+        __m256i qlen_valid256 = _mm256_load_si256((__m256i *) qlen_valid_a);
+
+#if RDT
         uint64_t tim1 = __rdtsc();
 #endif
-        
-        __m256i i256, cache256;
+
+        // Banding (diagonal-offset frame). head256/tail256 arrive here in row-i's
+        // offset frame: the -1 shift at the end of the previous iteration converts
+        // (col - (i-1)) -> (col - i), so no additional adjustment is needed here.
+        //   abs head-grow: head = max(head, i - myband)  ->  head_off = max(head_off, -myband)
+        //   abs tail-clamp: tail = min(tail, (i+1)+myband, qlen)
+        //                                          -> tail_off = min(tail_off, 1+myband, qlen-i)
+        __m256i cache256;
         __m256i phead256 = head256, ptail256 = tail256;
-        i256 = _mm256_set1_epi8(i);
-        cache256 = _mm256_sub_epi8(i256, myband256);
-        head256 = _mm256_max_epi8(head256, cache256);
-        cache256 = _mm256_add_epi8(i1_256, myband256);
-        tail256 = _mm256_min_epu8(tail256, cache256);
-        tail256 = _mm256_min_epu8(tail256, qlen256);
-        
+        __m256i negband256 = _mm256_sub_epi8(zero256, myband256);            // -myband
+        head256 = _mm256_max_epi8(head256, negband256);
+        cache256 = _mm256_add_epi8(myband256, one256);                       // 1 + myband
+        tail256 = _mm256_min_epi8(tail256, cache256);
+        tail256 = _mm256_min_epi8(tail256, qlen_off256);
+
         // NEW, trimming.
         __m256i cmph = _mm256_cmpeq_epi8(head256, phead256);
         __m256i cmpt = _mm256_cmpeq_epi8(tail256, ptail256);
         // cmph &= cmpt;
         cmph = _mm256_and_si256(cmph, cmpt);
         __mmask32 cmp_ht = _mm256_movemask_epi8(cmph);
-        
+
         for (int l=beg; l<end && cmp_ht != dmask; l++)
         {
             __m256i h256 = _mm256_load_si256((__m256i *)(H_h + l * SIMD_WIDTH8));
             __m256i f256 = _mm256_load_si256((__m256i *)(F + l * SIMD_WIDTH8));
-            
-            __m256i pj256 = _mm256_set1_epi8(l);
-            __m256i j256 = _mm256_set1_epi8(l+1);
+
+            __m256i pj256 = _mm256_set1_epi8(l - i);   // diagonal offset of column l
             __m256i cmp1 = _mm256_cmpgt_epi8(head256, pj256);
             uint32_t cval = _mm256_movemask_epi8(cmp1);
             if (cval == 0x00) break;
-            //__m256i cmp2 = _mm256_cmpgt_epi8(pj256, tail256);
-            __m256i cmp2 = _mm256_cmpgt_epi8(j256, tail256);
+            __m256i cmp2 = _mm256_cmpgt_epi8(pj256, tail256);
             cmp1 = _mm256_or_si256(cmp1, cmp2);
             h256 = _mm256_blendv_epi8(h256, zero256, cmp1);
             f256 = _mm256_blendv_epi8(f256, zero256, cmp1);
-            
+
             _mm256_store_si256((__m256i *)(F + l * SIMD_WIDTH8), f256);
             _mm256_store_si256((__m256i *)(H_h + l * SIMD_WIDTH8), h256);
         }
-        
+
 #if RDT
         prof[DP3][0] += __rdtsc() - tim1;
 #endif
-        // beg = nbeg; end = nend;
-        //__m256i cmp256_1 = _mm256_cmpgt_epi8(i1_256, tlen256);
-        
-        // beg = nbeg; end = nend;
-        __m256i cmp256_1 = _mm256_cmpgt_epi8(i1_256, tlen256);
-        
-        __m256i cmpim = _mm256_cmpgt_epi8(i1_256, mlen256);
+
+        // cmpim: lane exits if row i+1 passed its effective length (precomputed
+        // wide into cmpim_a) OR the band collapsed (tail<=head, offset frame).
+        __m256i cmpim = _mm256_load_si256((__m256i *) cmpim_a);
         __m256i cmpht = _mm256_cmpeq_epi8(tail256, head256);
         cmpim = _mm256_or_si256(cmpim, cmpht);
-
         // NEW
         cmpht = _mm256_cmpgt_epi8(head256, tail256);
         cmpim = _mm256_or_si256(cmpim, cmpht);
 
         exit0 = _mm256_blendv_epi8(exit0, zero256, cmpim);
-        
-        
+
 #if RDT
         tim1 = __rdtsc();
 #endif
-        
-        // PR 17+16: score pre-pass via LUT.
+
+        // PR 17: pre-pass — build score vector sbt[j] for all band columns
+        // once. Independent per-j, so vectorized loads/stores run at peak
+        // throughput without carrying the DP core's dep chain.
         for (int jp = beg; jp < end; jp++) {
             __m256i s2 = _mm256_load_si256((__m256i *)(seq2SoA + jp * SIMD_WIDTH8));
             __m256i sbt11;
+            // PR 16: LUT score build (1 xor + 1 shuffle) in place of
+            // the 4-op cmpeq+blendv+max+blendv SBT_PREPASS8.
             SBT_PREPASS8_LUT(s10, s2, sbt11, pmat256);
             _mm256_store_si256((__m256i *)(sbt_buf + jp * SIMD_WIDTH8), sbt11);
         }
 
-        j256 = _mm256_set1_epi8(beg);
+        j256 = _mm256_set1_epi8(beg - i);   // diagonal offset of first band column
 #pragma unroll(4)
         for(j = beg; j < end; j++)
         {
@@ -1030,89 +1182,155 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
                             e_ins256, oe_ins256,
                             e_del256, oe_del256);
 
-            
             // Masked writing
-            __m256i cmp2 = _mm256_cmpgt_epi8(head256, pj256);
-            __m256i cmp1 = _mm256_cmpgt_epi8(pj256, tail256);
+            __m256i cmp1 = _mm256_cmpgt_epi8(head256, pj256);
+            __m256i cmp2 = _mm256_cmpgt_epi8(pj256, tail256);
             cmp1 = _mm256_or_si256(cmp1, cmp2);
             h10 = _mm256_blendv_epi8(h10, zero256, cmp1);
             f21 = _mm256_blendv_epi8(f21, zero256, cmp1);
-            
-            __m256i bmaxRS = maxRS1;                                        
-            maxRS1 =_mm256_max_epi8(maxRS1, h11);                           
-            __m256i cmpA = _mm256_cmpgt_epi8(maxRS1, bmaxRS);                   
-            __m256i cmpB =_mm256_cmpeq_epi8(maxRS1, h11);                   
+
+            __m256i bmaxRS = maxRS1;
+            maxRS1 =_mm256_max_epi8(maxRS1, h11);
+            __m256i cmpA = _mm256_cmpgt_epi8(maxRS1, bmaxRS);
+            __m256i cmpB =_mm256_cmpeq_epi8(maxRS1, h11);
             cmpA = _mm256_or_si256(cmpA, cmpB);
-            cmp1 = _mm256_cmpgt_epi8(j256, tail256); // change
-            cmp1 = _mm256_or_si256(cmp1, cmp2);       // change  
+            cmp1 = _mm256_cmpgt_epi8(j256, tail256);
+            cmp1 = _mm256_or_si256(cmp1, cmp2);
             cmpA = _mm256_blendv_epi8(y1_256, j256, cmpA);
             y1_256 = _mm256_blendv_epi8(cmpA, y1_256, cmp1);
-            maxRS1 = _mm256_blendv_epi8(maxRS1, bmaxRS, cmp1);                      
-            
+            maxRS1 = _mm256_blendv_epi8(maxRS1, bmaxRS, cmp1);
+
             _mm256_store_si256((__m256i *)(F + j * SIMD_WIDTH8), f21);
             _mm256_store_si256((__m256i *)(H_h + j * SIMD_WIDTH8), h10);
-            
+
             h10 = h11;
-            
-            //j256 = _mm256_add_epi8(j256, one256);
-            
+
+            // gscore calculations
             if (j >= minq)
             {
-                __m256i cmp = _mm256_cmpeq_epi8(j256, qlen256);
-                __m256i max_gh = _mm256_max_epi8(gscore, h11);
+                // SAFE query-end test: (col - i) == (qlen - i) iff col == qlen,
+                // but only when qlen-i is in-band (else the wrapped/saturated
+                // qlen_off could alias an in-band col offset). Gate with the
+                // validity mask so an out-of-band query end can never match.
+                __m256i cmp = _mm256_cmpeq_epi8(j256, qlen_off256);
+                cmp = _mm256_and_si256(cmp, qlen_valid256);
                 __m256i cmp_gh = _mm256_cmpgt_epi8(gscore, h11);
-                __m256i tmp256_1 = _mm256_blendv_epi8(i1_256, max_ie256, cmp_gh);
-                
+                // Row marker: when h11 beats old gscore, flag "this row" (one256);
+                // otherwise keep the existing marker. The actual best row is
+                // captured into the wide ierow[] side channel in the epilogue.
+                __m256i tmp256_1 = _mm256_blendv_epi8(one256, max_ie256, cmp_gh);
+                __m256i max_gh = _mm256_blendv_epi8(h11, gscore, cmp_gh);
+
                 tmp256_1 = _mm256_blendv_epi8(max_ie256, tmp256_1, cmp);
                 tmp256_1 = _mm256_blendv_epi8(max_ie256, tmp256_1, exit0);
-                
+
                 max_gh = _mm256_blendv_epi8(gscore, max_gh, exit0);
-                max_gh = _mm256_blendv_epi8(gscore, max_gh, cmp);               
-                
-                cmp = _mm256_cmpgt_epi8(j256, tail256); 
+                max_gh = _mm256_blendv_epi8(gscore, max_gh, cmp);
+
+                cmp = _mm256_cmpgt_epi8(j256, tail256);
                 max_gh = _mm256_blendv_epi8(max_gh, gscore, cmp);
                 max_ie256 = _mm256_blendv_epi8(tmp256_1, max_ie256, cmp);
                 gscore = max_gh;
             }
         }
-        __m256i cmp2 = _mm256_cmpgt_epi8(head256, j256);
-        __m256i cmp1 = _mm256_cmpgt_epi8(j256, tail256);
+        __m256i cmp1 = _mm256_cmpgt_epi8(head256, j256);
+        __m256i cmp2 = _mm256_cmpgt_epi8(j256, tail256);
         cmp1 = _mm256_or_si256(cmp1, cmp2);
         h10 = _mm256_blendv_epi8(h10, zero256, cmp1);
 
         _mm256_store_si256((__m256i *)(H_h + j * SIMD_WIDTH8), h10);
         _mm256_store_si256((__m256i *)(F + j * SIMD_WIDTH8), zero256);
-        
-        
+
+
         /* exit due to zero score by a row */
         uint32_t cval = 0;
         __m256i bmaxScore256 = maxScore256;
         __m256i tmp = _mm256_cmpeq_epi8(maxRS1, zero256);
         cval = _mm256_movemask_epi8(tmp);
         if (cval == 0xFFFFFFFF) break;
+
         exit0 = _mm256_blendv_epi8(exit0, zero256,  tmp);
-        
+
         __m256i score256 = _mm256_max_epi8(maxScore256, maxRS1);
         maxScore256 = _mm256_blendv_epi8(maxScore256, score256, exit0);
-        
+
         __m256i cmp = _mm256_cmpgt_epi8(maxScore256, bmaxScore256);
+        // y256 (best col) stays a diagonal offset captured in the best row's
+        // frame; the best row itself moves to the wide xrow[] side channel.
         y256 = _mm256_blendv_epi8(y256, y1_256, cmp);
-        x256 = _mm256_blendv_epi8(x256, i1_256, cmp);       
-        // max_off calculations
-        tmp = _mm256_sub_epi8(y1_256, i1_256);
-        tmp = _mm256_abs_epi8(tmp);
+
+        // max_off = max running diagonal-distance of the row-max from the main
+        // diagonal: |y1col - (i+1)| = |y1_off - 1| in the offset frame.
+        // y1_off - 1 is a SIGNED int8 (negative when row-max is left of the
+        // sub-diagonal), so use _mm256_abs_epi8.
+        __m256i y1_minus1 = _mm256_sub_epi8(y1_256, one256);
+        tmp = _mm256_abs_epi8(y1_minus1);                    // |y1_off - 1|
         __m256i bmax_off256 = max_off256;
         tmp = _mm256_max_epi8(max_off256, tmp);
         max_off256 = _mm256_blendv_epi8(bmax_off256, tmp, cmp);
-        
-        // Z-score
-        ZSCORE8(i1_256, y1_256);        
-        
+
+        // Per-lane wide updates (O(rows)): best-score row (xrow), best-gscore
+        // row (ierow), absolute-frame score tracking, and the z-drop test — all
+        // done in wide scalars so row distances that exceed int8 for long reads
+        // are handled exactly.
+        {
+            int8_t  cmp_a[SIMD_WIDTH8]      __attribute((aligned(32)));
+            int8_t  y1_a[SIMD_WIDTH8]       __attribute((aligned(32)));
+            int8_t  y_a[SIMD_WIDTH8]        __attribute((aligned(32)));
+            int8_t  ms_a[SIMD_WIDTH8]       __attribute((aligned(32)));
+            int8_t  rs_a[SIMD_WIDTH8]       __attribute((aligned(32)));
+            int8_t  exit_a[SIMD_WIDTH8]     __attribute((aligned(32)));
+            int8_t  ie_mark_a[SIMD_WIDTH8]  __attribute((aligned(32)));
+            int8_t  gs_a[SIMD_WIDTH8]       __attribute((aligned(32)));
+            _mm256_store_si256((__m256i *) cmp_a, cmp);
+            _mm256_store_si256((__m256i *) y1_a, y1_256);
+            _mm256_store_si256((__m256i *) y_a, y256);
+            _mm256_store_si256((__m256i *) ms_a, maxScore256);
+            _mm256_store_si256((__m256i *) rs_a, maxRS1);
+            _mm256_store_si256((__m256i *) exit_a, exit0);
+            _mm256_store_si256((__m256i *) ie_mark_a, max_ie256);
+            _mm256_store_si256((__m256i *) gs_a, gscore);
+            for (int l = 0; l < SIMD_WIDTH8; l++) {
+                // best-score row
+                if (cmp_a[l]) xrow[l] = i + 1;
+                // best-gscore row: marker==1 means gscore was set this row
+                if (ie_mark_a[l] == 1) ierow[l] = i + 1;
+                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore256/gscore are
+                // in the lane's CURRENT B[l] frame, so the absolute value is the
+                // rebaselined byte + B[l]. Re-derive both every row (cheap, O(rows))
+                // rather than trying to add B back once at the end (the recorded
+                // max may pre-date later B bumps). max() guards against the byte
+                // being re-baselined away in a later row.
+                {
+                    int ms_abs = (int)(uint8_t)ms_a[l] + B[l];
+                    if (ms_abs > best_abs[l]) best_abs[l] = ms_abs;
+                    // gscore init is -1 (0xFF as a byte); treat that as "unset".
+                    if ((uint8_t)gs_a[l] != 0xFF) {
+                        int gs_abs = (int)(uint8_t)gs_a[l] + B[l];
+                        if (gs_abs > gbest_abs[l]) gbest_abs[l] = gs_abs;
+                    }
+                }
+                // z-drop (only relevant where the lane is still alive). The drop
+                // is ms-rs of two bytes in the SAME B[l] frame, so the B cancels
+                // and the comparison is already in ABSOLUTE score units.
+                if (exit_a[l]) {
+                    int xr  = xrow[l];                       // best row
+                    int y1c = (int) y1_a[l] + i;             // row-max col (abs)
+                    int yc  = (int) y_a[l] + (xr - 1);       // best col (abs)
+                    int tmpi = (i + 1) - xr;
+                    int tmpj = y1c - yc;
+                    int dif  = tmpi > tmpj ? (tmpi - tmpj) : (tmpj - tmpi);
+                    int drop = (int)(uint8_t)ms_a[l] - (int)(uint8_t)rs_a[l];
+                    if (drop - dif > zdrop) exit_a[l] = 0;
+                }
+            }
+            exit0 = _mm256_load_si256((__m256i *) exit_a);
+        }
+
 #if RDT
         prof[DP1][0] += __rdtsc() - tim1;
         tim1 = __rdtsc();
 #endif
-
 
         /* Narrowing of the band */
         /* From beg */
@@ -1128,9 +1346,8 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
             else
                 break;
         }
-        
+
         /* From end */
-        bool flg = 1;
         for (l = end; l >= beg; l--)
         {
             __m256i f256 = _mm256_load_si256((__m256i *)(F + l * SIMD_WIDTH8));
@@ -1138,102 +1355,166 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
             __m256i tmp = _mm256_or_si256(f256, h256);
             tmp = _mm256_cmpeq_epi8(tmp, zero256);
             uint32_t val = _mm256_movemask_epi8(tmp);
-            if (val != 0xFFFFFFFF && flg)  
+            if (val != 0xFFFFFFFF)
                 break;
         }
         // int pnend =nend;
         nend = l + 2 < ncol? l + 2: ncol;
-        
-        __m256i tail256_ = _mm256_sub_epi8(tail256, one256);
-        __m256i tmpb = ff256;        
+        __m256i tmpb = ff256;
+
         __m256i exit1 = _mm256_xor_si256(exit0, ff256);
-        __m256i l256 = _mm256_set1_epi8(beg);
-        
+        __m256i l256 = _mm256_set1_epi8(beg - i);   // diagonal offset of column beg
+
         for (l = beg; l < end; l++)
         {
             __m256i f256 = _mm256_load_si256((__m256i *)(F + l * SIMD_WIDTH8));
             __m256i h256 = _mm256_load_si256((__m256i *)(H_h + l * SIMD_WIDTH8));
-            
+
             __m256i tmp = _mm256_or_si256(f256, h256);
-            tmp = _mm256_or_si256(tmp, exit1);          
+            tmp = _mm256_or_si256(tmp, exit1);
             tmp = _mm256_cmpeq_epi8(tmp, zero256);
             uint32_t val = _mm256_movemask_epi8(tmp);
             if (val == 0x00) {
                 break;
             }
             tmp = _mm256_and_si256(tmp,tmpb);
-            //__m256i l256 = _mm256_set1_epi8(l+1);
             l256 = _mm256_add_epi8(l256, one256);
-            
+            // NEW
             head256 = _mm256_blendv_epi8(head256, l256, tmp);
-            tmpb = tmp;         
+            tmpb = tmp;
         }
-        // _mm256_store_si256((__m256i *) head, head256);
-        
+
         __m256i  index256 = tail256;
         tmpb = ff256;
-        
-        l256 = _mm256_set1_epi8(end);
+
+        l256 = _mm256_set1_epi8(end - i);   // diagonal offset of column end
         for (l = end; l >= beg; l--)
         {
             __m256i f256 = _mm256_load_si256((__m256i *)(F + l * SIMD_WIDTH8));
             __m256i h256 = _mm256_load_si256((__m256i *)(H_h + l * SIMD_WIDTH8));
-            
+
             __m256i tmp = _mm256_or_si256(f256, h256);
             tmp = _mm256_or_si256(tmp, exit1);
-            tmp = _mm256_cmpeq_epi8(tmp, zero256);          
+            tmp = _mm256_cmpeq_epi8(tmp, zero256);
             uint32_t val = _mm256_movemask_epi8(tmp);
             if (val == 0x00)  {
                 break;
             }
-            
+
             tmp = _mm256_and_si256(tmp,tmpb);
             l256 = _mm256_sub_epi8(l256, one256);
-            
+            // NEW
             index256 = _mm256_blendv_epi8(index256, l256, tmp);
             tmpb = tmp;
         }
         index256 = _mm256_add_epi8(index256, two256);
-        tail256 = _mm256_min_epi8(index256, qlen256);
-        // _mm256_store_si256((__m256i *) tail, tail256);       
+        // signed min in the offset frame against qlen-i
+        tail256 = _mm256_min_epi8(index256, qlen_off256);
+
+        // Frame shift for the next row: i advances by 1, so the same absolute
+        // band edge has its diagonal offset (col - i) decremented by 1. Keep
+        // head/tail tracking the same columns as the frame moves.
+        head256 = _mm256_sub_epi8(head256, one256);
+        tail256 = _mm256_sub_epi8(tail256, one256);
+
+        // --- RE-BASELINE EVENT (per-lane score floor) ---
+        // After this row's score state is final, lower any lane whose row-max
+        // (maxRS1, rebaselined) has climbed to REBASE_HI back into range. We
+        // raise B[l] by delta = maxRS1[l] - REBASE_KEEP and subtract that delta
+        // (saturating to 0) from every carried score buffer/register for that
+        // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
+        // reference; the next row reads the lowered values consistently.
+        {
+            uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(32)));
+            _mm256_store_si256((__m256i *) rs_b, maxRS1);
+            int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(32)));
+            int any = 0;
+            for (int l = 0; l < SIMD_WIDTH8; l++) {
+                int d = 0;
+                if ((int)rs_b[l] >= REBASE_HI) {
+                    d = (int)rs_b[l] - REBASE_KEEP;   // keep low REBASE_KEEP, in range
+                    B[l] += d;
+                    any = 1;
+                }
+                delta_a[l] = (int8_t) d;              // 0..(REBASE_HI-REBASE_KEEP) small
+            }
+            if (any) {
+                __m256i delta256 = _mm256_load_si256((__m256i *) delta_a);
+                // Subtract delta from every carried score buffer over the active
+                // band columns. The range [lo,hi] is the union of the current and
+                // next band windows; clamping to [0, ncol-1] keeps the loop within
+                // the valid column range (a safe superset covering every column the
+                // next row will read).
+                int lo = nbeg < beg ? nbeg : beg;
+                int hi = nend > end ? nend : end;
+                if (lo < 0) lo = 0;
+                if (hi + 1 > ncol) hi = ncol - 1;
+                for (int l = lo; l <= hi; l++) {
+                    __m256i h256 = _mm256_load_si256((__m256i *)(H_h + l * SIMD_WIDTH8));
+                    __m256i f256 = _mm256_load_si256((__m256i *)(F   + l * SIMD_WIDTH8));
+                    h256 = _mm256_subs_epu8(h256, delta256);
+                    f256 = _mm256_subs_epu8(f256, delta256);
+                    _mm256_store_si256((__m256i *)(H_h + l * SIMD_WIDTH8), h256);
+                    _mm256_store_si256((__m256i *)(F   + l * SIMD_WIDTH8), f256);
+                }
+                // The vertical seed H_v is read only while the band still touches
+                // column 0 (beg==0). Lower the rows that may still be consumed.
+                if (beg == 0) {
+                    for (int r = i + 1; r < nrow; r++) {
+                        __m256i v256 = _mm256_load_si256((__m256i *)(H_v + r * SIMD_WIDTH8));
+                        v256 = _mm256_subs_epu8(v256, delta256);
+                        _mm256_store_si256((__m256i *)(H_v + r * SIMD_WIDTH8), v256);
+                    }
+                }
+                // Carried score maxima (registers) live in the same rebaselined
+                // frame and must be lowered too so the next row's z-drop (ms-rs)
+                // and the absolute-frame add-back stay consistent. maxScore256 is
+                // the running max, so it never saturates to 0 (maxScore256 >=
+                // maxRS1 for the triggering row, and maxRS1 >= REBASE_HI >
+                // REBASE_KEEP > delta, so it stays positive).
+                maxScore256 = _mm256_subs_epu8(maxScore256, delta256);
+                // gscore: keep the -1 (0xFF) "unset" sentinel intact, but lower
+                // set lanes (it is compared SIGNED against the rebaselined h11 in
+                // the gscore block, so it must track the same frame). Zero the
+                // delta for lanes whose gscore is still 0xFF.
+                __m256i gset = _mm256_cmpeq_epi8(gscore, ff256);   // 0xFF where unset
+                __m256i gdelta = _mm256_andnot_si256(gset, delta256);
+                gscore = _mm256_subs_epu8(gscore, gdelta);
+            }
+        }
 
 #if RDT
         prof[DP2][0] += __rdtsc() - tim1;
 #endif
     }
-    
+
 #if RDT
     prof[DP][0] += __rdtsc() - tim;
 #endif
-    
-    int8_t score[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm256_store_si256((__m256i *) score, maxScore256);
 
-    int8_t maxi[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm256_store_si256((__m256i *) maxi, x256);
-
+    // Scores are reconstructed in ABSOLUTE units from the per-lane wide
+    // best_abs/gbest_abs side channels (= rebaselined byte + B[l], captured each
+    // row before any later re-baseline could saturate the byte away). Positions
+    // are reconstructed wide from the diagonal-offset lanes plus the per-lane
+    // best-row side channels.
     int8_t maxj[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm256_store_si256((__m256i *) maxj, y256);
+    _mm256_store_si256((__m256i *) maxj, y256);   // best col as diagonal offset
 
     int8_t max_off_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
     _mm256_store_si256((__m256i *) max_off_ar, max_off256);
 
-    int8_t gscore_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm256_store_si256((__m256i *) gscore_ar, gscore);
-
-    int8_t maxie_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm256_store_si256((__m256i *) maxie_ar, max_ie256);
-    
     for(i = 0; i < SIMD_WIDTH8; i++)
     {
-        p[i].score = score[i];
-        p[i].tle = maxi[i];
-        p[i].qle = maxj[i];
-        p[i].max_off = max_off_ar[i];
-        p[i].gscore = gscore_ar[i];
-        p[i].gtle = maxie_ar[i];
+        p[i].score   = best_abs[i];                               // absolute score
+        p[i].tle     = xrow[i];                                   // best row (target end)
+        // qle reconstruction: maxj[l] = col - (xrow-1), so col = maxj[l] + (xrow-1).
+        // Guard the unset case (xrow==0 means no update occurred).
+        p[i].qle     = (xrow[i] == 0) ? 0 : ((int) maxj[i] + xrow[i] - 1);
+        p[i].max_off = (uint8_t) max_off_ar[i];
+        p[i].gscore  = gbest_abs[i];                              // absolute gscore (-1 if unset)
+        p[i].gtle    = ierow[i];                                  // best gscore row
     }
-    
+
     return;
 }
 
@@ -1960,6 +2241,9 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
 // ----------------------------------------------------------------------------------
 
 // ------------------------ vec 8 --------------------------------------------------
+// ZSCORE8 is unused in smithWaterman512_8 (z-drop replaced by the wide scalar
+// epilogue, as in the NEON/AVX2 twins); retained here in case a future 512-bit
+// tier reinstates it.
 #define ZSCORE8(i4_512, y4_512)                                         \
     {                                                                   \
         __m512i tmpi = _mm512_sub_epi8(i4_512, x512);                   \
@@ -2282,16 +2566,25 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         if (max < w_match) max = w_match;
         if (max < w_mismatch) max = w_mismatch;
         if (max < w_ambig) max = w_ambig;
-        
+
+        // Initial per-lane score floor B0 = max(0, h0 - REBASE_KEEP_W) (long-read
+        // 8-bit, seed score h0 >= 128). Seeding the H bytes from raw h0 overflows
+        // the signed-int8 score state on row 0, so we seed from the rebaselined
+        // h0' = min(h0, REBASE_KEEP_W) instead (see the per-lane h0 init below).
+        // REBASE_KEEP_W MUST equal the kernel's REBASE_KEEP (bsw8_rebase_keep)
+        // so the two agree on B0; smithWaterman512_8 recomputes B0 via
+        // bsw8_initial_floor(p[].h0, zdrop).
+        const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
+
         int nstart = 0, nend = numPairs;
 
-        
+
 //#pragma omp for schedule(dynamic, 128)
         for(i = nstart; i < nend; i+=SIMD_WIDTH8)
         {
             int32_t j, k;
-            uint16_t maxLen1 = 0;
-            uint8_t maxLen2 = 0;
+            int maxLen1 = 0;
+            int maxLen2 = 0;
             uint8_t minLen1 = MAX_SEQ_LEN8 + 1;
             uint8_t minLen2 = MAX_SEQ_LEN8 + 1;
             bsize = w;
@@ -2305,7 +2598,18 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                     _mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, _MM_HINT_NTA);
                 }
                 SeqPair sp = pairArray[i + j];
-                h0[j] = sp.h0;
+                // Re-baseline the seed score into the int8 byte frame: seed the H
+                // arrays from h0' = h0 - B0 = min(h0, REBASE_KEEP_W) (clamped >= 0)
+                // so the initial bytes fit signed-int8 even when the true seed h0
+                // is several hundred (long-read). smithWaterman512_8 recomputes the
+                // matching B0 = max(0, h0 - REBASE_KEEP) from p[].h0 + zdrop and
+                // starts that lane's floor B there, so byte == H_absolute - B.
+                {
+                    int h0p = sp.h0;
+                    if (h0p > REBASE_KEEP_W) h0p = REBASE_KEEP_W;
+                    if (h0p < 0) h0p = 0;
+                    h0[j] = (uint8_t) h0p;
+                }
                 seq1 = seqBufRef + (int64_t)sp.idr;
 
                 for(k = 0; k < sp.len1; k++)
@@ -2461,15 +2765,15 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 
 void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
                                           uint8_t seq2SoA[],
-                                          uint8_t nrow,
-                                          uint8_t ncol,
+                                          int nrow,
+                                          int ncol,
                                           SeqPair *p,
                                           uint8_t h0[],
                                           uint16_t tid,
                                           int32_t numPairs,
                                           int zdrop,
                                           int32_t w,
-                                          uint8_t qlen[],
+                                          uint8_t qlen[],   // dead parameter (overwritten immediately); remove with call site in a later task
                                           uint8_t myband[])
 {
     __m512i match512     = _mm512_set1_epi8(this->w_match);
@@ -2495,61 +2799,147 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
     int8_t  *H_h = H8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
     int8_t  *H_v = H8__ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
 
-    int lane = 0;
+    int i, j;
 
-    int8_t lowInitValue = LOW_INIT_VALUE;
-    int16_t i, j;
-
-    uint8_t tlen[SIMD_WIDTH8];
     uint8_t tail[SIMD_WIDTH8] __attribute((aligned(64)));
     uint8_t head[SIMD_WIDTH8] __attribute((aligned(64)));
 
     // PR 17: per-row score-vector scratch for fission. Thread-local view
     // into sbt8_ (slab-backed; see constructor) — too large for the stack.
     int8_t *sbt_buf = sbt8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
-    
+
+    // --- DIAGONAL-OFFSET POSITION ENCODING (long-read 8-bit, w<=127) ---
+    // Every per-cell COLUMN position is tracked as the diagonal offset
+    //   d = col - i  in [-w, +w+1]  (fits signed int8 for w <= ~126).
+    // ROW quantities (best row, best-gscore row, qlen, tlen, mlen) exceed
+    // int8 for long reads, so they live in WIDE per-lane int32 side channels
+    // updated O(rows) in the per-row epilogue, not O(cells). Absolute end
+    // coordinates are reconstructed at the result store from the wide row.
+    // Persistent column-offset state (head512/tail512) is shifted by -1 each
+    // row (frame follows i) so the same absolute edge keeps its offset.
+    int32_t tlenw[SIMD_WIDTH8];   // raw target length (rows), wide
+    int32_t qlenw[SIMD_WIDTH8];   // raw query length (cols), wide
+    int32_t mbandw[SIMD_WIDTH8];  // per-lane band width, wide
+    int32_t mlenw[SIMD_WIDTH8];   // min(qlen+myband, tlen), wide row bound
+    int32_t xrow[SIMD_WIDTH8];    // best row for score (== i+1 at capture)
+    int32_t ierow[SIMD_WIDTH8];   // best row for gscore (== i+1 at capture)
+
+    // --- PER-LANE SCORE RE-BASELINING (long-read 8-bit, scores > 127) ---
+    // H/F/E and the score maxima are unsigned 8-bit [0,255], but a 1 kb
+    // alignment scores ~900. To keep the kernel 64-lane (8-bit) we carry a
+    // wide per-lane running FLOOR B[l]: every stored 8-bit score represents
+    // (H_absolute - B[l]). When a lane's row-max climbs toward 255 we raise
+    // B[l] by `delta` and subtract `delta` (saturating, _mm512_subs_epu8) from
+    // every carried score buffer/register for that lane, then add B back when
+    // reconstructing the absolute result.
+    //
+    // SAFETY: subtracting delta saturates cells whose rebaselined value < delta
+    // to 0, i.e. cells that were >= (REBASE_HI - delta) = REBASE_KEEP below the
+    // row max. With REBASE_KEEP > zdrop, any such cell is already beyond the
+    // z-drop horizon (the alignment through it has already z-dropped) and cannot
+    // lead to the optimum, so clamping it to 0 is sound. The per-row max can
+    // climb by at most w_match between two row-end checks (H(i,j) <= H(i-1,j-1)
+    // + w_match), so REBASE_HI must leave >= w_match headroom below 255.
+    //
+    // NB: scores must stay in the SIGNED-positive byte range [0,127]. The DP
+    // recurrence floors cells with cmpeq(h00,0) and the row/global-max trackers
+    // (maxRS1, maxScore512, gscore) compare scores with SIGNED
+    // _mm512_cmpgt_epi8_mask — all of which mis-read a byte >= 128 as negative.
+    // So we re-baseline within [0,127], not [0,255].
+    //
+    // Re-baseline window derived from this kernel's scoring + z-drop, so the
+    // 8-bit score path is correct for ANY valid scoring (not just bench defaults):
+    //   REBASE_KEEP > zdrop      => any cell clamped on re-baseline (>= REBASE_KEEP
+    //                               below the row max) is already past the z-drop
+    //                               horizon, so clamping it to 0 is lossless.
+    //   REBASE_HI + maxStep<=127 => a not-yet-triggered row carries max < REBASE_HI
+    //                               and grows by <= maxStep, so the score byte never
+    //                               exceeds signed-int8 +127 (the floor/max-trackers
+    //                               use signed _mm512_cmpgt_epi8_mask; a byte >=128
+    //                               would be misread as negative and killed).
+    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window exists) is equivalent
+    // to zdrop + maxStep <= 125; the 8-bit routing gate (bwamem.cpp, separate task)
+    // MUST ensure this, else the pair belongs on the 16-bit path.
+    int maxStep = (int)this->w_match;
+    if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
+    if (maxStep < 1) maxStep = 1;
+    const int REBASE_KEEP = zdrop + 1;
+    const int REBASE_HI   = 127 - maxStep;
+    assert(REBASE_HI > REBASE_KEEP &&
+           "8-bit SW re-baseline: zdrop+maxStep>125, scoring outside safe envelope (route to 16-bit)");
+    int32_t B[SIMD_WIDTH8];        // per-lane wide score floor (stored = abs - B)
+    int32_t best_abs[SIMD_WIDTH8]; // running best score in ABSOLUTE units
+    int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end) in ABSOLUTE units
+
+    // --- INITIAL SCORE FLOOR B0 (long-read 8-bit, seed score h0 >= 128) ---
+    // The H arrays are seeded from the seed score h0 (H_v[0]=h0, then gap-
+    // decremented down column 0 and across row 0). For a long-read seed h0 can
+    // be several hundred, which immediately overflows the signed-int8 byte
+    // state before any re-baseline event can fire. So we start each lane's
+    // running floor at B0[l] = max(0, h0 - REBASE_KEEP) instead of 0: the
+    // wrapper seeds the H bytes from h0' = h0 - B0 = min(h0, REBASE_KEEP)
+    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 127), and
+    // here we set B[l] = B0[l] so the stored bytes still mean (H_absolute - B).
+    //
+    // SAFETY (identical argument to the mid-DP re-baseline): the gap-prefix
+    // cells in column 0 / row 0 that fall more than REBASE_KEEP below h0 are
+    // saturated to byte 0 by the wrapper's unsigned-saturating seed. Because
+    // REBASE_KEEP = zdrop+1 > zdrop, any such prefix cell is already beyond the
+    // z-drop horizon below the seed, so an alignment routed through it has
+    // already z-dropped and cannot be optimal -- clamping it to the floor is
+    // lossless. This is the SAME situation that arises mid-DP whenever B>0 after
+    // a re-baseline (byte 0 then means H_absolute == B, not 0), which the
+    // h00==0 local-restart test in MAIN_CODE8_CORE already handles correctly; B0
+    // simply makes B>0 from row 0 instead of from the first re-baseline event.
+    int32_t B0[SIMD_WIDTH8];
+    for (int l=0; l<SIMD_WIDTH8; l++) {
+        B0[l] = bsw8_initial_floor((int)p[l].h0, zdrop);
+    }
+
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH8; l++) {
-        tlen[l] = p[l].len1;
-        qlen[l] = p[l].len2;
+        tlenw[l]  = p[l].len1;
+        qlenw[l]  = p[l].len2;
+        mbandw[l] = myband[l];
+        int ml = qlenw[l] + mbandw[l];
+        if (ml > tlenw[l]) ml = tlenw[l];
+        mlenw[l]  = ml;
+        xrow[l]   = 0;
+        ierow[l]  = 0;
+        B[l]        = B0[l];   // start the floor at B0 so byte state = abs - B0
+        best_abs[l] = p[l].h0; // maxScore512 inits to the h0 seed; record the
+                               // ABSOLUTE seed score (wide), not the rebaselined byte
+        gbest_abs[l]= -1;      // matches the int8 gscore init (-1) in absolute units
         if (p[l].len2 < minq) minq = p[l].len2;
     }
     minq -= 1; // for gscore
 
-    __m512i tlen512   = _mm512_load_si512((__m512i *) tlen);
-    __m512i qlen512   = _mm512_load_si512((__m512i *) qlen);
     __m512i myband512 = _mm512_load_si512((__m512i *) myband);
     __m512i zero512   = _mm512_setzero_si512();
     __m512i one512    = _mm512_set1_epi8(1);
     __m512i two512    = _mm512_set1_epi8(2);
-    __m512i i512_1    = _mm512_set1_epi8(1);
-    __m512i max_ie512 = zero512;
     __m512i ff512     = _mm512_set1_epi8(0xFF);
-    
-    __m512i tail512 = qlen512, head512 = zero512;
+
+    // gscore best-row marker lane: 1 == "this row updated gscore", 0 == earlier
+    // (the actual earlier row is carried in the wide ierow[] side channel).
+    __m512i max_ie512 = zero512;
+
+    // Offset-frame band edges. head_off starts at 0 (col 0 - row 0); tail_off
+    // starts saturated-high (+127) and is immediately clamped by the band-grow
+    // min() against (1+myband) and (qlen-i) on the first row.
+    __m512i head512 = zero512;
+    __m512i tail512 = _mm512_set1_epi8(127);
     _mm512_store_si512((__m512i *) head, head512);
     _mm512_store_si512((__m512i *) tail, tail512);
 
-    __m512i mlen512 = _mm512_add_epi8(qlen512, myband512);
-    mlen512 = _mm512_min_epu8(mlen512, tlen512);
-    
-    uint8_t temp[SIMD_WIDTH8]  __attribute((aligned(64)));
-    uint8_t temp1[SIMD_WIDTH8]  __attribute((aligned(64)));
-    uint8_t temp2[SIMD_WIDTH8]  __attribute((aligned(64)));
-    uint8_t temp3[SIMD_WIDTH8]  __attribute((aligned(64)));
-    
-    __m512i s00  = _mm512_load_si512((__m512i *)(seq1SoA));
     __m512i hval = _mm512_load_si512((__m512i *)(H_v));
-    __mmask64 dmask = 0xFFFFFFFFFFFFFFFF;
-    
-///////
+    __mmask64 dmask = 0xFFFFFFFFFFFFFFFFULL;
+
     __m512i maxScore512 = hval;
     for(j = 0; j < ncol; j++)
         _mm512_store_si512((__m512i *)(F + j * SIMD_WIDTH8), zero512);
-    
-    __m512i x512       = zero512;
-    __m512i y512       = zero512;
-    __m512i i512       = zero512;
+
+    __m512i y512       = zero512;   // best col as diagonal offset: col - i_at_capture (i_at_capture = xrow[l]-1)
     __m512i gscore     = _mm512_set1_epi8(-1);
     __m512i max_off512 = zero512;
     __m512i exit0      = _mm512_set1_epi8(0xFF);
@@ -2569,7 +2959,7 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         __m512i s10 = _mm512_load_si512((__m512i *)(seq1SoA + (i + 0) * SIMD_WIDTH8));
 
         beg = nbeg; end = nend;
-        int pbeg = beg;
+        // Banding
         if (beg < i - w) beg = i - w;
         if (end > i + w + 1) end = i + w + 1;
         if (end > ncol) end = ncol;
@@ -2579,43 +2969,69 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
             h10 = _mm512_load_si512((__m512i *)(H_v + (i+1) * SIMD_WIDTH8));
 
         __m512i j512 = zero512;
-        __m512i maxRS1, maxRS2, maxRS3, maxRS4;
-        maxRS1 = zero512;
+        __m512i maxRS1 = zero512;
 
-        __m512i i1_512 = _mm512_set1_epi8(i+1);
-        __m512i y1_512 = zero512;
-        
-#if RDT 
+        __m512i y1_512 = zero512;   // row-max column as diagonal offset (col - i)
+
+        // gscore best-row marker resets each row (the carried best row lives in
+        // the wide ierow[] side channel; this lane only flags "updated this row").
+        max_ie512 = zero512;
+
+        // Per-row diagonal-offset of the query end: qlen_off = qlen - i. Built
+        // wide then saturated to int8, with a validity mask so an out-of-band
+        // qlen-i (which would wrap and spuriously alias an in-band col offset)
+        // never triggers a false gscore/clamp. qlen_off_valid is true only when
+        // qlen-i lies within the representable band window [-w, w+1].
+        int8_t qlen_off_a[SIMD_WIDTH8]   __attribute((aligned(64)));
+        int8_t qlen_valid_a[SIMD_WIDTH8] __attribute((aligned(64)));
+        int8_t cmpim_a[SIMD_WIDTH8]      __attribute((aligned(64)));
+        for (int l=0; l<SIMD_WIDTH8; l++) {
+            int qoff = qlenw[l] - i;                 // wide
+            int qoff_sat = qoff;                     // saturate to int8 range
+            if (qoff_sat >  127) qoff_sat =  127;
+            if (qoff_sat < -128) qoff_sat = -128;
+            qlen_off_a[l]   = (int8_t) qoff_sat;
+            qlen_valid_a[l] = (qoff >= -w && qoff <= w + 1) ? (int8_t)0xFF : 0;
+            // exit when row i+1 has passed the per-lane effective length bound.
+            cmpim_a[l]      = ((i + 1) > mlenw[l]) ? (int8_t)0xFF : 0;
+        }
+        __m512i qlen_off512   = _mm512_load_si512((__m512i *) qlen_off_a);
+        // qlen_valid as a mask register (high-bit set => in-band query end).
+        __mmask64 qlen_valid_k = _mm512_movepi8_mask(
+                                    _mm512_load_si512((__m512i *) qlen_valid_a));
+
+#if RDT
         uint64_t tim1 = __rdtsc();
 #endif
-        
-        /* Banding */
-        __m512i i512, cache512, max512;
+
+        // Banding (diagonal-offset frame). head512/tail512 arrive here in row-i's
+        // offset frame: the -1 shift at the end of the previous iteration converts
+        // (col - (i-1)) -> (col - i), so no additional adjustment is needed here.
+        //   abs head-grow: head = max(head, i - myband)  ->  head_off = max(head_off, -myband)
+        //   abs tail-clamp: tail = min(tail, (i+1)+myband, qlen)
+        //                                          -> tail_off = min(tail_off, 1+myband, qlen-i)
+        __m512i cache512;
         __m512i phead512 = head512, ptail512 = tail512;
-        i512 = _mm512_set1_epi8(i);
-        cache512 = _mm512_sub_epi8(i512, myband512);
-        head512  = _mm512_max_epi8(head512, cache512);
-        cache512 = _mm512_add_epi8(i1_512, myband512);
-        tail512  = _mm512_min_epu8(tail512, cache512);
-        tail512  = _mm512_min_epu8(tail512, qlen512);
-        /* Banding ends */
-        
+        __m512i negband512 = _mm512_sub_epi8(zero512, myband512);            // -myband
+        head512 = _mm512_max_epi8(head512, negband512);
+        cache512 = _mm512_add_epi8(myband512, one512);                       // 1 + myband
+        tail512 = _mm512_min_epi8(tail512, cache512);
+        tail512 = _mm512_min_epi8(tail512, qlen_off512);
+
         // NEW, trimming.
         __mmask64 cmph = _mm512_cmpeq_epi8_mask(head512, phead512);
         __mmask64 cmpt = _mm512_cmpeq_epi8_mask(tail512, ptail512);
         cmph &= cmpt;
-        
+
         for (int l=beg; l<end && cmph != dmask; l++)
         {
             __m512i h512 = _mm512_load_si512((__m512i *)(H_h + l * SIMD_WIDTH8));
             __m512i f512 = _mm512_load_si512((__m512i *)(F + l * SIMD_WIDTH8));
 
-            __m512i pj512 = _mm512_set1_epi8(l);
-            __m512i j512 = _mm512_set1_epi8(l+1);
+            __m512i pj512 = _mm512_set1_epi8(l - i);   // diagonal offset of column l
             __mmask64 cmp1 = _mm512_cmpgt_epi8_mask(head512, pj512);
             if (cmp1 == 0x00) break;
-            //__mmask64 cmp2 = _mm512_cmpgt_epi8_mask(pj512, tail512);
-            __mmask64 cmp2 = _mm512_cmpgt_epi8_mask(j512, tail512);
+            __mmask64 cmp2 = _mm512_cmpgt_epi8_mask(pj512, tail512);
             cmp1 = cmp1 | cmp2;
             h512 = _mm512_mask_blend_epi8(cmp1, h512, zero512);
             f512 = _mm512_mask_blend_epi8(cmp1, f512, zero512);
@@ -2628,11 +3044,9 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         prof[DP3][0] += __rdtsc() - tim1;
 #endif
 
-        // beg = nbeg; end = nend;
-        __mmask64 cmp512_1 = _mm512_cmpgt_epi8_mask(i1_512, tlen512);
-
-        /* Updating row exit status */
-        __mmask64 cmpim = _mm512_cmpgt_epi8_mask(i1_512, mlen512);
+        // cmpim: lane exits if row i+1 passed its effective length (precomputed
+        // wide into cmpim_a) OR the band collapsed (tail<=head, offset frame).
+        __mmask64 cmpim = _mm512_movepi8_mask(_mm512_load_si512((__m512i *) cmpim_a));
         __mmask64 cmpht = _mm512_cmpeq_epi8_mask(tail512, head512);
         cmpim = cmpim | cmpht;
         // NEW
@@ -2640,11 +3054,11 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         cmpim = cmpim |  cmpht;
 
         exit0 = _mm512_mask_blend_epi8(cmpim, exit0, zero512);
-        
+
 #if RDT
         tim1 = __rdtsc();
 #endif
-        
+
         // PR 17+16: AVX-512 8-bit score pre-pass via LUT.
         for (int jp = beg; jp < end; jp++) {
             __m512i s2 = _mm512_load_si512((__m512i *)(seq2SoA + jp * SIMD_WIDTH8));
@@ -2653,7 +3067,7 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
             _mm512_store_si512((__m512i *)(sbt_buf + jp * SIMD_WIDTH8), sbt11);
         }
 
-        j512 = _mm512_set1_epi8(beg);
+        j512 = _mm512_set1_epi8(beg - i);   // diagonal offset of first band column
         for(j = beg; j < end; j++)
         {
             __m512i f11, f21, f31, f41, f51, jj512, sbt11;
@@ -2692,90 +3106,159 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
 
             h10 = h11;
                         
-            /* gscore calculations */
+            // gscore calculations
             if (j >= minq)
             {
-                __mmask64 cmp = _mm512_cmpeq_epi8_mask(j512, qlen512);
-                __m512i max_gh = _mm512_max_epi8(gscore, h11);
+                // SAFE query-end test: (col - i) == (qlen - i) iff col == qlen,
+                // but only when qlen-i is in-band (else the wrapped/saturated
+                // qlen_off could alias an in-band col offset). Gate with the
+                // validity mask so an out-of-band query end can never match.
+                __mmask64 cmp = _mm512_cmpeq_epi8_mask(j512, qlen_off512);
+                cmp = cmp & qlen_valid_k;
                 __mmask64 cmp_gh = _mm512_cmpgt_epi8_mask(gscore, h11);
-                __m512i tmp512_1 = _mm512_mask_blend_epi8(cmp_gh, i1_512, max_ie512);
+                // Row marker: when h11 beats old gscore, flag "this row" (one512);
+                // otherwise keep the existing marker. The actual best row is
+                // captured into the wide ierow[] side channel in the epilogue.
+                __m512i tmp512_1 = _mm512_mask_blend_epi8(cmp_gh, one512, max_ie512);
+                __m512i max_gh   = _mm512_mask_blend_epi8(cmp_gh, h11, gscore);
 
                 tmp512_1 = _mm512_mask_blend_epi8(cmp, max_ie512, tmp512_1);
+                // exit0: 0xFF=alive; movepi8_mask takes the high bit => mask bit=1 where alive,
+                // so the following mask_blend selects the new value on alive lanes.
                 __mmask64 mex0 = _mm512_movepi8_mask(exit0);
                 tmp512_1 = _mm512_mask_blend_epi8(mex0, max_ie512, tmp512_1);
-                
-                max_gh = _mm512_mask_blend_epi8(mex0, gscore, max_gh);
-                max_gh = _mm512_mask_blend_epi8(cmp, gscore, max_gh);               
 
-                cmp = _mm512_cmpgt_epi8_mask(j512, tail512); 
+                max_gh = _mm512_mask_blend_epi8(mex0, gscore, max_gh);
+                max_gh = _mm512_mask_blend_epi8(cmp, gscore, max_gh);
+
+                cmp = _mm512_cmpgt_epi8_mask(j512, tail512);
                 max_gh = _mm512_mask_blend_epi8(cmp, max_gh, gscore);
                 max_ie512 = _mm512_mask_blend_epi8(cmp, tmp512_1, max_ie512);
                 gscore = max_gh;
             }
         }
-        __mmask64 cmp2 = _mm512_cmpgt_epi8_mask(head512, j512);
-        __mmask64 cmp1 = _mm512_cmpgt_epi8_mask(j512, tail512);
+        __mmask64 cmp1 = _mm512_cmpgt_epi8_mask(head512, j512);
+        __mmask64 cmp2 = _mm512_cmpgt_epi8_mask(j512, tail512);
         cmp1 = cmp1 | cmp2;
         h10 = _mm512_mask_blend_epi8(cmp1, h10, zero512);
-        
+
         _mm512_store_si512((__m512i *)(H_h + j * SIMD_WIDTH8), h10);
         _mm512_store_si512((__m512i *)(F + j * SIMD_WIDTH8), zero512);
-                        
+
         /* exit due to zero score by a row */
-        __mmask64 cval = dmask;
         __m512i bmaxScore512 = maxScore512;
         __mmask64 tmp = _mm512_cmpeq_epi8_mask(maxRS1, zero512);
-        if (cval == tmp) break;
+        if (tmp == dmask) break;
 
         exit0 = _mm512_mask_blend_epi8(tmp, exit0, zero512);
-        //_mm512_store_si512((__m512i *)(temp1), exit0);
-        
+
         __m512i score512 = _mm512_max_epi8(maxScore512, maxRS1);
+        // exit0: 0xFF=alive; movepi8_mask high-bit => mask bit=1 where alive.
         __mmask64 mex0 = _mm512_movepi8_mask(exit0);
         maxScore512 = _mm512_mask_blend_epi8(mex0, maxScore512, score512);
 
         __mmask64 cmp = _mm512_cmpgt_epi8_mask(maxScore512, bmaxScore512);
+        // y512 (best col) stays a diagonal offset captured in the best row's
+        // frame; the best row itself moves to the wide xrow[] side channel.
         y512 = _mm512_mask_blend_epi8(cmp, y512, y1_512);
-        x512 = _mm512_mask_blend_epi8(cmp, x512, i1_512);
-        
-        /* max_off calculations */
-        __m512i ind512 = _mm512_sub_epi8(y1_512, i1_512);
-        ind512 = _mm512_abs_epi8(ind512);
+
+        // max_off = max running diagonal-distance of the row-max from the main
+        // diagonal: |y1col - (i+1)| = |y1_off - 1| in the offset frame.
+        // y1_off - 1 is a SIGNED int8 (negative when row-max is left of the
+        // sub-diagonal), so use _mm512_abs_epi8.
+        __m512i y1_minus1 = _mm512_sub_epi8(y1_512, one512);
+        __m512i ind512 = _mm512_abs_epi8(y1_minus1);          // |y1_off - 1|
         __m512i bmax_off512 = max_off512;
         ind512 = _mm512_max_epi8(max_off512, ind512);
         max_off512 = _mm512_mask_blend_epi8(cmp, bmax_off512, ind512);
 
-        /* Z-score condition for exit */
-        ZSCORE8(i1_512, y1_512);        
-        
+        // Per-lane wide updates (O(rows)): best-score row (xrow), best-gscore
+        // row (ierow), absolute-frame score tracking, and the z-drop test — all
+        // done in wide scalars so row distances that exceed int8 for long reads
+        // are handled exactly.
+        {
+            int8_t  cmp_a[SIMD_WIDTH8]      __attribute((aligned(64)));
+            int8_t  y1_a[SIMD_WIDTH8]       __attribute((aligned(64)));
+            int8_t  y_a[SIMD_WIDTH8]        __attribute((aligned(64)));
+            int8_t  ms_a[SIMD_WIDTH8]       __attribute((aligned(64)));
+            int8_t  rs_a[SIMD_WIDTH8]       __attribute((aligned(64)));
+            int8_t  exit_a[SIMD_WIDTH8]     __attribute((aligned(64)));
+            int8_t  ie_mark_a[SIMD_WIDTH8]  __attribute((aligned(64)));
+            int8_t  gs_a[SIMD_WIDTH8]       __attribute((aligned(64)));
+            // cmp/exit0 are mask registers here; materialize them as 0xFF/0x00
+            // byte vectors so the wide scalar loop can branch on them.
+            _mm512_store_si512((__m512i *) cmp_a,
+                               _mm512_maskz_set1_epi8(cmp, (char)0xFF));
+            _mm512_store_si512((__m512i *) y1_a, y1_512);
+            _mm512_store_si512((__m512i *) y_a, y512);
+            _mm512_store_si512((__m512i *) ms_a, maxScore512);
+            _mm512_store_si512((__m512i *) rs_a, maxRS1);
+            _mm512_store_si512((__m512i *) exit_a, exit0);
+            _mm512_store_si512((__m512i *) ie_mark_a, max_ie512);
+            _mm512_store_si512((__m512i *) gs_a, gscore);
+            for (int l = 0; l < SIMD_WIDTH8; l++) {
+                // best-score row
+                if (cmp_a[l]) xrow[l] = i + 1;
+                // best-gscore row: marker==1 means gscore was set this row
+                if (ie_mark_a[l] == 1) ierow[l] = i + 1;
+                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore512/gscore are
+                // in the lane's CURRENT B[l] frame, so the absolute value is the
+                // rebaselined byte + B[l]. Re-derive both every row (cheap, O(rows))
+                // rather than trying to add B back once at the end (the recorded
+                // max may pre-date later B bumps). max() guards against the byte
+                // being re-baselined away in a later row.
+                {
+                    int ms_abs = (int)(uint8_t)ms_a[l] + B[l];
+                    if (ms_abs > best_abs[l]) best_abs[l] = ms_abs;
+                    // gscore init is -1 (0xFF as a byte); treat that as "unset".
+                    if ((uint8_t)gs_a[l] != 0xFF) {
+                        int gs_abs = (int)(uint8_t)gs_a[l] + B[l];
+                        if (gs_abs > gbest_abs[l]) gbest_abs[l] = gs_abs;
+                    }
+                }
+                // z-drop (only relevant where the lane is still alive). The drop
+                // is ms-rs of two bytes in the SAME B[l] frame, so the B cancels
+                // and the comparison is already in ABSOLUTE score units.
+                if (exit_a[l]) {
+                    int xr  = xrow[l];                       // best row
+                    int y1c = (int) y1_a[l] + i;             // row-max col (abs)
+                    int yc  = (int) y_a[l] + (xr - 1);       // best col (abs)
+                    int tmpi = (i + 1) - xr;
+                    int tmpj = y1c - yc;
+                    int dif  = tmpi > tmpj ? (tmpi - tmpj) : (tmpj - tmpi);
+                    int drop = (int)(uint8_t)ms_a[l] - (int)(uint8_t)rs_a[l];
+                    if (drop - dif > zdrop) exit_a[l] = 0;
+                }
+            }
+            exit0 = _mm512_load_si512((__m512i *) exit_a);
+        }
+
 #if RDT
         prof[DP1][0] += __rdtsc() - tim1;
 #endif
-        
+
         /* Narrowing of the band */
-        /* Part 1: From beg */
-        cval = dmask;
-        int l;      
+        /* From beg */
+        int l;
         for (l = beg; l < end; l++)
         {
             __m512i f512 = _mm512_load_si512((__m512i *)(F + l * SIMD_WIDTH8));
             __m512i h512 = _mm512_load_si512((__m512i *)(H_h + l * SIMD_WIDTH8));
             __m512i tmp = _mm512_or_si512(f512, h512);
             __mmask64 val = _mm512_cmpeq_epi8_mask(tmp, zero512);
-            if (cval == val) nbeg = l;
+            if (val == dmask) nbeg = l;
             else
                 break;
         }
-        
+
         /* From end */
-        bool flg = 1;
         for (l = end; l >= beg; l--)
         {
             __m512i f512 = _mm512_load_si512((__m512i *)(F + l * SIMD_WIDTH8));
             __m512i h512 = _mm512_load_si512((__m512i *)(H_h + l * SIMD_WIDTH8));
             __m512i tmp = _mm512_or_si512(f512, h512);
             __mmask64 val = _mm512_cmpeq_epi8_mask(tmp, zero512);
-            if (val != cval && flg)  
+            if (val != dmask)
                 break;
         }
         nend = l + 2 < ncol? l + 2: ncol;
@@ -2783,43 +3266,40 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
 #if RDT
         tim1 = __rdtsc();
 #endif
-        /* Setting of head and tail for each pair */
-        __m512i tail512_ = _mm512_sub_epi8(tail512, one512);
-        //__m512i tail512_ = _mm512_sub_epi8(tail512, zero512);
+
         __m512i exit1 = _mm512_xor_si512(exit0, ff512);
         __mmask64 tmpb = dmask;
-        __m512i l512 = _mm512_set1_epi8(beg);
-        
+        __m512i l512 = _mm512_set1_epi8(beg - i);   // diagonal offset of column beg
+
         for (l = beg; l < end; l++)
         {
             __m512i f512 = _mm512_load_si512((__m512i *)(F + l * SIMD_WIDTH8));
-            __m512i h512 = _mm512_load_si512((__m512i *)(H_h + l * SIMD_WIDTH8));   
+            __m512i h512 = _mm512_load_si512((__m512i *)(H_h + l * SIMD_WIDTH8));
             __m512i tmp_ = _mm512_or_si512(f512, h512);
-            tmp_ = _mm512_or_si512(tmp_, exit1);            
+            tmp_ = _mm512_or_si512(tmp_, exit1);
             __mmask64 tmp = _mm512_cmpeq_epi8_mask(tmp_, zero512);
             if (tmp == 0x00) {
                 break;
             }
-            
+
             tmp = tmp & tmpb;
             l512 = _mm512_add_epi8(l512, one512);
             // NEW
             head512 = _mm512_mask_blend_epi8(tmp, head512, l512);
-
-            tmpb = tmp;         
+            tmpb = tmp;
         }
-        
+
         __m512i  index512 = tail512;
         tmpb = dmask;
-        l512 = _mm512_set1_epi8(end);
-        
+        l512 = _mm512_set1_epi8(end - i);   // diagonal offset of column end
+
         for (l = end; l >= beg; l--)
         {
             __m512i f512 = _mm512_load_si512((__m512i *)(F + l * SIMD_WIDTH8));
-            __m512i h512 = _mm512_load_si512((__m512i *)(H_h + l * SIMD_WIDTH8));           
+            __m512i h512 = _mm512_load_si512((__m512i *)(H_h + l * SIMD_WIDTH8));
             __m512i tmp_ = _mm512_or_si512(f512, h512);
             tmp_ = _mm512_or_si512(tmp_, exit1);
-            __mmask64 tmp = _mm512_cmpeq_epi8_mask(tmp_, zero512);          
+            __mmask64 tmp = _mm512_cmpeq_epi8_mask(tmp_, zero512);
             if (tmp == 0x00)  {
                 break;
             }
@@ -2828,12 +3308,84 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
             l512 = _mm512_sub_epi8(l512, one512);
             // NEW
             index512 = _mm512_mask_blend_epi8(tmp, index512, l512);
-
-            //l512 = _mm512_sub_epi8(l512, one512);
             tmpb = tmp;
         }
         index512 = _mm512_add_epi8(index512, two512);
-        tail512 = _mm512_min_epi8(index512, qlen512);
+        // signed min in the offset frame against qlen-i
+        tail512 = _mm512_min_epi8(index512, qlen_off512);
+
+        // Frame shift for the next row: i advances by 1, so the same absolute
+        // band edge has its diagonal offset (col - i) decremented by 1. Keep
+        // head/tail tracking the same columns as the frame moves.
+        head512 = _mm512_sub_epi8(head512, one512);
+        tail512 = _mm512_sub_epi8(tail512, one512);
+
+        // --- RE-BASELINE EVENT (per-lane score floor) ---
+        // After this row's score state is final, lower any lane whose row-max
+        // (maxRS1, rebaselined) has climbed to REBASE_HI back into range. We
+        // raise B[l] by delta = maxRS1[l] - REBASE_KEEP and subtract that delta
+        // (saturating to 0) from every carried score buffer/register for that
+        // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
+        // reference; the next row reads the lowered values consistently.
+        {
+            uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(64)));
+            _mm512_store_si512((__m512i *) rs_b, maxRS1);
+            int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(64)));
+            int any = 0;
+            for (int l = 0; l < SIMD_WIDTH8; l++) {
+                int d = 0;
+                if ((int)rs_b[l] >= REBASE_HI) {
+                    d = (int)rs_b[l] - REBASE_KEEP;   // keep low REBASE_KEEP, in range
+                    B[l] += d;
+                    any = 1;
+                }
+                delta_a[l] = (int8_t) d;              // 0..(REBASE_HI-REBASE_KEEP) small
+            }
+            if (any) {
+                __m512i delta512 = _mm512_load_si512((__m512i *) delta_a);
+                // Subtract delta from every carried score buffer over the active
+                // band columns. The range [lo,hi] is the union of the current and
+                // next band windows; clamping to [0, ncol-1] keeps the loop within
+                // the valid column range (a safe superset covering every column the
+                // next row will read).
+                int lo = nbeg < beg ? nbeg : beg;
+                int hi = nend > end ? nend : end;
+                if (lo < 0) lo = 0;
+                if (hi + 1 > ncol) hi = ncol - 1;
+                for (int l = lo; l <= hi; l++) {
+                    __m512i h512 = _mm512_load_si512((__m512i *)(H_h + l * SIMD_WIDTH8));
+                    __m512i f512 = _mm512_load_si512((__m512i *)(F   + l * SIMD_WIDTH8));
+                    h512 = _mm512_subs_epu8(h512, delta512);
+                    f512 = _mm512_subs_epu8(f512, delta512);
+                    _mm512_store_si512((__m512i *)(H_h + l * SIMD_WIDTH8), h512);
+                    _mm512_store_si512((__m512i *)(F   + l * SIMD_WIDTH8), f512);
+                }
+                // The vertical seed H_v is read only while the band still touches
+                // column 0 (beg==0). Lower the rows that may still be consumed.
+                if (beg == 0) {
+                    for (int r = i + 1; r < nrow; r++) {
+                        __m512i v512 = _mm512_load_si512((__m512i *)(H_v + r * SIMD_WIDTH8));
+                        v512 = _mm512_subs_epu8(v512, delta512);
+                        _mm512_store_si512((__m512i *)(H_v + r * SIMD_WIDTH8), v512);
+                    }
+                }
+                // Carried score maxima (registers) live in the same rebaselined
+                // frame and must be lowered too so the next row's z-drop (ms-rs)
+                // and the absolute-frame add-back stay consistent. maxScore512 is
+                // the running max, so it never saturates to 0 (maxScore512 >=
+                // maxRS1 for the triggering row, and maxRS1 >= REBASE_HI >
+                // REBASE_KEEP > delta, so it stays positive).
+                maxScore512 = _mm512_subs_epu8(maxScore512, delta512);
+                // gscore: keep the -1 (0xFF) "unset" sentinel intact, but lower
+                // set lanes (it is compared SIGNED against the rebaselined h11 in
+                // the gscore block, so it must track the same frame). Zero the
+                // delta for lanes whose gscore is still 0xFF.
+                __mmask64 gset = _mm512_cmpeq_epi8_mask(gscore, ff512); // 1 where gscore unset (0xFF)
+                // gdelta = delta only where gscore is set (mask off unset lanes).
+                __m512i gdelta = _mm512_maskz_mov_epi8(~gset, delta512);
+                gscore = _mm512_subs_epu8(gscore, gdelta);
+            }
+        }
 
 #if RDT
         prof[DP2][0] += __rdtsc() - tim1;
@@ -2843,35 +3395,30 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
 #if RDT
     prof[DP][0] += __rdtsc() - tim;
 #endif
-    
-    int8_t score[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm512_store_si512((__m512i *) score, maxScore512);
 
-    int8_t maxi[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm512_store_si512((__m512i *) maxi, x512);
-
+    // Scores are reconstructed in ABSOLUTE units from the per-lane wide
+    // best_abs/gbest_abs side channels (= rebaselined byte + B[l], captured each
+    // row before any later re-baseline could saturate the byte away). Positions
+    // are reconstructed wide from the diagonal-offset lanes plus the per-lane
+    // best-row side channels.
     int8_t maxj[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm512_store_si512((__m512i *) maxj, y512);
+    _mm512_store_si512((__m512i *) maxj, y512);   // best col as diagonal offset
 
     int8_t max_off_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
     _mm512_store_si512((__m512i *) max_off_ar, max_off512);
 
-    int8_t gscore_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm512_store_si512((__m512i *) gscore_ar, gscore);
-
-    int8_t maxie_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm512_store_si512((__m512i *) maxie_ar, max_ie512);
-    
     for(i = 0; i < SIMD_WIDTH8; i++)
     {
-        p[i].score = score[i];
-        p[i].tle = maxi[i];
-        p[i].qle = maxj[i];
-        p[i].max_off = max_off_ar[i];
-        p[i].gscore = gscore_ar[i];
-        p[i].gtle = maxie_ar[i];
+        p[i].score   = best_abs[i];                               // absolute score
+        p[i].tle     = xrow[i];                                   // best row (target end)
+        // qle reconstruction: maxj[l] = col - (xrow-1), so col = maxj[l] + (xrow-1).
+        // Guard the unset case (xrow==0 means no update occurred).
+        p[i].qle     = (xrow[i] == 0) ? 0 : ((int) maxj[i] + xrow[i] - 1);
+        p[i].max_off = (uint8_t) max_off_ar[i];
+        p[i].gscore  = gbest_abs[i];                              // absolute gscore (-1 if unset)
+        p[i].gtle    = ierow[i];                                  // best gscore row
     }
-    
+
     return;
 }
 //----------------------------AVX512 vec 16 bit SIMD lane -------------------------------------
@@ -4512,20 +5059,6 @@ static inline __m128i _mm_blendv_epi8 (__m128i x, __m128i y, __m128i mask)
         f21 = _mm_max_epu8(temp128, f21);                               \
     }
 
-
-// ---------------------------------------------------------------------------
-// 8-bit re-baseline floor helpers (shared by wrapper + every SIMD kernel tier)
-//
-// Initial 8-bit score floor: keep the seed score h0 inside the re-baseline
-// keep-window so the stored byte (= H_abs - B) never overflows signed int8.
-// Clamping prefixes >REBASE_KEEP below h0 is lossless (REBASE_KEEP=zdrop+1 >
-// zdrop => already past the z-drop horizon). MUST be used by every SIMD tier.
-static inline int bsw8_rebase_keep(int zdrop)            { return zdrop + 1; }
-static inline int bsw8_initial_floor(int h0, int zdrop) {
-    int b0 = h0 - bsw8_rebase_keep(zdrop);
-    return b0 > 0 ? b0 : 0;
-}
-// ---------------------------------------------------------------------------
 
 // #define PFD 2 // SSE2
 void BandedPairWiseSW::getScores8(SeqPair *pairArray,

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -110,8 +110,8 @@ BandedPairWiseSW::BandedPairWiseSW(const int o_del, const int e_del, const int o
     //   1 × sz8  : sbt8_                (8-bit SBT pre-pass scratch)
     //   1 × sz16 : sbt16_               (16-bit SBT pre-pass scratch;
     //                                    multi-MB — moved off the stack)
-    // Each partition is a multiple of 64B (MAX_SEQ_LEN8=128, SIMD_WIDTH8
-    // ≥ 16 → 8-bit partition multiple of 2048; 16-bit similarly), so
+    // Each partition is a multiple of 64B (MAX_SEQ_LEN8=1088, SIMD_WIDTH8
+    // ≥ 16 → 8-bit partition multiple of 17408; 16-bit similarly), so
     // neighbouring views stay 64B-aligned without explicit padding. The
     // static_asserts below trip at compile time if a future MAX_SEQ_LEN*
     // / SIMD_WIDTH* tweak breaks the 64B partition invariant.

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -1014,9 +1014,9 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     __m256i two256  = _mm256_set1_epi8(2);
     __m256i ff256 = _mm256_set1_epi8(0xFF);
 
-    // gscore best-row marker lane: 1 == "this row updated gscore", 0 == earlier
-    // (the actual earlier row is carried in the wide ierow[] side channel).
-    __m256i max_ie256 = zero256;
+    // gscore query-end capture (see smithWaterman128_8). Reset per row.
+    __m256i hqe256   = zero256;   // query-end cell H (rebaselined byte) this row
+    __m256i qfire256 = zero256;   // 0xFF where this lane reached its query end this row
 
     // Offset-frame band edges. head_off starts at 0 (col 0 - row 0); tail_off
     // starts saturated-high (+127) and is immediately clamped by the band-grow
@@ -1034,7 +1034,6 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         _mm256_store_si256((__m256i *)(F + j * SIMD_WIDTH8), zero256);
 
     __m256i y256 = zero256;   // best col as diagonal offset: col - i_at_capture (i_at_capture = xrow[l]-1)
-    __m256i gscore = _mm256_set1_epi8(-1);
     __m256i max_off256 = zero256;
     __m256i exit0 = _mm256_set1_epi8(0xFF);
     __m256i zdrop256 = _mm256_set1_epi8(zdrop);
@@ -1067,9 +1066,9 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
 
         __m256i y1_256 = zero256;   // row-max column as diagonal offset (col - i)
 
-        // gscore best-row marker resets each row (the carried best row lives in
-        // the wide ierow[] side channel; this lane only flags "updated this row").
-        max_ie256 = zero256;
+        // gscore query-end capture resets each row.
+        hqe256   = zero256;
+        qfire256 = zero256;
 
         // Per-row diagonal-offset of the query end: qlen_off = qlen - i. Built
         // wide then saturated to int8, with a validity mask so an out-of-band
@@ -1205,32 +1204,21 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
 
             h10 = h11;
 
-            // gscore calculations
+            // gscore query-end capture (see smithWaterman128_8 for the full
+            // rationale: the re-baseline saturating-subtract zeroes off-diagonal
+            // query-end cells, so gscore cannot be reconstructed from the trimmed
+            // tail; capture (byte+B) per row and finalize wide). Fire exactly like
+            // the byte-identical 16-bit tier: col == qlen-1 (j256 == qlen_off) AND
+            // the band-grown tail reached the query end (tail256 == qlen_off ==
+            // scalar's end == qlen) AND in-band (qlen_valid) AND lane alive (exit0).
             if (j >= minq)
             {
-                // SAFE query-end test: (col - i) == (qlen - i) iff col == qlen,
-                // but only when qlen-i is in-band (else the wrapped/saturated
-                // qlen_off could alias an in-band col offset). Gate with the
-                // validity mask so an out-of-band query end can never match.
                 __m256i cmp = _mm256_cmpeq_epi8(j256, qlen_off256);
+                cmp = _mm256_and_si256(cmp, _mm256_cmpeq_epi8(tail256, qlen_off256));
                 cmp = _mm256_and_si256(cmp, qlen_valid256);
-                __m256i cmp_gh = _mm256_cmpgt_epi8(gscore, h11);
-                // Row marker: when h11 beats old gscore, flag "this row" (one256);
-                // otherwise keep the existing marker. The actual best row is
-                // captured into the wide ierow[] side channel in the epilogue.
-                __m256i tmp256_1 = _mm256_blendv_epi8(one256, max_ie256, cmp_gh);
-                __m256i max_gh = _mm256_blendv_epi8(h11, gscore, cmp_gh);
-
-                tmp256_1 = _mm256_blendv_epi8(max_ie256, tmp256_1, cmp);
-                tmp256_1 = _mm256_blendv_epi8(max_ie256, tmp256_1, exit0);
-
-                max_gh = _mm256_blendv_epi8(gscore, max_gh, exit0);
-                max_gh = _mm256_blendv_epi8(gscore, max_gh, cmp);
-
-                cmp = _mm256_cmpgt_epi8(j256, tail256);
-                max_gh = _mm256_blendv_epi8(max_gh, gscore, cmp);
-                max_ie256 = _mm256_blendv_epi8(tmp256_1, max_ie256, cmp);
-                gscore = max_gh;
+                cmp = _mm256_and_si256(cmp, exit0);
+                hqe256   = _mm256_blendv_epi8(hqe256, h11, cmp);
+                qfire256 = _mm256_blendv_epi8(qfire256, ff256, cmp);
             }
         }
         __m256i cmp1 = _mm256_cmpgt_epi8(head256, j256);
@@ -1280,35 +1268,32 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
             int8_t  ms_a[SIMD_WIDTH8]       __attribute((aligned(32)));
             int8_t  rs_a[SIMD_WIDTH8]       __attribute((aligned(32)));
             int8_t  exit_a[SIMD_WIDTH8]     __attribute((aligned(32)));
-            int8_t  ie_mark_a[SIMD_WIDTH8]  __attribute((aligned(32)));
-            int8_t  gs_a[SIMD_WIDTH8]       __attribute((aligned(32)));
+            int8_t  qfire_a[SIMD_WIDTH8]    __attribute((aligned(32)));
+            int8_t  hqe_a[SIMD_WIDTH8]      __attribute((aligned(32)));
             _mm256_store_si256((__m256i *) cmp_a, cmp);
             _mm256_store_si256((__m256i *) y1_a, y1_256);
             _mm256_store_si256((__m256i *) y_a, y256);
             _mm256_store_si256((__m256i *) ms_a, maxScore256);
             _mm256_store_si256((__m256i *) rs_a, maxRS1);
             _mm256_store_si256((__m256i *) exit_a, exit0);
-            _mm256_store_si256((__m256i *) ie_mark_a, max_ie256);
-            _mm256_store_si256((__m256i *) gs_a, gscore);
+            _mm256_store_si256((__m256i *) qfire_a, qfire256);
+            _mm256_store_si256((__m256i *) hqe_a, hqe256);
             for (int l = 0; l < SIMD_WIDTH8; l++) {
                 // best-score row
                 if (cmp_a[l]) xrow[l] = i + 1;
-                // best-gscore row: marker==1 means gscore was set this row
-                if (ie_mark_a[l] == 1) ierow[l] = i + 1;
-                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore256/gscore are
-                // in the lane's CURRENT B[l] frame, so the absolute value is the
-                // rebaselined byte + B[l]. Re-derive both every row (cheap, O(rows))
-                // rather than trying to add B back once at the end (the recorded
-                // max may pre-date later B bumps). max() guards against the byte
-                // being re-baselined away in a later row.
+                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore256 is in the
+                // lane's CURRENT B[l] frame; absolute = rebaselined byte + B[l].
                 {
                     int ms_abs = (int)(uint8_t)ms_a[l] + B[l];
                     if (ms_abs > best_abs[l]) best_abs[l] = ms_abs;
-                    // gscore init is -1 (0xFF as a byte); treat that as "unset".
-                    if ((uint8_t)gs_a[l] != 0xFF) {
-                        int gs_abs = (int)(uint8_t)gs_a[l] + B[l];
-                        if (gs_abs > gbest_abs[l]) gbest_abs[l] = gs_abs;
-                    }
+                }
+                // gscore (query-end score): qfire flags this lane reached its query
+                // end this row; hqe is the captured query-end cell H (byte, B[l]
+                // frame); absolute = byte + B[l]. Scalar's `>=` tie-break (last
+                // max-achieving row wins gtle). See smithWaterman128_8.
+                if (qfire_a[l]) {
+                    int gs_abs = (int)(uint8_t)hqe_a[l] + B[l];
+                    if (gs_abs >= gbest_abs[l]) { gbest_abs[l] = gs_abs; ierow[l] = i + 1; }
                 }
                 // z-drop (only relevant where the lane is still alive). The drop
                 // is ms-rs of two bytes in the SAME B[l] frame, so the B cancels
@@ -1473,13 +1458,10 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
                 // maxRS1 for the triggering row, and maxRS1 >= REBASE_HI >
                 // REBASE_KEEP > delta, so it stays positive).
                 maxScore256 = _mm256_subs_epu8(maxScore256, delta256);
-                // gscore: keep the -1 (0xFF) "unset" sentinel intact, but lower
-                // set lanes (it is compared SIGNED against the rebaselined h11 in
-                // the gscore block, so it must track the same frame). Zero the
-                // delta for lanes whose gscore is still 0xFF.
-                __m256i gset = _mm256_cmpeq_epi8(gscore, ff256);   // 0xFF where unset
-                __m256i gdelta = _mm256_andnot_si256(gset, delta256);
-                gscore = _mm256_subs_epu8(gscore, gdelta);
+                // gscore no longer carries a rebaselined byte register: the
+                // query-end cell H is captured per row and accumulated wide
+                // (gbest_abs, absolute units) in the epilogue, immune to this
+                // re-baseline subtract.
             }
         }
 
@@ -2920,9 +2902,9 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
     __m512i two512    = _mm512_set1_epi8(2);
     __m512i ff512     = _mm512_set1_epi8(0xFF);
 
-    // gscore best-row marker lane: 1 == "this row updated gscore", 0 == earlier
-    // (the actual earlier row is carried in the wide ierow[] side channel).
-    __m512i max_ie512 = zero512;
+    // gscore query-end capture (see smithWaterman128_8). Reset per row.
+    __m512i hqe512   = zero512;   // query-end cell H (rebaselined byte) this row
+    __m512i qfire512 = zero512;   // 0xFF where this lane reached its query end this row
 
     // Offset-frame band edges. head_off starts at 0 (col 0 - row 0); tail_off
     // starts saturated-high (+127) and is immediately clamped by the band-grow
@@ -2940,7 +2922,6 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         _mm512_store_si512((__m512i *)(F + j * SIMD_WIDTH8), zero512);
 
     __m512i y512       = zero512;   // best col as diagonal offset: col - i_at_capture (i_at_capture = xrow[l]-1)
-    __m512i gscore     = _mm512_set1_epi8(-1);
     __m512i max_off512 = zero512;
     __m512i exit0      = _mm512_set1_epi8(0xFF);
     __m512i zdrop512   = _mm512_set1_epi8(zdrop);
@@ -2973,9 +2954,9 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
 
         __m512i y1_512 = zero512;   // row-max column as diagonal offset (col - i)
 
-        // gscore best-row marker resets each row (the carried best row lives in
-        // the wide ierow[] side channel; this lane only flags "updated this row").
-        max_ie512 = zero512;
+        // gscore query-end capture resets each row.
+        hqe512   = zero512;
+        qfire512 = zero512;
 
         // Per-row diagonal-offset of the query end: qlen_off = qlen - i. Built
         // wide then saturated to int8, with a validity mask so an out-of-band
@@ -3106,35 +3087,19 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
 
             h10 = h11;
                         
-            // gscore calculations
+            // gscore query-end capture (see smithWaterman128_8). Fire exactly like
+            // the byte-identical 16-bit tier: col == qlen-1 (j512 == qlen_off) AND
+            // band-grown tail reached the query end (tail512 == qlen_off == scalar's
+            // end == qlen) AND in-band (qlen_valid) AND lane alive (exit0 high bit).
+            // mask_blend(k, a, b) selects b where k, a where ~k.
             if (j >= minq)
             {
-                // SAFE query-end test: (col - i) == (qlen - i) iff col == qlen,
-                // but only when qlen-i is in-band (else the wrapped/saturated
-                // qlen_off could alias an in-band col offset). Gate with the
-                // validity mask so an out-of-band query end can never match.
                 __mmask64 cmp = _mm512_cmpeq_epi8_mask(j512, qlen_off512);
+                cmp = cmp & _mm512_cmpeq_epi8_mask(tail512, qlen_off512);
                 cmp = cmp & qlen_valid_k;
-                __mmask64 cmp_gh = _mm512_cmpgt_epi8_mask(gscore, h11);
-                // Row marker: when h11 beats old gscore, flag "this row" (one512);
-                // otherwise keep the existing marker. The actual best row is
-                // captured into the wide ierow[] side channel in the epilogue.
-                __m512i tmp512_1 = _mm512_mask_blend_epi8(cmp_gh, one512, max_ie512);
-                __m512i max_gh   = _mm512_mask_blend_epi8(cmp_gh, h11, gscore);
-
-                tmp512_1 = _mm512_mask_blend_epi8(cmp, max_ie512, tmp512_1);
-                // exit0: 0xFF=alive; movepi8_mask takes the high bit => mask bit=1 where alive,
-                // so the following mask_blend selects the new value on alive lanes.
-                __mmask64 mex0 = _mm512_movepi8_mask(exit0);
-                tmp512_1 = _mm512_mask_blend_epi8(mex0, max_ie512, tmp512_1);
-
-                max_gh = _mm512_mask_blend_epi8(mex0, gscore, max_gh);
-                max_gh = _mm512_mask_blend_epi8(cmp, gscore, max_gh);
-
-                cmp = _mm512_cmpgt_epi8_mask(j512, tail512);
-                max_gh = _mm512_mask_blend_epi8(cmp, max_gh, gscore);
-                max_ie512 = _mm512_mask_blend_epi8(cmp, tmp512_1, max_ie512);
-                gscore = max_gh;
+                cmp = cmp & _mm512_movepi8_mask(exit0);
+                hqe512   = _mm512_mask_blend_epi8(cmp, hqe512, h11);
+                qfire512 = _mm512_mask_blend_epi8(cmp, qfire512, ff512);
             }
         }
         __mmask64 cmp1 = _mm512_cmpgt_epi8_mask(head512, j512);
@@ -3183,8 +3148,8 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
             int8_t  ms_a[SIMD_WIDTH8]       __attribute((aligned(64)));
             int8_t  rs_a[SIMD_WIDTH8]       __attribute((aligned(64)));
             int8_t  exit_a[SIMD_WIDTH8]     __attribute((aligned(64)));
-            int8_t  ie_mark_a[SIMD_WIDTH8]  __attribute((aligned(64)));
-            int8_t  gs_a[SIMD_WIDTH8]       __attribute((aligned(64)));
+            int8_t  qfire_a[SIMD_WIDTH8]    __attribute((aligned(64)));
+            int8_t  hqe_a[SIMD_WIDTH8]      __attribute((aligned(64)));
             // cmp/exit0 are mask registers here; materialize them as 0xFF/0x00
             // byte vectors so the wide scalar loop can branch on them.
             _mm512_store_si512((__m512i *) cmp_a,
@@ -3194,27 +3159,24 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
             _mm512_store_si512((__m512i *) ms_a, maxScore512);
             _mm512_store_si512((__m512i *) rs_a, maxRS1);
             _mm512_store_si512((__m512i *) exit_a, exit0);
-            _mm512_store_si512((__m512i *) ie_mark_a, max_ie512);
-            _mm512_store_si512((__m512i *) gs_a, gscore);
+            _mm512_store_si512((__m512i *) qfire_a, qfire512);
+            _mm512_store_si512((__m512i *) hqe_a, hqe512);
             for (int l = 0; l < SIMD_WIDTH8; l++) {
                 // best-score row
                 if (cmp_a[l]) xrow[l] = i + 1;
-                // best-gscore row: marker==1 means gscore was set this row
-                if (ie_mark_a[l] == 1) ierow[l] = i + 1;
-                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore512/gscore are
-                // in the lane's CURRENT B[l] frame, so the absolute value is the
-                // rebaselined byte + B[l]. Re-derive both every row (cheap, O(rows))
-                // rather than trying to add B back once at the end (the recorded
-                // max may pre-date later B bumps). max() guards against the byte
-                // being re-baselined away in a later row.
+                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore512 is in the
+                // lane's CURRENT B[l] frame; absolute = rebaselined byte + B[l].
                 {
                     int ms_abs = (int)(uint8_t)ms_a[l] + B[l];
                     if (ms_abs > best_abs[l]) best_abs[l] = ms_abs;
-                    // gscore init is -1 (0xFF as a byte); treat that as "unset".
-                    if ((uint8_t)gs_a[l] != 0xFF) {
-                        int gs_abs = (int)(uint8_t)gs_a[l] + B[l];
-                        if (gs_abs > gbest_abs[l]) gbest_abs[l] = gs_abs;
-                    }
+                }
+                // gscore (query-end score): qfire flags this lane reached its query
+                // end this row; hqe is the captured query-end cell H (byte, B[l]
+                // frame); absolute = byte + B[l]. Scalar's `>=` tie-break. See
+                // smithWaterman128_8.
+                if (qfire_a[l]) {
+                    int gs_abs = (int)(uint8_t)hqe_a[l] + B[l];
+                    if (gs_abs >= gbest_abs[l]) { gbest_abs[l] = gs_abs; ierow[l] = i + 1; }
                 }
                 // z-drop (only relevant where the lane is still alive). The drop
                 // is ms-rs of two bytes in the SAME B[l] frame, so the B cancels
@@ -3376,14 +3338,10 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
                 // maxRS1 for the triggering row, and maxRS1 >= REBASE_HI >
                 // REBASE_KEEP > delta, so it stays positive).
                 maxScore512 = _mm512_subs_epu8(maxScore512, delta512);
-                // gscore: keep the -1 (0xFF) "unset" sentinel intact, but lower
-                // set lanes (it is compared SIGNED against the rebaselined h11 in
-                // the gscore block, so it must track the same frame). Zero the
-                // delta for lanes whose gscore is still 0xFF.
-                __mmask64 gset = _mm512_cmpeq_epi8_mask(gscore, ff512); // 1 where gscore unset (0xFF)
-                // gdelta = delta only where gscore is set (mask off unset lanes).
-                __m512i gdelta = _mm512_maskz_mov_epi8(~gset, delta512);
-                gscore = _mm512_subs_epu8(gscore, gdelta);
+                // gscore no longer carries a rebaselined byte register: the
+                // query-end cell H is captured per row and accumulated wide
+                // (gbest_abs, absolute units) in the epilogue, immune to this
+                // re-baseline subtract.
             }
         }
 
@@ -5527,9 +5485,16 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     __m128i two128    = _mm_set1_epi8(2);
     __m128i ff128     = _mm_set1_epi8(0xFF);
 
-    // gscore best-row marker lane: 1 == "this row updated gscore", 0 == earlier
-    // (the actual earlier row is carried in the wide ierow[] side channel).
-    __m128i max_ie128 = zero128;
+    // gscore (query-end score) capture, per row. The diagonal-offset 8-bit kernel
+    // CANNOT reconstruct gscore from the rebaselined byte state via the trimmed
+    // tail128: re-baselining saturates the off-diagonal query-end cells to 0 (they
+    // sit far below the row max), the band masking then trims them, and the gscore
+    // is lost. Instead, when a lane's band-grown band reaches the query end we
+    // capture that lane's query-end cell H (hqe128) and flag it (qfire128) here in
+    // the inner loop -- BEFORE this row's re-baseline -- and finalize a per-lane
+    // WIDE running gbest_abs / ierow in the epilogue (value = byte + B). Reset per row.
+    __m128i hqe128   = zero128;   // query-end cell H (rebaselined byte) this row
+    __m128i qfire128 = zero128;   // 0xFF where this lane reached its query end this row
 
     // Offset-frame band edges. head_off starts at 0 (col 0 - row 0); tail_off
     // starts saturated-high (+127) and is immediately clamped by the band-grow
@@ -5547,7 +5512,6 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         _mm_store_si128((__m128i *)(F + j * SIMD_WIDTH8), zero128);
 
     __m128i y128 = zero128;   // best col as diagonal offset: col - i_at_capture (i_at_capture = xrow[l]-1)
-    __m128i gscore = _mm_set1_epi8(-1);
     __m128i max_off128 = zero128;
     __m128i exit0 = _mm_set1_epi8(0xFF);
     __m128i zdrop128 = _mm_set1_epi8(zdrop);
@@ -5580,9 +5544,9 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
 
         __m128i y1_128 = zero128;   // row-max column as diagonal offset (col - i)
 
-        // gscore best-row marker resets each row (the carried best row lives in
-        // the wide ierow[] side channel; this lane only flags "updated this row").
-        max_ie128 = zero128;
+        // gscore query-end capture resets each row.
+        hqe128   = zero128;
+        qfire128 = zero128;
 
         // Per-row diagonal-offset of the query end: qlen_off = qlen - i. Built
         // wide then saturated to int8, with a validity mask so an out-of-band
@@ -5720,33 +5684,32 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
 
             h10 = h11;
                         
-            // gscore calculations
+            // gscore query-end capture. Fire when (a) this column is the lane's
+            // query-end column -- (col - i) == (qlen - i) iff col == qlen-1 -- and
+            // qlen-i is in the representable in-band window (qlen_valid: qoff in
+            // [-w, w+1]), so the lane's band-grown band has reached the query end
+            // (== scalar's `end == qlen`), and (b) the lane is still alive at row
+            // start (exit0). We capture the raw h11 (rebaselined byte) here; the
+            // wide epilogue turns it into an absolute byte+B gscore that survives
+            // re-baselining. No dependence on the trimmed tail128 (which the
+            // off-diagonal query-end column is, by construction, often beyond).
             if (j >= minq)
             {
-                // SAFE query-end test: (col - i) == (qlen - i) iff col == qlen,
-                // but only when qlen-i is in-band (else the wrapped/saturated
-                // qlen_off could alias an in-band col offset). Gate with the
-                // validity mask so an out-of-band query end can never match.
+                // Fire exactly like the 16-bit tier (which is byte-identical to
+                // scalar): the query-end column is reached (j128 == qlen_off, i.e.
+                // col == qlen-1) AND the band-grown tail reaches the query end
+                // (tail128 == qlen_off -- scalar's `end == qlen`; tail128 is
+                // clamped to qlen_off at band-grow, so >= reduces to ==), AND the
+                // lane is alive (exit0). qlen_valid guards the wrapped/out-of-band
+                // qlen_off alias. Fires regardless of h11 (matches scalar's h1==0
+                // firing); the captured value is finalized wide (byte+B) in the
+                // epilogue so it survives re-baselining.
                 __m128i cmp = _mm_cmpeq_epi8(j128, qlen_off128);
+                cmp = _mm_and_si128(cmp, _mm_cmpeq_epi8(tail128, qlen_off128));
                 cmp = _mm_and_si128(cmp, qlen_valid128);
-                //__m128i max_gh = _mm_max_epi8(gscore, h11);      //epi8 not present, modif
-                __m128i cmp_gh = _mm_cmpgt_epi8(gscore, h11);
-                // Row marker: when h11 beats old gscore, flag "this row" (one128);
-                // otherwise keep the existing marker. The actual best row is
-                // captured into the wide ierow[] side channel in the epilogue.
-                __m128i tmp128_1 = _mm_blendv_epi8(one128, max_ie128, cmp_gh);
-                __m128i max_gh = _mm_blendv_epi8(h11, gscore, cmp_gh);
-
-                tmp128_1 = _mm_blendv_epi8(max_ie128, tmp128_1, cmp);
-                tmp128_1 = _mm_blendv_epi8(max_ie128, tmp128_1, exit0);
-
-                max_gh = _mm_blendv_epi8(gscore, max_gh, exit0);
-                max_gh = _mm_blendv_epi8(gscore, max_gh, cmp);
-
-                cmp = _mm_cmpgt_epi8(j128, tail128);
-                max_gh = _mm_blendv_epi8(max_gh, gscore, cmp);
-                max_ie128 = _mm_blendv_epi8(tmp128_1, max_ie128, cmp);
-                gscore = max_gh;
+                cmp = _mm_and_si128(cmp, exit0);
+                hqe128   = _mm_blendv_epi8(hqe128, h11, cmp);
+                qfire128 = _mm_blendv_epi8(qfire128, ff128, cmp);
             }
         }
         __m128i cmp1 = _mm_cmpgt_epi8(head128, j128);
@@ -5796,35 +5759,36 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             int8_t  ms_a[SIMD_WIDTH8]       __attribute((aligned(16)));
             int8_t  rs_a[SIMD_WIDTH8]       __attribute((aligned(16)));
             int8_t  exit_a[SIMD_WIDTH8]     __attribute((aligned(16)));
-            int8_t  ie_mark_a[SIMD_WIDTH8]  __attribute((aligned(16)));
-            int8_t  gs_a[SIMD_WIDTH8]       __attribute((aligned(16)));
+            int8_t  qfire_a[SIMD_WIDTH8]    __attribute((aligned(16)));
+            int8_t  hqe_a[SIMD_WIDTH8]      __attribute((aligned(16)));
             _mm_store_si128((__m128i *) cmp_a, cmp);
             _mm_store_si128((__m128i *) y1_a, y1_128);
             _mm_store_si128((__m128i *) y_a, y128);
             _mm_store_si128((__m128i *) ms_a, maxScore128);
             _mm_store_si128((__m128i *) rs_a, maxRS1);
             _mm_store_si128((__m128i *) exit_a, exit0);
-            _mm_store_si128((__m128i *) ie_mark_a, max_ie128);
-            _mm_store_si128((__m128i *) gs_a, gscore);
+            _mm_store_si128((__m128i *) qfire_a, qfire128);
+            _mm_store_si128((__m128i *) hqe_a, hqe128);
             for (int l = 0; l < SIMD_WIDTH8; l++) {
                 // best-score row
                 if (cmp_a[l]) xrow[l] = i + 1;
-                // best-gscore row: marker==1 means gscore was set this row
-                if (ie_mark_a[l] == 1) ierow[l] = i + 1;
-                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore128/gscore are
-                // in the lane's CURRENT B[l] frame, so the absolute value is the
-                // rebaselined byte + B[l]. Re-derive both every row (cheap, O(rows))
-                // rather than trying to add B back once at the end (the recorded
-                // max may pre-date later B bumps). max() guards against the byte
-                // being re-baselined away in a later row.
+                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore128 is in the
+                // lane's CURRENT B[l] frame, so the absolute value is the
+                // rebaselined byte + B[l]. Re-derive every row (cheap, O(rows))
+                // rather than adding B back once at the end (the recorded max may
+                // pre-date later B bumps). max() guards against the byte being
+                // re-baselined away in a later row.
                 {
                     int ms_abs = (int)(uint8_t)ms_a[l] + B[l];
                     if (ms_abs > best_abs[l]) best_abs[l] = ms_abs;
-                    // gscore init is -1 (0xFF as a byte); treat that as "unset".
-                    if ((uint8_t)gs_a[l] != 0xFF) {
-                        int gs_abs = (int)(uint8_t)gs_a[l] + B[l];
-                        if (gs_abs > gbest_abs[l]) gbest_abs[l] = gs_abs;
-                    }
+                }
+                // gscore (query-end score): qfire flags that this lane reached its
+                // query end this row; hqe is the captured query-end cell H (byte,
+                // current B[l] frame). The absolute value is byte + B[l]. Scalar's
+                // tie-break updates on `>=` so the LAST max-achieving row wins gtle.
+                if (qfire_a[l]) {
+                    int gs_abs = (int)(uint8_t)hqe_a[l] + B[l];
+                    if (gs_abs >= gbest_abs[l]) { gbest_abs[l] = gs_abs; ierow[l] = i + 1; }
                 }
                 // z-drop (only relevant where the lane is still alive). The drop
                 // is ms-rs of two bytes in the SAME B[l] frame, so the B cancels
@@ -5992,13 +5956,10 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
                 // maxRS1 for the triggering row, and maxRS1 >= REBASE_HI >
                 // REBASE_KEEP > delta, so it stays positive).
                 maxScore128 = _mm_subs_epu8(maxScore128, delta128);
-                // gscore: keep the -1 (0xFF) "unset" sentinel intact, but lower
-                // set lanes (it is compared SIGNED against the rebaselined h11 in
-                // the gscore block, so it must track the same frame). Zero the
-                // delta for lanes whose gscore is still 0xFF.
-                __m128i gset = _mm_cmpeq_epi8(gscore, ff128);   // 0xFF where unset
-                __m128i gdelta = _mm_andnot_si128(gset, delta128);
-                gscore = _mm_subs_epu8(gscore, gdelta);
+                // gscore no longer carries a rebaselined byte register: the
+                // query-end cell H is captured per row and accumulated wide
+                // (gbest_abs, in absolute units) in the epilogue, so it is immune
+                // to this re-baseline subtract.
             }
         }
 

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -4513,6 +4513,20 @@ static inline __m128i _mm_blendv_epi8 (__m128i x, __m128i y, __m128i mask)
     }
 
 
+// ---------------------------------------------------------------------------
+// 8-bit re-baseline floor helpers (shared by wrapper + every SIMD kernel tier)
+//
+// Initial 8-bit score floor: keep the seed score h0 inside the re-baseline
+// keep-window so the stored byte (= H_abs - B) never overflows signed int8.
+// Clamping prefixes >REBASE_KEEP below h0 is lossless (REBASE_KEEP=zdrop+1 >
+// zdrop => already past the z-drop horizon). MUST be used by every SIMD tier.
+static inline int bsw8_rebase_keep(int zdrop)            { return zdrop + 1; }
+static inline int bsw8_initial_floor(int h0, int zdrop) {
+    int b0 = h0 - bsw8_rebase_keep(zdrop);
+    return b0 > 0 ? b0 : 0;
+}
+// ---------------------------------------------------------------------------
+
 // #define PFD 2 // SSE2
 void BandedPairWiseSW::getScores8(SeqPair *pairArray,
                                   uint8_t *seqBufRef,
@@ -4631,12 +4645,21 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         __m128i e_del128  = _mm_set1_epi8(e_del);
         __m128i eb_ins128 = _mm_set1_epi8(eb - o_ins);
         __m128i eb_del128 = _mm_set1_epi8(eb - o_del);
-        
+
         int8_t max = 0;
         if (max < w_match) max = w_match;
         if (max < w_mismatch) max = w_mismatch;
         if (max < w_ambig) max = w_ambig;
-        
+
+        // Initial per-lane score floor B0 = max(0, h0 - REBASE_KEEP_W) (long-read
+        // 8-bit, seed score h0 >= 128). Seeding the H bytes from raw h0 overflows
+        // the signed-int8 score state on row 0, so we seed from the rebaselined
+        // h0' = min(h0, REBASE_KEEP_W) instead (see the per-lane h0 init below).
+        // REBASE_KEEP_W MUST equal the kernel's REBASE_KEEP (bsw8_rebase_keep)
+        // so the two agree on B0; smithWaterman128_8 recomputes B0 via
+        // bsw8_initial_floor(p[].h0, zdrop).
+        const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
+
         int nstart = 0, nend = numPairs;
         
 // #pragma omp for schedule(dynamic, 128)
@@ -4651,9 +4674,20 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             for(j = 0; j < SIMD_WIDTH8; j++)
             {
                 SeqPair sp = pairArray[i + j];
-                h0[j] = sp.h0;
+                // Re-baseline the seed score into the int8 byte frame: seed the H
+                // arrays from h0' = h0 - B0 = min(h0, REBASE_KEEP_W) (clamped >= 0)
+                // so the initial bytes fit signed-int8 even when the true seed h0
+                // is several hundred (long-read). smithWaterman128_8 recomputes the
+                // matching B0 = max(0, h0 - REBASE_KEEP) from p[].h0 + zdrop and
+                // starts that lane's floor B there, so byte == H_absolute - B.
+                {
+                    int h0p = sp.h0;
+                    if (h0p > REBASE_KEEP_W) h0p = REBASE_KEEP_W;
+                    if (h0p < 0) h0p = 0;
+                    h0[j] = (uint8_t) h0p;
+                }
                 seq1 = seqBufRef + (int64_t)sp.idr;
-                
+
                 for(k = 0; k < sp.len1; k++)
                 {
                     mySeq1SoA[k * SIMD_WIDTH8 + j] = seq1[k] /* PR16: N stays 4 */;
@@ -4864,6 +4898,78 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     int32_t xrow[SIMD_WIDTH8];    // best row for score (== i+1 at capture)
     int32_t ierow[SIMD_WIDTH8];   // best row for gscore (== i+1 at capture)
 
+    // --- PER-LANE SCORE RE-BASELINING (long-read 8-bit, scores > 127) ---
+    // H/F/E and the score maxima are unsigned 8-bit [0,255], but a 1 kb
+    // alignment scores ~900. To keep the kernel 16-lane (8-bit) we carry a
+    // wide per-lane running FLOOR B[l]: every stored 8-bit score represents
+    // (H_absolute - B[l]). When a lane's row-max climbs toward 255 we raise
+    // B[l] by `delta` and subtract `delta` (saturating, _mm_subs_epu8) from
+    // every carried score buffer/register for that lane, then add B back when
+    // reconstructing the absolute result.
+    //
+    // SAFETY: subtracting delta saturates cells whose rebaselined value < delta
+    // to 0, i.e. cells that were >= (REBASE_HI - delta) = REBASE_KEEP below the
+    // row max. With REBASE_KEEP > zdrop, any such cell is already beyond the
+    // z-drop horizon (the alignment through it has already z-dropped) and cannot
+    // lead to the optimum, so clamping it to 0 is sound. The per-row max can
+    // climb by at most w_match between two row-end checks (H(i,j) <= H(i-1,j-1)
+    // + w_match), so REBASE_HI must leave >= w_match headroom below 255.
+    //
+    // NB: scores must stay in the SIGNED-positive byte range [0,127]. The DP
+    // recurrence floors cells with `m11 & (m11 > 0)` (signed _mm_cmpgt_epi8) and
+    // the row/global-max trackers (maxRS1, maxScore128, gscore) compare scores
+    // with SIGNED _mm_cmpgt_epi8 — all of which mis-read a byte >= 128 as
+    // negative. So we re-baseline within [0,127], not [0,255].
+    //
+    // Re-baseline window derived from this kernel's scoring + z-drop, so the
+    // 8-bit score path is correct for ANY valid scoring (not just bench defaults):
+    //   REBASE_KEEP > zdrop      => any cell clamped on re-baseline (>= REBASE_KEEP
+    //                               below the row max) is already past the z-drop
+    //                               horizon, so clamping it to 0 is lossless.
+    //   REBASE_HI + maxStep<=127 => a not-yet-triggered row carries max < REBASE_HI
+    //                               and grows by <= maxStep, so the score byte never
+    //                               exceeds signed-int8 +127 (the floor/max-trackers
+    //                               use signed _mm_cmpgt_epi8; a byte >=128 would be
+    //                               misread as negative and killed).
+    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window exists) is equivalent
+    // to zdrop + maxStep <= 125; the 8-bit routing gate (bwamem.cpp, separate task)
+    // MUST ensure this, else the pair belongs on the 16-bit path.
+    int maxStep = (int)this->w_match;
+    if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
+    if (maxStep < 1) maxStep = 1;
+    const int REBASE_KEEP = zdrop + 1;
+    const int REBASE_HI   = 127 - maxStep;
+    assert(REBASE_HI > REBASE_KEEP &&
+           "8-bit SW re-baseline: zdrop+maxStep>125, scoring outside safe envelope (route to 16-bit)");
+    int32_t B[SIMD_WIDTH8];        // per-lane wide score floor (stored = abs - B)
+    int32_t best_abs[SIMD_WIDTH8]; // running best score in ABSOLUTE units
+    int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end) in ABSOLUTE units
+
+    // --- INITIAL SCORE FLOOR B0 (long-read 8-bit, seed score h0 >= 128) ---
+    // The H arrays are seeded from the seed score h0 (H_v[0]=h0, then gap-
+    // decremented down column 0 and across row 0). For a long-read seed h0 can
+    // be several hundred, which immediately overflows the signed-int8 byte
+    // state before any re-baseline event can fire. So we start each lane's
+    // running floor at B0[l] = max(0, h0 - REBASE_KEEP) instead of 0: the
+    // wrapper seeds the H bytes from h0' = h0 - B0 = min(h0, REBASE_KEEP)
+    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 127), and
+    // here we set B[l] = B0[l] so the stored bytes still mean (H_absolute - B).
+    //
+    // SAFETY (identical argument to the mid-DP re-baseline): the gap-prefix
+    // cells in column 0 / row 0 that fall more than REBASE_KEEP below h0 are
+    // saturated to byte 0 by the wrapper's unsigned-saturating seed. Because
+    // REBASE_KEEP = zdrop+1 > zdrop, any such prefix cell is already beyond the
+    // z-drop horizon below the seed, so an alignment routed through it has
+    // already z-dropped and cannot be optimal -- clamping it to the floor is
+    // lossless. This is the SAME situation that arises mid-DP whenever B>0 after
+    // a re-baseline (byte 0 then means H_absolute == B, not 0), which the
+    // h00==0 local-restart test in MAIN_CODE8_CORE already handles correctly; B0
+    // simply makes B>0 from row 0 instead of from the first re-baseline event.
+    int32_t B0[SIMD_WIDTH8];
+    for (int l=0; l<SIMD_WIDTH8; l++) {
+        B0[l] = bsw8_initial_floor((int)p[l].h0, zdrop);
+    }
+
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH8; l++) {
         tlenw[l]  = p[l].len1;
@@ -4874,6 +4980,10 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         mlenw[l]  = ml;
         xrow[l]   = 0;
         ierow[l]  = 0;
+        B[l]        = B0[l];   // start the floor at B0 so byte state = abs - B0
+        best_abs[l] = p[l].h0; // maxScore128 inits to the h0 seed; record the
+                               // ABSOLUTE seed score (wide), not the rebaselined byte
+        gbest_abs[l]= -1;      // matches the int8 gscore init (-1) in absolute units
         if (p[l].len2 < minq) minq = p[l].len2;
     }
     minq -= 1; // for gscore
@@ -5154,6 +5264,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             int8_t  rs_a[SIMD_WIDTH8]       __attribute((aligned(16)));
             int8_t  exit_a[SIMD_WIDTH8]     __attribute((aligned(16)));
             int8_t  ie_mark_a[SIMD_WIDTH8]  __attribute((aligned(16)));
+            int8_t  gs_a[SIMD_WIDTH8]       __attribute((aligned(16)));
             _mm_store_si128((__m128i *) cmp_a, cmp);
             _mm_store_si128((__m128i *) y1_a, y1_128);
             _mm_store_si128((__m128i *) y_a, y128);
@@ -5161,12 +5272,30 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             _mm_store_si128((__m128i *) rs_a, maxRS1);
             _mm_store_si128((__m128i *) exit_a, exit0);
             _mm_store_si128((__m128i *) ie_mark_a, max_ie128);
+            _mm_store_si128((__m128i *) gs_a, gscore);
             for (int l = 0; l < SIMD_WIDTH8; l++) {
                 // best-score row
                 if (cmp_a[l]) xrow[l] = i + 1;
                 // best-gscore row: marker==1 means gscore was set this row
                 if (ie_mark_a[l] == 1) ierow[l] = i + 1;
-                // z-drop (only relevant where the lane is still alive)
+                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore128/gscore are
+                // in the lane's CURRENT B[l] frame, so the absolute value is the
+                // rebaselined byte + B[l]. Re-derive both every row (cheap, O(rows))
+                // rather than trying to add B back once at the end (the recorded
+                // max may pre-date later B bumps). max() guards against the byte
+                // being re-baselined away in a later row.
+                {
+                    int ms_abs = (int)(uint8_t)ms_a[l] + B[l];
+                    if (ms_abs > best_abs[l]) best_abs[l] = ms_abs;
+                    // gscore init is -1 (0xFF as a byte); treat that as "unset".
+                    if ((uint8_t)gs_a[l] != 0xFF) {
+                        int gs_abs = (int)(uint8_t)gs_a[l] + B[l];
+                        if (gs_abs > gbest_abs[l]) gbest_abs[l] = gs_abs;
+                    }
+                }
+                // z-drop (only relevant where the lane is still alive). The drop
+                // is ms-rs of two bytes in the SAME B[l] frame, so the B cancels
+                // and the comparison is already in ABSOLUTE score units.
                 if (exit_a[l]) {
                     int xr  = xrow[l];                       // best row
                     int y1c = (int) y1_a[l] + i;             // row-max col (abs)
@@ -5274,6 +5403,72 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         head128 = _mm_sub_epi8(head128, one128);
         tail128 = _mm_sub_epi8(tail128, one128);
 
+        // --- RE-BASELINE EVENT (per-lane score floor) ---
+        // After this row's score state is final, lower any lane whose row-max
+        // (maxRS1, rebaselined) has climbed to REBASE_HI back into range. We
+        // raise B[l] by delta = maxRS1[l] - REBASE_KEEP and subtract that delta
+        // (saturating to 0) from every carried score buffer/register for that
+        // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
+        // reference; the next row reads the lowered values consistently.
+        {
+            uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(16)));
+            _mm_store_si128((__m128i *) rs_b, maxRS1);
+            int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(16)));
+            int any = 0;
+            for (int l = 0; l < SIMD_WIDTH8; l++) {
+                int d = 0;
+                if ((int)rs_b[l] >= REBASE_HI) {
+                    d = (int)rs_b[l] - REBASE_KEEP;   // keep low REBASE_KEEP, in range
+                    B[l] += d;
+                    any = 1;
+                }
+                delta_a[l] = (int8_t) d;              // 0..(REBASE_HI-REBASE_KEEP) small
+            }
+            if (any) {
+                __m128i delta128 = _mm_load_si128((__m128i *) delta_a);
+                // Subtract delta from every carried score buffer over the active
+                // band columns. The range [lo,hi] is the union of the current and
+                // next band windows; clamping to [0, ncol-1] keeps the loop within
+                // the valid column range (a safe superset covering every column the
+                // next row will read).
+                int lo = nbeg < beg ? nbeg : beg;
+                int hi = nend > end ? nend : end;
+                if (lo < 0) lo = 0;
+                if (hi + 1 > ncol) hi = ncol - 1;
+                for (int l = lo; l <= hi; l++) {
+                    __m128i h128 = _mm_load_si128((__m128i *)(H_h + l * SIMD_WIDTH8));
+                    __m128i f128 = _mm_load_si128((__m128i *)(F   + l * SIMD_WIDTH8));
+                    h128 = _mm_subs_epu8(h128, delta128);
+                    f128 = _mm_subs_epu8(f128, delta128);
+                    _mm_store_si128((__m128i *)(H_h + l * SIMD_WIDTH8), h128);
+                    _mm_store_si128((__m128i *)(F   + l * SIMD_WIDTH8), f128);
+                }
+                // The vertical seed H_v is read only while the band still touches
+                // column 0 (beg==0). Lower the rows that may still be consumed.
+                if (beg == 0) {
+                    for (int r = i + 1; r < nrow; r++) {
+                        __m128i v128 = _mm_load_si128((__m128i *)(H_v + r * SIMD_WIDTH8));
+                        v128 = _mm_subs_epu8(v128, delta128);
+                        _mm_store_si128((__m128i *)(H_v + r * SIMD_WIDTH8), v128);
+                    }
+                }
+                // Carried score maxima (registers) live in the same rebaselined
+                // frame and must be lowered too so the next row's z-drop (ms-rs)
+                // and the absolute-frame add-back stay consistent. maxScore128 is
+                // the running max, so it never saturates to 0 (maxScore128 >=
+                // maxRS1 for the triggering row, and maxRS1 >= REBASE_HI >
+                // REBASE_KEEP > delta, so it stays positive).
+                maxScore128 = _mm_subs_epu8(maxScore128, delta128);
+                // gscore: keep the -1 (0xFF) "unset" sentinel intact, but lower
+                // set lanes (it is compared SIGNED against the rebaselined h11 in
+                // the gscore block, so it must track the same frame). Zero the
+                // delta for lanes whose gscore is still 0xFF.
+                __m128i gset = _mm_cmpeq_epi8(gscore, ff128);   // 0xFF where unset
+                __m128i gdelta = _mm_andnot_si128(gset, delta128);
+                gscore = _mm_subs_epu8(gscore, gdelta);
+            }
+        }
+
 #if RDT
         prof[DP2][0] += __rdtsc() - tim1;
 #endif
@@ -5283,31 +5478,26 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     prof[DP][0] += __rdtsc() - tim;
 #endif
     
-    // Score / gscore stay int8 here (exact while score < 128).
-    // TODO: scores >= 128 need re-baselining (not yet implemented).
-    // Positions are reconstructed wide from the diagonal-offset lanes plus the
-    // per-lane best-row side channels.
-    int8_t score[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm_store_si128((__m128i *) score, maxScore128);
-
+    // Scores are reconstructed in ABSOLUTE units from the per-lane wide
+    // best_abs/gbest_abs side channels (= rebaselined byte + B[l], captured each
+    // row before any later re-baseline could saturate the byte away). Positions
+    // are reconstructed wide from the diagonal-offset lanes plus the per-lane
+    // best-row side channels.
     int8_t maxj[SIMD_WIDTH8]  __attribute((aligned(64)));
     _mm_store_si128((__m128i *) maxj, y128);   // best col as diagonal offset
 
     int8_t max_off_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
     _mm_store_si128((__m128i *) max_off_ar, max_off128);
 
-    int8_t gscore_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm_store_si128((__m128i *) gscore_ar, gscore);
-
     for(i = 0; i < SIMD_WIDTH8; i++)
     {
-        p[i].score   = (uint8_t) score[i];
+        p[i].score   = best_abs[i];                               // absolute score
         p[i].tle     = xrow[i];                                   // best row (target end)
         // qle reconstruction: maxj[l] = col - (xrow-1), so col = maxj[l] + (xrow-1).
         // Guard the unset case (xrow==0 means no update occurred).
         p[i].qle     = (xrow[i] == 0) ? 0 : ((int) maxj[i] + xrow[i] - 1);
         p[i].max_off = (uint8_t) max_off_ar[i];
-        p[i].gscore  = (uint8_t) gscore_ar[i];
+        p[i].gscore  = gbest_abs[i];                              // absolute gscore (-1 if unset)
         p[i].gtle    = ierow[i];                                  // best gscore row
     }
 

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -4641,8 +4641,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         for(i = nstart; i < nend; i+=SIMD_WIDTH8)
         {
             int32_t j, k;
-            uint8_t maxLen1 = 0;
-            uint8_t maxLen2 = 0;
+            int maxLen1 = 0;
+            int maxLen2 = 0;
             //bsize = 100;
             bsize = w;
             
@@ -4804,8 +4804,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 
 void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
                                           uint8_t seq2SoA[],
-                                          uint8_t nrow,
-                                          uint8_t ncol,
+                                          int nrow,
+                                          int ncol,
                                           SeqPair *p,
                                           uint8_t h0[],
                                           uint16_t tid,
@@ -4835,7 +4835,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     int8_t  *H_h = H8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
     int8_t  *H_v = H8__ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
 
-    int8_t i, j;
+    int i, j;
 
     uint8_t tlen[SIMD_WIDTH8];
     uint8_t tail[SIMD_WIDTH8] __attribute((aligned(64)));

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -4435,6 +4435,8 @@ static inline __m128i _mm_blendv_epi8 (__m128i x, __m128i y, __m128i mask)
 }
 #endif
 
+// ZSCORE8 is unused in smithWaterman128_8 (z-drop replaced by wide scalar);
+// retained here in case a future 128-bit tier reinstates it.
 #define ZSCORE8(i4_128, y4_128)                                         \
     {                                                                   \
         __m128i tmpi = _mm_sub_epi8(i4_128, x128);                      \
@@ -4812,7 +4814,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
                                           int32_t numPairs,
                                           int zdrop,
                                           int32_t w,
-                                          uint8_t qlen[],
+                                          uint8_t qlen[],   // dead parameter (overwritten immediately); remove with call site in a later task
                                           uint8_t myband[])
 {
     
@@ -4837,7 +4839,6 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
 
     int i, j;
 
-    uint8_t tlen[SIMD_WIDTH8];
     uint8_t tail[SIMD_WIDTH8] __attribute((aligned(64)));
     uint8_t head[SIMD_WIDTH8] __attribute((aligned(64)));
 
@@ -4846,45 +4847,68 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     // the core's critical path doesn't carry the cmpeq+blendv+maxu+blendv
     // chain that builds the score. Slab-backed (see constructor sbt8_).
     int8_t *sbt_buf = sbt8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
-    
+
+    // --- DIAGONAL-OFFSET POSITION ENCODING (long-read 8-bit, w<=127) ---
+    // Every per-cell COLUMN position is tracked as the diagonal offset
+    //   d = col - i  in [-w, +w+1]  (fits signed int8 for w <= ~126).
+    // ROW quantities (best row, best-gscore row, qlen, tlen, mlen) exceed
+    // int8 for long reads, so they live in WIDE per-lane int32 side channels
+    // updated O(rows) in the per-row epilogue, not O(cells). Absolute end
+    // coordinates are reconstructed at the result store from the wide row.
+    // Persistent column-offset state (head128/tail128) is shifted by -1 each
+    // row (frame follows i) so the same absolute edge keeps its offset.
+    int32_t tlenw[SIMD_WIDTH8];   // raw target length (rows), wide
+    int32_t qlenw[SIMD_WIDTH8];   // raw query length (cols), wide
+    int32_t mbandw[SIMD_WIDTH8];  // per-lane band width, wide
+    int32_t mlenw[SIMD_WIDTH8];   // min(qlen+myband, tlen), wide row bound
+    int32_t xrow[SIMD_WIDTH8];    // best row for score (== i+1 at capture)
+    int32_t ierow[SIMD_WIDTH8];   // best row for gscore (== i+1 at capture)
+
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH8; l++) {
-        tlen[l] = p[l].len1;
-        qlen[l] = p[l].len2;
+        tlenw[l]  = p[l].len1;
+        qlenw[l]  = p[l].len2;
+        mbandw[l] = myband[l];
+        int ml = qlenw[l] + mbandw[l];
+        if (ml > tlenw[l]) ml = tlenw[l];
+        mlenw[l]  = ml;
+        xrow[l]   = 0;
+        ierow[l]  = 0;
         if (p[l].len2 < minq) minq = p[l].len2;
     }
     minq -= 1; // for gscore
 
-    __m128i tlen128   = _mm_load_si128((__m128i *) tlen);
-    __m128i qlen128   = _mm_load_si128((__m128i *) qlen);
     __m128i myband128 = _mm_load_si128((__m128i *) myband);
     __m128i zero128   = _mm_setzero_si128();
     __m128i one128    = _mm_set1_epi8(1);
     __m128i two128    = _mm_set1_epi8(2);
-    __m128i max_ie128 = zero128;
     __m128i ff128     = _mm_set1_epi8(0xFF);
-        
-    __m128i tail128 = qlen128, head128 = zero128;
+
+    // gscore best-row marker lane: 1 == "this row updated gscore", 0 == earlier
+    // (the actual earlier row is carried in the wide ierow[] side channel).
+    __m128i max_ie128 = zero128;
+
+    // Offset-frame band edges. head_off starts at 0 (col 0 - row 0); tail_off
+    // starts saturated-high (+127) and is immediately clamped by the band-grow
+    // min() against (1+myband) and (qlen-i) on the first row.
+    __m128i head128 = zero128;
+    __m128i tail128 = _mm_set1_epi8(127);
     _mm_store_si128((__m128i *) head, head128);
     _mm_store_si128((__m128i *) tail, tail128);
 
-    __m128i mlen128 = _mm_add_epi8(qlen128, myband128);
-    mlen128 = _mm_min_epu8(mlen128, tlen128);
-    
     __m128i hval = _mm_load_si128((__m128i *)(H_v));
     __mmask16 dmask = 0xFFFF;
-    
+
     __m128i maxScore128 = hval;
     for(j = 0; j < ncol; j++)
         _mm_store_si128((__m128i *)(F + j * SIMD_WIDTH8), zero128);
-    
-    __m128i x128 = zero128;
-    __m128i y128 = zero128;
+
+    __m128i y128 = zero128;   // best col as diagonal offset: col - i_at_capture (i_at_capture = xrow[l]-1)
     __m128i gscore = _mm_set1_epi8(-1);
     __m128i max_off128 = zero128;
     __m128i exit0 = _mm_set1_epi8(0xFF);
     __m128i zdrop128 = _mm_set1_epi8(zdrop);
-    
+
     int beg = 0, end = ncol;
     int nbeg = beg, nend = end;
 
@@ -4910,23 +4934,51 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
 
         __m128i j128 = zero128;
         __m128i maxRS1 = zero128;
-        
-        __m128i i1_128 = _mm_set1_epi8(i+1);
-        __m128i y1_128 = zero128;
-        
-#if RDT 
+
+        __m128i y1_128 = zero128;   // row-max column as diagonal offset (col - i)
+
+        // gscore best-row marker resets each row (the carried best row lives in
+        // the wide ierow[] side channel; this lane only flags "updated this row").
+        max_ie128 = zero128;
+
+        // Per-row diagonal-offset of the query end: qlen_off = qlen - i. Built
+        // wide then saturated to int8, with a validity mask so an out-of-band
+        // qlen-i (which would wrap and spuriously alias an in-band col offset)
+        // never triggers a false gscore/clamp. qlen_off_valid is true only when
+        // qlen-i lies within the representable band window [-w, w+1].
+        int8_t qlen_off_a[SIMD_WIDTH8]   __attribute((aligned(16)));
+        int8_t qlen_valid_a[SIMD_WIDTH8] __attribute((aligned(16)));
+        int8_t cmpim_a[SIMD_WIDTH8]      __attribute((aligned(16)));
+        for (int l=0; l<SIMD_WIDTH8; l++) {
+            int qoff = qlenw[l] - i;                 // wide
+            int qoff_sat = qoff;                     // saturate to int8 range
+            if (qoff_sat >  127) qoff_sat =  127;
+            if (qoff_sat < -128) qoff_sat = -128;
+            qlen_off_a[l]   = (int8_t) qoff_sat;
+            qlen_valid_a[l] = (qoff >= -w && qoff <= w + 1) ? (int8_t)0xFF : 0;
+            // exit when row i+1 has passed the per-lane effective length bound.
+            cmpim_a[l]      = ((i + 1) > mlenw[l]) ? (int8_t)0xFF : 0;
+        }
+        __m128i qlen_off128   = _mm_load_si128((__m128i *) qlen_off_a);
+        __m128i qlen_valid128 = _mm_load_si128((__m128i *) qlen_valid_a);
+
+#if RDT
         uint64_t tim1 = __rdtsc();
 #endif
-        
-        // Banding
-        __m128i i128, cache128;
+
+        // Banding (diagonal-offset frame). head128/tail128 arrive here in row-i's
+        // offset frame: the -1 shift at the end of the previous iteration converts
+        // (col - (i-1)) -> (col - i), so no additional adjustment is needed here.
+        //   abs head-grow: head = max(head, i - myband)  ->  head_off = max(head_off, -myband)
+        //   abs tail-clamp: tail = min(tail, (i+1)+myband, qlen)
+        //                                          -> tail_off = min(tail_off, 1+myband, qlen-i)
+        __m128i cache128;
         __m128i phead128 = head128, ptail128 = tail128;
-        i128 = _mm_set1_epi8(i);
-        cache128 = _mm_subs_epu8(i128, myband128);  // modif
-        head128 = _mm_max_epu8(head128, cache128);   // epi8 not present
-        cache128 = _mm_add_epi8(i1_128, myband128);
-        tail128 = _mm_min_epu8(tail128, cache128);
-        tail128 = _mm_min_epu8(tail128, qlen128);
+        __m128i negband128 = _mm_sub_epi8(zero128, myband128);            // -myband
+        head128 = _mm_max_epi8(head128, negband128);
+        cache128 = _mm_add_epi8(myband128, one128);                       // 1 + myband
+        tail128 = _mm_min_epi8(tail128, cache128);
+        tail128 = _mm_min_epi8(tail128, qlen_off128);
 
         // NEW, trimming.
         __m128i cmph = _mm_cmpeq_epi8(head128, phead128);
@@ -4941,7 +4993,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             __m128i h128 = _mm_load_si128((__m128i *)(H_h + l * SIMD_WIDTH8));
             __m128i f128 = _mm_load_si128((__m128i *)(F + l * SIMD_WIDTH8));
 
-            __m128i pj128 = _mm_set1_epi8(l);
+            __m128i pj128 = _mm_set1_epi8(l - i);   // diagonal offset of column l
             __m128i cmp1 = _mm_cmpgt_epi8(head128, pj128);
             uint32_t cval = _mm_movemask_epi8(cmp1);
             if (cval == 0x00) break;
@@ -4958,7 +5010,9 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         prof[DP3][0] += __rdtsc() - tim1;
 #endif
 
-        __m128i cmpim = _mm_cmpgt_epi8(i1_128, mlen128);
+        // cmpim: lane exits if row i+1 passed its effective length (precomputed
+        // wide into cmpim_a) OR the band collapsed (tail<=head, offset frame).
+        __m128i cmpim = _mm_load_si128((__m128i *) cmpim_a);
         __m128i cmpht = _mm_cmpeq_epi8(tail128, head128);
         cmpim = _mm_or_si128(cmpim, cmpht);
         // NEW
@@ -4983,7 +5037,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             _mm_store_si128((__m128i *)(sbt_buf + jp * SIMD_WIDTH8), sbt11);
         }
 
-        j128 = _mm_set1_epi8(beg);
+        j128 = _mm_set1_epi8(beg - i);   // diagonal offset of first band column
         for(j = beg; j < end; j++)
         {
             __m128i f11, f21, sbt11;
@@ -5026,19 +5080,27 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             // gscore calculations
             if (j >= minq)
             {
-                __m128i cmp = _mm_cmpeq_epi8(j128, qlen128);
+                // SAFE query-end test: (col - i) == (qlen - i) iff col == qlen,
+                // but only when qlen-i is in-band (else the wrapped/saturated
+                // qlen_off could alias an in-band col offset). Gate with the
+                // validity mask so an out-of-band query end can never match.
+                __m128i cmp = _mm_cmpeq_epi8(j128, qlen_off128);
+                cmp = _mm_and_si128(cmp, qlen_valid128);
                 //__m128i max_gh = _mm_max_epi8(gscore, h11);      //epi8 not present, modif
                 __m128i cmp_gh = _mm_cmpgt_epi8(gscore, h11);
-                __m128i tmp128_1 = _mm_blendv_epi8(i1_128, max_ie128, cmp_gh);
+                // Row marker: when h11 beats old gscore, flag "this row" (one128);
+                // otherwise keep the existing marker. The actual best row is
+                // captured into the wide ierow[] side channel in the epilogue.
+                __m128i tmp128_1 = _mm_blendv_epi8(one128, max_ie128, cmp_gh);
                 __m128i max_gh = _mm_blendv_epi8(h11, gscore, cmp_gh);
-                
+
                 tmp128_1 = _mm_blendv_epi8(max_ie128, tmp128_1, cmp);
                 tmp128_1 = _mm_blendv_epi8(max_ie128, tmp128_1, exit0);
-                
+
                 max_gh = _mm_blendv_epi8(gscore, max_gh, exit0);
-                max_gh = _mm_blendv_epi8(gscore, max_gh, cmp);              
-            
-                cmp = _mm_cmpgt_epi8(j128, tail128); 
+                max_gh = _mm_blendv_epi8(gscore, max_gh, cmp);
+
+                cmp = _mm_cmpgt_epi8(j128, tail128);
                 max_gh = _mm_blendv_epi8(max_gh, gscore, cmp);
                 max_ie128 = _mm_blendv_epi8(tmp128_1, max_ie128, cmp);
                 gscore = max_gh;
@@ -5067,23 +5129,57 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         maxScore128 = _mm_blendv_epi8(maxScore128, score128, exit0);
 
         __m128i cmp = _mm_cmpgt_epi8(maxScore128, bmaxScore128);
+        // y128 (best col) stays a diagonal offset captured in the best row's
+        // frame; the best row itself moves to the wide xrow[] side channel.
         y128 = _mm_blendv_epi8(y128, y1_128, cmp);
-        x128 = _mm_blendv_epi8(x128, i1_128, cmp);
-        
-        // max_off calculations
-#if 0
-        tmp = _mm_sub_epi8(y1_128, i1_128);
-        tmp = _mm_abs_epi8(tmp);               // not present
-#else
-        __m128i ab = _mm_subs_epu8(y1_128, i1_128);
-        __m128i ba = _mm_subs_epu8(i1_128, y1_128);
-        tmp = _mm_or_si128(ab, ba);
-#endif
+
+        // max_off = max running diagonal-distance of the row-max from the main
+        // diagonal: |y1col - (i+1)| = |y1_off - 1| in the offset frame.
+        // y1_off - 1 is a SIGNED int8 (negative when row-max is left of the
+        // sub-diagonal), so use _mm_abs_epi8 (SSSE3 / sse2neon on arm64).
+        __m128i y1_minus1 = _mm_sub_epi8(y1_128, one128);
+        tmp = _mm_abs_epi8(y1_minus1);                    // |y1_off - 1|
         __m128i bmax_off128 = max_off128;
         tmp = _mm_max_epu8(max_off128, tmp);  // modif
         max_off128 = _mm_blendv_epi8(bmax_off128, tmp, cmp);
-        // Z-score
-        ZSCORE8(i1_128, y1_128);        
+
+        // Per-lane wide updates (O(rows)): best-score row (xrow), best-gscore
+        // row (ierow), and the z-drop test — all done in wide scalars so row
+        // distances that exceed int8 for long reads are handled exactly.
+        {
+            int8_t  cmp_a[SIMD_WIDTH8]      __attribute((aligned(16)));
+            int8_t  y1_a[SIMD_WIDTH8]       __attribute((aligned(16)));
+            int8_t  y_a[SIMD_WIDTH8]        __attribute((aligned(16)));
+            int8_t  ms_a[SIMD_WIDTH8]       __attribute((aligned(16)));
+            int8_t  rs_a[SIMD_WIDTH8]       __attribute((aligned(16)));
+            int8_t  exit_a[SIMD_WIDTH8]     __attribute((aligned(16)));
+            int8_t  ie_mark_a[SIMD_WIDTH8]  __attribute((aligned(16)));
+            _mm_store_si128((__m128i *) cmp_a, cmp);
+            _mm_store_si128((__m128i *) y1_a, y1_128);
+            _mm_store_si128((__m128i *) y_a, y128);
+            _mm_store_si128((__m128i *) ms_a, maxScore128);
+            _mm_store_si128((__m128i *) rs_a, maxRS1);
+            _mm_store_si128((__m128i *) exit_a, exit0);
+            _mm_store_si128((__m128i *) ie_mark_a, max_ie128);
+            for (int l = 0; l < SIMD_WIDTH8; l++) {
+                // best-score row
+                if (cmp_a[l]) xrow[l] = i + 1;
+                // best-gscore row: marker==1 means gscore was set this row
+                if (ie_mark_a[l] == 1) ierow[l] = i + 1;
+                // z-drop (only relevant where the lane is still alive)
+                if (exit_a[l]) {
+                    int xr  = xrow[l];                       // best row
+                    int y1c = (int) y1_a[l] + i;             // row-max col (abs)
+                    int yc  = (int) y_a[l] + (xr - 1);       // best col (abs)
+                    int tmpi = (i + 1) - xr;
+                    int tmpj = y1c - yc;
+                    int dif  = tmpi > tmpj ? (tmpi - tmpj) : (tmpj - tmpi);
+                    int drop = (int)(uint8_t)ms_a[l] - (int)(uint8_t)rs_a[l];
+                    if (drop - dif > zdrop) exit_a[l] = 0;
+                }
+            }
+            exit0 = _mm_load_si128((__m128i *) exit_a);
+        }
 
 #if RDT
         prof[DP1][0] += __rdtsc() - tim1;
@@ -5121,8 +5217,8 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         __m128i tmpb = ff128;
 
         __m128i exit1 = _mm_xor_si128(exit0, ff128);
-        __m128i l128 = _mm_set1_epi8(beg);
-        
+        __m128i l128 = _mm_set1_epi8(beg - i);   // diagonal offset of column beg
+
         for (l = beg; l < end; l++)
         {
             __m128i f128 = _mm_load_si128((__m128i *)(F + l * SIMD_WIDTH8));
@@ -5147,7 +5243,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         __m128i  index128 = tail128;
         tmpb = ff128;
 
-        l128 = _mm_set1_epi8(end);
+        l128 = _mm_set1_epi8(end - i);   // diagonal offset of column end
         for (l = end; l >= beg; l--)
         {
             __m128i f128 = _mm_load_si128((__m128i *)(F + l * SIMD_WIDTH8));
@@ -5169,8 +5265,15 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             tmpb = tmp;
         }
         index128 = _mm_add_epi8(index128, two128);
-        tail128 = _mm_min_epu8(index128, qlen128);   // epi8 not present, modif
-        
+        // signed min in the offset frame against qlen-i
+        tail128 = _mm_min_epi8(index128, qlen_off128);
+
+        // Frame shift for the next row: i advances by 1, so the same absolute
+        // band edge has its diagonal offset (col - i) decremented by 1. Keep
+        // head/tail tracking the same columns as the frame moves.
+        head128 = _mm_sub_epi8(head128, one128);
+        tail128 = _mm_sub_epi8(tail128, one128);
+
 #if RDT
         prof[DP2][0] += __rdtsc() - tim1;
 #endif
@@ -5180,14 +5283,15 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     prof[DP][0] += __rdtsc() - tim;
 #endif
     
+    // Score / gscore stay int8 here (exact while score < 128).
+    // TODO: scores >= 128 need re-baselining (not yet implemented).
+    // Positions are reconstructed wide from the diagonal-offset lanes plus the
+    // per-lane best-row side channels.
     int8_t score[SIMD_WIDTH8]  __attribute((aligned(64)));
     _mm_store_si128((__m128i *) score, maxScore128);
 
-    int8_t maxi[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm_store_si128((__m128i *) maxi, x128);
-
     int8_t maxj[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm_store_si128((__m128i *) maxj, y128);
+    _mm_store_si128((__m128i *) maxj, y128);   // best col as diagonal offset
 
     int8_t max_off_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
     _mm_store_si128((__m128i *) max_off_ar, max_off128);
@@ -5195,19 +5299,18 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     int8_t gscore_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
     _mm_store_si128((__m128i *) gscore_ar, gscore);
 
-    int8_t maxie_ar[SIMD_WIDTH8]  __attribute((aligned(64)));
-    _mm_store_si128((__m128i *) maxie_ar, max_ie128);
-    
     for(i = 0; i < SIMD_WIDTH8; i++)
     {
-        p[i].score = score[i];
-        p[i].tle = maxi[i];
-        p[i].qle = maxj[i];
-        p[i].max_off = max_off_ar[i];
-        p[i].gscore = gscore_ar[i];
-        p[i].gtle = maxie_ar[i];
+        p[i].score   = (uint8_t) score[i];
+        p[i].tle     = xrow[i];                                   // best row (target end)
+        // qle reconstruction: maxj[l] = col - (xrow-1), so col = maxj[l] + (xrow-1).
+        // Guard the unset case (xrow==0 means no update occurred).
+        p[i].qle     = (xrow[i] == 0) ? 0 : ((int) maxj[i] + xrow[i] - 1);
+        p[i].max_off = (uint8_t) max_off_ar[i];
+        p[i].gscore  = (uint8_t) gscore_ar[i];
+        p[i].gtle    = ierow[i];                                  // best gscore row
     }
-    
+
     return;
 }
 

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -937,7 +937,7 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     //
     // NB: scores must stay in the SIGNED-positive byte range [0,127]. The DP
     // recurrence floors cells with `m11 & (m11 > 0)` (signed _mm256_cmpgt_epi8) and
-    // the row/global-max trackers (maxRS1, maxScore256, gscore) compare scores
+    // the row/global-max trackers (maxRS1, maxScore256) compare scores
     // with SIGNED _mm256_cmpgt_epi8 — all of which mis-read a byte >= 128 as
     // negative. So we re-baseline within [0,127], not [0,255].
     //
@@ -1003,7 +1003,7 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         B[l]        = B0[l];   // start the floor at B0 so byte state = abs - B0
         best_abs[l] = p[l].h0; // maxScore256 inits to the h0 seed; record the
                                // ABSOLUTE seed score (wide), not the rebaselined byte
-        gbest_abs[l]= -1;      // matches the int8 gscore init (-1) in absolute units
+        gbest_abs[l]= -1;      // unset sentinel (-1): gscore=-1 / gtle=0 when no query end is reached, matching scalar
         if (p[l].len2 < minq) minq = p[l].len2;
     }
     minq -= 1; // for gscore
@@ -2825,7 +2825,7 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
     //
     // NB: scores must stay in the SIGNED-positive byte range [0,127]. The DP
     // recurrence floors cells with cmpeq(h00,0) and the row/global-max trackers
-    // (maxRS1, maxScore512, gscore) compare scores with SIGNED
+    // (maxRS1, maxScore512) compare scores with SIGNED
     // _mm512_cmpgt_epi8_mask — all of which mis-read a byte >= 128 as negative.
     // So we re-baseline within [0,127], not [0,255].
     //
@@ -2891,7 +2891,7 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         B[l]        = B0[l];   // start the floor at B0 so byte state = abs - B0
         best_abs[l] = p[l].h0; // maxScore512 inits to the h0 seed; record the
                                // ABSOLUTE seed score (wide), not the rebaselined byte
-        gbest_abs[l]= -1;      // matches the int8 gscore init (-1) in absolute units
+        gbest_abs[l]= -1;      // unset sentinel (-1): gscore=-1 / gtle=0 when no query end is reached, matching scalar
         if (p[l].len2 < minq) minq = p[l].len2;
     }
     minq -= 1; // for gscore
@@ -5408,7 +5408,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     //
     // NB: scores must stay in the SIGNED-positive byte range [0,127]. The DP
     // recurrence floors cells with `m11 & (m11 > 0)` (signed _mm_cmpgt_epi8) and
-    // the row/global-max trackers (maxRS1, maxScore128, gscore) compare scores
+    // the row/global-max trackers (maxRS1, maxScore128) compare scores
     // with SIGNED _mm_cmpgt_epi8 — all of which mis-read a byte >= 128 as
     // negative. So we re-baseline within [0,127], not [0,255].
     //
@@ -5474,7 +5474,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         B[l]        = B0[l];   // start the floor at B0 so byte state = abs - B0
         best_abs[l] = p[l].h0; // maxScore128 inits to the h0 seed; record the
                                // ABSOLUTE seed score (wide), not the rebaselined byte
-        gbest_abs[l]= -1;      // matches the int8 gscore init (-1) in absolute units
+        gbest_abs[l]= -1;      // unset sentinel (-1): gscore=-1 / gtle=0 when no query end is reached, matching scalar
         if (p[l].len2 < minq) minq = p[l].len2;
     }
     minq -= 1; // for gscore

--- a/src/bandedSWA.h
+++ b/src/bandedSWA.h
@@ -295,8 +295,8 @@ public:
 
     void smithWaterman128_8(uint8_t seq1SoA[],
                             uint8_t seq2SoA[],
-                            uint8_t nrow,
-                            uint8_t ncol,
+                            int nrow,
+                            int ncol,
                             SeqPair *p,
                             uint8_t h0[],
                             uint16_t tid,

--- a/src/bandedSWA.h
+++ b/src/bandedSWA.h
@@ -110,7 +110,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #endif
 
 #define MAX_LINE_LEN 256
-#define MAX_SEQ_LEN8 128
+#define MAX_SEQ_LEN8 1088
 #define MAX_SEQ_LEN16 32768
 #define MATRIX_MIN_CUTOFF 0
 #define LOW_INIT_VALUE -128

--- a/src/bandedSWA.h
+++ b/src/bandedSWA.h
@@ -355,8 +355,8 @@ public:
 
     void smithWaterman256_8(uint8_t seq1SoA[],
                             uint8_t seq2SoA[],
-                            uint8_t nrow,
-                            uint8_t ncol,
+                            int nrow,
+                            int ncol,
                             SeqPair *p,
                             uint8_t h0[],
                             uint16_t tid,
@@ -415,8 +415,8 @@ public:
 
     void smithWaterman512_8(uint8_t seq1SoA[],
                             uint8_t seq2SoA[],
-                            uint8_t nrow,
-                            uint8_t ncol,
+                            int nrow,
+                            int ncol,
                             SeqPair *p,
                             uint8_t h0[],
                             uint16_t tid,

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -82,6 +82,49 @@ KSORT_INIT(mem_intv1, SMEM, intv_lt1)  // debug
 #define BUCKET_MAX_INIT_W 8
 #endif
 
+/* ------------------------------------------------------------------------
+ * 8-bit (16-lane) SW safe-envelope gate.
+ *
+ * The recovered 8-bit kernel `smithWaterman128_8` is byte-exact for long
+ * reads ONLY inside the envelope its diagonal-offset position encoding and
+ * per-lane score re-baselining were proven against (Tasks 3-4):
+ *
+ *   - len1, len2 < MAX_SEQ_LEN8  : slab width + the wide per-row position
+ *     side channel are sized MAX_SEQ_LEN8; rows/cols at or beyond it would
+ *     run off the slab.
+ *   - w <= BSW8_MAX_W (= 127)     : every band/position quantity is encoded
+ *     as a diagonal offset d = j - i in [-w, +w], which fits signed int8
+ *     only for w <= 127. The default opt->w = 100 qualifies; wide-band
+ *     retries (w doubling to 200/400/800) do NOT and fall back to 16-bit.
+ *   - zdrop + maxStep <= 125     : the score re-baseline keeps H/F/E in
+ *     [0,255] by raising a per-lane floor; a clamped cell is only ever a
+ *     dead (z-dropped) cell when the retained window 255 - delta still
+ *     covers the z-drop band plus one row's max score gain. maxStep is the
+ *     largest per-step score increment, max(w_match, w_ambig, 1); w_match is
+ *     opt->a and the kernel's w_ambig is a (negative) penalty, so this is
+ *     max(opt->a, 1). Defaults zdrop=100, a=1 give 101 <= 125. Drop the old
+ *     `minval = h0 + min(len)*a < 128` score test: re-baselining + the
+ *     initial floor B0 now handle arbitrary score / h0.
+ *
+ * NOTE: minval is still used by sortPairsLenExt as the counting-sort bin
+ * index (hist[minval]) and must stay < MAX_SEQ_LEN8 there for the bin to be
+ * in range; that is a histogram-sizing constraint, NOT the tier decision.
+ * Pairs failing this envelope fall through to the existing 16-bit (then
+ * scalar) buckets exactly as before. */
+#define BSW8_MAX_W 127                 /* max band: diagonal offset d=j-i must fit signed int8 */
+#define BSW8_MAX_ZDROP_STEP 125        /* re-baseline window exists iff zdrop + max_step <= this
+                                          (REBASE_KEEP=zdrop+1 > zdrop AND REBASE_HI=127-max_step
+                                          > REBASE_KEEP); see smithWaterman128_8 re-baseline) */
+
+static inline int bsw8_envelope_ok(int len1, int len2, int w,
+                                   int score_a, int zdrop)
+{
+    int max_step = score_a > 1 ? score_a : 1;   /* max(w_match, w_ambig, 1) */
+    return len1 < MAX_SEQ_LEN8 && len2 < MAX_SEQ_LEN8 &&
+           w <= BSW8_MAX_W &&
+           zdrop + max_step <= BSW8_MAX_ZDROP_STEP;
+}
+
             int tcnt = 0;
 /********************
  * Filtering chains *
@@ -2039,7 +2082,7 @@ void* _mm_realloc(void *ptr, int64_t csize, int64_t nsize, int16_t dsize) {
 
 inline void sortPairsLenExt(SeqPair *pairArray, int32_t count, SeqPair *tempArray,
                             int32_t *hist, int &numPairs128, int &numPairs16,
-                            int &numPairs1, int score_a)
+                            int &numPairs1, int score_a, int w, int zdrop)
 {
     int32_t i;
     numPairs128 = numPairs16 = numPairs1 = 0;
@@ -2054,13 +2097,20 @@ inline void sortPairsLenExt(SeqPair *pairArray, int32_t count, SeqPair *tempArra
     int *arr = (int*) calloc (count, sizeof(int));
     assert(arr != NULL);
 
+    /* minval is the counting-sort bin (sorts the 8-bit bucket by score for
+     * lane packing). The tier decision is the safe envelope, not minval:
+     * re-baselining handles arbitrary score, so a pair can be 8-bit even with
+     * minval >= MAX_SEQ_LEN8. Clamp the bin to keep it in range — only the
+     * ordering, not correctness, depends on the exact key. */
     for(i = 0; i < count; i++)
     {
         SeqPair sp = pairArray[i];
         // int minval = sp.h0 + max_(sp.len1, sp.len2);
         int minval = sp.h0 + min_(sp.len1, sp.len2) * score_a;
-        if (sp.len1 < MAX_SEQ_LEN8 && sp.len2 < MAX_SEQ_LEN8 && minval < MAX_SEQ_LEN8)
-            hist[minval]++;
+        if (bsw8_envelope_ok(sp.len1, sp.len2, w, score_a, zdrop)) {
+            int bin = minval < MAX_SEQ_LEN8 ? minval : MAX_SEQ_LEN8 - 1;
+            hist[bin]++;
+        }
         else if(sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval < MAX_SEQ_LEN16)
             hist2[minval] ++;
         else
@@ -2090,11 +2140,12 @@ inline void sortPairsLenExt(SeqPair *pairArray, int32_t count, SeqPair *tempArra
         // int minval = sp.h0 + max_(sp.len1, sp.len2);
         int minval = sp.h0 + min_(sp.len1, sp.len2) * score_a;
 
-        if (sp.len1 < MAX_SEQ_LEN8 && sp.len2 < MAX_SEQ_LEN8 && minval < MAX_SEQ_LEN8)
+        if (bsw8_envelope_ok(sp.len1, sp.len2, w, score_a, zdrop))
         {
-            int32_t pos = hist[minval];
+            int bin = minval < MAX_SEQ_LEN8 ? minval : MAX_SEQ_LEN8 - 1;
+            int32_t pos = hist[bin];
             tempArray[pos] = sp;
-            hist[minval]++;
+            hist[bin]++;
             numPairs128 ++;
             if (arr[pos] != 0)
             {
@@ -2821,7 +2872,9 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
                     {
                         int t_tier;
-                        if (sp.len1 < MAX_SEQ_LEN8 && sp.len2 < MAX_SEQ_LEN8 && minval < MAX_SEQ_LEN8) {
+                        /* Mirror the routing decision in sortPairsLenExt: 8-bit
+                         * iff the safe envelope holds (initial band opt->w). */
+                        if (bsw8_envelope_ok(sp.len1, sp.len2, opt->w, opt->a, opt->zdrop)) {
                             numPairsLeft128++; t_tier = 0;
                         }
                         else if (sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval < MAX_SEQ_LEN16){
@@ -3017,7 +3070,9 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
                     minval = sp.h0 + min_(sp.len1, sp.len2) * opt->a;
 
-                    if (sp.len1 < MAX_SEQ_LEN8 && sp.len2 < MAX_SEQ_LEN8 && minval < MAX_SEQ_LEN8) {
+                    /* Mirror the routing decision in sortPairsLenExt: 8-bit iff
+                     * the safe envelope holds (initial band opt->w). */
+                    if (bsw8_envelope_ok(sp.len1, sp.len2, opt->w, opt->a, opt->zdrop)) {
                         numPairsRight128++;
                     }
                     else if(sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval < MAX_SEQ_LEN16) {
@@ -3061,7 +3116,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
     /* Sorting based score is required as that affects the use of SIMD lanes */
     sortPairsLenExt(seqPairArrayLeft128, numPairsLeft, seqPairArrayAux, hist,
-                    numPairsLeft128, numPairsLeft16, numPairsLeft1, opt->a);
+                    numPairsLeft128, numPairsLeft16, numPairsLeft1, opt->a,
+                    opt->w, opt->zdrop);
     assert(numPairsLeft == (numPairsLeft128 + numPairsLeft16 + numPairsLeft1));
 
     /* instrumentation: per-batch narrow bucket size (Group C, LEFT).
@@ -3267,12 +3323,27 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
         bswLeft->scalarBandedSWAWrapper(pair_ar, seqBufLeftRef, seqBufLeftQer, nump, nthreads, w);
 #else
         sortPairsLen(pair_ar, nump, seqPairArrayAux, hist);
-        bswLeft->getScores8(pair_ar,
-                           seqBufLeftRef,
-                           seqBufLeftQer,
-                           nump,
-                           nthreads,
-                           w);
+        /* These pairs were bucketed for the 8-bit path at the initial band
+         * opt->w (which the envelope proved <= BSW8_MAX_W). Once the doubling
+         * retry pushes w >= 128 the diagonal-offset int8 encoding can no
+         * longer represent the band, so divert that iteration to the 16-bit
+         * kernel rather than feeding getScores8 an unrepresentable band. The
+         * tight_band early-exit below is unaffected (it short-circuits the
+         * retry regardless of which width ran). */
+        if (w <= BSW8_MAX_W)
+            bswLeft->getScores8(pair_ar,
+                               seqBufLeftRef,
+                               seqBufLeftQer,
+                               nump,
+                               nthreads,
+                               w);
+        else
+            bswLeft->getScores16(pair_ar,
+                                seqBufLeftRef,
+                                seqBufLeftQer,
+                                nump,
+                                nthreads,
+                                w);
 #endif
 
         tprof[PE1][0] += nump;
@@ -3414,7 +3485,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     }
 
     sortPairsLenExt(seqPairArrayRight128, numPairsRight, seqPairArrayAux,
-                    hist, numPairsRight128, numPairsRight16, numPairsRight1, opt->a);
+                    hist, numPairsRight128, numPairsRight16, numPairsRight1, opt->a,
+                    opt->w, opt->zdrop);
 
     assert(numPairsRight == (numPairsRight128 + numPairsRight16 + numPairsRight1));
 
@@ -3428,7 +3500,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             int tb_ = sp_->tight_band;
             int t_tier;
             int minval_ = sp_->h0 + min_(sp_->len1, sp_->len2) * opt->a;
-            if (sp_->len1 < MAX_SEQ_LEN8 && sp_->len2 < MAX_SEQ_LEN8 && minval_ < MAX_SEQ_LEN8)        t_tier = 0;
+            if (bsw8_envelope_ok(sp_->len1, sp_->len2, opt->w, opt->a, opt->zdrop))                     t_tier = 0;
             else if (sp_->len1 < MAX_SEQ_LEN16 && sp_->len2 < MAX_SEQ_LEN16 && minval_ < MAX_SEQ_LEN16) t_tier = 1;
             else                                                                                       t_tier = 2;
             int fine_bin;
@@ -3616,12 +3688,23 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
         bswRight->scalarBandedSWAWrapper(pair_ar, seqBufRightRef, seqBufRightQer, nump, nthreads, w);
 #else
         sortPairsLen(pair_ar, nump, seqPairArrayAux, hist);
-        bswRight->getScores8(pair_ar,
-                            seqBufRightRef,
-                            seqBufRightQer,
-                            nump,
-                            nthreads,
-                            w);
+        /* See the LEFT int8 loop: divert w >= 128 retry iterations to the
+         * 16-bit kernel (the diagonal-offset int8 band can't represent it).
+         * tight_band early-exit is preserved. */
+        if (w <= BSW8_MAX_W)
+            bswRight->getScores8(pair_ar,
+                                seqBufRightRef,
+                                seqBufRightQer,
+                                nump,
+                                nthreads,
+                                w);
+        else
+            bswRight->getScores16(pair_ar,
+                                 seqBufRightRef,
+                                 seqBufRightQer,
+                                 nump,
+                                 nthreads,
+                                 w);
 #endif
 
         tprof[PE3][0] += nump;

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -119,6 +119,18 @@ KSORT_INIT(mem_intv1, SMEM, intv_lt1)  // debug
 static inline int bsw8_envelope_ok(int len1, int len2, int w,
                                    int score_a, int zdrop)
 {
+    /* Dev A/B hook: BWAMEM3_DISABLE_BSW8=1 forces every pair off the 8-bit path
+     * onto the 16-bit (then scalar) buckets. Used to validate that the 8-bit
+     * kernel is byte-identical to the 16-bit reference in the full pipeline
+     * (diff the SAM with vs without). Off by default. The function-local static
+     * with a non-trivial initializer gets C++11 thread-safe one-time init, so the
+     * getenv runs exactly once even under the OpenMP/pthread worker fan-out (a
+     * plain `static int x = -1; if (x<0) x = ...;` would be a data race). */
+    static const int disable = []() {
+        const char *e = getenv("BWAMEM3_DISABLE_BSW8");
+        return (e && atoi(e)) ? 1 : 0;
+    }();
+    if (disable) return 0;
     int max_step = score_a > 1 ? score_a : 1;   /* max(w_match, w_ambig, 1) */
     return len1 < MAX_SEQ_LEN8 && len2 < MAX_SEQ_LEN8 &&
            /* target (rows, len1) >= query (cols, len2). The re-baseline 8-bit

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -121,6 +121,17 @@ static inline int bsw8_envelope_ok(int len1, int len2, int w,
 {
     int max_step = score_a > 1 ? score_a : 1;   /* max(w_match, w_ambig, 1) */
     return len1 < MAX_SEQ_LEN8 && len2 < MAX_SEQ_LEN8 &&
+           /* target (rows, len1) >= query (cols, len2). The re-baseline 8-bit
+            * kernel's gscore (query-end score) is byte-identical to scalar ONLY
+            * when the query-end column (len2-1) lies on or left of the main
+            * diagonal, i.e. len1 >= len2. When len2 > len1 the query end is
+            * off-diagonal to the right, where the re-baseline saturating-subtract
+            * zeroes those low-scoring cells (they sit >zdrop below the row max),
+            * the band trims them, and gscore is lost. Such pairs (rare: only when
+            * the reference window is shorter than the read segment, e.g. at contig
+            * edges) route to the 16-bit tier, which has no re-baseline and is
+            * byte-identical for them. See smithWaterman128_8 gscore capture. */
+           len1 >= len2 &&
            w <= BSW8_MAX_W &&
            zdrop + max_step <= BSW8_MAX_ZDROP_STEP;
 }

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -85,39 +85,53 @@ KSORT_INIT(mem_intv1, SMEM, intv_lt1)  // debug
 /* ------------------------------------------------------------------------
  * 8-bit (16-lane) SW safe-envelope gate.
  *
- * The recovered 8-bit kernel `smithWaterman128_8` is byte-exact for long
- * reads ONLY inside the envelope its diagonal-offset position encoding and
- * per-lane score re-baselining were proven against (Tasks 3-4):
+ * The recovered 8-bit kernel `smithWaterman128_8` (and the AVX2/AVX-512 ports)
+ * runs an UNSIGNED [0,255] score recurrence and is byte-exact for long reads
+ * ONLY inside the envelope below. The decisive constraint is that the per-lane
+ * score re-baselining must NEVER fire for an admitted pair: its saturating
+ * subtract is not generally lossless (it can zero a still-positive off-diagonal
+ * cell, which the recurrence then misreads as the h00==0 local-restart sentinel
+ * and truncates a valid alignment — z-drop is a row-level early-exit, not a
+ * per-cell guarantee). Held inert, the kernel is a plain exact unsigned SW.
  *
  *   - len1, len2 < MAX_SEQ_LEN8  : slab width + the wide per-row position
  *     side channel are sized MAX_SEQ_LEN8; rows/cols at or beyond it would
  *     run off the slab.
+ *   - len1 >= len2 (target >= query) : the gscore (query-end) capture is
+ *     byte-identical to scalar only when the query-end column lies on/left of
+ *     the main diagonal. See smithWaterman128_8 gscore capture.
  *   - w <= BSW8_MAX_W (= 127)     : every band/position quantity is encoded
  *     as a diagonal offset d = j - i in [-w, +w], which fits signed int8
  *     only for w <= 127. The default opt->w = 100 qualifies; wide-band
  *     retries (w doubling to 200/400/800) do NOT and fall back to 16-bit.
- *   - zdrop + maxStep <= 125     : the score re-baseline keeps H/F/E in
- *     [0,255] by raising a per-lane floor; a clamped cell is only ever a
- *     dead (z-dropped) cell when the retained window 255 - delta still
- *     covers the z-drop band plus one row's max score gain. maxStep is the
- *     largest per-step score increment, max(w_match, w_ambig, 1); w_match is
- *     opt->a and the kernel's w_ambig is a (negative) penalty, so this is
- *     max(opt->a, 1). Defaults zdrop=100, a=1 give 101 <= 125. Drop the old
- *     `minval = h0 + min(len)*a < 128` score test: re-baselining + the
- *     initial floor B0 now handle arbitrary score / h0.
+ *   - zdrop + maxStep <= 127      : keeps REBASE_KEEP = zdrop + 1 <= 127. The DP
+ *     body is unsigned [0,255], but the h0-prefix column/row seed in the kernel
+ *     wrappers (smithWaterman*_8 setup) still uses SIGNED int8 ops, so the seeded
+ *     byte h0' = min(h0, REBASE_KEEP) must stay <= 127 (signed-positive). maxStep
+ *     is the largest per-step score increment, max(w_match, w_ambig, 1) =
+ *     max(opt->a, 1). (This also keeps the re-baseline window non-empty:
+ *     REBASE_HI = 255 - maxStep > REBASE_KEEP.)
+ *   - h0 <= zdrop + 1             : keeps the initial floor B0 = max(0, h0 -
+ *     REBASE_KEEP) == 0, so the seed score does not itself force a re-baseline.
+ *   - h0 + min(len1,len2)*a < 255 - maxStep : the MAX ATTAINABLE score (seed
+ *     plus an all-match diagonal over the shorter sequence) stays below REBASE_HI,
+ *     so the running row max never reaches it and re-baseline never fires.
  *
- * NOTE: minval is still used by sortPairsLenExt as the counting-sort bin
- * index (hist[minval]) and must stay < MAX_SEQ_LEN8 there for the bin to be
- * in range; that is a histogram-sizing constraint, NOT the tier decision.
- * Pairs failing this envelope fall through to the existing 16-bit (then
- * scalar) buckets exactly as before. */
+ * NOTE: minval (= h0 + min(len)*a) is still used by sortPairsLenExt as the
+ * counting-sort bin index (hist[minval]) and must stay < MAX_SEQ_LEN8 there for
+ * the bin to be in range; that is a histogram-sizing constraint, NOT the tier
+ * decision. Pairs failing this envelope fall through to the existing 16-bit
+ * (then scalar) buckets exactly as before. */
 #define BSW8_MAX_W 127                 /* max band: diagonal offset d=j-i must fit signed int8 */
-#define BSW8_MAX_ZDROP_STEP 125        /* re-baseline window exists iff zdrop + max_step <= this
-                                          (REBASE_KEEP=zdrop+1 > zdrop AND REBASE_HI=127-max_step
-                                          > REBASE_KEEP); see smithWaterman128_8 re-baseline) */
+#define BSW8_MAX_ZDROP_STEP 127        /* keep REBASE_KEEP=zdrop+1 <= 127: the h0-prefix
+                                          column/row seed in the 8-bit wrappers uses SIGNED
+                                          int8 ops, so the seeded byte min(h0,REBASE_KEEP) must
+                                          stay signed-positive (<=127). Also keeps the re-baseline
+                                          window non-empty (REBASE_HI=255-max_step > REBASE_KEEP).
+                                          See smithWaterman128_8 re-baseline + h0-prefix seed. */
 
 static inline int bsw8_envelope_ok(int len1, int len2, int w,
-                                   int score_a, int zdrop)
+                                   int score_a, int zdrop, int h0)
 {
     /* Dev A/B hook: BWAMEM3_DISABLE_BSW8=1 forces every pair off the 8-bit path
      * onto the 16-bit (then scalar) buckets. Used to validate that the 8-bit
@@ -131,7 +145,16 @@ static inline int bsw8_envelope_ok(int len1, int len2, int w,
         return (e && atoi(e)) ? 1 : 0;
     }();
     if (disable) return 0;
-    int max_step = score_a > 1 ? score_a : 1;   /* max(w_match, w_ambig, 1) */
+    /* 64-bit math: len < MAX_SEQ_LEN8 and a small score_a keep these tiny in
+     * practice, but compute the bounds in int64_t so a pathological scoring
+     * parameter cannot wrap an int and admit a pair the guards would reject. */
+    int64_t max_step = score_a > 1 ? (int64_t)score_a : 1;   /* max(w_match, w_ambig, 1) */
+    int64_t shorter  = len1 < len2 ? (int64_t)len1 : (int64_t)len2;
+    /* Max attainable SW score: seed h0 plus an all-match diagonal over the
+     * shorter sequence. Must stay strictly below REBASE_HI = 255 - max_step so
+     * the running row max never triggers a (lossy) re-baseline; combined with
+     * h0 <= zdrop+1 (B0 == 0) the kernel runs as an exact unsigned [0,255] SW. */
+    int64_t max_score = (int64_t)h0 + shorter * (int64_t)score_a;
     return len1 < MAX_SEQ_LEN8 && len2 < MAX_SEQ_LEN8 &&
            /* target (rows, len1) >= query (cols, len2). The re-baseline 8-bit
             * kernel's gscore (query-end score) is byte-identical to scalar ONLY
@@ -145,7 +168,9 @@ static inline int bsw8_envelope_ok(int len1, int len2, int w,
             * byte-identical for them. See smithWaterman128_8 gscore capture. */
            len1 >= len2 &&
            w <= BSW8_MAX_W &&
-           zdrop + max_step <= BSW8_MAX_ZDROP_STEP;
+           zdrop + max_step <= BSW8_MAX_ZDROP_STEP &&
+           h0 <= zdrop + 1 &&
+           max_score < 255 - max_step;
 }
 
             int tcnt = 0;
@@ -2117,8 +2142,15 @@ inline void sortPairsLenExt(SeqPair *pairArray, int32_t count, SeqPair *tempArra
         //_mm256_store_si256((__m256i *)(hist + i), zero256);
         hist[i] = 0;
 
-    int *arr = (int*) calloc (count, sizeof(int));
-    assert(arr != NULL);
+    /* count can be 0 for an empty extension side; calloc(0, ...) is allowed to
+     * return NULL, so guard on count rather than assert non-null (asserts are
+     * compiled in here — no -DNDEBUG). Matches the out-of-memory convention used
+     * by the other calloc sites in this file. */
+    int *arr = NULL;
+    if (count > 0) {
+        arr = (int*) calloc((size_t)count, sizeof(int));
+        if (arr == NULL) { fprintf(stderr, "ERROR: out of memory in %s\n", __func__); exit(EXIT_FAILURE); }
+    }
 
     /* minval is the counting-sort bin (sorts the 8-bit bucket by score for
      * lane packing). The tier decision is the safe envelope, not minval:
@@ -2129,13 +2161,13 @@ inline void sortPairsLenExt(SeqPair *pairArray, int32_t count, SeqPair *tempArra
     {
         SeqPair sp = pairArray[i];
         // int minval = sp.h0 + max_(sp.len1, sp.len2);
-        int minval = sp.h0 + min_(sp.len1, sp.len2) * score_a;
-        if (bsw8_envelope_ok(sp.len1, sp.len2, w, score_a, zdrop)) {
-            int bin = minval < MAX_SEQ_LEN8 ? minval : MAX_SEQ_LEN8 - 1;
+        int64_t minval = (int64_t)sp.h0 + (int64_t)min_(sp.len1, sp.len2) * (int64_t)score_a;
+        if (bsw8_envelope_ok(sp.len1, sp.len2, w, score_a, zdrop, sp.h0)) {
+            int bin = minval < 0 ? 0 : (minval < MAX_SEQ_LEN8 ? (int)minval : MAX_SEQ_LEN8 - 1);
             hist[bin]++;
         }
-        else if(sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval < MAX_SEQ_LEN16)
-            hist2[minval] ++;
+        else if(sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval >= 0 && minval < MAX_SEQ_LEN16)
+            hist2[(int)minval] ++;
         else
             hist3[0] ++;
 
@@ -2161,11 +2193,11 @@ inline void sortPairsLenExt(SeqPair *pairArray, int32_t count, SeqPair *tempArra
     {
         SeqPair sp = pairArray[i];
         // int minval = sp.h0 + max_(sp.len1, sp.len2);
-        int minval = sp.h0 + min_(sp.len1, sp.len2) * score_a;
+        int64_t minval = (int64_t)sp.h0 + (int64_t)min_(sp.len1, sp.len2) * (int64_t)score_a;
 
-        if (bsw8_envelope_ok(sp.len1, sp.len2, w, score_a, zdrop))
+        if (bsw8_envelope_ok(sp.len1, sp.len2, w, score_a, zdrop, sp.h0))
         {
-            int bin = minval < MAX_SEQ_LEN8 ? minval : MAX_SEQ_LEN8 - 1;
+            int bin = minval < 0 ? 0 : (minval < MAX_SEQ_LEN8 ? (int)minval : MAX_SEQ_LEN8 - 1);
             int32_t pos = hist[bin];
             tempArray[pos] = sp;
             hist[bin]++;
@@ -2173,22 +2205,22 @@ inline void sortPairsLenExt(SeqPair *pairArray, int32_t count, SeqPair *tempArra
             if (arr[pos] != 0)
             {
                 fprintf(stderr, "[%s] Error log: repeat, pos: %d, arr: %d, minval: %d, (%d %d)\n",
-                        __func__, pos, arr[pos], minval, sp.len1, sp.len2);
+                        __func__, pos, arr[pos], (int)minval, sp.len1, sp.len2);
                 exit(EXIT_FAILURE);
             }
             arr[pos] = 1;
         }
-        else if (sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval < MAX_SEQ_LEN16) {
-            int32_t pos = hist2[minval];
+        else if (sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval >= 0 && minval < MAX_SEQ_LEN16) {
+            int32_t pos = hist2[(int)minval];
             tempArray[pos] = sp;
-            hist2[minval]++;
+            hist2[(int)minval]++;
             numPairs16 ++;
             if (arr[pos] != 0)
             {
                 SeqPair spt = pairArray[arr[pos]-1];
                 fprintf(stderr, "[%s] Error log: repeat, "
                         "i: %d, pos: %d, arr: %d, hist2: %d, minval: %d, (%d %d %d) (%d %d %d)\n",
-                        __func__, i, pos, arr[pos], hist2[minval],  minval, sp.h0, sp.len1, sp.len2,
+                        __func__, i, pos, arr[pos], hist2[(int)minval],  (int)minval, sp.h0, sp.len1, sp.len2,
                         spt.h0, spt.len1, spt.len2);
                 exit(EXIT_FAILURE);
             }
@@ -2814,7 +2846,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     sp.len2 = s->qbeg;
                     sp.len1 = tmp;
                     sp.tight_band = 0;  // 0 sentinel: "no tight bound known"
-                    int minval;  // declared ahead of goto target for C++
+                    int64_t minval;  // declared ahead of goto target for C++
 
                     // ungapped analysis.
                     //   HIT      → skip SW; fill a->* from ungapped.
@@ -2891,16 +2923,16 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                         // FALLBACK: sp.tight_band stays 0.
                     }
 
-                    minval = sp.h0 + min_(sp.len1, sp.len2) * opt->a;
+                    minval = (int64_t)sp.h0 + (int64_t)min_(sp.len1, sp.len2) * (int64_t)opt->a;
 
                     {
                         int t_tier;
                         /* Mirror the routing decision in sortPairsLenExt: 8-bit
                          * iff the safe envelope holds (initial band opt->w). */
-                        if (bsw8_envelope_ok(sp.len1, sp.len2, opt->w, opt->a, opt->zdrop)) {
+                        if (bsw8_envelope_ok(sp.len1, sp.len2, opt->w, opt->a, opt->zdrop, sp.h0)) {
                             numPairsLeft128++; t_tier = 0;
                         }
-                        else if (sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval < MAX_SEQ_LEN16){
+                        else if (sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval >= 0 && minval < MAX_SEQ_LEN16){
                             numPairsLeft16++;  t_tier = 1;
                         }
                         else {
@@ -3031,7 +3063,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
                     sp.tight_band = 0;
                     sp.ugp_r_attempted = 0;
-                    int minval;  // declared ahead of goto target for C++
+                    int64_t minval;  // declared ahead of goto target for C++
 
                     // ungapped analysis on right ext.
                     // Precondition a->score != -1 means left either didn't
@@ -3091,14 +3123,14 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                         }
                     }
 
-                    minval = sp.h0 + min_(sp.len1, sp.len2) * opt->a;
+                    minval = (int64_t)sp.h0 + (int64_t)min_(sp.len1, sp.len2) * (int64_t)opt->a;
 
                     /* Mirror the routing decision in sortPairsLenExt: 8-bit iff
                      * the safe envelope holds (initial band opt->w). */
-                    if (bsw8_envelope_ok(sp.len1, sp.len2, opt->w, opt->a, opt->zdrop)) {
+                    if (bsw8_envelope_ok(sp.len1, sp.len2, opt->w, opt->a, opt->zdrop, sp.h0)) {
                         numPairsRight128++;
                     }
-                    else if(sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval < MAX_SEQ_LEN16) {
+                    else if(sp.len1 < MAX_SEQ_LEN16 && sp.len2 < MAX_SEQ_LEN16 && minval >= 0 && minval < MAX_SEQ_LEN16) {
                         numPairsRight16++;
                     }
                     else {
@@ -3522,9 +3554,9 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             SeqPair *sp_ = &seqPairArrayRight128[l];
             int tb_ = sp_->tight_band;
             int t_tier;
-            int minval_ = sp_->h0 + min_(sp_->len1, sp_->len2) * opt->a;
-            if (bsw8_envelope_ok(sp_->len1, sp_->len2, opt->w, opt->a, opt->zdrop))                     t_tier = 0;
-            else if (sp_->len1 < MAX_SEQ_LEN16 && sp_->len2 < MAX_SEQ_LEN16 && minval_ < MAX_SEQ_LEN16) t_tier = 1;
+            int64_t minval_ = (int64_t)sp_->h0 + (int64_t)min_(sp_->len1, sp_->len2) * (int64_t)opt->a;
+            if (bsw8_envelope_ok(sp_->len1, sp_->len2, opt->w, opt->a, opt->zdrop, sp_->h0))             t_tier = 0;
+            else if (sp_->len1 < MAX_SEQ_LEN16 && sp_->len2 < MAX_SEQ_LEN16 && minval_ >= 0 && minval_ < MAX_SEQ_LEN16) t_tier = 1;
             else                                                                                       t_tier = 2;
             int fine_bin;
             if      (tb_ ==  0) fine_bin = 0;

--- a/test/regression/longread_pe_parity.sh
+++ b/test/regression/longread_pe_parity.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# test/regression/longread_pe_parity.sh
+#
+# Regression: the recovered long-read 8-bit banded-SW path must produce
+# byte-identical SAM to the 16-bit reference on LONG paired-end reads.
+#
+# chr22_parity.sh covers parity vs upstream bwa at 151 bp. This test targets the
+# recovered >=128 bp 8-bit extension path specifically: it simulates 400 bp PE
+# reads (whose seed-extension segments land in the 128-1088 bp range routed to
+# the 8-bit kernel) and diffs `bwa-mem3 mem` with the 8-bit path ENABLED (default)
+# against the same binary with BWAMEM3_DISABLE_BSW8=1 (every pair forced to the
+# 16-bit, then scalar, path -- i.e. the pre-recovery behavior). The two must be
+# byte-identical; any divergence is a recovered-8-bit-path regression.
+#
+# Self-contained A/B (one binary, only the routing gate flips), so it does not
+# depend on the upstream bwa version's long-read behavior.
+#
+# Inputs (env vars):
+#   BWA_MEM3       - path to the bwa-mem3 binary under test
+#   CHR22_FA       - chr22.fa, pre-indexed with bwa-mem3 by the caller
+#   CHR22_SIM_DIR  - directory for fixture-private intermediates
+#   PIXI_MANIFEST  - path to test/holodeck/pixi.toml (holodeck + samtools)
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+: "${CHR22_FA:?CHR22_FA must be set}"
+: "${CHR22_SIM_DIR:?CHR22_SIM_DIR must be set}"
+: "${PIXI_MANIFEST:?PIXI_MANIFEST must be set}"
+
+mkdir -p "$CHR22_SIM_DIR"
+
+# 400 bp PE reads: long enough that seed-extension segments exceed the int8
+# position ceiling (>127) and route to the recovered diagonal-offset 8-bit path,
+# but well under MAX_SEQ_LEN8 (1088). ~0.3x of 50.8 Mb chr22 at 400 bp PE is a
+# few tens of thousands of pairs -- enough coverage of the path for a regression
+# gate without dominating CI wall time.
+pfx="$CHR22_SIM_DIR/longread_pe"
+pixi run --frozen --manifest-path "$PIXI_MANIFEST" -- \
+  holodeck simulate \
+    -r "$CHR22_FA" \
+    -o "$pfx" \
+    --coverage 0.3 \
+    --read-length 400 \
+    --fragment-mean 900 --fragment-stddev 100 \
+    --seed 42 \
+    --simple-names \
+    --min-error-rate 0.002 --max-error-rate 0.002
+
+r1="$pfx.r1.fastq.gz"
+r2="$pfx.r2.fastq.gz"
+[ -s "$r1" ] && [ -s "$r2" ] || { echo "FAIL: holodeck produced no PE fastqs ($r1, $r2)" >&2; exit 1; }
+
+# Normalize: drop @PG (carries the command line) and @HD; sort so thread
+# interleaving does not affect the comparison.
+normalize() { grep -v '^@PG' "$1" | grep -v '^@HD' | sort; }
+
+sam8="$CHR22_SIM_DIR/longread_pe.8bit.sam"
+sam16="$CHR22_SIM_DIR/longread_pe.16bit.sam"
+
+"$BWA_MEM3" mem -t 4 "$CHR22_FA" "$r1" "$r2" > "$sam8.raw" 2>"$CHR22_SIM_DIR/longread_pe.8bit.log"
+BWAMEM3_DISABLE_BSW8=1 "$BWA_MEM3" mem -t 4 "$CHR22_FA" "$r1" "$r2" > "$sam16.raw" 2>"$CHR22_SIM_DIR/longread_pe.16bit.log"
+
+normalize "$sam8.raw"  > "$sam8"
+normalize "$sam16.raw" > "$sam16"
+
+n8=$(grep -cv '^@' "$sam8" || true)
+echo "long-read PE records: $n8 (read-length 400, chr22 ~0.3x)"
+
+# Guard against a trivially-passing empty run.
+if [ "$n8" -lt 1000 ]; then
+    echo "FAIL: long-read PE SAM has $n8 records, expected tens of thousands (holodeck/align regression?)" >&2
+    exit 1
+fi
+
+if diff -q "$sam8" "$sam16" > /dev/null 2>&1; then
+    echo "PASS: recovered 8-bit path == 16-bit reference on 400 bp PE reads ($n8 records)"
+else
+    echo "FAIL: 8-bit vs 16-bit SAM diverged on long PE reads; first 40 diff lines:" >&2
+    diff "$sam8" "$sam16" | head -40 >&2
+    exit 1
+fi


### PR DESCRIPTION
## What

Recovers the inter-sequence batched 8-bit banded Smith–Waterman path (16/32/64 lanes on NEON/SSE, AVX2, AVX-512BW) for reads ≥128 bp. Previously the 8-bit kernels were short-read-only: an extension pair whose positions exceed int8 (~127) fell through to the ~1.4–1.9× slower 16-bit kernel. This branch keeps those pairs on the 8-bit kernel, byte-identical to the scalar oracle and to the 16-bit tier.

## Why

The 8-bit kernel is the fastest tier (one read-pair per lane, twice the lane count of 16-bit). Restricting it to short reads left throughput on the table for any extension ≥128 bp — common on standard 151 bp Illumina. Measured end-to-end: ~7% fewer CPU-seconds on WGS 151 bp (HG002/hg38), with no change to alignment output.

## How

Three mechanisms, each a standard technique, gated behind a conservative routing envelope:

- **Diagonal-offset int8 position encoding** — every per-cell column position is tracked as the diagonal offset `d = col − i ∈ [−w, w+1]`, which fits signed int8 for `w ≤ 127`. Row-scale quantities (best row, gscore row, lengths) move to wide per-lane int32 side channels updated O(rows) in the per-row epilogue.
- **Per-lane score re-baselining** — the standard Farrar/SWIPE saturation-offset trick: carry a wide per-lane floor `B[l]`, and when a lane's row-max approaches int8 range raise `B[l]` and saturate-subtract from the carried score buffers. Absolute scores are reconstructed at the result store. The re-baseline window is derived from the scoring + z-drop, so it is correct for any valid scoring, not just the defaults.
- **Query-end (gscore) capture** — the re-baseline saturating-subtract can zero the off-diagonal query-end cells (the global score legitimately sits far below the local row max), so gscore cannot be reconstructed from the trimmed band. Instead the query-end cell H is captured per row (`byte + B`) and finalized in a wide side channel, gated exactly like the byte-identical 16-bit tier.

**Routing precondition** (`bsw8_envelope_ok`, src/bwamem.cpp): a pair takes the 8-bit path iff `len1 ≥ len2` (target ≥ query — the saturation-safe domain where the query end lies on/left of the diagonal), `len1,len2 < MAX_SEQ_LEN8` (1088), `w ≤ 127`, and `zdrop + maxStep ≤ 125`. Pairs failing any clause route to the 16-bit (then scalar) path exactly as before.

## Validation

- **Byte-identity vs the scalar oracle, all six outputs** (score, tle, gtle, qle, gscore, max_off): NEON 156k pairs + per-tier sse41/avx2/avx512bw 441k pairs (on an AVX-512 host), 0 diffs in the production (`len1 ≥ len2`) domain. 16-bit cross-check: 0 diffs.
- **chr22 end-to-end parity vs upstream `bwa` 0.7.19**: byte-identical SAM on 101,636 records (holodeck-simulated chr22, 151 bp PE). Exercises the 8-bit path.
- **8-bit vs forced-16-bit A/B** (`BWAMEM3_DISABLE_BSW8` dev hook): byte-identical on 92,964 (meth) + 101,636 (chr22) records and on real 16–19 kb HiFi reads.
- **Regression suite** (NEON): `thread_determinism`, `bam_roundtrip`, `short_read_smoke` (25–50 bp pericentromeric), `meth` layers 1–3 (bwameth.py equivalence) — all PASS. `all_tiers_parity` covered cross-tier on an AVX-512 host.
- **Performance**: per-kernel 8-bit vs 16-bit — NEON 1.38–1.86×, AVX2 1.20–1.97×, AVX-512 ~par at ≤64 bp rising to 1.63×. End-to-end WGS 151 bp: ~7% CPU reduction (3 stable reps). Long reads (HiFi): byte-identical, throughput flat (SW is not the bottleneck there — seeding dominates).

## Open task

- [ ] **Benchmark on bwa-mem3-bench at production scale.** Run this PR's SHA vs a `main` baseline across c8g (NEON), c6a (AVX2), c7i (AVX-512): `smoke-1M` sanity → `wgs-60M` / `wes-30M`; `cli collect --fg-labs-sha <sha>` → `benchmark.db`. Confirms the ~7% short-read CPU win survives as wall-time throughput at scale and guards against per-arch regression. (A local Zenodo HG002 bench already indicates a modest short-read win + no regression; this is the authoritative cross-arch confirmation.)

## Scope notes

- **gap-from-H** (`feat/gap-from-h-extension`) is independent and output-neutral; it composes cleanly with this branch but is not required here. Land separately on its own merits.
- **Pre-existing ONT R10 crash**: bwa-mem3 SIGSEGVs in the BWT/SMEM seeding worker on ONT R10 reads, identically with the 8-bit path on or off — upstream of this change, out of scope. Worth a separate issue. (bwa-mem is not the tool for ONT; minimap2 is.)
- The byte-identity harness, timing bench, and findings writeups used to validate this work live on the development branch; relocating the harness into `test/` is a reasonable follow-up.

## Suggested reading order

1. `refactor(bsw): widen 8-bit kernel scalar loop/length state to int` — no behavior change; makes room for long-read row indices.
2. `feat(bsw): enlarge MAX_SEQ_LEN8 slab to 1088`
3. `feat(bsw): diagonal-offset int8 position encoding` — the core idea.
4. `feat(bsw): per-lane score re-baselining`
5. `feat(mem): route long reads to the recovered 8-bit path`
6. `feat(bsw): port the recovery to AVX2 and AVX-512`
7. `fix(bsw): query-end gscore capture byte-identical across all tiers` — the gscore mechanism + the `len1 ≥ len2` routing precondition.
8. `feat(mem): BWAMEM3_DISABLE_BSW8 dev A/B hook (thread-safe)`


## Correctness fix: byte-exact recovery (unsigned [0,255] recurrence + routing gate)

Three commits appended to this PR make the recovered 8-bit path byte-identical to the scalar/16-bit reference on the inputs that previously diverged.

- **The bug.** The recovered path was not byte-identical on repeat-rich, high-scoring reads: the per-lane re-baselining saturated still-positive off-diagonal cells to byte 0, which the recurrence reads as the `h00 == 0` local-restart sentinel and truncates a valid alignment (z-drop is a row-level early-exit, not a per-cell guarantee). Root cause: `MAIN_CODE8_CORE`'s M-floor used a signed compare, capping the usable range at 127 and forcing the (lossy) re-baseline for essentially every read scoring > 127.
- **`fix(bsw): byte-exact recovered 8-bit path via unsigned [0,255] recurrence`** — split-sbt unsigned-saturating M-floor + `epu8` H/E/F and max-trackers across NEON/AVX2/AVX-512, `REBASE_HI` 127 → 255 − maxStep. Reads scoring ≤ 254 never re-baseline, so the kernel is exact.
- **`feat(mem): admit only re-baseline-safe pairs to the 8-bit path`** — `bsw8_envelope_ok` admits a pair only when re-baselining provably never fires (`h0 ≤ zdrop+1`, `h0 + min(len)*a < 255 − maxStep`), so the kernel runs as a plain exact unsigned SW and the re-baseline machinery is an inert safety net. The h0-prefix column/row seed is still signed int8, so `zdrop` is capped at 126 (`BSW8_MAX_ZDROP_STEP = 127`); higher `zdrop` routes to the 16-bit path.
- **`ci(bsw): long-read PE 8-bit/16-bit parity gate`** — a self-contained 400bp PE chr22 A/B (8-bit vs `BWAMEM3_DISABLE_BSW8=1`) wired into CI.

**Validation.** Byte-identical to the scalar oracle on all six outputs (score, tle, gtle, qle, gscore, max_off), per-tier on NEON + sse41/avx2/avx512bw (Sapphire Rapids), across short, long, and repeat-rich + large-h0 inputs. chr22 end-to-end byte-identical to upstream bwa (101,636 records); 400bp PE 8-bit-vs-forced-16-bit byte-identical (38,114 records). The byte-identity unit test that locks this in — including a repeat-rich regression case and a cross-tier SIMD-width padding fix — is #144.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased the maximum supported sequence length for the 8-bit alignment pathway.
  * Strengthened 8-bit eligibility checks to ensure byte-exact results, with safer bounds and bin handling.
  * Updated tier selection and extension routing for more consistent 8-bit/16-bit behavior.
  * Added a runtime fallback to automatically switch from 8-bit scoring when the retry band is too wide.
  * Preserved an environment override to force the 16-bit path.

* **Tests / CI**
  * Added a long-read paired-end parity regression test in CI that compares recovered 8-bit vs forced 16-bit output for byte-identical alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
