### PR TITLE
refactor(bsw): derive extension gaps from H (standard Gotoh), not M

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -254,12 +254,18 @@ int BandedPairWiseSW::scalarBandedSWA(int qlen, const uint8_t *query,
             h1 = h;             // save H(i,j) to h1 for the next column
             mj = m > h? mj : j; // record the position where max score is achieved
             m = m > h? m : h;   // m is stored at eh[mj+1]
-            t = M - oe_del;
+            // gap-from-H (standard Gotoh): gap-open is subtracted from the cell
+            // max H(i,j)=h, not the diagonal-only M. This matches ksw2/minimap2
+            // and is the convention the int8 delta recurrence requires. The final
+            // reported CIGAR/score still come from ksw_global2 (gap-from-M), so
+            // alignment output is unchanged; this only governs the extension
+            // boundary scorer. See FINDINGS-delta-recurrence.md (task #16).
+            t = h - oe_del;
             t = t > 0? t : 0;
             e -= e_del;
             e = e > t? e : t;   // computed E(i+1,j)
             p->e = e;           // save E(i+1,j) for the next row
-            t = M - oe_ins;
+            t = h - oe_ins;
             t = t > 0? t : 0;
             f -= e_ins;
             f = f > t? f : t;   // computed F(i,j+1)
@@ -362,11 +368,11 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
         m11 = _mm256_blendv_epi8(m11, zero256, cmp11);                  \
         h11 = _mm256_max_epi8(m11, e11);                                \
         h11 = _mm256_max_epi8(h11, f11);                                \
-        __m256i temp256 = _mm256_sub_epi8(m11, oe_ins256);              \
+        __m256i temp256 = _mm256_sub_epi8(h11, oe_ins256);              \
         __m256i val256  = _mm256_max_epi8(temp256, zero256);            \
         e11 = _mm256_sub_epi8(e11, e_ins256);                           \
         e11 = _mm256_max_epi8(val256, e11);                             \
-        temp256 = _mm256_sub_epi8(m11, oe_del256);                      \
+        temp256 = _mm256_sub_epi8(h11, oe_del256);                      \
         val256  = _mm256_max_epi8(temp256, zero256);                    \
         f21 = _mm256_sub_epi8(f11, e_del256);                           \
         f21 = _mm256_max_epi8(val256, f21);                             \
@@ -404,11 +410,11 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
         m11 = _mm256_blendv_epi16(m11, zero256, cmp11);                 \
         h11 = _mm256_max_epi16(m11, e11);                               \
         h11 = _mm256_max_epi16(h11, f11);                               \
-        __m256i temp256 = _mm256_sub_epi16(m11, oe_ins256);             \
+        __m256i temp256 = _mm256_sub_epi16(h11, oe_ins256);             \
         __m256i val256  = _mm256_max_epi16(temp256, zero256);           \
         e11 = _mm256_sub_epi16(e11, e_ins256);                          \
         e11 = _mm256_max_epi16(val256, e11);                            \
-        temp256 = _mm256_sub_epi16(m11, oe_del256);                     \
+        temp256 = _mm256_sub_epi16(h11, oe_del256);                     \
         val256  = _mm256_max_epi16(temp256, zero256);                   \
         f21 = _mm256_sub_epi16(f11, e_del256);                          \
         f21 = _mm256_max_epi16(val256, f21);                            \
@@ -442,10 +448,11 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
         m11 = _mm256_blendv_epi8(m11, zero256, cmp11);  /* h00==0 -> local restart */ \
         h11 = _mm256_max_epu8(m11, e11);                                \
         h11 = _mm256_max_epu8(h11, f11);                                \
-        __m256i temp256 = _mm256_subs_epu8(m11, oe_ins256);            \
+        /* gap-open from H (standard Gotoh), unsigned-saturating */      \
+        __m256i temp256 = _mm256_subs_epu8(h11, oe_ins256);            \
         e11 = _mm256_subs_epu8(e11, e_ins256);                          \
         e11 = _mm256_max_epu8(temp256, e11);                            \
-        temp256 = _mm256_subs_epu8(m11, oe_del256);                    \
+        temp256 = _mm256_subs_epu8(h11, oe_del256);                    \
         f21 = _mm256_subs_epu8(f11, e_del256);                          \
         f21 = _mm256_max_epu8(temp256, f21);                            \
     }
@@ -465,11 +472,11 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
         m11 = _mm256_blendv_epi16(m11, zero256, cmp11);                 \
         h11 = _mm256_max_epi16(m11, e11);                               \
         h11 = _mm256_max_epi16(h11, f11);                               \
-        __m256i temp256 = _mm256_sub_epi16(m11, oe_ins256);             \
+        __m256i temp256 = _mm256_sub_epi16(h11, oe_ins256);             \
         __m256i val256  = _mm256_max_epi16(temp256, zero256);           \
         e11 = _mm256_sub_epi16(e11, e_ins256);                          \
         e11 = _mm256_max_epi16(val256, e11);                            \
-        temp256 = _mm256_sub_epi16(m11, oe_del256);                     \
+        temp256 = _mm256_sub_epi16(h11, oe_del256);                     \
         val256  = _mm256_max_epi16(temp256, zero256);                   \
         f21 = _mm256_sub_epi16(f11, e_del256);                          \
         f21 = _mm256_max_epi16(val256, f21);                            \
@@ -2273,11 +2280,11 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         m11 = _mm512_mask_blend_epi8(cmp11, m11, zero512);              \
         h11 = _mm512_max_epi8(m11, e11);                                \
         h11 = _mm512_max_epi8(h11, f11);                                \
-        temp512 = _mm512_sub_epi8(m11, oe_ins512);                      \
+        temp512 = _mm512_sub_epi8(h11, oe_ins512);                      \
         val512  = _mm512_max_epi8(temp512, zero512);                    \
         e11 = _mm512_sub_epi8(e11, e_ins512);                           \
         e11 = _mm512_max_epi8(val512, e11);                             \
-        temp512 = _mm512_sub_epi8(m11, oe_del512);                      \
+        temp512 = _mm512_sub_epi8(h11, oe_del512);                      \
         val512  = _mm512_max_epi8(temp512, zero512);                    \
         f21 = _mm512_sub_epi8(f11, e_del512);                           \
         f21 = _mm512_max_epi8(val512, f21);                             \
@@ -2314,11 +2321,11 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         m11 = _mm512_mask_blend_epi16(cmp11, m11, zero512);             \
         h11 = _mm512_max_epi16(m11, e11);                               \
         h11 = _mm512_max_epi16(h11, f11);                               \
-        temp512 = _mm512_sub_epi16(m11, oe_ins512);                     \
+        temp512 = _mm512_sub_epi16(h11, oe_ins512);                     \
         val512  = _mm512_max_epi16(temp512, zero512);                   \
         e11 = _mm512_sub_epi16(e11, e_ins512);                          \
         e11 = _mm512_max_epi16(val512, e11);                            \
-        temp512 = _mm512_sub_epi16(m11, oe_del512);                     \
+        temp512 = _mm512_sub_epi16(h11, oe_del512);                     \
         val512  = _mm512_max_epi16(temp512, zero512);                   \
         f21 = _mm512_sub_epi16(f11, e_del512);                          \
         f21 = _mm512_max_epi16(val512, f21);                            \
@@ -2351,10 +2358,11 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         m11 = _mm512_mask_blend_epi8(cmp11, m11, zero512);  /* h00==0 -> local restart */ \
         h11 = _mm512_max_epu8(m11, e11);                                \
         h11 = _mm512_max_epu8(h11, f11);                                \
-        __m512i temp512 = _mm512_subs_epu8(m11, oe_ins512);            \
+        /* gap-open from H (standard Gotoh), unsigned-saturating */      \
+        __m512i temp512 = _mm512_subs_epu8(h11, oe_ins512);            \
         e11 = _mm512_subs_epu8(e11, e_ins512);                          \
         e11 = _mm512_max_epu8(temp512, e11);                            \
-        temp512 = _mm512_subs_epu8(m11, oe_del512);                    \
+        temp512 = _mm512_subs_epu8(h11, oe_del512);                    \
         f21 = _mm512_subs_epu8(f11, e_del512);                          \
         f21 = _mm512_max_epu8(temp512, f21);                            \
     }
@@ -2375,11 +2383,11 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         m11 = _mm512_mask_blend_epi16(cmp11, m11, zero512);             \
         h11 = _mm512_max_epi16(m11, e11);                               \
         h11 = _mm512_max_epi16(h11, f11);                               \
-        __m512i temp512 = _mm512_sub_epi16(m11, oe_ins512);             \
+        __m512i temp512 = _mm512_sub_epi16(h11, oe_ins512);             \
         __m512i val512  = _mm512_max_epi16(temp512, zero512);           \
         e11 = _mm512_sub_epi16(e11, e_ins512);                          \
         e11 = _mm512_max_epi16(val512, e11);                            \
-        temp512 = _mm512_sub_epi16(m11, oe_del512);                     \
+        temp512 = _mm512_sub_epi16(h11, oe_del512);                     \
         val512  = _mm512_max_epi16(temp512, zero512);                   \
         f21 = _mm512_sub_epi16(f11, e_del512);                          \
         f21 = _mm512_max_epi16(val512, f21);                            \
@@ -4168,11 +4176,11 @@ _mm_blendv_epi16(__m128i x, __m128i y, __m128i mask)
         m11 = _mm_blendv_epi16(m11, zero128, cmp11);                    \
         h11 = _mm_max_epi16(m11, e11);                                  \
         h11 = _mm_max_epi16(h11, f11);                                  \
-        __m128i temp128 = _mm_sub_epi16(m11, oe_ins128);                \
+        __m128i temp128 = _mm_sub_epi16(h11, oe_ins128);                \
         __m128i val128  = _mm_max_epi16(temp128, zero128);              \
         e11 = _mm_sub_epi16(e11, e_ins128);                             \
         e11 = _mm_max_epi16(val128, e11);                               \
-        temp128 = _mm_sub_epi16(m11, oe_del128);                        \
+        temp128 = _mm_sub_epi16(h11, oe_del128);                        \
         val128  = _mm_max_epi16(temp128, zero128);                      \
         f21 = _mm_sub_epi16(f11, e_del128);                             \
         f21 = _mm_max_epi16(val128, f21);                               \
@@ -4195,11 +4203,11 @@ _mm_blendv_epi16(__m128i x, __m128i y, __m128i mask)
         m11 = _mm_blendv_epi16(m11, zero128, cmp11);                    \
         h11 = _mm_max_epi16(m11, e11);                                  \
         h11 = _mm_max_epi16(h11, f11);                                  \
-        __m128i temp128 = _mm_sub_epi16(m11, oe_ins128);                \
+        __m128i temp128 = _mm_sub_epi16(h11, oe_ins128);                \
         __m128i val128  = _mm_max_epi16(temp128, zero128);              \
         e11 = _mm_sub_epi16(e11, e_ins128);                             \
         e11 = _mm_max_epi16(val128, e11);                               \
-        temp128 = _mm_sub_epi16(m11, oe_del128);                        \
+        temp128 = _mm_sub_epi16(h11, oe_del128);                        \
         val128  = _mm_max_epi16(temp128, zero128);                      \
         f21 = _mm_sub_epi16(f11, e_del128);                             \
         f21 = _mm_max_epi16(val128, f21);                               \
@@ -5000,10 +5008,10 @@ static inline __m128i _mm_blendv_epi8 (__m128i x, __m128i y, __m128i mask)
         m11 = _mm_and_si128(m11, _mm_cmpgt_epi8(m11, zero128));         \
         h11 = _mm_max_epu8(m11, e11);                                   \
         h11 = _mm_max_epu8(h11, f11);                                   \
-        __m128i temp128 = _mm_subs_epu8(m11, oe_ins128);                \
+        __m128i temp128 = _mm_subs_epu8(h11, oe_ins128);                \
         e11 = _mm_subs_epu8(e11, e_ins128);                             \
         e11 = _mm_max_epu8(temp128, e11);                               \
-        temp128 = _mm_subs_epu8(m11, oe_del128);                        \
+        temp128 = _mm_subs_epu8(h11, oe_del128);                        \
         f21 = _mm_subs_epu8(f11, e_del128);                             \
         f21 = _mm_max_epu8(temp128, f21);                               \
     }
@@ -5044,10 +5052,10 @@ static inline __m128i _mm_blendv_epi8 (__m128i x, __m128i y, __m128i mask)
         m11 = _mm_blendv_epi8(m11, zero128, cmp11);  /* h00==0 -> local restart */ \
         h11 = _mm_max_epu8(m11, e11);                                   \
         h11 = _mm_max_epu8(h11, f11);                                   \
-        __m128i temp128 = _mm_subs_epu8(m11, oe_ins128);                \
+        __m128i temp128 = _mm_subs_epu8(h11, oe_ins128);                \
         e11 = _mm_subs_epu8(e11, e_ins128);                             \
         e11 = _mm_max_epu8(temp128, e11);                               \
-        temp128 = _mm_subs_epu8(m11, oe_del128);                        \
+        temp128 = _mm_subs_epu8(h11, oe_del128);                        \
         f21 = _mm_subs_epu8(f11, e_del128);                             \
         f21 = _mm_max_epu8(temp128, f21);                               \
     }


### PR DESCRIPTION
> **Stacked on #140** (`feat(bsw): recover the 8-bit banded SW path for reads ≥128 bp`). Base is `pr/longread-sw-8bit`; review/merge #140 first. This PR's own diff is the 26-line gap-open change below.

## What

Switches BandedPairWiseSW's banded Smith–Waterman extension scorer from deriving the gap-open penalty from the diagonal-only match value `M` (`M − oe`, a bwa idiosyncrasy — "disallow a cigar like 100M3I3D20M") to deriving it from the cell max `H` (`h − oe`, standard Gotoh). All 26 gap-open sites: 2 scalar + 24 SIMD across the 128/256/512 `MAIN_CODE{,_CORE}{8,16}` macros.

## Why

`h − oe` is the convention used by ksw2 / minimap2. It is also what an int8 difference (Suzuki–Kasahara) recurrence requires (under gap-from-M the `E − H` delta is unbounded for int8; under gap-from-H it is bounded) — though that recurrence was evaluated and not adopted, so this lands purely as a convention-alignment cleanup.

## Output is unchanged

The extension scorer only finds the alignment **boundary**; the reported CIGAR and score come from `ksw_global2` (unchanged, still gap-from-M). So alignment output does not change. Verified byte-identical to upstream `bwa` 0.7.19 on chr22 (101,636 records, holodeck 151 bp PE) **on top of the recovered 8-bit path**, and 8-bit vs forced-16-bit (`BWAMEM3_DISABLE_BSW8`) remains byte-identical under gap-from-H. The standalone change was previously verified byte-identical to `main` on 601,725 (NEON) + 200,611×2 (avx2/avx512bw) real records.

## Notes

- Independent of #140 — composes cleanly (this stack is for review/merge ordering, not a hard dependency).
- No parity-baseline change needed (output unchanged vs main).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected banded Smith-Waterman alignment gap penalty scoring formula to match standard industry conventions and mathematical specifications. This update ensures consistent, accurate results across all available CPU implementations and processing optimizations. Alignment scores and results may differ from previous versions due to this correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->