### PR TITLE
fix(seeding): widen SMEM read positions from int16_t to int32_t (long-read SIGSEGV)

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -366,7 +366,7 @@ void FMI_search::load_index()
 }
 
 void FMI_search::getSMEMsOnePosOneThread(uint8_t *enc_qdb,
-                                         int16_t *query_pos_array,
+                                         int32_t *query_pos_array,
                                          int32_t *min_intv_array,
                                          int32_t *rid_array,
                                          int32_t numReads,
@@ -592,13 +592,13 @@ struct FMI_search::BatchSlot {
     // Input identity — copied at init, never mutated thereafter.
     int32_t input_idx;           // index into the caller's input arrays
     int32_t rid;                 // rid_array[input_idx]
-    int16_t start_pos;           // query_pos_array[input_idx] (saved for bwd init)
+    int32_t start_pos;           // query_pos_array[input_idx] (saved for bwd init)
     int32_t min_intv;            // min_intv_array[input_idx]
     int32_t readlength;          // seq_[rid].l_seq
     int32_t offset;              // query_cum_len_ar[rid]
 
     // Output for query_pos_array[input_idx] write-back at flush time.
-    int16_t next_x;
+    int32_t next_x;
 
     // Walk state (mirrors scalar locals).
     SMEM smem;                   // current SA interval
@@ -653,7 +653,7 @@ void FMI_search::ls_prefetch_cp_occ_t1(const BatchSlot *s)
 //                      we match that (zero matches emitted, ready to flush).
 void FMI_search::ls_init_slot(BatchSlot *s,
                               int32_t input_idx,
-                              const int16_t *query_pos_array,
+                              const int32_t *query_pos_array,
                               const int32_t *min_intv_array,
                               const int32_t *rid_array,
                               const bseq1_t *seq_,
@@ -858,7 +858,7 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                          SMEM *matchArray,
                                          int64_t *__numTotalSmem)
 {
-    int16_t *query_pos_array = (int16_t *)_mm_malloc(numReads * sizeof(int16_t), 64);
+    int32_t *query_pos_array = (int32_t *)_mm_malloc(numReads * sizeof(int32_t), 64);
 
     int32_t i;
     for(i = 0; i < numReads; i++)
@@ -916,7 +916,7 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
 }
 
 void FMI_search::getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
-                                                   int16_t *query_pos_array,
+                                                   int32_t *query_pos_array,
                                                    int32_t *min_intv_array,
                                                    int32_t *rid_array,
                                                    int32_t numReads,
@@ -1077,7 +1077,7 @@ int64_t FMI_search::bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,
     for(i = 0; i < numReads; i++)
     {
         int readlength = seq_[i].l_seq;
-        int16_t x = 0;
+        int32_t x = 0;
         while(x < readlength)
         {
             int next_x = x + 1;

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -153,7 +153,7 @@ class FMI_search: public indexEle
 
     /* matchArray must hold at least numReads * max_readlength SMEMs (caller-sized). */
     void getSMEMsOnePosOneThread(uint8_t *enc_qdb,
-                                 int16_t *query_pos_array,
+                                 int32_t *query_pos_array,
                                  int32_t *min_intv_array,
                                  int32_t *rid_array,
                                  int32_t numReads,
@@ -174,7 +174,7 @@ class FMI_search: public indexEle
      * buffers flushed by input-index cursor.
      * matchArray must hold at least numReads * max_readlength SMEMs (caller-sized). */
     void getSMEMsOnePosOneThread_lockstep(uint8_t *enc_qdb,
-                                          int16_t *query_pos_array,
+                                          int32_t *query_pos_array,
                                           int32_t *min_intv_array,
                                           int32_t *rid_array,
                                           int32_t numReads,
@@ -300,7 +300,7 @@ private:
     struct BatchSlot;
 
     void ls_init_slot(BatchSlot *s, int32_t input_idx,
-                      const int16_t *query_pos_array,
+                      const int32_t *query_pos_array,
                       const int32_t *min_intv_array,
                       const int32_t *rid_array,
                       const bseq1_t *seq_,

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -685,7 +685,7 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
                        int nseq,
                        SMEM *matchArray,
                        int32_t *min_intv_ar,
-                       int16_t *query_pos_ar,
+                       int32_t *query_pos_ar,
                        uint8_t *enc_qdb,
                        int32_t *rid,
                        mem_cache *mmc,
@@ -1085,9 +1085,10 @@ int mem_kernel1_core(FMI_search *fmi,
     // subsequent batches even when enc_qdb is undersized.
     if (tot_len > mmc->wsize_qdb[tid]) {
         int64_t tmp = mmc->wsize_qdb[tid];
-        mmc->enc_qdb[tid] = (uint8_t *) realloc(mmc->enc_qdb[tid],
-                                                tot_len * sizeof(uint8_t));
-        assert(mmc->enc_qdb[tid] != NULL);
+        uint8_t *new_enc_qdb = (uint8_t *) realloc(mmc->enc_qdb[tid],
+                                                   tot_len * sizeof(uint8_t));
+        if (new_enc_qdb == NULL) err_fatal(__func__, "out of memory growing enc_qdb");
+        mmc->enc_qdb[tid] = new_enc_qdb;
         mmc->wsize_qdb[tid] = tot_len;
         if (bwa_verbose >= 4) {
             fprintf(stderr, "[%0.4d] Re-allocating enc_qdb: "
@@ -1113,18 +1114,26 @@ int mem_kernel1_core(FMI_search *fmi,
         mmc->matchArray[tid]   = (SMEM *) _mm_realloc(mmc->matchArray[tid],
                                                       tmp, mmc->wsize_mem[tid], sizeof(SMEM));
             //realloc(mmc->matchArray[tid], mmc->wsize_mem[tid] *   sizeof(SMEM));
-        mmc->min_intv_ar[tid]  = (int32_t *) realloc(mmc->min_intv_ar[tid],
-                                                     mmc->wsize_mem[tid] *  sizeof(int32_t));
-        mmc->query_pos_ar[tid] = (int16_t *) realloc(mmc->query_pos_ar[tid],
-                                                     mmc->wsize_mem[tid] *  sizeof(int16_t));
-        mmc->rid[tid]          = (int32_t *) realloc(mmc->rid[tid],
-                                                      mmc->wsize_mem[tid] * sizeof(int32_t));
+        int32_t *new_min_intv_ar = (int32_t *) realloc(mmc->min_intv_ar[tid],
+                                                       mmc->wsize_mem[tid] * sizeof(int32_t));
+        if (new_min_intv_ar == NULL) err_fatal(__func__, "out of memory growing min_intv_ar");
+        mmc->min_intv_ar[tid] = new_min_intv_ar;
+
+        int32_t *new_query_pos_ar = (int32_t *) realloc(mmc->query_pos_ar[tid],
+                                                        mmc->wsize_mem[tid] * sizeof(int32_t));
+        if (new_query_pos_ar == NULL) err_fatal(__func__, "out of memory growing query_pos_ar");
+        mmc->query_pos_ar[tid] = new_query_pos_ar;
+
+        int32_t *new_rid = (int32_t *) realloc(mmc->rid[tid],
+                                               mmc->wsize_mem[tid] * sizeof(int32_t));
+        if (new_rid == NULL) err_fatal(__func__, "out of memory growing rid");
+        mmc->rid[tid] = new_rid;
         // w.mmc.lim[l]        = (int32_t *) _mm_malloc((BATCH_SIZE + 32) * sizeof(int32_t), 64);
     }
 
     SMEM    *matchArray   = mmc->matchArray[tid];
     int32_t *min_intv_ar  = mmc->min_intv_ar[tid];
-    int16_t *query_pos_ar = mmc->query_pos_ar[tid];
+    int32_t *query_pos_ar = mmc->query_pos_ar[tid];
     uint8_t *enc_qdb      = mmc->enc_qdb[tid];
     int32_t *rid          = mmc->rid[tid];
     int64_t  *wsize_mem   = &mmc->wsize_mem[tid];

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -213,7 +213,7 @@ typedef struct
     int32_t *min_intv_ar[MAX_THREADS];
     int32_t *rid[MAX_THREADS];
     int32_t *lim[MAX_THREADS];
-    int16_t *query_pos_ar[MAX_THREADS];
+    int32_t *query_pos_ar[MAX_THREADS];
     uint8_t *enc_qdb[MAX_THREADS];
     
     int64_t wsize_mem[MAX_THREADS];

--- a/test/integration/smem2_test.cpp
+++ b/test/integration/smem2_test.cpp
@@ -43,7 +43,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 
 int myrank, num_ranks;
 
-int32_t read_smem2_input(char *fname, char *query_seq, int16_t *query_pos_array, int32_t *min_intv_array, int32_t readlen)
+int32_t read_smem2_input(char *fname, char *query_seq, int32_t *query_pos_array, int32_t *min_intv_array, int32_t readlen)
 {
     FILE *smem2_fp = fopen(fname, "r");
     assert(smem2_fp != NULL);
@@ -62,7 +62,7 @@ int32_t read_smem2_input(char *fname, char *query_seq, int16_t *query_pos_array,
         //printf("2.0\n");
         memcpy(query_seq + numReads * readlen, line, readlen);
         //printf("3.0\n");
-        fscanf(smem2_fp, "%hd", query_pos_array + numReads);
+        fscanf(smem2_fp, "%d", query_pos_array + numReads);
         //printf("4.0\n");
         fscanf(smem2_fp, "%d", min_intv_array + numReads);
         //printf("4.1\n");
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
     }
 
     char *query_seq=(char *)malloc(QUERY_DB_SIZE*sizeof(char));
-    int16_t *query_pos_array = (int16_t *)_mm_malloc(MAX_NUM_QUERIES * sizeof(int16_t), 64);
+    int32_t *query_pos_array = (int32_t *)_mm_malloc(MAX_NUM_QUERIES * sizeof(int32_t), 64);
     int32_t *min_intv_array = (int32_t *)_mm_malloc(MAX_NUM_QUERIES * sizeof(int32_t), 64);
     int32_t *rid_array = (int32_t *)_mm_malloc(MAX_NUM_QUERIES * sizeof(int32_t), 64);
     int readlength=atoi(argv[4]);

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -119,6 +119,45 @@ for LEN_FQ in long_read_300bp long_read_1kbp long_read_3kbp; do
 done
 
 
+# --- ultra-long-read crash regression (read length > INT16_MAX) -----------
+# Pre-fix, read positions in the SMEM seeding path were int16_t:
+# query_pos_array (FMI_search getSMEMsAllPos/OnePos/lockstep + caller's
+# mmc->query_pos_ar), BatchSlot.start_pos/next_x, and the walk index `x`
+# in bwtSeedStrategyAllPosOneThread. For a read longer than INT16_MAX
+# (32767) bp the position incremented past 32767 and wrapped negative, so
+# the re-seed loops (`while (x < readlength)` and the getSMEMsAllPos
+# do/while) never advanced past the wrap point. They emitted SMEMs without
+# bound until matchArray overran -> heap corruption / SIGSEGV. The
+# 300bp-3kbp cases above all stay under 32767 and never exposed it; phiX
+# (~5 kb) is too small to host the alignment, so use the checked-in 1 Mb
+# synthetic reference and a 40 kb read sliced from it.
+SYN="$FIXTURES/synthetic_1mb.fa"
+if [[ ! -s "$SYN.bwt.2bit.64" || ! -s "$SYN.0123" || ! -s "$SYN.amb" || \
+      ! -s "$SYN.ann"         || ! -s "$SYN.pac" ]]; then
+    "$BWAMEM3" index "$SYN" >/dev/null 2>&1 || fail "bwa-mem3 index on synthetic_1mb.fa failed"
+fi
+# Slice a 40 kb read (> 32767) from the middle of the reference so it maps
+# back cleanly. Derived at run time rather than committed as a fixture.
+ULTRALONG_FA="$(mktemp "$HERE/.ultralong_40kbp.XXXXXX.fa")"
+# Append to (don't replace) the EXIT trap installed earlier so the temp FASTA
+# is removed on early failure or in parallel runs, not just on success.
+trap 'rm -f "$OUT_FILE" "$FKSW" "$HEADER_OUT" "$ULTRALONG_FA"' EXIT
+awk 'NR==1 && /^>/ {next} {seq = seq $0}
+     END { print ">ultralong_40kbp"; print substr(seq, 100001, 40000) }' \
+    "$SYN" > "$ULTRALONG_FA"
+LR_LEN="$(awk 'NR==2 {print length($0)}' "$ULTRALONG_FA")"
+[[ "$LR_LEN" -gt 32767 ]] || fail "ultralong fixture is ${LR_LEN}bp, need > 32767 (INT16_MAX)"
+RAW="$("$BWAMEM3" mem "$SYN" "$ULTRALONG_FA" 2>/dev/null)" \
+    || fail "bwa-mem3 mem ultralong ${LR_LEN}bp: non-zero exit (int16 position-overflow regression)"
+OUT="$(printf '%s\n' "$RAW" | grep -v '^@' || true)"
+[[ -n "$OUT" ]] || fail "bwa-mem3 mem ultralong: no SAM records emitted"
+# The primary record (flag < 256, not 4=unmapped) must align.
+PRIMARY_MAPPED="$(echo "$OUT" | awk '$2 < 256 && $2 != 4 {c++} END {print c+0}')"
+[[ "$PRIMARY_MAPPED" -ge 1 ]] || fail "bwa-mem3 mem ultralong ${LR_LEN}bp: primary read unmapped"
+rm -f "$ULTRALONG_FA"   # cleaned here on success; EXIT trap covers early-failure paths
+ok "bwa-mem3 mem ultralong ${LR_LEN}bp (> 32767, mapped)"
+
+
 # --- interleaved -p mode regression --------------------------------------
 # Bugs covered:
 #  - Empty/zero-length-read batches (which a malformed FASTQ that bseq parses

--- a/test/smem_lockstep_parity_test.cpp
+++ b/test/smem_lockstep_parity_test.cpp
@@ -49,7 +49,7 @@ static bool run_case(FMI_search *fmi,
                      int32_t max_readlength,
                      int32_t minSeedLen,
                      uint8_t *enc_qdb,
-                     int16_t *query_pos_array_in,
+                     int32_t *query_pos_array_in,
                      int32_t *min_intv_array_in,
                      int32_t *rid_array_in,
                      const bseq1_t *seq_,
@@ -62,14 +62,22 @@ static bool run_case(FMI_search *fmi,
     SMEM *scalar_out   = (SMEM *)_mm_malloc(max_out * sizeof(SMEM), 64);
     SMEM *lockstep_out = (SMEM *)_mm_malloc(max_out * sizeof(SMEM), 64);
 
-    int16_t *qpa_s = (int16_t *)malloc(numReads * sizeof(int16_t));
-    int16_t *qpa_l = (int16_t *)malloc(numReads * sizeof(int16_t));
+    int32_t *qpa_s = (int32_t *)malloc(numReads * sizeof(int32_t));
+    int32_t *qpa_l = (int32_t *)malloc(numReads * sizeof(int32_t));
     int32_t *mia_s = (int32_t *)malloc(numReads * sizeof(int32_t));
     int32_t *mia_l = (int32_t *)malloc(numReads * sizeof(int32_t));
     int32_t *rid_s = (int32_t *)malloc(numReads * sizeof(int32_t));
     int32_t *rid_l = (int32_t *)malloc(numReads * sizeof(int32_t));
-    memcpy(qpa_s, query_pos_array_in, numReads * sizeof(int16_t));
-    memcpy(qpa_l, query_pos_array_in, numReads * sizeof(int16_t));
+    if (!qpa_s || !qpa_l || !mia_s || !mia_l || !rid_s || !rid_l) {
+        fprintf(stderr, "[FAIL] %s: allocation failed\n", case_name);
+        _mm_free(scalar_out);
+        _mm_free(lockstep_out);
+        free(qpa_s); free(qpa_l); free(mia_s); free(mia_l); free(rid_s); free(rid_l);
+        total_cases++;
+        return false;
+    }
+    memcpy(qpa_s, query_pos_array_in, numReads * sizeof(int32_t));
+    memcpy(qpa_l, query_pos_array_in, numReads * sizeof(int32_t));
     memcpy(mia_s, min_intv_array_in, numReads * sizeof(int32_t));
     memcpy(mia_l, min_intv_array_in, numReads * sizeof(int32_t));
     memcpy(rid_s, rid_array_in, numReads * sizeof(int32_t));
@@ -108,7 +116,7 @@ static bool run_case(FMI_search *fmi,
                     a.rid, a.m, a.n, (long long)a.k, (long long)a.l, (long long)a.s,
                     b.rid, b.m, b.n, (long long)b.k, (long long)b.l, (long long)b.s);
             ok = false;
-        } else if (memcmp(qpa_s, qpa_l, numReads * sizeof(int16_t)) != 0) {
+        } else if (memcmp(qpa_s, qpa_l, numReads * sizeof(int32_t)) != 0) {
             fprintf(stderr, "[FAIL] %s: query_pos_array write-back differs\n", case_name);
             ok = false;
         } else {
@@ -179,7 +187,7 @@ int main(int argc, char *argv[]) {
         int32_t max_readlength = 32;
         uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
-        int16_t qpa[] = {0, 0};
+        int32_t qpa[] = {0, 0};
         int32_t mia[] = {1, 1};
         int32_t rid[] = {0, 1};
         run_case(fmi, "Case 1: two simple reads",
@@ -200,7 +208,7 @@ int main(int argc, char *argv[]) {
         int32_t max_readlength = 40;
         uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
-        int16_t qpa[] = {0, 0};
+        int32_t qpa[] = {0, 0};
         int32_t mia[] = {1, 1};
         int32_t rid[] = {0, 1};
         run_case(fmi, "Case 2: numReads < N",
@@ -223,7 +231,7 @@ int main(int argc, char *argv[]) {
         int32_t max_readlength = 32;
         uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
-        int16_t qpa[] = {0, 0, 0, 0};
+        int32_t qpa[] = {0, 0, 0, 0};
         int32_t mia[] = {1, 1, 1, 1};
         int32_t rid[] = {0, 1, 2, 3};
         run_case(fmi, "Case 3: numReads == N",
@@ -246,7 +254,7 @@ int main(int argc, char *argv[]) {
         int32_t max_readlength = 32;
         uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
-        int16_t qpa[] = {0, 0, 0, 0, 0};
+        int32_t qpa[] = {0, 0, 0, 0, 0};
         int32_t mia[] = {1, 1, 1, 1, 1};
         int32_t rid[] = {0, 1, 2, 3, 4};
         run_case(fmi, "Case 4: numReads == N+1",
@@ -271,7 +279,7 @@ int main(int argc, char *argv[]) {
         int32_t max_readlength = 32;
         uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
-        int16_t qpa[] = {0, 0, 0, 0};
+        int32_t qpa[] = {0, 0, 0, 0};
         int32_t mia[] = {1, 1, 1, 1};
         int32_t rid[] = {0, 1, 2, 3};
         run_case(fmi, "Case 5: first base non-ACGT",
@@ -299,7 +307,7 @@ int main(int argc, char *argv[]) {
         int32_t max_readlength = 32;
         uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
-        int16_t qpa[] = {0, 0, 0, 0, 0, 0, 0};
+        int32_t qpa[] = {0, 0, 0, 0, 0, 0, 0};
         int32_t mia[] = {1, 1, 1, 1, 1, 1, 1};
         int32_t rid[] = {0, 1, 2, 3, 4, 5, 6};
         run_case(fmi, "Case 6: numReads not divisible by N",
@@ -324,7 +332,7 @@ int main(int argc, char *argv[]) {
         int32_t max_readlength = 32;
         uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
-        int16_t qpa[] = {5, 10, 0, 15};   /* mixed start positions */
+        int32_t qpa[] = {5, 10, 0, 15};   /* mixed start positions */
         int32_t mia[] = {1, 1, 1, 1};
         int32_t rid[] = {0, 1, 2, 3};
         run_case(fmi, "Case 7: mixed start_pos",
@@ -358,7 +366,7 @@ int main(int argc, char *argv[]) {
         int32_t max_readlength = 300;
         uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
-        int16_t qpa[] = {0, 0};
+        int32_t qpa[] = {0, 0};
         int32_t mia[] = {1, 1};
         int32_t rid[] = {0, 1};
         run_case(fmi, "Case 8: real 300bp SRR6109255.100035",
@@ -409,7 +417,7 @@ int main(int argc, char *argv[]) {
          * structure changes in production, update both drivers here to match. */
         /* Scalar outer driver. */
         int64_t n_s = 0;
-        int16_t qpa_s[2] = {0, 0};
+        int32_t qpa_s[2] = {0, 0};
         {
             int32_t rid_work[2] = {0, 1};
             int32_t mia_work[2] = {1, 1};
@@ -435,7 +443,7 @@ int main(int argc, char *argv[]) {
 
         /* Lockstep outer driver. */
         int64_t n_l = 0;
-        int16_t qpa_l[2] = {0, 0};
+        int32_t qpa_l[2] = {0, 0};
         {
             int32_t rid_work[2] = {0, 1};
             int32_t mia_work[2] = {1, 1};
@@ -509,7 +517,7 @@ int main(int argc, char *argv[]) {
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
         /* Start mid-read (past adapter) and use a large min_intv so the
          * forward walk will terminate via the newSmem.s < min_intv branch. */
-        int16_t qpa[] = {100, 100};
+        int32_t qpa[] = {100, 100};
         int32_t mia[] = {1000, 1000};
         int32_t rid[] = {0, 1};
         run_case(fmi, "Case 10: forward-ext min_intv break",
@@ -538,7 +546,7 @@ int main(int argc, char *argv[]) {
         int32_t max_readlength = 1500;
         uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
-        int16_t qpa[] = {0, 0};
+        int32_t qpa[] = {0, 0};
         int32_t mia[] = {1, 1};
         int32_t rid[] = {0, 1};
         run_case(fmi, "Case 11: long reads (1000bp, 1500bp)",
@@ -568,7 +576,7 @@ int main(int argc, char *argv[]) {
         int32_t max_readlength = 1500;
         uint8_t *enc_qdb; bseq1_t *seq_; int32_t *cum_len;
         encode_reads(reads, numReads, &enc_qdb, &seq_, &cum_len);
-        int16_t qpa[] = {0, 0};
+        int32_t qpa[] = {0, 0};
         int32_t mia[] = {1, 1};
         int32_t rid[] = {0, 1};
         run_case(fmi, "Case 12: long reads with mid-read N",


### PR DESCRIPTION
## Summary

`bwa-mem3 mem` segfaults on any read longer than **32767 bp** (`INT16_MAX`). Reads at or below that length are unaffected. This surfaces on long-read input — ONT/HiFi reads over ~32 kb — where it is a hard crash (SIGSEGV); short-read workloads never reach the threshold.

## Root cause

Read positions in the SMEM seeding path are stored as `int16_t`:

- `query_pos_array` in `getSMEMsAllPosOneThread`, `getSMEMsOnePosOneThread`, and the lockstep variant, plus the caller's `mmc->query_pos_ar`
- `BatchSlot.start_pos` and `BatchSlot.next_x`
- the walk index `x` in `bwtSeedStrategyAllPosOneThread` (the third-round seeding pass, on by default since `max_mem_intv` defaults to 20)

When a read's query position increments past 32767 it wraps negative, so the re-seed loops — `while (x < readlength)` in `bwtSeedStrategyAllPosOneThread`, and the `do { ... } while (numActive > 0)` driver in `getSMEMsAllPosOneThread` — never advance past the wrap point. They keep emitting SMEMs without bound until `matchArray` overruns its allocation, corrupting the heap and crashing.

Diagnosis: lldb pinned the fault at `FMI_search.cpp:1037` (`matchArray[numTotalSmem++] = …`) with a multi-hundred-MB write offset (millions of SMEMs for a single read — far beyond the `numReads * max_readlength` contract). Length bisection confirmed the boundary is exactly `INT16_MAX`: a read truncated to 30000 bp aligns cleanly, the same read at 33000 bp crashes.

## Fix

Widen every query-position field to `int32_t`. Read length is already an `int`, so `int32_t` is the correct type and the prior `int16_t` was an unsafe space optimization.

15 lines across `src/FMI_search.{cpp,h}` and `src/bwamem.{cpp,h}`.

## Verification

- **Crash resolved:** 33k / 40k / 50k bp reads now exit 0 and map; a 40 kb read sliced from a 1 Mb reference maps back exactly (`POS=100001 MAPQ=60 40000M`). A real ONT-100 set (with a 248 kb read) that previously SIGSEGV'd now maps 100/100 primary, exit 0.
- **Behaviour-neutral for normal reads:** SAM output is **byte-identical** to the pre-fix build on Illumina, HiFi, and SBX inputs (verified by diffing a clean build of this base vs the fixed build; 0 differing records).
- **Tests:** full unit suite passes, including the existing lockstep parity test (12/12). Adds a `>32767 bp` regression case to the long-read suite in `run_unit_tests.sh` (a 40 kb read derived from the checked-in `synthetic_1mb` reference; phiX is too small to host the alignment). Widens the query-position types in `smem_lockstep_parity_test` and `smem2_test` to match the new signatures.

## Notes

This is a correctness fix only — it stops the crash and makes long reads map. It does not make `bwa-mem3` *fast* on long reads (banded SW over a 248 kb read is inherently slow); minimap2 / minibwa remain the right tools for long-read alignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue that could fail for reads longer than 32,767 bp by extending internal query-position handling to 32-bit values.

* **Tests**
  * Added an ultra-long read (> INT16_MAX) regression test to prevent future crashes and mapping regressions.
  * Updated lockstep parity and SMEM integration tests to use 32-bit query-position buffers for consistent verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->