### PR TITLE
refactor(bsw): drop the dead qlen[] parameter from the 8-bit kernels

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -821,7 +821,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                                numPairs,
                                zdrop,
                                bsize,
-                               qlen,
                                myband);
         }
     }
@@ -878,7 +877,6 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
                                           int32_t numPairs,
                                           int zdrop,
                                           int32_t w,
-                                          uint8_t qlen[],   // dead parameter (overwritten immediately); remove with call site in a later task
                                           uint8_t myband[])
 {
     __m256i match256     = _mm256_set1_epi8(this->w_match);
@@ -2727,7 +2725,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                                numPairs,
                                zdrop,
                                bsize,
-                               qlen,
                                myband);
         }
     }
@@ -2783,7 +2780,6 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
                                           int32_t numPairs,
                                           int zdrop,
                                           int32_t w,
-                                          uint8_t qlen[],   // dead parameter (overwritten immediately); remove with call site in a later task
                                           uint8_t myband[])
 {
     __m512i match512     = _mm512_set1_epi8(this->w_match);
@@ -5325,7 +5321,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                                numPairs,
                                zdrop,
                                bsize,
-                               qlen,
                                myband);         
         }
     }
@@ -5380,7 +5375,6 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
                                           int32_t numPairs,
                                           int zdrop,
                                           int32_t w,
-                                          uint8_t qlen[],   // dead parameter (overwritten immediately); remove with call site in a later task
                                           uint8_t myband[])
 {
     

--- a/src/bandedSWA.h
+++ b/src/bandedSWA.h
@@ -303,7 +303,6 @@ public:
                             int32_t numPairs,
                             int zdrop,
                             int32_t w,
-                            uint8_t qlen[],
                             uint8_t myband[]);
     // 16 bit vector code section
     void getScores16(SeqPair *pairArray,
@@ -363,7 +362,6 @@ public:
                             int32_t numPairs,
                             int zdrop,
                             int32_t w,
-                            uint8_t qlen[],
                             uint8_t myband[]);
     // 16 bit vector code section
     void getScores16(SeqPair *pairArray,
@@ -423,7 +421,6 @@ public:
                             int32_t numPairs,
                             int zdrop,
                             int32_t w,
-                            uint8_t qlen[],
                             uint8_t myband[]);
 
     // 16 bit vector code section


### PR DESCRIPTION
Stacked on #140. The three 8-bit kernels (smithWaterman128_8/256_8/512_8) take a `uint8_t qlen[]` parameter they never read — the recovered long-read path recomputes its own per-lane qlen from `p[l].len2` internally. Removes the dead parameter from the signatures (header + defs) and the three call sites.

The wrappers' local `qlen[]`/`qlen128` (loaded for band sizing) and the 16-bit kernels' `qlen[]` (genuinely used) are untouched. Pure signature cleanup, no behavior change: NEON builds clean, chr22 parity vs upstream bwa unchanged (101,636 records); x86 tiers build-verified in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal computational routines to improve maintainability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->