### PR TITLE
docs: add memory budgeting and data-type (Hi-C) tuning guide

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,6 +17,7 @@
 - [Output: SAM/BAM, headers, tags](user-guide/output.md)
 - [Threading and resource use](user-guide/threading.md)
 - [Memory allocator (mimalloc)](user-guide/allocator.md)
+- [Memory budgeting and data-type tuning](user-guide/memory-and-data-types.md)
 - [Tips and best practices](user-guide/tips.md)
 
 # Performance

--- a/docs/src/user-guide/memory-and-data-types.md
+++ b/docs/src/user-guide/memory-and-data-types.md
@@ -1,0 +1,127 @@
+# Memory budgeting and data-type tuning
+
+Most short-read alignments run comfortably with default settings. A handful of
+situations push memory hard enough to matter: tight memory caps (containers,
+cgroups, schedulers), very high thread counts, and data types with unusually
+wide insert-size distributions such as Hi-C. This page explains how peak memory
+is built up, how to fit a run inside a fixed cap, and how to align Hi-C and
+similar data without wasting memory.
+
+## How peak memory is built up
+
+Peak resident memory during `bwa-mem3 mem` is the sum of two parts:
+
+```text
+peak RSS  ≈  resident index  +  per-batch working set
+```
+
+**Resident index.** The FM-index, packed reference, and related structures are
+loaded once and shared across all threads (there is no per-thread copy). For
+hg38 the resident index baseline is roughly **21 GB**. This is fixed for a given
+reference and does not change with `-t` or `-K`.
+
+**Per-batch working set.** On top of the index, each in-flight batch holds the
+reads, their seeds, candidate alignment regions, and the reference windows used
+by mate rescue. This scales with the *effective batch size* (below) and with the
+data: longer reference windows — for example wide mate-rescue windows — make it
+larger.
+
+## Effective batch size: `-K` and the `-t` multiplier
+
+The single most important knob for per-batch memory is the effective batch size,
+and it is easy to misjudge because of how it interacts with `-t`:
+
+```text
+no -K     effective batch = chunk_size × n_threads   (chunk_size default 10,000,000)
+-K INT    effective batch = INT                       (fixed, regardless of n_threads)
+```
+
+So with the default `chunk_size` and `-t 16`, each batch is
+`10,000,000 × 16 = 160,000,000` bases — **not** 10 M. Setting `-K 1000000` makes
+the batch a fixed 1 M bases regardless of thread count: in that example a **160×**
+reduction in the per-batch working set, not 10×.
+
+Two consequences worth remembering:
+
+- Raising `-t` raises peak memory by default, because the batch grows with the
+  thread count. If you scale threads up on a memory-constrained host, scale `-K`
+  down to compensate.
+- `-K` also makes output deterministic across different `-t` values (see
+  [`-K` in the mem reference](../cli/mem.md)), which is why it is useful for
+  reproducibility independent of memory.
+
+## Fitting a run inside a memory cap
+
+Under a hard cap (a `--memory` cgroup limit, a Slurm `--mem`, a container limit),
+budget like this:
+
+```text
+per-batch budget  ≈  memory cap  −  resident index  −  headroom
+```
+
+For hg38 under a 28 GB cap, that is roughly `28 − 21 − a couple GB ≈ a few GB`
+for the per-batch working set — not much. The levers, in order of preference:
+
+1. **Lower `-K`.** `-K 1000000` keeps the per-batch working set well under 1 GB
+   for typical short reads and costs little throughput. This is the first thing
+   to try.
+2. **Lower `-t`.** Fewer threads shrink the default batch (since it is
+   `chunk_size × n_threads`) and reduce concurrency-related overhead. Prefer
+   adjusting `-K` first so you keep your cores busy.
+3. **Use `bwa-mem3 shm`** if you run several samples on one host: the index is
+   mapped from a shared segment and its pages are shared across processes, so the
+   ~21 GB index is paid once rather than per process. See
+   [Quick start: shared-memory index](../getting-started/quick-shm.md).
+
+> **Tip — a silent OOM looks like a truncated BAM**
+>
+> When the kernel OOM-kills `bwa-mem3` (for example, a process exceeding its
+> cgroup limit), it receives `SIGKILL` with no error message. A downstream
+> `samtools` in the same pipe may still exit 0, leaving a **header-only or
+> truncated BAM that masquerades as success**. Always run alignment pipes under
+> `set -o pipefail` and verify the output BAM is non-empty (e.g. a record count
+> or `samtools quickcheck`) before treating a run as complete.
+
+## Hi-C and other wide-insert data
+
+Mate rescue searches a reference window whose width is derived from the observed
+insert-size distribution (roughly the inter-quartile range of inferred insert
+sizes, scaled out by several multiples). For standard paired-end libraries this
+window is a few hundred bases. For **Hi-C** (and capture-C / 3C-style data) the
+"insert size" between mates is not a library property at all — mates are ligation
+contacts that can sit anywhere in the genome — so the inferred distribution is
+enormously wide and the per-attempt rescue window balloons to tens of kilobases.
+The result is both wasted compute and a large per-batch working set, which is a
+common cause of OOM on Hi-C.
+
+The fix is to align Hi-C the way Hi-C pipelines expect, with `-5SP`:
+
+```sh
+bwa-mem3 mem -5SP -t 16 --bam ref.fa hic_R1.fq.gz hic_R2.fq.gz \
+  | samtools sort -n -@ 2 -o hic.namesorted.bam -
+```
+
+- **`-S`** skips mate rescue — this removes the wide rescue windows entirely and
+  is the bulk of the memory and time saving.
+- **`-P`** skips pairing, which is meaningless for Hi-C contacts.
+- **`-5`** marks the alignment with the smallest coordinate as primary for split
+  reads, the convention expected by Hi-C tools (Juicer, Arima, pairtools, etc.).
+
+`-5SP` is the standard Hi-C invocation for the `bwa mem` family; it is the
+*correct* mode for Hi-C, not merely a memory workaround. Because it changes which
+alignments are reported, apply it consistently across any runs you intend to
+compare. Hi-C output is typically name-sorted (`samtools sort -n`) for the
+downstream contact caller rather than coordinate-sorted.
+
+For other data with genuinely large but real inserts (e.g. some long-fragment or
+mate-pair libraries), mate rescue is still meaningful — keep it, but lower `-K`
+to bound the per-batch working set rather than disabling rescue.
+
+---
+
+**See also:**
+[Threading and resource use](threading.md) ·
+[Aligning short reads (mem)](aligning.md) ·
+[`mem` CLI reference](../cli/mem.md) ·
+[Quick start: shared-memory index](../getting-started/quick-shm.md) ·
+[Best Practices: anti-patterns](../best-practices/anti-patterns.md)

--- a/docs/src/user-guide/threading.md
+++ b/docs/src/user-guide/threading.md
@@ -25,7 +25,7 @@ Thread count and wall-clock alignment time scale well to approximately 16–32
 threads on a modern CPU. Beyond that, several effects conspire to flatten the
 curve:
 
-1. **FM-index bandwidth.** The index for hg38 is ~28 GB and does not fit in
+1. **FM-index bandwidth.** The index for hg38 is ~21 GB and does not fit in
    the L3 cache of any current server. At high thread counts, threads contend
    for memory bandwidth accessing the BWT.
 2. **IO contention.** On spinning disk or a shared network filesystem,
@@ -68,9 +68,15 @@ and [Best Practices: multi-sample workflows](../best-practices/multi-sample.md).
 
 ## Memory use
 
-Peak RAM during alignment is dominated by the in-memory FM-index. For hg38,
-expect roughly 28 GB of resident memory per `bwa-mem3 mem` process. Additional
-memory is used per batch (`-K` reads × read length × a small constant).
+Peak RAM during alignment is the resident index plus a per-batch working set.
+The index dominates: for hg38 the resident baseline is roughly 21 GB per
+`bwa-mem3 mem` process, fixed regardless of `-t` or `-K`. The per-batch working
+set is added on top and scales with the *effective* batch size, which by default
+is `chunk_size × n_threads` (so `-t 16` at the default `chunk_size` buffers
+160 M bases per batch, not 10 M). On memory-constrained hosts, or for data with
+wide mate-rescue windows such as Hi-C, this per-batch term is what tips a run
+into OOM — see
+[Memory budgeting and data-type tuning](memory-and-data-types.md).
 
 With `bwa-mem3 shm`, the index is mapped from a shared-memory segment, so
 multiple concurrent `mem` processes share the same physical pages. The OS
@@ -85,7 +91,7 @@ process.
 
 ## IO recommendations
 
-- **Use local NVMe storage** for the index files when possible. The ~28 GB BWT
+- **Use local NVMe storage** for the index files when possible. The ~16 GB BWT
   read is the dominant IO event at the start of each `mem` run.
 - **Write BAM (`--bam`) to a fast local disk** or pipe directly to
   `samtools sort`. Avoid writing uncompressed SAM to a network filesystem.
@@ -96,6 +102,7 @@ process.
 
 **See also:**
 [Aligning short reads (mem)](aligning.md) ·
+[Memory budgeting and data-type tuning](memory-and-data-types.md) ·
 [Memory allocator (mimalloc)](allocator.md) ·
 [Quick start: shared-memory index](../getting-started/quick-shm.md) ·
 [Best Practices: multi-sample workflows](../best-practices/multi-sample.md) ·


### PR DESCRIPTION
## What

Adds a new User Guide page, **Memory budgeting and data-type tuning** (`docs/src/user-guide/memory-and-data-types.md`), and corrects two memory figures in `threading.md`.

The page documents how peak `bwa-mem3 mem` memory is built up and how to keep a run inside a memory cap:

- **Memory model:** `peak RSS ≈ resident index + per-batch working set`. The hg38 resident index baseline is ~21 GB.
- **Effective batch size:** by default the per-batch working set scales as `chunk_size × n_threads`, so `-t 16` at the default `chunk_size` buffers 160 M bases per batch — not 10 M. `-K INT` overrides this to a fixed total regardless of thread count. This is why `-K 1000000` is a ~160× reduction at `-t 16`, not 10×.
- **Fitting under a cap:** budgeting recipe (`cap − index − headroom`), preferring `-K` then `-t`, and `shm` for multi-sample hosts.
- **Silent-OOM trap:** an OOM-killed aligner (`SIGKILL`) can leave a header-only/truncated BAM that masquerades as success; run pipes under `set -o pipefail` and verify the BAM is non-empty.
- **Hi-C recipe:** mate-rescue windows are derived from the inferred insert-size distribution, which is meaningless for Hi-C contacts, so windows balloon to tens of kb and drive OOM. The fix is the canonical `-5SP` invocation, which removes the windows and is the correct mode for Hi-C — not merely a memory workaround.

## Why

A Hi-C dataset OOM-killed under a 28 GB cap on arm64. Root cause was memory, not an alignment bug: the ~21 GB index leaves little headroom, and the default `chunk_size × n_threads` batch combined with Hi-C's pathologically wide mate-rescue windows tipped it over. There was no existing documentation on memory budgeting, the `-K`/`-t` interaction, or data-type-specific tuning, and `threading.md` overstated the hg38 index as ~28 GB resident (the measured baseline is ~21 GB).

## Changes

- New page `user-guide/memory-and-data-types.md` + `SUMMARY.md` nav entry (under User Guide).
- `threading.md`: index figure ~28 GB → ~21 GB (resident) / ~16 GB (on-disk BWT read), and clarified that per-batch memory scales with `chunk_size × n_threads`, cross-linking the new page.

Docs-only; `mdbook build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Memory budgeting and data-type tuning” guide covering peak memory composition, how `-K` and `-t` affect effective batch size, and strategies to stay within memory limits (including optional shared-memory indexing).
  * Expanded OOM troubleshooting notes for truncated/header-only BAMs after kernel SIGKILL.
  * Updated the threading guide with revised hg38 sizing metrics and clearer resident index vs. per-batch working set guidance, plus refreshed local NVMe/IO notes and cross-links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->