### PR TITLE
perf(bsw): short-circuit the inert per-row re-baseline scan

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -1426,6 +1426,11 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
         // reference; the next row reads the lowered values consistently.
         {
+            /* Fast path: one vector test for "any lane >= REBASE_HI?" — see the
+             * 128-bit kernel. Under the routing envelope this is ~always false, so
+             * the per-lane scalar scan + maxRS1 store below are skipped each row. */
+            __m256i hi256 = _mm256_set1_epi8((int8_t) REBASE_HI);
+            if (_mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_subs_epu8(hi256, maxRS1), zero256))) {
             uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(32)));
             _mm256_store_si256((__m256i *) rs_b, maxRS1);
             int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(32)));
@@ -1479,6 +1484,7 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
                 // (gbest_abs, absolute units) in the epilogue, immune to this
                 // re-baseline subtract.
             }
+            }   /* end "any lane >= REBASE_HI" fast-path guard */
         }
 
 #if RDT
@@ -3319,6 +3325,10 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
         // reference; the next row reads the lowered values consistently.
         {
+            /* Fast path: one vector test for "any lane >= REBASE_HI?" — see the
+             * 128-bit kernel. Under the routing envelope this is ~always false, so
+             * the per-lane scalar scan + maxRS1 store below are skipped each row. */
+            if (_mm512_cmpge_epu8_mask(maxRS1, _mm512_set1_epi8((int8_t) REBASE_HI))) {
             uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(64)));
             _mm512_store_si512((__m512i *) rs_b, maxRS1);
             int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(64)));
@@ -3372,6 +3382,7 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
                 // (gbest_abs, absolute units) in the epilogue, immune to this
                 // re-baseline subtract.
             }
+            }   /* end "any lane >= REBASE_HI" fast-path guard */
         }
 
 #if RDT
@@ -5954,6 +5965,13 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
         // reference; the next row reads the lowered values consistently.
         {
+            /* Fast path: one vector test for "any lane >= REBASE_HI?". Under the
+             * routing envelope no admitted pair ever reaches REBASE_HI (the gate
+             * keeps the max attainable score below it), so this is ~always false and
+             * the per-lane scalar scan + maxRS1 store below are skipped each row.
+             * Unsigned >=: subs_epu8(REBASE_HI, maxRS1)==0 iff maxRS1 >= REBASE_HI. */
+            __m128i hi128 = _mm_set1_epi8((int8_t) REBASE_HI);
+            if (_mm_movemask_epi8(_mm_cmpeq_epi8(_mm_subs_epu8(hi128, maxRS1), zero128))) {
             uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(16)));
             _mm_store_si128((__m128i *) rs_b, maxRS1);
             int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(16)));
@@ -6007,6 +6025,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
                 // (gbest_abs, in absolute units) in the epilogue, so it is immune
                 // to this re-baseline subtract.
             }
+            }   /* end "any lane >= REBASE_HI" fast-path guard */
         }
 
 #if RDT


### PR DESCRIPTION
> **Stacked on #140** (the recovered 8-bit long-read path). Perf follow-up tracked in #146.

## What

The per-row re-baseline event in `smithWaterman{128,256,512}_8` ran a scalar per-lane loop every row — `SIMD_WIDTH8` iterations plus a `maxRS1` store — to find any lane whose row-max had reached `REBASE_HI`. But the routing envelope (`bsw8_envelope_ok`) admits a pair only when its max attainable score stays below `REBASE_HI`, so for every admitted pair the scan **never** finds a qualifying lane and the entire block is a no-op. That's pure overhead each row, widest on AVX-512 (64 scalar iterations/row).

This gates the block behind a single vector test for "does any lane reach `REBASE_HI`?":
- NEON / AVX2: `subs_epu8(REBASE_HI, maxRS1) == 0` ⟺ `maxRS1 >= REBASE_HI`, reduced via `cmpeq` + `movemask`.
- AVX-512: native `_mm512_cmpge_epu8_mask`.

When the mask is empty — the common case under the gate — the scalar scan and the `maxRS1` store are skipped entirely.

## Byte-identical

When the mask is empty the old code did nothing anyway (the scalar loop's body only fires for lanes `>= REBASE_HI`); when it's non-empty the original block runs unchanged. So output is identical for every input.

## Validation

- **NEON:** chr22 end-to-end byte-identical to upstream bwa (101,636 records); 400bp PE 8-bit-vs-forced-16-bit byte-identical (38,114 records).
- **x86 (Sapphire Rapids):** per-tier build + repeat-rich `getScores8`-vs-scalar probe on sse41/avx2/avx512bw — 0 diffs.

## Notes

The re-baseline machinery is retained (it's the safety net the gate relies on); this only skips the *detection* scan when the vector test proves no lane needs it. Composes with the deferred epilogue-vectorization item (#146) which targets the other per-row scalar loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized computational performance through selective skipping of unnecessary processing steps in alignment kernels when conditions are unmet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->