### PR TITLE
refactor(bsw): remove dead SW code paths (SORT_PAIRS, non-CORE macros, SSE2 polyfill)

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -490,42 +490,6 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
 //----------------------------------------------------------------------------------
 // B-SWA - Vector code
 // ------------------------- AVX2 - 8 bit SIMD_LANES ---------------------------
-inline void sortPairsLen(SeqPair *pairArray, int32_t count, SeqPair *tempArray,
-                         int16_t *hist)
-{
-
-    int32_t i;
-    __m256i zero256 = _mm256_setzero_si256();
-    for(i = 0; i <= MAX_SEQ_LEN8; i+=16)
-        _mm256_store_si256((__m256i *)(hist + i), zero256);
-    
-    for(i = 0; i < count; i++)
-    {
-        SeqPair sp = pairArray[i];
-        hist[sp.len1]++;
-    }
-
-    int32_t cumulSum = 0;
-    for(i = 0; i <= MAX_SEQ_LEN8; i++)
-    {
-        int32_t cur = hist[i];
-        hist[i] = cumulSum;
-        // histb[i] = cumulSum;
-        cumulSum += cur;
-    }
-
-    for(i = 0; i < count; i++)
-    {
-        SeqPair sp = pairArray[i];
-        int32_t pos = hist[sp.len1];
-        tempArray[pos] = sp;
-        hist[sp.len1]++;
-    }
-
-    for(i = 0; i < count; i++) {
-        pairArray[i] = tempArray[i];
-    }
-}
 
 inline void sortPairsId(SeqPair *pairArray, int32_t first, int32_t count,
                         SeqPair *tempArray)
@@ -608,33 +572,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
     st2 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS     // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-
-    // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
-                                               sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN8 + 32) * numThreads *
-                                          sizeof(int16_t), 64);
-
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-        int16_t *myHist = hist + tid * (MAX_SEQ_LEN8 + 32);
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsLen(pairArray + first, last - first, myTempArray, myHist);
-        }
-    }
-    _mm_free(hist);
-    _mm_free(tempArray);
-#endif
 
 #if RDT
     st3 = ___rdtsc();
@@ -836,27 +773,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
     st4 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS      // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    {
-    // Sort the sequences according to increasing order of id
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsId(pairArray + first, first, last - first, myTempArray);
-        }
-    }
-    _mm_free(tempArray);
-    }
-#endif
 
 #if RDT
     st5 = ___rdtsc();
@@ -1583,35 +1499,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     st2 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS      // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
-                                               sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN16 + 16) * numThreads *
-                                          sizeof(int16_t), 64);
-    int16_t *histb = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN16 + 16) * numThreads *
-                                           sizeof(int16_t), 64);
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-        int16_t *myHist = hist + tid * (MAX_SEQ_LEN16 + 16);
-        int16_t *myHistb = histb + tid * (MAX_SEQ_LEN16 + 16);
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsLen(pairArray + first, last - first, myTempArray, myHist, myHistb);
-        }
-    }
-    _mm_free(histb);
-    _mm_free(hist);
-    _mm_free(tempArray);
-#endif
 
 #if RDT 
     st3 = ___rdtsc();
@@ -1784,27 +1671,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     st4 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS      // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    {
-    // Sort the sequences according to increasing order of id
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsId(pairArray + first, first, last - first, myTempArray);
-        }
-    }
-    _mm_free(tempArray);
-    }
-#endif
 
 #if RDT
     st5 = ___rdtsc();
@@ -2392,48 +2258,6 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
     }
 
 
-inline void sortPairsLen(SeqPair *pairArray, int32_t count,
-                         SeqPair *tempArray, int16_t *hist,
-                         int16_t *histb)
-{
-    int32_t i;
-    __m512i zero512 = _mm512_setzero_si512();
-    for(i = 0; i <= MAX_SEQ_LEN8; i+=32)
-    {
-        _mm512_store_si512((__m512i *)(hist + i), zero512);
-        _mm512_store_si512((__m512i *)(histb + i), zero512);
-    }
-    
-    for(i = 0; i < count; i++)
-    {
-        SeqPair sp = pairArray[i];
-        hist[sp.len1]++;
-        // histb[sp.len1]++;
-    }
-
-    int32_t prev = 0;
-    int32_t cumulSum = 0;
-    for(i = 0; i <= MAX_SEQ_LEN8; i++)
-    {
-        int32_t cur = hist[i];
-        hist[i] = cumulSum;
-        // histb[i] = cumulSum;
-        cumulSum += cur;
-    }
-
-    for(i = 0; i < count; i++)
-    {
-        SeqPair sp = pairArray[i];
-        int32_t pos = hist[sp.len1];
-
-        tempArray[pos] = sp;
-        hist[sp.len1]++;
-    }
-
-    for(i = 0; i < count; i++) {
-        pairArray[i] = tempArray[i];
-    }
-}
 
 inline void sortPairsId(SeqPair *pairArray, int32_t first, int32_t count,
                         SeqPair *tempArray)
@@ -2512,35 +2336,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
     st2 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
-                                               sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN8 + 32) * numThreads *
-                                          sizeof(int16_t), 64);
-    int16_t *histb = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN8 + 32) * numThreads *
-                                           sizeof(int16_t), 64);
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-        int16_t *myHist = hist + tid * (MAX_SEQ_LEN8 + 32);
-        int16_t *myHistb = histb + tid * (MAX_SEQ_LEN8 + 32);
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsLen(pairArray + first, last - first, myTempArray, myHist, myHistb);
-        }
-    }
-    _mm_free(histb);
-    _mm_free(hist);
-    _mm_free(tempArray);
-#endif
     
 #if RDT
     st3 = ___rdtsc();
@@ -2741,27 +2536,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
     st4 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    {
-    // Sort the sequences according to increasing order of id
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsId(pairArray + first, first, last - first, myTempArray);
-        }
-    }
-    _mm_free(tempArray);
-    }
-#endif
 
 #if RDT 
     st5 = ___rdtsc();
@@ -3474,31 +3248,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     st2 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
-                                               sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN16 + 32) * numThreads *
-                                          sizeof(int16_t), 64);
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-        int16_t *myHist = hist + tid * (MAX_SEQ_LEN16 + 32);
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsLen(pairArray + first, last - first, myTempArray, myHist);
-        }
-    }
-    _mm_free(hist);
-    _mm_free(tempArray);
-#endif
     
 #if RDT
     st3 = ___rdtsc();
@@ -3677,27 +3426,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     st4 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    {
-    // Sort the sequences according to increasing order of id
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsId(pairArray + first, first, last - first, myTempArray);
-        }
-    }
-    _mm_free(tempArray);
-    }
-#endif
 
 #if RDT
     st5 = ___rdtsc();
@@ -4210,43 +3938,6 @@ _mm_blendv_epi16(__m128i x, __m128i y, __m128i mask)
     }
 
 
-inline void sortPairsLen(SeqPair *pairArray, int32_t count, SeqPair *tempArray,
-                         int16_t *hist, int16_t *histb)
-{
-    int32_t i;
-
-    __m128i zero128 = _mm_setzero_si128();
-    for(i = 0; i <= MAX_SEQ_LEN16; i+=8)
-    {
-        _mm_store_si128((__m128i *)(hist + i), zero128);
-    }
-    
-    for(i = 0; i < count; i++)
-    {
-        SeqPair sp = pairArray[i];
-        hist[sp.len1]++;
-    }
-
-    int32_t cumulSum = 0;
-    for(i = 0; i <= MAX_SEQ_LEN16; i++)
-    {
-        int32_t cur = hist[i];
-        hist[i] = cumulSum;
-        cumulSum += cur;
-    }
-
-    for(i = 0; i < count; i++)
-    {
-        SeqPair sp = pairArray[i];
-        int32_t pos = hist[sp.len1];
-        tempArray[pos] = sp;
-        hist[sp.len1]++;
-    }
-    
-    for(i = 0; i < count; i++) {
-        pairArray[i] = tempArray[i];
-    }
-}
 
 inline void sortPairsId(SeqPair *pairArray, int32_t first,
                         int32_t count, SeqPair *tempArray)
@@ -4326,35 +4017,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     st2 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
-                                               sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN16 + 16) * numThreads *
-                                          sizeof(int16_t), 64);
-    int16_t *histb = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN16 + 16) * numThreads *
-                                           sizeof(int16_t), 64);
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = 0;
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-        int16_t *myHist = hist + tid * (MAX_SEQ_LEN16 + 16);
-        int16_t *myHistb = histb + tid * (MAX_SEQ_LEN16 + 16);
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsLen(pairArray + first, last - first, myTempArray, myHist, myHistb);
-        }
-    }
-    _mm_free(histb);
-    _mm_free(hist);
-    _mm_free(tempArray);
-#endif
 
 #if RDT
     st3 = ___rdtsc();
@@ -4526,27 +4188,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     st4 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    {
-    // Sort the sequences according to increasing order of id
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsId(pairArray + first, first, last - first, myTempArray);
-        }
-    }
-    _mm_free(tempArray);
-    }
-#endif
 
 #if RDT
     st5 = ___rdtsc();
@@ -5117,35 +4758,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
     st2 = ___rdtsc();
 #endif
     
-#if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    // Sort the sequences according to decreasing order of lengths
-    SeqPair *tempArray = (SeqPair *)_mm_malloc((size_t)SORT_BLOCK_SIZE * numThreads *
-                                               sizeof(SeqPair), 64);
-    int16_t *hist = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN8 + 32) * numThreads *
-                                          sizeof(int16_t), 64);
-    int16_t *histb = (int16_t *)_mm_malloc((size_t)(MAX_SEQ_LEN8 + 32) * numThreads *
-                                           sizeof(int16_t), 64);
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-        int16_t *myHist = hist + tid * (MAX_SEQ_LEN8 + 32);
-        int16_t *myHistb = histb + tid * (MAX_SEQ_LEN8 + 32);
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsLen(pairArray + first, last - first, myTempArray, myHist, myHistb);
-        }
-    }
-    _mm_free(histb);
-    _mm_free(hist);
-    _mm_free(tempArray);
-#endif
 
 #if RDT
     st3 = ___rdtsc();
@@ -5336,27 +4948,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
      st4 = ___rdtsc();
 #endif
      
-#if SORT_PAIRS       // disbaled in bwa-mem2 (only used in separate benchmark bsw code)
-    {
-    // Sort the sequences according to increasing order of id
-#pragma omp parallel num_threads(numThreads)
-    {
-        int32_t tid = omp_get_thread_num();
-        SeqPair *myTempArray = tempArray + tid * SORT_BLOCK_SIZE;
-
-#pragma omp for
-        for(ii = 0; ii < roundNumPairs; ii+=SORT_BLOCK_SIZE)
-        {
-            int32_t first, last;
-            first = ii;
-            last  = ii + SORT_BLOCK_SIZE;
-            if(last > roundNumPairs) last = roundNumPairs;
-            sortPairsId(pairArray + first, first, last - first, myTempArray);
-        }
-    }
-    _mm_free(tempArray);
-    }
-#endif
 
 #if RDT
     st5 = ___rdtsc();

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -4495,14 +4495,10 @@ void BandedPairWiseSW::smithWaterman128_16(uint16_t seq1SoA[],
 }
 
 /********************************************************************************/
-/* SSE2 - 8 bit version */
-#ifndef __SSE4_1__
-static inline __m128i _mm_blendv_epi8 (__m128i x, __m128i y, __m128i mask)
-{
-    // Replace bit in x with bit in y when matching bit in mask is set:
-    return _mm_or_si128(_mm_andnot_si128(mask, x), _mm_and_si128(mask, y));
-}
-#endif
+/* 128-bit - 8 bit version */
+// NB: the 128-bit kernel requires SSE4.1 (max_epi8 / min_epi8 / blendv_epi8); the
+// lowest x86 build tier is sse41 and arm64 routes through sse2neon, so no
+// sub-SSE4.1 polyfill is needed.
 
 // ZSCORE8 is unused in smithWaterman128_8 (z-drop replaced by wide scalar);
 // retained here in case a future 128-bit tier reinstates it.

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -356,27 +356,6 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
     }
 
 
-#define MAIN_CODE8(s1, s2, h00, h11, e11, f11, f21, zero256,  maxScore256, e_ins256, oe_ins256, e_del256, oe_del256, y256, maxRS) \
-    {                                                                   \
-        __m256i cmp11 = _mm256_cmpeq_epi8(s1, s2);                      \
-        __m256i sbt11 = _mm256_blendv_epi8(mismatch256, match256, cmp11); \
-        __m256i tmp256 = _mm256_max_epu8(s1, s2);                       \
-        /*tmp256 = _mm256_cmpeq_epi8(tmp256, val102);*/                 \
-        sbt11 = _mm256_blendv_epi8(sbt11, w_ambig_256, tmp256);         \
-        __m256i m11 = _mm256_add_epi8(h00, sbt11);                      \
-        cmp11 = _mm256_cmpeq_epi8(h00, zero256);                        \
-        m11 = _mm256_blendv_epi8(m11, zero256, cmp11);                  \
-        h11 = _mm256_max_epi8(m11, e11);                                \
-        h11 = _mm256_max_epi8(h11, f11);                                \
-        __m256i temp256 = _mm256_sub_epi8(h11, oe_ins256);              \
-        __m256i val256  = _mm256_max_epi8(temp256, zero256);            \
-        e11 = _mm256_sub_epi8(e11, e_ins256);                           \
-        e11 = _mm256_max_epi8(val256, e11);                             \
-        temp256 = _mm256_sub_epi8(h11, oe_del256);                      \
-        val256  = _mm256_max_epi8(temp256, zero256);                    \
-        f21 = _mm256_sub_epi8(f11, e_del256);                           \
-        f21 = _mm256_max_epi8(val256, f21);                             \
-    }
 
 // ------------------------ vec 16 --------------------------------------------------
 #define _mm256_blendv_epi16(a,b,c)              \
@@ -399,26 +378,6 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
     }
 
 
-#define MAIN_CODE16(s1, s2, h00, h11, e11, f11, f21, zero256,  maxScore256, e_ins256, oe_ins256, e_del256, oe_del256, y256, maxRS) \
-    {                                                                   \
-        __m256i cmp11 = _mm256_cmpeq_epi16(s1, s2);                     \
-        __m256i sbt11 = _mm256_blendv_epi16(mismatch256, match256, cmp11); \
-        __m256i tmp256 = _mm256_max_epu16(s1, s2);                      \
-        sbt11 = _mm256_blendv_epi16(sbt11, w_ambig_256, tmp256);        \
-        __m256i m11 = _mm256_add_epi16(h00, sbt11);                     \
-        cmp11 = _mm256_cmpeq_epi16(h00, zero256);                       \
-        m11 = _mm256_blendv_epi16(m11, zero256, cmp11);                 \
-        h11 = _mm256_max_epi16(m11, e11);                               \
-        h11 = _mm256_max_epi16(h11, f11);                               \
-        __m256i temp256 = _mm256_sub_epi16(h11, oe_ins256);             \
-        __m256i val256  = _mm256_max_epi16(temp256, zero256);           \
-        e11 = _mm256_sub_epi16(e11, e_ins256);                          \
-        e11 = _mm256_max_epi16(val256, e11);                            \
-        temp256 = _mm256_sub_epi16(h11, oe_del256);                     \
-        val256  = _mm256_max_epi16(temp256, zero256);                   \
-        f21 = _mm256_sub_epi16(f11, e_del256);                          \
-        f21 = _mm256_max_epi16(val256, f21);                            \
-    }
 
 // --- PR 17/16: AVX2 LUT primitive ---
 // pmat256 must have the 16-byte LUT broadcast into both 128-bit halves
@@ -2129,30 +2088,6 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
     }
 
 
-#define MAIN_CODE8(s1, s2, h00, h11, e11, f11, f21, zero512,  maxScore512, e_ins512, oe_ins512, e_del512, oe_del512, y512, maxRS) \
-    {                                                                   \
-        __mmask64 cmp11;                                                \
-        __m512i sbt11, tmp512, m11, temp512, val512;                    \
-        cmp11 = _mm512_cmpeq_epi8_mask(s1, s2);                         \
-        sbt11 = _mm512_mask_blend_epi8(cmp11, mismatch512, match512);   \
-        tmp512 = _mm512_max_epu8(s1, s2);                               \
-        cmp11 = _mm512_movepi8_mask(tmp512);                            \
-        /*tmp512 = _mm512_cmpeq_epi8(tmp512, val102);*/                 \
-        sbt11 = _mm512_mask_blend_epi8(cmp11, sbt11, w_ambig_512);      \
-        m11 = _mm512_add_epi8(h00, sbt11);                              \
-        cmp11 = _mm512_cmpeq_epi8_mask(h00, zero512);                   \
-        m11 = _mm512_mask_blend_epi8(cmp11, m11, zero512);              \
-        h11 = _mm512_max_epi8(m11, e11);                                \
-        h11 = _mm512_max_epi8(h11, f11);                                \
-        temp512 = _mm512_sub_epi8(h11, oe_ins512);                      \
-        val512  = _mm512_max_epi8(temp512, zero512);                    \
-        e11 = _mm512_sub_epi8(e11, e_ins512);                           \
-        e11 = _mm512_max_epi8(val512, e11);                             \
-        temp512 = _mm512_sub_epi8(h11, oe_del512);                      \
-        val512  = _mm512_max_epi8(temp512, zero512);                    \
-        f21 = _mm512_sub_epi8(f11, e_del512);                           \
-        f21 = _mm512_max_epi8(val512, f21);                             \
-    }
 
 // ------------------------ vec 16 --------------------------------------------------
 #define ZSCORE16(i4_512, y4_512)                                            \
@@ -2170,30 +2105,6 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         exit0 = _mm512_mask_blend_epi16(cmp, exit0, zero512);           \
     }
 
-#define MAIN_CODE16(s1, s2, h00, h11, e11, f11, f21, zero512,  maxScore512, e_ins512, oe_ins512, e_del512, oe_del512, y512, maxRS) \
-    {                                                                   \
-        __mmask32 cmp11;                                                \
-        __m512i sbt11, tmp512, m11, temp512, val512;                    \
-        cmp11 = _mm512_cmpeq_epi16_mask(s1, s2);                        \
-        sbt11 = _mm512_mask_blend_epi16(cmp11, mismatch512, match512);  \
-        tmp512 = _mm512_max_epu16(s1, s2);                              \
-        cmp11 = _mm512_movepi16_mask(tmp512);                           \
-        /*tmp512 = _mm512_cmpeq_epi16(tmp512, val102);*/                \
-        sbt11 = _mm512_mask_blend_epi16(cmp11, sbt11, w_ambig_512);     \
-        m11 = _mm512_add_epi16(h00, sbt11);                             \
-        cmp11 = _mm512_cmpeq_epi16_mask(h00, zero512);                  \
-        m11 = _mm512_mask_blend_epi16(cmp11, m11, zero512);             \
-        h11 = _mm512_max_epi16(m11, e11);                               \
-        h11 = _mm512_max_epi16(h11, f11);                               \
-        temp512 = _mm512_sub_epi16(h11, oe_ins512);                     \
-        val512  = _mm512_max_epi16(temp512, zero512);                   \
-        e11 = _mm512_sub_epi16(e11, e_ins512);                          \
-        e11 = _mm512_max_epi16(val512, e11);                            \
-        temp512 = _mm512_sub_epi16(h11, oe_del512);                     \
-        val512  = _mm512_max_epi16(temp512, zero512);                   \
-        f21 = _mm512_sub_epi16(f11, e_del512);                          \
-        f21 = _mm512_max_epi16(val512, f21);                            \
-    }
 
 // --- PR 17/16: AVX-512BW LUT primitive ---
 // Broadcast the 16-byte pmat into all four 128-bit lanes.
@@ -3888,27 +3799,6 @@ _mm_blendv_epi16(__m128i x, __m128i y, __m128i mask)
     }
 
 
-#define MAIN_CODE16(s1, s2, h00, h11, e11, f11, f21, zero256,  maxScore128, e_ins128, oe_ins128, e_del128, oe_del128, y128, maxRS) \
-    {                                                                   \
-        __m128i cmp11 = _mm_cmpeq_epi16(s1, s2);                        \
-        __m128i sbt11 = _mm_blendv_epi16(mismatch128, match128, cmp11); \
-        __m128i tmp128 = _mm_max_epu16(s1, s2);                         \
-        tmp128 = _mm_cmpeq_epi16(tmp128, ff128);                        \
-        sbt11 = _mm_blendv_epi16(sbt11, w_ambig_128, tmp128);           \
-        __m128i m11 = _mm_add_epi16(h00, sbt11);                        \
-        cmp11 = _mm_cmpeq_epi16(h00, zero128);                          \
-        m11 = _mm_blendv_epi16(m11, zero128, cmp11);                    \
-        h11 = _mm_max_epi16(m11, e11);                                  \
-        h11 = _mm_max_epi16(h11, f11);                                  \
-        __m128i temp128 = _mm_sub_epi16(h11, oe_ins128);                \
-        __m128i val128  = _mm_max_epi16(temp128, zero128);              \
-        e11 = _mm_sub_epi16(e11, e_ins128);                             \
-        e11 = _mm_max_epi16(val128, e11);                               \
-        temp128 = _mm_sub_epi16(h11, oe_del128);                        \
-        val128  = _mm_max_epi16(temp128, zero128);                      \
-        f21 = _mm_sub_epi16(f11, e_del128);                             \
-        f21 = _mm_max_epi16(val128, f21);                               \
-    }
 
 // PR 17: 16-bit fission primitives, mirror of the 8-bit pair above.
 #define SBT_PREPASS16(s1, s2, sbt11_out, mismatch128, match128, w_ambig_128, ff128) \
@@ -4632,26 +4522,6 @@ static inline __m128i _mm_blendv_epi8 (__m128i x, __m128i y, __m128i mask)
     }
 
 
-#define MAIN_CODE8(s1, s2, h00, h11, e11, f11, f21, zero128,  maxScore128, e_ins128, oe_ins128, e_del128, oe_del128, y128, maxRS) \
-    {                                                                   \
-        __m128i cmp11 = _mm_cmpeq_epi8(s1, s2);                         \
-        __m128i sbt11 = _mm_blendv_epi8(mismatch128, match128, cmp11);  \
-        __m128i tmp128 = _mm_max_epu8(s1, s2);                          \
-        tmp128 = _mm_cmpeq_epi8(tmp128, ff128);                         \
-        sbt11 = _mm_blendv_epi8(sbt11, w_ambig_128, tmp128);            \
-        __m128i m11 = _mm_add_epi8(h00, sbt11);                         \
-        cmp11 = _mm_cmpeq_epi8(h00, zero128);                           \
-        m11 = _mm_blendv_epi8(m11, zero128, cmp11);                     \
-        m11 = _mm_and_si128(m11, _mm_cmpgt_epi8(m11, zero128));         \
-        h11 = _mm_max_epu8(m11, e11);                                   \
-        h11 = _mm_max_epu8(h11, f11);                                   \
-        __m128i temp128 = _mm_subs_epu8(h11, oe_ins128);                \
-        e11 = _mm_subs_epu8(e11, e_ins128);                             \
-        e11 = _mm_max_epu8(temp128, e11);                               \
-        temp128 = _mm_subs_epu8(h11, oe_del128);                        \
-        f21 = _mm_subs_epu8(f11, e_del128);                             \
-        f21 = _mm_max_epu8(temp128, f21);                               \
-    }
 
 // --- PR 17/16: SSE2/NEON LUT primitive ---
 // With the asymmetric AMBIG encoding (target N=4, query N=8), the low 4 bits


### PR DESCRIPTION
Removes three families of dead code from `src/bandedSWA.cpp` surfaced while working on the recovered long-read 8-bit SW path. **No behavior change** — every target is either `#if`-disabled or uninvoked, so the change is compile-output-identical by construction. Tracked in #146.

## What

- **`refactor(bsw): remove the disabled SORT_PAIRS length-sort machinery`** — deletes all 12 `#if SORT_PAIRS` blocks (the macro is never defined; the comment in-tree reads "disbaled in bwa-mem2, only used in separate benchmark bsw code") and the 3 now-unused `sortPairsLen` definitions. Bonus: those `sortPairsLen` variants harbored latent heap bugs (the 128-bit one zeroed `hist[0..MAX_SEQ_LEN16]` into a `MAX_SEQ_LEN8`-sized buffer; the AVX2/AVX-512 ones under-zeroed their 16-bit callers' hist) — deleting the dead code removes the landmine. Each block's `tempArray`/`hist`/`histb` alloc+free was fully self-contained inside its guard (verified), so nothing dangles.
- **`refactor(bsw): remove the dead non-CORE MAIN_CODE8/MAIN_CODE16 macros`** — deletes the 6 non-`_CORE` macro definitions. Every invocation is the `_CORE` variant (verified), so these were unreachable — and stale (the dead `MAIN_CODE8` still carried the old signed `m11 & (m11>0)` M-floor).
- **`refactor(bsw): drop the vestigial sub-SSE4.1 blendv polyfill; document the SSE4.1 floor`** — deletes the `#ifndef __SSE4_1__` `_mm_blendv_epi8` polyfill (never compiled — the kernel already requires SSE4.1 via `max_epi8`/`min_epi8`, the lowest x86 tier is `sse41`, and arm64 routes through sse2neon), and replaces it with a comment documenting the floor.

**Net: 1 file, +4 / −547.**

## Why

These were a recurring "wait, which one is live?" trap, and the `sortPairsLen` overflow cost real debugging time during an unrelated hunt. Removing them shrinks the file and eliminates the landmine. Git preserves the deletions if length-sorted batching is ever revisited (see #146) — it would be a clean reimplementation, not a revival.

## Validation

Compile-output-identical by construction. NEON build green; full per-tier build (sse41/avx2/avx512bw) confirmed on x86. chr22 parity unaffected (no live code touched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized sequence alignment scoring kernels across multiple processor architectures for improved performance.
  * Removed legacy code paths and streamlined implementation complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->