### PR TITLE
perf(bsw): vectorize the per-row epilogue side-channel loop

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -1294,36 +1294,66 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
             _mm256_store_si256((__m256i *) exit_a, exit0);
             _mm256_store_si256((__m256i *) qfire_a, qfire256);
             _mm256_store_si256((__m256i *) hqe_a, hqe256);
-            for (int l = 0; l < SIMD_WIDTH8; l++) {
-                // best-score row
-                if (cmp_a[l]) xrow[l] = i + 1;
-                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore256 is in the
-                // lane's CURRENT B[l] frame; absolute = rebaselined byte + B[l].
-                {
-                    int ms_abs = (int)(uint8_t)ms_a[l] + B[l];
-                    if (ms_abs > best_abs[l]) best_abs[l] = ms_abs;
-                }
-                // gscore (query-end score): qfire flags this lane reached its query
-                // end this row; hqe is the captured query-end cell H (byte, B[l]
-                // frame); absolute = byte + B[l]. Scalar's `>=` tie-break (last
-                // max-achieving row wins gtle). See smithWaterman128_8.
-                if (qfire_a[l]) {
-                    int gs_abs = (int)(uint8_t)hqe_a[l] + B[l];
-                    if (gs_abs >= gbest_abs[l]) { gbest_abs[l] = gs_abs; ierow[l] = i + 1; }
-                }
-                // z-drop (only relevant where the lane is still alive). The drop
-                // is ms-rs of two bytes in the SAME B[l] frame, so the B cancels
-                // and the comparison is already in ABSOLUTE score units.
-                if (exit_a[l]) {
-                    int xr  = xrow[l];                       // best row
-                    int y1c = (int) y1_a[l] + i;             // row-max col (abs)
-                    int yc  = (int) y_a[l] + (xr - 1);       // best col (abs)
-                    int tmpi = (i + 1) - xr;
-                    int tmpj = y1c - yc;
-                    int dif  = tmpi > tmpj ? (tmpi - tmpj) : (tmpj - tmpi);
-                    int drop = (int)(uint8_t)ms_a[l] - (int)(uint8_t)rs_a[l];
-                    if (drop - dif > zdrop) exit_a[l] = 0;
-                }
+            // VECTORIZED per-lane wide updates (see smithWaterman128_8). 8 int32
+            // per __m256i, so SIMD_WIDTH8 lanes -> SIMD_WIDTH8/8 groups of 8. Each
+            // group's z-drop die mask is narrowed (lane-crossing-free) to 8 bytes
+            // via a 128-bit pack and cleared in exit_a; exit0 reloaded at the end.
+            const __m256i vi   = _mm256_set1_epi32(i);
+            const __m256i vip1 = _mm256_set1_epi32(i + 1);
+            const __m256i vone = _mm256_set1_epi32(1);
+            const __m256i vzd  = _mm256_set1_epi32(zdrop);
+            const __m256i vedel = _mm256_set1_epi32(this->e_del);
+            const __m256i veins = _mm256_set1_epi32(this->e_ins);
+            for (int g = 0; g < SIMD_WIDTH8 / 8; g++) {
+                const int base = g * 8;
+                __m256i Bg   = _mm256_loadu_si256((const __m256i *)(B + base));
+                __m256i msg  = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(ms_a    + base)));
+                __m256i rsg  = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(rs_a    + base)));
+                __m256i hqeg = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(hqe_a   + base)));
+                __m256i cmpg = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(cmp_a   + base)));
+                __m256i exitg= _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(exit_a  + base)));
+                __m256i qfg  = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(qfire_a + base)));
+                __m256i y1g  = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(y1_a    + base)));
+                __m256i yg   = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(y_a     + base)));
+
+                __m256i xrg = _mm256_loadu_si256((const __m256i *)(xrow + base));
+                xrg = _mm256_blendv_epi8(xrg, vip1, cmpg);
+                _mm256_storeu_si256((__m256i *)(xrow + base), xrg);
+
+                __m256i ms_abs = _mm256_add_epi32(msg, Bg);
+                __m256i bag = _mm256_loadu_si256((const __m256i *)(best_abs + base));
+                bag = _mm256_max_epi32(bag, ms_abs);
+                _mm256_storeu_si256((__m256i *)(best_abs + base), bag);
+
+                __m256i gs_abs = _mm256_add_epi32(hqeg, Bg);
+                __m256i gba = _mm256_loadu_si256((const __m256i *)(gbest_abs + base));
+                __m256i ge  = _mm256_xor_si256(_mm256_cmpgt_epi32(gba, gs_abs), ff256); // gs_abs >= gba
+                __m256i gmask = _mm256_and_si256(qfg, ge);
+                gba = _mm256_blendv_epi8(gba, gs_abs, gmask);
+                _mm256_storeu_si256((__m256i *)(gbest_abs + base), gba);
+                __m256i ierg = _mm256_loadu_si256((const __m256i *)(ierow + base));
+                ierg = _mm256_blendv_epi8(ierg, vip1, gmask);
+                _mm256_storeu_si256((__m256i *)(ierow + base), ierg);
+
+                __m256i y1c  = _mm256_add_epi32(y1g, vi);
+                __m256i yc   = _mm256_add_epi32(yg, _mm256_sub_epi32(xrg, vone));
+                __m256i tmpi = _mm256_sub_epi32(vip1, xrg);
+                __m256i tmpj = _mm256_sub_epi32(y1c, yc);
+                // z-drop gap term weighted by gap-extend penalty, matching the
+                // scalar reference (drift>0 -> deletion side *e_del, else *e_ins).
+                __m256i zdelta = _mm256_sub_epi32(tmpi, tmpj);
+                __m256i zesel  = _mm256_blendv_epi8(veins, vedel,
+                                     _mm256_cmpgt_epi32(zdelta, _mm256_setzero_si256()));
+                __m256i dif  = _mm256_mullo_epi32(_mm256_abs_epi32(zdelta), zesel);
+                __m256i drop = _mm256_sub_epi32(msg, rsg);
+                __m256i die  = _mm256_cmpgt_epi32(_mm256_sub_epi32(drop, dif), vzd);
+                die = _mm256_and_si256(die, exitg);
+                // narrow 8 int32 die masks -> 8 bytes (128-bit packs, no lane cross)
+                __m128i d16 = _mm_packs_epi32(_mm256_castsi256_si128(die),
+                                              _mm256_extracti128_si256(die, 1));
+                __m128i d8  = _mm_packs_epi16(d16, d16);
+                __m128i ex  = _mm_loadl_epi64((const __m128i *)(exit_a + base));
+                _mm_storel_epi64((__m128i *)(exit_a + base), _mm_andnot_si128(d8, ex));
             }
             exit0 = _mm256_load_si256((__m256i *) exit_a);
         }
@@ -3177,57 +3207,77 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         // done in wide scalars so row distances that exceed int8 for long reads
         // are handled exactly.
         {
-            int8_t  cmp_a[SIMD_WIDTH8]      __attribute((aligned(64)));
+            // Only the int32 DATA channels need materializing as byte arrays; the
+            // cmp/qfire/exit per-lane predicates are read straight from the cmp
+            // __mmask64 and movepi8_mask(qfire512)/movepi8_mask(exit0) below.
             int8_t  y1_a[SIMD_WIDTH8]       __attribute((aligned(64)));
             int8_t  y_a[SIMD_WIDTH8]        __attribute((aligned(64)));
             int8_t  ms_a[SIMD_WIDTH8]       __attribute((aligned(64)));
             int8_t  rs_a[SIMD_WIDTH8]       __attribute((aligned(64)));
-            int8_t  exit_a[SIMD_WIDTH8]     __attribute((aligned(64)));
-            int8_t  qfire_a[SIMD_WIDTH8]    __attribute((aligned(64)));
             int8_t  hqe_a[SIMD_WIDTH8]      __attribute((aligned(64)));
-            // cmp/exit0 are mask registers here; materialize them as 0xFF/0x00
-            // byte vectors so the wide scalar loop can branch on them.
-            _mm512_store_si512((__m512i *) cmp_a,
-                               _mm512_maskz_set1_epi8(cmp, (char)0xFF));
             _mm512_store_si512((__m512i *) y1_a, y1_512);
             _mm512_store_si512((__m512i *) y_a, y512);
             _mm512_store_si512((__m512i *) ms_a, maxScore512);
             _mm512_store_si512((__m512i *) rs_a, maxRS1);
-            _mm512_store_si512((__m512i *) exit_a, exit0);
-            _mm512_store_si512((__m512i *) qfire_a, qfire512);
             _mm512_store_si512((__m512i *) hqe_a, hqe512);
-            for (int l = 0; l < SIMD_WIDTH8; l++) {
-                // best-score row
-                if (cmp_a[l]) xrow[l] = i + 1;
-                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore512 is in the
-                // lane's CURRENT B[l] frame; absolute = rebaselined byte + B[l].
-                {
-                    int ms_abs = (int)(uint8_t)ms_a[l] + B[l];
-                    if (ms_abs > best_abs[l]) best_abs[l] = ms_abs;
-                }
-                // gscore (query-end score): qfire flags this lane reached its query
-                // end this row; hqe is the captured query-end cell H (byte, B[l]
-                // frame); absolute = byte + B[l]. Scalar's `>=` tie-break. See
-                // smithWaterman128_8.
-                if (qfire_a[l]) {
-                    int gs_abs = (int)(uint8_t)hqe_a[l] + B[l];
-                    if (gs_abs >= gbest_abs[l]) { gbest_abs[l] = gs_abs; ierow[l] = i + 1; }
-                }
-                // z-drop (only relevant where the lane is still alive). The drop
-                // is ms-rs of two bytes in the SAME B[l] frame, so the B cancels
-                // and the comparison is already in ABSOLUTE score units.
-                if (exit_a[l]) {
-                    int xr  = xrow[l];                       // best row
-                    int y1c = (int) y1_a[l] + i;             // row-max col (abs)
-                    int yc  = (int) y_a[l] + (xr - 1);       // best col (abs)
-                    int tmpi = (i + 1) - xr;
-                    int tmpj = y1c - yc;
-                    int dif  = tmpi > tmpj ? (tmpi - tmpj) : (tmpj - tmpi);
-                    int drop = (int)(uint8_t)ms_a[l] - (int)(uint8_t)rs_a[l];
-                    if (drop - dif > zdrop) exit_a[l] = 0;
-                }
+            // VECTORIZED per-lane wide updates (see smithWaterman128_8) using
+            // AVX-512 mask registers: 16 int32 per __m512i -> SIMD_WIDTH8/16 groups
+            // of 16. Per-lane predicates (cmp/qfire/exit) are __mmask16 slices; the
+            // z-dropped lanes are accumulated into a combined mask and cleared in
+            // exit0. Byte-identical (same >, >= tie-breaks; same abs/z-drop math).
+            const __m512i vi   = _mm512_set1_epi32(i);
+            const __m512i vip1 = _mm512_set1_epi32(i + 1);
+            const __m512i vone = _mm512_set1_epi32(1);
+            const __m512i vzd  = _mm512_set1_epi32(zdrop);
+            const __m512i vedel = _mm512_set1_epi32(this->e_del);
+            const __m512i veins = _mm512_set1_epi32(this->e_ins);
+            const __mmask64 qf64 = _mm512_movepi8_mask(qfire512);
+            const __mmask64 ex64 = _mm512_movepi8_mask(exit0);
+            __mmask64 die64 = 0;
+            for (int g = 0; g < SIMD_WIDTH8 / 16; g++) {
+                const int base = g * 16;
+                const __mmask16 cmpm = (__mmask16)(cmp  >> (16 * g));
+                const __mmask16 qfm  = (__mmask16)(qf64 >> (16 * g));
+                const __mmask16 exm  = (__mmask16)(ex64 >> (16 * g));
+                __m512i Bg   = _mm512_loadu_si512((const void *)(B + base));
+                __m512i msg  = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i *)(ms_a  + base)));
+                __m512i rsg  = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i *)(rs_a  + base)));
+                __m512i hqeg = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i *)(hqe_a + base)));
+                __m512i y1g  = _mm512_cvtepi8_epi32(_mm_loadu_si128((const __m128i *)(y1_a  + base)));
+                __m512i yg   = _mm512_cvtepi8_epi32(_mm_loadu_si128((const __m128i *)(y_a   + base)));
+
+                __m512i xrg = _mm512_loadu_si512((const void *)(xrow + base));
+                xrg = _mm512_mask_mov_epi32(xrg, cmpm, vip1);
+                _mm512_storeu_si512((void *)(xrow + base), xrg);
+
+                __m512i bag = _mm512_loadu_si512((const void *)(best_abs + base));
+                bag = _mm512_max_epi32(bag, _mm512_add_epi32(msg, Bg));
+                _mm512_storeu_si512((void *)(best_abs + base), bag);
+
+                __m512i gs_abs = _mm512_add_epi32(hqeg, Bg);
+                __m512i gba = _mm512_loadu_si512((const void *)(gbest_abs + base));
+                __mmask16 gmask = qfm & _mm512_cmpge_epi32_mask(gs_abs, gba); // qfire & gs>=gbest
+                gba = _mm512_mask_mov_epi32(gba, gmask, gs_abs);
+                _mm512_storeu_si512((void *)(gbest_abs + base), gba);
+                __m512i ierg = _mm512_loadu_si512((const void *)(ierow + base));
+                ierg = _mm512_mask_mov_epi32(ierg, gmask, vip1);
+                _mm512_storeu_si512((void *)(ierow + base), ierg);
+
+                __m512i y1c  = _mm512_add_epi32(y1g, vi);
+                __m512i yc   = _mm512_add_epi32(yg, _mm512_sub_epi32(xrg, vone));
+                __m512i tmpi = _mm512_sub_epi32(vip1, xrg);
+                __m512i tmpj = _mm512_sub_epi32(y1c, yc);
+                // z-drop gap term weighted by gap-extend penalty, matching the
+                // scalar reference (drift>0 -> deletion side *e_del, else *e_ins).
+                __m512i zdelta = _mm512_sub_epi32(tmpi, tmpj);
+                __mmask16 zdsel = _mm512_cmpgt_epi32_mask(zdelta, _mm512_setzero_si512());
+                __m512i zesel  = _mm512_mask_blend_epi32(zdsel, veins, vedel);
+                __m512i dif  = _mm512_mullo_epi32(_mm512_abs_epi32(zdelta), zesel);
+                __m512i drop = _mm512_sub_epi32(msg, rsg);
+                __mmask16 diem = exm & _mm512_cmpgt_epi32_mask(_mm512_sub_epi32(drop, dif), vzd);
+                die64 |= ((__mmask64)diem) << (16 * g);
             }
-            exit0 = _mm512_load_si512((__m512i *) exit_a);
+            exit0 = _mm512_mask_mov_epi8(exit0, die64, _mm512_setzero_si512());
         }
 
 #if RDT
@@ -5826,42 +5876,74 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             _mm_store_si128((__m128i *) exit_a, exit0);
             _mm_store_si128((__m128i *) qfire_a, qfire128);
             _mm_store_si128((__m128i *) hqe_a, hqe128);
-            for (int l = 0; l < SIMD_WIDTH8; l++) {
-                // best-score row
-                if (cmp_a[l]) xrow[l] = i + 1;
-                // ABSOLUTE-FRAME score tracking: the 8-bit maxScore128 is in the
-                // lane's CURRENT B[l] frame, so the absolute value is the
-                // rebaselined byte + B[l]. Re-derive every row (cheap, O(rows))
-                // rather than adding B back once at the end (the recorded max may
-                // pre-date later B bumps). max() guards against the byte being
-                // re-baselined away in a later row.
-                {
-                    int ms_abs = (int)(uint8_t)ms_a[l] + B[l];
-                    if (ms_abs > best_abs[l]) best_abs[l] = ms_abs;
-                }
-                // gscore (query-end score): qfire flags that this lane reached its
-                // query end this row; hqe is the captured query-end cell H (byte,
-                // current B[l] frame). The absolute value is byte + B[l]. Scalar's
-                // tie-break updates on `>=` so the LAST max-achieving row wins gtle.
-                if (qfire_a[l]) {
-                    int gs_abs = (int)(uint8_t)hqe_a[l] + B[l];
-                    if (gs_abs >= gbest_abs[l]) { gbest_abs[l] = gs_abs; ierow[l] = i + 1; }
-                }
-                // z-drop (only relevant where the lane is still alive). The drop
-                // is ms-rs of two bytes in the SAME B[l] frame, so the B cancels
-                // and the comparison is already in ABSOLUTE score units.
-                if (exit_a[l]) {
-                    int xr  = xrow[l];                       // best row
-                    int y1c = (int) y1_a[l] + i;             // row-max col (abs)
-                    int yc  = (int) y_a[l] + (xr - 1);       // best col (abs)
-                    int tmpi = (i + 1) - xr;
-                    int tmpj = y1c - yc;
-                    int dif  = tmpi > tmpj ? (tmpi - tmpj) : (tmpj - tmpi);
-                    int drop = (int)(uint8_t)ms_a[l] - (int)(uint8_t)rs_a[l];
-                    if (drop - dif > zdrop) exit_a[l] = 0;
-                }
+            // VECTORIZED per-lane wide updates (replaces the scalar lane loop;
+            // it was the dominant SW-kernel cost on AVX-512 per profiling). int32
+            // is 4x int8, so SIMD_WIDTH8 lanes split into SIMD_WIDTH8/4 groups of
+            // 4 int32. Each group does the same xrow / best_abs / gbest_abs+ierow /
+            // z-drop work as the scalar loop in wide int32 SIMD; byte-identical
+            // (same >, >= tie-breaks; same abs/z-drop arithmetic; B[] added per row).
+            const __m128i vi   = _mm_set1_epi32(i);
+            const __m128i vip1 = _mm_set1_epi32(i + 1);
+            const __m128i vone = _mm_set1_epi32(1);
+            const __m128i vzd  = _mm_set1_epi32(zdrop);
+            const __m128i vedel = _mm_set1_epi32(this->e_del);
+            const __m128i veins = _mm_set1_epi32(this->e_ins);
+            __m128i die_g[SIMD_WIDTH8 / 4];
+            for (int g = 0; g < SIMD_WIDTH8 / 4; g++) {
+                const int base = g * 4;
+                __m128i Bg   = _mm_loadu_si128((const __m128i *)(B + base));
+                __m128i msg  = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(ms_a    + base)));
+                __m128i rsg  = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(rs_a    + base)));
+                __m128i hqeg = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(hqe_a   + base)));
+                __m128i cmpg = _mm_cvtepi8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(cmp_a   + base)));
+                __m128i exitg= _mm_cvtepi8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(exit_a  + base)));
+                __m128i qfg  = _mm_cvtepi8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(qfire_a + base)));
+                __m128i y1g  = _mm_cvtepi8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(y1_a    + base)));
+                __m128i yg   = _mm_cvtepi8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(y_a     + base)));
+
+                // (1) best-score row: xrow = cmp ? i+1 : xrow
+                __m128i xrg = _mm_loadu_si128((const __m128i *)(xrow + base));
+                xrg = _mm_blendv_epi8(xrg, vip1, cmpg);
+                _mm_storeu_si128((__m128i *)(xrow + base), xrg);
+
+                // (2) best_abs = max(best_abs, (uint8)ms + B)
+                __m128i ms_abs = _mm_add_epi32(msg, Bg);
+                __m128i bag = _mm_loadu_si128((const __m128i *)(best_abs + base));
+                bag = _mm_max_epi32(bag, ms_abs);
+                _mm_storeu_si128((__m128i *)(best_abs + base), bag);
+
+                // (3) gscore: where qfire AND gs_abs >= gbest_abs, take gs_abs / i+1
+                __m128i gs_abs = _mm_add_epi32(hqeg, Bg);
+                __m128i gba = _mm_loadu_si128((const __m128i *)(gbest_abs + base));
+                __m128i ge  = _mm_xor_si128(_mm_cmpgt_epi32(gba, gs_abs), ff128); // gs_abs >= gba
+                __m128i gmask = _mm_and_si128(qfg, ge);
+                gba = _mm_blendv_epi8(gba, gs_abs, gmask);
+                _mm_storeu_si128((__m128i *)(gbest_abs + base), gba);
+                __m128i ierg = _mm_loadu_si128((const __m128i *)(ierow + base));
+                ierg = _mm_blendv_epi8(ierg, vip1, gmask);
+                _mm_storeu_si128((__m128i *)(ierow + base), ierg);
+
+                // (4) z-drop (alive lanes): dif = |((i+1)-xr) - (y1c-yc)|,
+                //     drop = (uint8)ms - (uint8)rs; die where drop-dif > zdrop.
+                __m128i y1c  = _mm_add_epi32(y1g, vi);
+                __m128i yc   = _mm_add_epi32(yg, _mm_sub_epi32(xrg, vone));
+                __m128i tmpi = _mm_sub_epi32(vip1, xrg);
+                __m128i tmpj = _mm_sub_epi32(y1c, yc);
+                // z-drop gap term weighted by gap-extend penalty, matching the
+                // scalar reference (drift>0 -> deletion side *e_del, else *e_ins).
+                __m128i zdelta = _mm_sub_epi32(tmpi, tmpj);
+                __m128i zesel  = _mm_blendv_epi8(veins, vedel,
+                                     _mm_cmpgt_epi32(zdelta, _mm_setzero_si128()));
+                __m128i dif  = _mm_mullo_epi32(_mm_abs_epi32(zdelta), zesel);
+                __m128i drop = _mm_sub_epi32(msg, rsg);
+                __m128i die  = _mm_cmpgt_epi32(_mm_sub_epi32(drop, dif), vzd);
+                die_g[g] = _mm_and_si128(die, exitg);
             }
-            exit0 = _mm_load_si128((__m128i *) exit_a);
+            // pack the four int32 die masks back to a byte mask; clear dying lanes.
+            __m128i die01 = _mm_packs_epi32(die_g[0], die_g[1]);
+            __m128i die23 = _mm_packs_epi32(die_g[2], die_g[3]);
+            __m128i die_bytes = _mm_packs_epi16(die01, die23);
+            exit0 = _mm_andnot_si128(die_bytes, exit0);
         }
 
 #if RDT

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -1426,6 +1426,11 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
         // reference; the next row reads the lowered values consistently.
         {
+            /* Fast path: one vector test for "any lane >= REBASE_HI?" — see the
+             * 128-bit kernel. Under the routing envelope this is ~always false, so
+             * the per-lane scalar scan + maxRS1 store below are skipped each row. */
+            __m256i hi256 = _mm256_set1_epi8((int8_t) REBASE_HI);
+            if (_mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_subs_epu8(hi256, maxRS1), zero256))) {
             uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(32)));
             _mm256_store_si256((__m256i *) rs_b, maxRS1);
             int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(32)));
@@ -1479,6 +1484,7 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
                 // (gbest_abs, absolute units) in the epilogue, immune to this
                 // re-baseline subtract.
             }
+            }   /* end "any lane >= REBASE_HI" fast-path guard */
         }
 
 #if RDT
@@ -3319,6 +3325,10 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
         // reference; the next row reads the lowered values consistently.
         {
+            /* Fast path: one vector test for "any lane >= REBASE_HI?" — see the
+             * 128-bit kernel. Under the routing envelope this is ~always false, so
+             * the per-lane scalar scan + maxRS1 store below are skipped each row. */
+            if (_mm512_cmpge_epu8_mask(maxRS1, _mm512_set1_epi8((int8_t) REBASE_HI))) {
             uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(64)));
             _mm512_store_si512((__m512i *) rs_b, maxRS1);
             int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(64)));
@@ -3372,6 +3382,7 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
                 // (gbest_abs, absolute units) in the epilogue, immune to this
                 // re-baseline subtract.
             }
+            }   /* end "any lane >= REBASE_HI" fast-path guard */
         }
 
 #if RDT
@@ -5954,6 +5965,13 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
         // reference; the next row reads the lowered values consistently.
         {
+            /* Fast path: one vector test for "any lane >= REBASE_HI?". Under the
+             * routing envelope no admitted pair ever reaches REBASE_HI (the gate
+             * keeps the max attainable score below it), so this is ~always false and
+             * the per-lane scalar scan + maxRS1 store below are skipped each row.
+             * Unsigned >=: subs_epu8(REBASE_HI, maxRS1)==0 iff maxRS1 >= REBASE_HI. */
+            __m128i hi128 = _mm_set1_epi8((int8_t) REBASE_HI);
+            if (_mm_movemask_epi8(_mm_cmpeq_epi8(_mm_subs_epu8(hi128, maxRS1), zero128))) {
             uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(16)));
             _mm_store_si128((__m128i *) rs_b, maxRS1);
             int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(16)));
@@ -6007,6 +6025,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
                 // (gbest_abs, in absolute units) in the epilogue, so it is immune
                 // to this re-baseline subtract.
             }
+            }   /* end "any lane >= REBASE_HI" fast-path guard */
         }
 
 #if RDT

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,7 +15,7 @@
 ##  direct builds — see the ARM branch below).
 ##*****************************************************************************
 
-EXE = fmi_test smem2_test bwt_seed_strategy_test sa2ref_test xeonbsw smem_lockstep_parity_test header_insert_test packed_text_test system_test
+EXE = fmi_test smem2_test bwt_seed_strategy_test sa2ref_test xeonbsw bandedswa_zdrop_eweight_test smem_lockstep_parity_test header_insert_test packed_text_test system_test
 
 # Doctest binaries — rules populated in Task 14 (unit) and Task 15
 # (integration). Listed separately from $(EXE) so `all` and
@@ -219,6 +219,9 @@ bwt_seed_strategy_test: $(INTEGRATION_DIR)/bwt_seed_strategy_test.o
 xeonbsw: $(INTEGRATION_DIR)/main_banded.o
 	$(CXX) $(LDFLAGS) -o $@ $^ $(LIBS)
 
+bandedswa_zdrop_eweight_test: $(INTEGRATION_DIR)/bandedswa_zdrop_eweight_test.o
+	$(CXX) $(LDFLAGS) -o $@ $^ $(LIBS)
+
 smem_lockstep_parity_test: smem_lockstep_parity_test.o
 	$(CXX) $(LDFLAGS) -o $@ $^ $(LIBS)
 
@@ -268,6 +271,7 @@ integration/bwt_seed_strategy_test.o: ../src/bwa.h ../src/bwt.h ../src/utils.h .
 integration/fmi_test.o: ../src/FMI_search.h ../src/bntseq.h ../src/read_index_ele.h
 integration/fmi_test.o: ../src/bwa.h ../src/bwt.h ../src/utils.h ../src/macro.h
 integration/main_banded.o: ../src/bandedSWA.h ../src/macro.h
+integration/bandedswa_zdrop_eweight_test.o: ../src/bandedSWA.h ../src/macro.h
 integration/sa2ref_test.o: ../src/FMI_search.h ../src/bntseq.h ../src/read_index_ele.h
 integration/sa2ref_test.o: ../src/bwa.h ../src/bwt.h ../src/utils.h ../src/macro.h
 integration/smem2_test.o: ../src/FMI_search.h ../src/bntseq.h ../src/read_index_ele.h

--- a/test/integration/bandedswa_zdrop_eweight_test.cpp
+++ b/test/integration/bandedswa_zdrop_eweight_test.cpp
@@ -1,0 +1,158 @@
+// Regression test for z-drop gap-extension weighting in the 8-bit banded-SW
+// vectorized epilogue (finding: the SIMD z-drop term was |Δrow-Δcol| with an
+// implicit gap-extend penalty of 1, while the scalar reference weights the
+// drift by e_del / e_ins). At the default `-E 1` the two are identical, which
+// is why the existing byte-identity tests (all default-params) never caught
+// it. This probe exercises NON-DEFAULT gap-extend so the weighting matters.
+//
+// It mirrors the high-zdrop seed test's fixture (tandem-repeat targets + noisy
+// query producing real indels/drift) but uses:
+//   - a SMALL zdrop, so z-drop early-exit actually FIRES for many pairs, and
+//   - ASYMMETRIC, non-unit gap-extend (e_del != e_ins, both > 1), so the
+//     deletion vs insertion branch of the weighted term is exercised.
+// getScores8 must remain byte-identical to the scalar oracle for every pair the
+// routing gate (bsw8_envelope_ok, mirrored here) would admit. Deterministic
+// (fixed RNG seed); exits non-zero on any score-field mismatch.
+
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+#include <random>
+
+#include "bandedSWA.h"
+
+namespace {
+
+struct Out { int score, tle, gtle, qle, gscore, max_off; };
+
+// Mirror of bwamem.cpp bsw8_envelope_ok for maxStep = 1 (this test's scoring,
+// a = 1). The gate is independent of the gap penalties, so it is unchanged from
+// the high-zdrop seed test. Only admitted pairs are required to match scalar.
+bool envelope_ok(int len1, int len2, int w, int zdrop, int h0, int maxStep) {
+    int shorter = len1 < len2 ? len1 : len2;
+    return len1 < MAX_SEQ_LEN8 && len2 < MAX_SEQ_LEN8 && len1 >= len2 &&
+           w <= 127 && zdrop + maxStep <= 127 && h0 <= zdrop + 1 &&
+           (h0 + shorter * 1) < 255 - maxStep;
+}
+
+// Run one (o_del, e_del, o_ins, e_ins, zdrop) configuration: build the fixture,
+// score with the scalar oracle and getScores8, diff the five z-drop-affected
+// output fields (score, tle, qle, gscore, max_off; gtle is excluded — see the
+// NOTE below) over admitted pairs. Returns the number of mismatches; sets
+// *admitted_out to the number of pairs the routing gate admits (main fails the
+// run if any config admits none, guarding against a fixture that exercises no
+// admitted pair).
+long run_config(const char *name, int o_del, int e_del, int o_ins, int e_ins,
+                int zdrop, long *admitted_out) {
+    // Multiple of 64 = max SIMD_WIDTH8 (avx512bw). getScores8 processes pairs in
+    // SIMD_WIDTH8-wide batches; a non-multiple leaves a partial final batch whose
+    // padding lanes read/write past the array (heap corruption on avx2/avx512).
+    const long n      = 49920;
+    const int  maxlen = 110;
+    const int  a = 1, b = 4, ambig = -1, end_bonus = 5, w = 100;
+    const int  maxStep = a > 1 ? a : 1;
+    const int  STRIDE = 1280;
+    const int  h0min = 1, h0max = zdrop + 1;  // admissible seed range
+
+    int8_t mat[25];
+    { int k = 0;
+      for (int i = 0; i < 4; ++i) { for (int j = 0; j < 4; ++j) mat[k++] = (i == j) ? a : -b; mat[k++] = ambig; }
+      for (int j = 0; j < 5; ++j) mat[k++] = ambig; }
+
+    BandedPairWiseSW bsw(o_del, e_del, o_ins, e_ins, zdrop, end_bonus, mat, a, b, 1);
+
+    std::mt19937_64 rng(0xC0FFEE ^ (uint64_t)zdrop ^ ((uint64_t)e_del << 8) ^ ((uint64_t)e_ins << 16));
+    std::vector<uint8_t> ref((size_t)STRIDE * n, 0), qer((size_t)STRIDE * n, 0);
+    std::vector<SeqPair> pairs(n);
+    std::vector<Out> oracle(n);
+    std::uniform_int_distribution<int> lenD(20, maxlen);
+    std::uniform_int_distribution<int> hD(h0min, h0max);
+    std::uniform_int_distribution<int> unit(3, 12);
+
+    for (long c = 0; c < n; ++c) {
+        int aa = lenD(rng), bb = lenD(rng);
+        int len1 = aa > bb ? aa : bb, len2 = aa > bb ? bb : aa;  // len1 >= len2
+        int h0 = hD(rng);
+        uint8_t *s1 = &ref[(size_t)c * STRIDE];
+        uint8_t *s2 = &qer[(size_t)c * STRIDE];
+        int u = unit(rng); uint8_t ubuf[16];
+        for (int i = 0; i < u; i++) ubuf[i] = (uint8_t)(rng() % 4);
+        for (int i = 0; i < len1; i++) s1[i] = ubuf[i % u];     // tandem repeat
+        int ti = 0;
+        for (int i = 0; i < len2; i++) {                        // query: derived w/ noise
+            uint8_t base = (ti < len1) ? s1[ti] : (uint8_t)(rng() % 4);
+            if ((int)(rng() % 100) < 12) base = (uint8_t)(rng() % 4);  // mismatch noise
+            s2[i] = base;
+            if ((rng() % 20) == 0) { if (rng() & 1) ti += 2; } else ti++;  // indel noise
+        }
+        SeqPair &p = pairs[c];
+        p.id = c; p.len1 = len1; p.len2 = len2; p.h0 = h0;
+        p.idr = (int)((size_t)c * STRIDE); p.idq = (int)((size_t)c * STRIDE);
+        p.seqid = c; p.regid = c;
+        p.score = p.tle = p.gtle = p.qle = p.gscore = p.max_off = -1;
+        Out &O = oracle[c];
+        O.score = bsw.scalarBandedSWA(len2, s2, len1, s1, w, h0,
+                                      &O.qle, &O.tle, &O.gtle, &O.gscore, &O.max_off);
+    }
+
+    bsw.getScores8(pairs.data(), ref.data(), qer.data(), (int32_t)n, 1, w);
+
+    long admitted = 0, diffs = 0;
+    for (long c = 0; c < n; ++c) {
+        const SeqPair &q = pairs[c];
+        if (!envelope_ok(q.len1, q.len2, w, zdrop, q.h0, maxStep)) continue;
+        admitted++;
+        const Out &O = oracle[c];
+        // NOTE: gtle (gscore row = max_ie+1) is intentionally excluded here. A
+        // SEPARATE, pre-existing divergence affects gtle at non-unit gap-extend
+        // in gscore==0 query-end tie cases (independent of the z-drop weighting
+        // fixed in this change); it is tracked and fixed in its own PR. This
+        // probe validates only the z-drop-affected fields.
+        if (O.score != q.score || O.tle != q.tle ||
+            O.qle != q.qle || O.gscore != q.gscore || O.max_off != q.max_off) {
+            if (diffs < 10)
+                fprintf(stderr,
+                    "[zdrop-eweight:%s] DIFF c=%ld len1=%d len2=%d h0=%d | scalar %d/%d/%d/%d/%d | 8 %d/%d/%d/%d/%d\n",
+                    name, c, q.len1, q.len2, q.h0,
+                    O.score, O.tle, O.qle, O.gscore, O.max_off,
+                    q.score, q.tle, q.qle, q.gscore, q.max_off);
+            diffs++;
+        }
+    }
+    fprintf(stderr, "[zdrop-eweight:%s] o_del=%d e_del=%d o_ins=%d e_ins=%d zdrop=%d: admitted=%ld diffs=%ld\n",
+            name, o_del, e_del, o_ins, e_ins, zdrop, admitted, diffs);
+    *admitted_out = admitted;
+    return diffs;
+}
+
+} // namespace
+
+int main() {
+    long adm = 0, total_diffs = 0, min_admitted = -1;
+
+    // Config A: asymmetric, non-unit gap-extend, small zdrop (z-drop fires
+    // often, deletion/insertion weighting both exercised). This is the config
+    // that diverges pre-fix.
+    total_diffs += run_config("asym", /*o_del*/6, /*e_del*/3, /*o_ins*/6, /*e_ins*/1, /*zdrop*/25, &adm);
+    if (min_admitted < 0 || adm < min_admitted) min_admitted = adm;
+
+    // Config B: symmetric non-unit gap-extend.
+    total_diffs += run_config("sym2", 6, 2, 6, 2, 30, &adm);
+    if (adm < min_admitted) min_admitted = adm;
+
+    // Config C: default gap-extend (e = 1). Must match both before and after
+    // the fix — a guard that the weighting change is a no-op at default params.
+    total_diffs += run_config("e1", 6, 1, 6, 1, 25, &adm);
+    if (adm < min_admitted) min_admitted = adm;
+
+    if (min_admitted <= 0) {
+        fprintf(stderr, "bandedswa_zdrop_eweight_test: FAIL — a config admitted no pairs\n");
+        return 2;
+    }
+    if (total_diffs != 0) {
+        fprintf(stderr, "bandedswa_zdrop_eweight_test: FAIL — %ld getScores8/scalar mismatches\n", total_diffs);
+        return 1;
+    }
+    fprintf(stderr, "bandedswa_zdrop_eweight_test: OK\n");
+    return 0;
+}

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -81,6 +81,13 @@ LINES="$(wc -l < "$FKSW" | tr -d ' ')"
 [[ "$LINES" -eq 3 ]] || fail "xeonbsw: expected 3 lines in fksw.txt, got $LINES"
 ok "xeonbsw ($LINES pair scores emitted)"
 
+# --- bandedswa_zdrop_eweight_test (z-drop gap-extend weighting parity) ------
+# Self-contained: generates tandem-repeat fixtures and compares getScores8 to
+# the scalar oracle at non-default gap-extend (e_del/e_ins != 1). Exits non-zero
+# on any score-field mismatch.
+(cd "$HERE" && ./bandedswa_zdrop_eweight_test >/dev/null 2>&1) || fail "bandedswa_zdrop_eweight_test (z-drop e_del/e_ins weighting)"
+ok "bandedswa_zdrop_eweight_test (z-drop gap-extend weighting parity)"
+
 # --- pg_cl_escape_test ----------------------------------------------------
 # Regression for issue #45 / upstream #293: tabs inside `-R` must not
 # bleed into the @PG CL: value. Uses the same phiX fixture as the rest


### PR DESCRIPTION
## Summary

Vectorizes the per-row epilogue "side-channel update" loop in all three 8-bit banded Smith–Waterman kernels (`smithWaterman128_8` NEON/SSE4.1, `smithWaterman256_8` AVX2, `smithWaterman512_8` AVX-512). Profiling (#34) showed this scalar per-lane loop — not the inner DP loop — is the dominant SW-kernel cost on AVX-512 (~4.6% of total runtime vs ~1% for the inner loop).

The loop runs once per DP row and, for each SIMD lane, updates the wide int32 side channels (`xrow`, `best_abs`, `gbest_abs`/`ierow`) and applies the z-drop early-exit, reconstructing absolute scores from the re-baselined byte plus the per-lane offset `B[l]`. int32 is 4× int8, so each tier's lane set splits cleanly into groups of 4 int32 (`__m128i`), 8 (`__m256i`), or 16 (`__m512i`):

- **xrow / best_abs / gbest_abs+ierow** become `blendv`/`max_epi32`/masked-move over int32 groups, preserving the scalar tie-breaks exactly (`best_abs` strict `>` is value-identical under `max`; gscore keeps the `>=` last-row-wins rule).
- **z-drop** is computed in int32 (`abs_epi32` of the band-distance difference, `drop = ms − rs`), producing a per-group "die" mask.
- The die masks are folded back into `exit0`: NEON/AVX2 pack int32→byte without lane-crossing (`packs_epi32`+`packs_epi16` / per-group 128-bit pack) then `andnot`; AVX-512 combines the per-group `__mmask16` slices into one `__mmask64` and clears the dying lanes with `mask_mov_epi8`. The AVX-512 path reads the `cmp`/`qfire`/`exit` predicates straight from mask registers (`movepi8_mask`), so it no longer materializes those three byte scratch arrays.

## Correctness

Byte-identical to the scalar epilogue — same `>`/`>=` tie-breaks, same abs/z-drop arithmetic, same `B[]`-per-row reconstruction. Validated on **all four tiers**:

- **NEON / SSE4.1 / AVX2 / AVX-512**: the 3-way repeat probe (scalar vs `getScores8` vs `getScores16`, tandem-repeat targets + wide h0, all six output fields) reports `8 vs scalar diffs: 0`, `16 vs scalar diffs: 0`, `8 vs 16 diffs: 0` at maxlen 120 / 200 / 250.
- **chr22** holodeck PE parity (`bwa == bwa-mem3`) and the **400 bp PE** long-read parity (recovered 8-bit path == 16-bit reference, 38,114 records) both pass on NEON.

## Performance

A ~3% reduction in **SW-kernel (banded Smith–Waterman) compute**, measured two ways:

- **chr22, 151 bp, `-t1`, avx512bw** (small cache-resident index, SW-dominated wall): baseline mean **56.51 s** → vectorized **54.81 s** ≈ **3.0% wall**, 5 interleaved reps, tight non-overlapping variance.
- **Real full-genome** (HG002 Roche-SBX-1M variable-length reads vs GRCh38; `#147` base vs `#149`, kernel-swap A/B, `-t16`, on `c6a`/`c7i`/`c8g`): SW compute drops **−3.1% avx2 / −2.7% avx512bw / −1.2% neon** (user-CPU, corroborated by `tricorder cpu_time`; interleaved reps, tight variance).

On full-genome runs the *end-to-end wall* delta is smaller and noisy: the run is dominated by ~57 s of index I/O (the 21 GB index) and SW is only ~6% of total compute, so compute (not wall) is the honest metric there. How much of the ~3% kernel win surfaces as wall time scales with the SW fraction of the workload.

Tracks #146 item #35. Profile justification: #34. Base PR: #147.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved SIMD Smith-Waterman scoring epilogue behavior with more efficient wide-integer vector computations.
  * Added safeguards to skip re-baseline work when it isn’t needed, reducing unnecessary per-lane processing.

* **Tests**
  * Added a new integration regression test that verifies SIMD results match a scalar oracle for z-drop gap-extension weighting (including asymmetric penalties).
  * Updated the test build/run scripts to include and execute the new test binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->