### PR TITLE
fix(bsw): bound getScores8/16 prefetch reads to the padding contract

### DIFF
--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -506,3 +506,14 @@ jobs:
           make ASAN=1 arch="$MAKE_ARCH" CXX="ccache g++" CC="ccache gcc" kswv_nrow_zero_test
           ./kswv_nrow_zero_test
           ccache --show-stats | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Build + run bandedswa_padding_test (ASan)
+        # issue 146: getScores8/16 prefetch-read pairArray[i+j+PFD] past a
+        # caller's minimal roundup(numPairs, SIMD_WIDTH) allocation. Under ASan
+        # a tight-allocation caller trips heap-buffer-overflow; the bounded
+        # prefetch runs clean. `make clean` forces full recompile under asan.
+        run: |
+          make clean
+          make ASAN=1 arch="$MAKE_ARCH" CXX="ccache g++" CC="ccache gcc" bandedswa_padding_test
+          ./bandedswa_padding_test
+          ccache --show-stats | tee -a "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -398,7 +398,7 @@ ifneq ($(strip $(DISABLE_BATCHED_MATESW)),)
     CPPFLAGS += -DDISABLE_BATCHED_MATESW=$(DISABLE_BATCHED_MATESW)
 endif
 
-.PHONY:all myall arm64 clean depend single all-single print-mimalloc-config kswv_nrow_zero_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test test test-injection FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean docs docs-serve docs-cli docs-clean docs-install-tools
+.PHONY:all myall arm64 clean depend single all-single print-mimalloc-config kswv_nrow_zero_test bandedswa_padding_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test test test-injection FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean docs docs-serve docs-cli docs-clean docs-install-tools
 .SUFFIXES:.cpp .o
 
 .cpp.o:
@@ -510,6 +510,21 @@ src/kswv.native.o: src/kswv.cpp
 kswv_nrow_zero_test: $(BWA_LIB) $(HTS_LIB) src/kswv.native.o test/kswv_nrow_zero_test.o
 	$(CXX) $(BASE_CXXFLAGS) -march=native $(LDFLAGS) test/kswv_nrow_zero_test.o src/kswv.native.o $(BWA_LIB) $(LIBS) -o $@
 
+# Native-tier copy of bandedSWA.cpp, linked ahead of libbwa.a for the same
+# reason as src/kswv.native.o: on x86 multi-tier builds libbwa.a's baseline
+# bandedSWA.o is compiled at BASELINE_ARCH (avx2), which lacks the 512-wide
+# wrappers; the native copy guarantees the host's widest getScores8/16 (and
+# their PFD8/PFD16 prefetch sites) are the ones the padding test exercises.
+# On arm64 -march=native resolves to the NEON baseline already.
+src/bandedSWA.native.o: src/bandedSWA.cpp
+	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
+
+# getScores8/16 padding-lane / prefetch contract regression. Meaningful under
+# ASan (`make ASAN=1 bandedswa_padding_test`): a tight-allocation caller that
+# over-reads the SeqPair array aborts; the bounded prefetch runs clean.
+bandedswa_padding_test: $(BWA_LIB) $(HTS_LIB) src/bandedSWA.native.o test/bandedswa_padding_test.o
+	$(CXX) $(BASE_CXXFLAGS) -march=native $(LDFLAGS) test/bandedswa_padding_test.o src/bandedSWA.native.o $(BWA_LIB) $(LIBS) -o $@
+
 # Build the test binaries with the same ARCH_FLAGS as libbwa.a so the
 # test binary's kswv.h preprocessor state (SIMD_WIDTH8, BWA_TESTS_HAVE_KSWV)
 # matches what libbwa.a was compiled with. Consumed by ci.yml so that e.g.
@@ -568,10 +583,11 @@ test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
 # Note: depends on `bwa-mem3` so version_banner.sh has a binary to grep —
 # previously `test:` only built the test harness binaries, not the main
 # executable.
-test: test-binaries kswv_nrow_zero_test shm_section_find_test shm_lock_destroy_test bwa-mem3
+test: test-binaries kswv_nrow_zero_test bandedswa_padding_test shm_section_find_test shm_lock_destroy_test bwa-mem3
 	./test/bwa_mem3_tests_unit
 	./test/bwa_mem3_tests_integration
 	./kswv_nrow_zero_test
+	./bandedswa_padding_test
 	./shm_section_find_test
 	./shm_lock_destroy_test
 	BWA_MEM3=./bwa-mem3 ./test/regression/version_banner.sh
@@ -586,6 +602,9 @@ test-injection: bwa-mem3
 		./test/regression/host_floor_enforce.sh
 
 test/kswv_nrow_zero_test.o: test/kswv_nrow_zero_test.cpp
+	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
+
+test/bandedswa_padding_test.o: test/bandedswa_padding_test.cpp
 	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 test/shm_section_find_test.o: test/shm_section_find_test.cpp
@@ -660,7 +679,7 @@ $(MIMALLOC_LIB):
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
 clean: pgo-clean profile-clean lto-clean
-	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test bwa-mem3.arm64
+	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test bandedswa_padding_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test bwa-mem3.arm64
 	rm -f $(LIBSAIS_OBJS)
 	rm -f src/*.gcno src/*.gcda
 	$(MAKE) -C test clean

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -1572,6 +1572,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
         pairArray[ii].id = ii;
         pairArray[ii].len1 = 0;
         pairArray[ii].len2 = 0;
+        pairArray[ii].idr = 0;
+        pairArray[ii].idq = 0;
     }
 
 #if RDT 
@@ -1655,7 +1657,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
             uint64_t tim;
             for(j = 0; j < SIMD_WIDTH16; j++)
             {
-                { // prefetch block
+                if ((i + j + PFD) < roundNumPairs) { // prefetch block (bounded; see getScores8/16 contract)
                     SeqPair spf = pairArray[i + j + PFD];
                     _mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, _MM_HINT_NTA);
                     _mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, _MM_HINT_NTA);
@@ -1696,7 +1698,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
 //-------------------
             for(j = 0; j < SIMD_WIDTH16; j++)
             {
-                { // prefetch block
+                if ((i + j + PFD) < roundNumPairs) { // prefetch block (bounded; see getScores8/16 contract)
                     SeqPair spf = pairArray[i + j + PFD];
                     _mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, _MM_HINT_NTA);
                     _mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, _MM_HINT_NTA);
@@ -2500,6 +2502,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         pairArray[ii].id = ii;
         pairArray[ii].len1 = 0;
         pairArray[ii].len2 = pairArray[numPairs - 1].len2;
+        pairArray[ii].idr = 0;
+        pairArray[ii].idq = 0;
     }
 
 #if RDT
@@ -2602,7 +2606,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             uint64_t tim;
             for(j = 0; j < SIMD_WIDTH8; j++)
             {
-                { // prefetch block
+                if ((i + j + PFD8) < roundNumPairs) { // prefetch block (bounded; see getScores8/16 contract)
                     SeqPair spf = pairArray[i + j + PFD8];
                     _mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, _MM_HINT_NTA);
                     _mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, _MM_HINT_NTA);
@@ -2653,7 +2657,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 //-------------------
             for(j = 0; j < SIMD_WIDTH8; j++)
             {
-                { // prefetch block
+                if ((i + j + PFD8) < roundNumPairs) { // prefetch block (bounded; see getScores8/16 contract)
                     SeqPair spf = pairArray[i + j + PFD8];
                     _mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, _MM_HINT_NTA);
                     _mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, _MM_HINT_NTA);
@@ -3464,6 +3468,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
         pairArray[ii].id = ii;
         pairArray[ii].len1 = 0;
         pairArray[ii].len2 = 0;
+        pairArray[ii].idr = 0;
+        pairArray[ii].idq = 0;
     }
 
 #if RDT
@@ -3546,7 +3552,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
 
             for(j = 0; j < SIMD_WIDTH16; j++)
             {
-                { // prefetch block
+                if ((i + j + PFD16) < roundNumPairs) { // prefetch block (bounded; see getScores8/16 contract)
                     SeqPair spf = pairArray[i + j + PFD16];
                     _mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, _MM_HINT_NTA);
                     _mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, _MM_HINT_NTA);
@@ -3589,7 +3595,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
 //-------------------
             for(j = 0; j < SIMD_WIDTH16; j++)
             {
-                { // prefetch block
+                if ((i + j + PFD16) < roundNumPairs) { // prefetch block (bounded; see getScores8/16 contract)
                     SeqPair spf = pairArray[i + j + PFD16];
                     _mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, _MM_HINT_NTA);
                     _mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, _MM_HINT_NTA);
@@ -4316,6 +4322,8 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
         pairArray[ii].id = ii;
         pairArray[ii].len1 = 0;
         pairArray[ii].len2 = 0;
+        pairArray[ii].idr = 0;
+        pairArray[ii].idq = 0;
     }
 
 #if RDT
@@ -4399,7 +4407,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
 
             for(j = 0; j < SIMD_WIDTH16; j++)
             {
-                { // prefetch block
+                if ((i + j + PFD) < roundNumPairs) { // prefetch block (bounded; see getScores8/16 contract)
                     SeqPair spf = pairArray[i + j + PFD];
                     _mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr, _MM_HINT_NTA);
                     _mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, _MM_HINT_NTA);
@@ -4440,7 +4448,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
 //-------------------
             for(j = 0; j < SIMD_WIDTH16; j++)
             {
-                { // prefetch block
+                if ((i + j + PFD) < roundNumPairs) { // prefetch block (bounded; see getScores8/16 contract)
                     SeqPair spf = pairArray[i + j + PFD];
                     _mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq, _MM_HINT_NTA);
                     _mm_prefetch((const char*) seqBufQer + (int64_t)spf.idq + 64, _MM_HINT_NTA);

--- a/src/bandedSWA.h
+++ b/src/bandedSWA.h
@@ -191,6 +191,30 @@ public:
                                         int nthreads,
                                         int32_t w) = 0;
 
+    /* Batched banded Smith-Waterman over `numPairs` SeqPairs.
+     *
+     * PADDING-LANE CONTRACT (must be honored by every caller):
+     * the kernel rounds the batch up to a whole number of SIMD lanes
+     * (SIMD_WIDTH8 for getScores8, SIMD_WIDTH16 for getScores16 — tier
+     * dependent, up to 64) and *writes* the trailing padding lanes
+     * pairArray[numPairs .. roundup(numPairs, SIMD_WIDTH)) itself, setting
+     * their id and zeroing len1/len2/idr/idq. The caller MUST therefore allocate at
+     * least roundup(numPairs, SIMD_WIDTH) SeqPair slots, NOT just numPairs, or those
+     * writes (and the SoA gather that reads len1/len2 back) run off the end of
+     * the array. A caller that does not know the active tier should round up to
+     * the max lane count (64). The pipeline over-allocates and is safe; a
+     * direct caller that sized the array to exactly numPairs crashed on
+     * AVX2/AVX-512 — see the test helper BatchBuffers
+     * (test/framework/seqpair_batch.h), which allocates numPairs + SIMD_WIDTH8
+     * SeqPair slots and so satisfies this rule.
+     *
+     * Prefetch reads of pairArray[i+j+PFD] are bounded to < roundNumPairs, so
+     * the kernel never reads past the rounded-up region (no extra +PFD slack is
+     * required of the caller). Those bounded prefetches still touch the kernel's
+     * own padding lanes, reading back their idr/idq to form a prefetch address;
+     * the kernel zeroes idr/idq above so that read is well-defined and the
+     * resulting hint lands at seqBufRef/seqBufQer offset 0 (in-bounds) even when
+     * the caller left the padding slots uninitialized. */
     virtual void getScores8(SeqPair *pairArray,
                             uint8_t *seqBufRef,
                             uint8_t *seqBufQer,
@@ -198,6 +222,8 @@ public:
                             uint16_t numThreads,
                             int32_t w) = 0;
 
+    /* See getScores8 for the padding-lane / prefetch contract (identical, with
+     * SIMD_WIDTH16 lanes). */
     virtual void getScores16(SeqPair *pairArray,
                              uint8_t *seqBufRef,
                              uint8_t *seqBufQer,

--- a/test/bandedswa_padding_test.cpp
+++ b/test/bandedswa_padding_test.cpp
@@ -1,0 +1,89 @@
+// Regression test for the BandedPairWiseSW::getScores8/getScores16
+// padding-lane / prefetch contract (issue 146 item: "harden the getScores8/16
+// padding/prefetch contract").
+//
+// The batched banded-SW kernels round numPairs up to a whole number of SIMD
+// lanes (SIMD_WIDTH8 / SIMD_WIDTH16) and (a) WRITE the trailing padding lanes
+// pairArray[numPairs .. roundNumPairs) and (b) PREFETCH-READ pairArray[i+j+PFD]
+// in the SoA-packing loop. A caller that sizes pairArray to exactly
+// roundup(numPairs, SIMD_WIDTH) is honoring the documented contract — yet
+// before the prefetch was bounded, the last group's pairArray[i+j+PFD] read ran
+// PFD SeqPairs past the end of that allocation. Harmless in production (the
+// pipeline over-allocates) but a real heap-buffer-overflow that AddressSanitizer
+// aborts on, and exactly the crash a direct caller hit on AVX2/AVX-512.
+//
+// This test sizes pairArray to the MINIMAL contract size (no slack) and calls
+// both entry points. With the `(i + j + PFD) < roundNumPairs` guard it runs
+// clean; without it, the ASan CI lane (`make ASAN=1 bandedswa_padding_test`)
+// reports a heap-buffer-overflow READ inside smithWatermanBatchWrapper{8,16}.
+//
+// Arch coverage is implicit in the build: the binary is compiled -march=native
+// and linked against a native-tier src/bandedSWA.native.o, so the host's
+// widest wrappers (NEON 256/16, or x86 512/8 + 512/16 with their PFD8/PFD16
+// prefetch sites) are the ones exercised.
+
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+#include "bandedSWA.h"
+
+static int32_t roundup(int32_t n, int32_t w) { return ((n + w - 1) / w) * w; }
+
+// Build a batch of `numPairs` valid pairs, allocate EXACTLY roundup(numPairs,
+// width) SeqPair slots (the minimal contract — the kernel fills the padding
+// lanes itself), and score it. Every pair points at the same modest ref/query
+// prefix so the DP runs and the SoA-packing loop (which holds the prefetch)
+// executes for every lane.
+static void run(BandedPairWiseSW &bsw, int32_t numPairs, int32_t width,
+                bool eightBit) {
+    const int32_t segLen = 48;     // modest, < int8 range, exercises real DP
+    const int32_t w       = 100;   // band
+
+    // Size the ref/query buffers past segLen so the kernel's lookahead
+    // _mm_prefetch(seqBufRef + idr + 64) hint lands inside the allocation (a
+    // prefetch never faults, but keeping it in-bounds avoids any false read
+    // signal and mirrors production, where seqBufRef is large).
+    std::vector<uint8_t> ref((size_t)segLen + 128, 0);
+    std::vector<uint8_t> qer((size_t)segLen + 128, 0);
+
+    const int32_t rounded = roundup(numPairs, width);
+    std::vector<SeqPair> pairs(rounded);   // EXACTLY the contract size, no slack
+    for (int32_t i = 0; i < numPairs; i++) {
+        SeqPair sp = {};
+        sp.id = i; sp.seqid = i; sp.regid = i;
+        sp.idr = 0; sp.idq = 0;
+        sp.len1 = segLen; sp.len2 = segLen;
+        sp.h0 = 1;
+        sp.score = sp.tle = sp.gtle = sp.qle = sp.gscore = sp.max_off = -1;
+        pairs[i] = sp;
+    }
+
+    if (eightBit) bsw.getScores8(pairs.data(), ref.data(), qer.data(), numPairs, 1, w);
+    else          bsw.getScores16(pairs.data(), ref.data(), qer.data(), numPairs, 1, w);
+}
+
+int main() {
+    const int8_t a = 1, b = 4, ambig = -1;
+    const int o = 6, e = 1, zdrop = 100, end_bonus = 5;
+    int8_t mat[25];
+    { int k = 0;
+      for (int i = 0; i < 4; ++i) { for (int j = 0; j < 4; ++j) mat[k++] = (i == j) ? a : -b; mat[k++] = ambig; }
+      for (int j = 0; j < 5; ++j) mat[k++] = ambig; }
+
+    BandedPairWiseSW bsw(o, e, o, e, zdrop, end_bonus, mat, a, b, 1);
+
+    // numPairs that are not multiples of the width (so padding lanes are
+    // written) plus exact multiples (so the prefetch reaches the very last
+    // group). 1 forces a single partly-padded group; the others span several.
+    const int32_t cases[] = {1, 3, 7, 33, 64, 100, 129};
+    for (int32_t n : cases) {
+        fprintf(stderr, "[bandedswa-padding] 8-bit  numPairs=%d ...\n", n);
+        run(bsw, n, SIMD_WIDTH8, /*eightBit=*/true);
+        fprintf(stderr, "[bandedswa-padding] 16-bit numPairs=%d ...\n", n);
+        run(bsw, n, SIMD_WIDTH16, /*eightBit=*/false);
+    }
+
+    fprintf(stderr, "bandedswa_padding_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Hardens the `BandedPairWiseSW::getScores8` / `getScores16` padding-lane / prefetch contract (issue #146 follow-up item).

The batched banded-SW kernels prefetch-read `pairArray[i + j + PFD]` in the SoA-packing loop. On the last SIMD group that index reaches `PFD` SeqPairs past `roundup(numPairs, SIMD_WIDTH)`. A caller that sizes `pairArray` to exactly that rounded-up count — the documented minimum — then suffers a heap over-read of the SeqPair array. Production over-allocates so it stayed silent, but a direct caller that sized the array to exactly `numPairs` crashed on AVX2/AVX-512 this cycle.

## Changes

- **Bound every prefetch read** with `(i + j + PFD) < roundNumPairs` (all 8 sites across the AVX2-16, AVX-512-8, AVX-512-16, and NEON-16 wrappers). The prefetch is a hint, so skipping it for the final `PFD` lanes of a batch is behavior-neutral; the kernel now never touches a SeqPair past the rounded-up region. This also *removes* the `+ PFD` slack the contract previously demanded of callers.
- **Document the contract** on the `getScores8`/`getScores16` interface declarations: the kernel writes the padding lanes `pairArray[numPairs .. roundup(numPairs, SIMD_WIDTH))` itself, so the caller must allocate at least `roundup(numPairs, SIMD_WIDTH)` SeqPair slots (round up to 64 if the active tier is unknown). References the existing `BatchBuffers` test helper, which already satisfies the rule.
- **Add `bandedswa_padding_test`**: an ASan regression that sizes `pairArray` to the minimal contract (no slack) and runs both entry points across several `numPairs` (non-multiples + exact multiples of the SIMD width). Wired into the `proto-neon-kswv` ASan lane (`make ASAN=1 bandedswa_padding_test`) so CI catches a regression. Linked against a native-tier `src/bandedSWA.native.o` so the host's widest wrappers (and their `PFD8`/`PFD16` prefetch sites) are the ones exercised.

## Validation

- **NEON repeat probe** (3-way scalar vs `getScores8` vs `getScores16`, all six output fields): `8 vs scalar = 0`, `16 vs scalar = 0`, `8 vs 16 = 0` at maxlen 120 / 200 / 250 — the prefetch guard is a strict subset of prefetches and cannot change scores.
- **ASan A/B** (same probe and the new committed test, guarded vs `origin/main` unguarded `bandedSWA`):
  - unguarded → `heap-buffer-overflow READ of size 4` in `smithWatermanBatchWrapper16` (the `pairArray[i+j+PFD]` read), traced to the test's `getScores16` call and its exactly-sized `std::vector<SeqPair>`.
  - guarded → clean, `bandedswa_padding_test: OK`.
- `make ASAN=1 bandedswa_padding_test` (the exact CI invocation) builds and runs clean.

Tracks #146.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented possible out-of-bounds reads during SIMD batch scoring by constraining look-ahead prefetches to the padded/rounded lane range.

* **New Features**
  * Added a new regression test (`bandedswa_padding_test`) that exercises padding behavior under exact and non-exact SIMD lane counts.

* **Tests**
  * Extended CI ASan runs to include the new regression test and validate the safety scenario.

* **Documentation**
  * Documented the padding and prefetch safety contract for batch scoring APIs (applies consistently across related scoring variants).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->