### PR TITLE
feat(bsw): make the 8-bit h0-prefix seed unsigned [0,255]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,7 @@ ifneq ($(strip $(DISABLE_BATCHED_MATESW)),)
     CPPFLAGS += -DDISABLE_BATCHED_MATESW=$(DISABLE_BATCHED_MATESW)
 endif
 
-.PHONY:all myall arm64 clean depend single all-single print-mimalloc-config kswv_nrow_zero_test bandedswa_padding_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test test test-injection FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean docs docs-serve docs-cli docs-clean docs-install-tools
+.PHONY:all myall arm64 clean depend single all-single print-mimalloc-config kswv_nrow_zero_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test test test-injection FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean docs docs-serve docs-cli docs-clean docs-install-tools
 .SUFFIXES:.cpp .o
 
 .cpp.o:
@@ -524,7 +524,7 @@ kswv_nrow_zero_test: $(BWA_LIB) $(HTS_LIB) src/kswv.native.o test/kswv_nrow_zero
 # reason as src/kswv.native.o: on x86 multi-tier builds libbwa.a's baseline
 # bandedSWA.o is compiled at BASELINE_ARCH (avx2), which lacks the 512-wide
 # wrappers; the native copy guarantees the host's widest getScores8/16 (and
-# their PFD8/PFD16 prefetch sites) are the ones the padding test exercises.
+# their PFD8/PFD16 prefetch sites) are the ones these tests exercise.
 # On arm64 -march=native resolves to the NEON baseline already.
 src/bandedSWA.native.o: src/bandedSWA.cpp
 	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
@@ -534,6 +534,11 @@ src/bandedSWA.native.o: src/bandedSWA.cpp
 # over-reads the SeqPair array aborts; the bounded prefetch runs clean.
 bandedswa_padding_test: $(BWA_LIB) $(HTS_LIB) src/bandedSWA.native.o test/bandedswa_padding_test.o
 	$(CXX) $(BASE_CXXFLAGS) -march=native $(LDFLAGS) test/bandedswa_padding_test.o src/bandedSWA.native.o $(BWA_LIB) $(LIBS) -o $@
+
+# Unsigned h0-prefix seed regression: getScores8 vs scalar at zdrop > 126 with
+# seed prefix bytes > 127 (the range the old signed seed could not represent).
+bandedswa_highzdrop_seed_test: $(BWA_LIB) $(HTS_LIB) src/bandedSWA.native.o test/bandedswa_highzdrop_seed_test.o
+	$(CXX) $(BASE_CXXFLAGS) -march=native $(LDFLAGS) test/bandedswa_highzdrop_seed_test.o src/bandedSWA.native.o $(BWA_LIB) $(LIBS) -o $@
 
 # Build the test binaries with the same ARCH_FLAGS as libbwa.a so the
 # test binary's kswv.h preprocessor state (SIMD_WIDTH8, BWA_TESTS_HAVE_KSWV)
@@ -599,11 +604,12 @@ test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
 # Note: depends on `bwa-mem3` so version_banner.sh has a binary to grep —
 # previously `test:` only built the test harness binaries, not the main
 # executable.
-test: test-binaries kswv_nrow_zero_test bandedswa_padding_test shm_section_find_test shm_lock_destroy_test bwa-mem3
+test: test-binaries kswv_nrow_zero_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_lock_destroy_test bwa-mem3
 	./test/bwa_mem3_tests_unit
 	./test/bwa_mem3_tests_integration
 	./kswv_nrow_zero_test
 	./bandedswa_padding_test
+	./bandedswa_highzdrop_seed_test
 	./shm_section_find_test
 	./shm_lock_destroy_test
 	BWA_MEM3=./bwa-mem3 ./test/regression/version_banner.sh
@@ -621,6 +627,9 @@ test/kswv_nrow_zero_test.o: test/kswv_nrow_zero_test.cpp
 	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 test/bandedswa_padding_test.o: test/bandedswa_padding_test.cpp
+	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
+
+test/bandedswa_highzdrop_seed_test.o: test/bandedswa_highzdrop_seed_test.cpp
 	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 test/shm_section_find_test.o: test/shm_section_find_test.cpp
@@ -695,7 +704,7 @@ $(MIMALLOC_LIB):
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
 clean: pgo-clean profile-clean lto-clean
-	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test bandedswa_padding_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test bwa-mem3.arm64
+	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test bwa-mem3.arm64
 	rm -f $(LIBSAIS_OBJS)
 	rm -f src/*.gcno src/*.gcda
 	$(MAKE) -C test clean

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -75,7 +75,7 @@ static inline T effective_threads(T n) { return n < 1 ? T(1) : n; }
 // 8-bit re-baseline floor helpers (shared by wrapper + every SIMD kernel tier)
 //
 // Initial 8-bit score floor: keep the seed score h0 inside the re-baseline
-// keep-window so the stored byte (= H_abs - B) never overflows signed int8.
+// keep-window so the stored byte (= H_abs - B) stays within the unsigned [0,255] range.
 // Clamping prefixes >REBASE_KEEP below h0 is lossless (REBASE_KEEP=zdrop+1 >
 // zdrop => already past the z-drop horizon). MUST be used by every SIMD tier.
 // Defined at file scope (before any tier #if block) so every kernel variant
@@ -580,12 +580,13 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         // so the two agree on B0; smithWaterman256_8 recomputes B0 via
         // bsw8_initial_floor(p[].h0, zdrop).
         const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
-        // The h0-prefix column/row seed below uses SIGNED int8 ops, so the seeded
-        // byte min(h0, REBASE_KEEP_W) must stay <= 127 (signed-positive). The
-        // routing gate (bsw8_envelope_ok) enforces zdrop <= 126; assert for any
-        // direct caller that bypasses the gate.
-        assert(REBASE_KEEP_W <= 127 &&
-               "8-bit h0-prefix seed is signed int8; REBASE_KEEP>127 (zdrop>126) -> route to 16-bit");
+        // The h0-prefix column/row seed below is unsigned-saturating [0,255], so
+        // the seeded byte min(h0, REBASE_KEEP_W) only needs to fit a uint8. The
+        // routing gate (bsw8_envelope_ok) enforces zdrop + maxStep <= 253 (so the
+        // re-baseline window REBASE_HI = 255 - maxStep > REBASE_KEEP holds);
+        // assert the byte bound for any direct caller that bypasses the gate.
+        assert(REBASE_KEEP_W <= 255 &&
+               "8-bit h0-prefix seed byte min(h0,REBASE_KEEP) must fit uint8 (zdrop<=254)");
 
         int nstart = 0, nend = numPairs;
 
@@ -612,6 +613,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                     int h0p = sp.h0;
                     if (h0p > REBASE_KEEP_W) h0p = REBASE_KEEP_W;
                     if (h0p < 0) h0p = 0;
+                    // Always-on uint8 guard (asserts are compiled out in release):
+                    // a direct caller that bypasses the gate with zdrop > 254 would
+                    // otherwise truncate the seed byte. In-envelope REBASE_KEEP_W <= 253,
+                    // so this never fires on the production path.
+                    if (h0p > 255) h0p = 255;
                     h0[j] = (uint8_t) h0p;
                 }
                 seq1 = seqBufRef + (int64_t)sp.idr;
@@ -638,12 +644,17 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 //--------------------
             __m256i h0_256 = _mm256_load_si256((__m256i*) h0);
             _mm256_store_si256((__m256i *) H2, h0_256);
-            __m256i tmp256 = _mm256_sub_epi8(h0_256, o_del256);
+            // h0-prefix deletion seed, unsigned-saturating [0,255]. Was signed
+            // sub_epi8 + max_epi8(.,0) floor, which required the seed byte
+            // min(h0,REBASE_KEEP) <= 127 and so capped zdrop at 126. subs_epu8
+            // floors at 0 inherently and feeds the floored value forward;
+            // byte-identical for the monotone-decreasing affine prefix. Mirrors
+            // smithWaterman128_8 (the NEON reference, already unsigned here).
+            __m256i tmp256 = _mm256_subs_epu8(h0_256, o_del256);
 
             for(k = 1; k < maxLen1; k++) {
-                tmp256 = _mm256_sub_epi8(tmp256, e_del256);
-                __m256i tmp256_ = _mm256_max_epi8(tmp256, zero256);
-                _mm256_store_si256((__m256i *)(H2 + k* SIMD_WIDTH8), tmp256_);
+                tmp256 = _mm256_subs_epu8(tmp256, e_del256);
+                _mm256_store_si256((__m256i *)(H2 + k* SIMD_WIDTH8), tmp256);
             }
 //-------------------
             for(j = 0; j < SIMD_WIDTH8; j++)
@@ -674,20 +685,17 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 
 //------------------------
             _mm256_store_si256((__m256i *) H1, h0_256);
-            __m256i cmp256 = _mm256_cmpgt_epi8(h0_256, oe_ins256);
-            tmp256 = _mm256_sub_epi8(h0_256, oe_ins256);
-            // _mm256_store_si256((__m256i *) (H1 + SIMD_WIDTH8), tmp256);
-
-            tmp256 = _mm256_blendv_epi8(zero256, tmp256, cmp256);
+            // h0-prefix insertion seed, unsigned-saturating [0,255]:
+            // H1[1] = max(0, h0' - oe_ins), then -e_ins per step. subs_epu8
+            // replaces the signed cmpgt+sub+blendv (first gap) and sub+max_epi8
+            // (extensions); byte-identical for h0' in [0,255].
+            tmp256 = _mm256_subs_epu8(h0_256, oe_ins256);
             _mm256_store_si256((__m256i *) (H1 + SIMD_WIDTH8), tmp256);
             for(k = 2; k < maxLen2; k++)
             {
-                // __m256i h1_256 = _mm256_load_si256((__m256i *) (H1 + (k-1) * SIMD_WIDTH8));
-                __m256i h1_256 = tmp256;
-                tmp256 = _mm256_sub_epi8(h1_256, e_ins256);
-                tmp256 = _mm256_max_epi8(tmp256, zero256);
+                tmp256 = _mm256_subs_epu8(tmp256, e_ins256);
                 _mm256_store_si256((__m256i *)(H1 + k*SIMD_WIDTH8), tmp256);
-            }           
+            }
 //------------------------
             /* Banding calculation in pre-processing */
             uint8_t myband[SIMD_WIDTH8] __attribute__((aligned(64)));
@@ -841,10 +849,10 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     // The re-baseline machinery below is retained only as a safety net; pairs that
     // could exceed the envelope take the 16-bit path.
     // Precondition REBASE_HI > REBASE_KEEP (a non-empty window) holds for
-    // zdrop + maxStep <= 253; the routing gate enforces the tighter
-    // zdrop + maxStep <= 127 because the h0-prefix column/row seed (wrapper setup
-    // below) uses SIGNED int8 ops, so the seeded byte min(h0, REBASE_KEEP) must
-    // stay <= 127 (signed-positive).
+    // zdrop + maxStep <= 253, which is exactly what the routing gate enforces.
+    // The h0-prefix column/row seed (wrapper setup below) is unsigned-saturating
+    // [0,255] and imposes no tighter ceiling; it previously used signed int8 ops
+    // that required the seed byte <= 127 and capped zdrop at 126.
     int maxStep = (int)this->w_match;
     if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
     if (maxStep < 1) maxStep = 1;
@@ -859,11 +867,11 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     // --- INITIAL SCORE FLOOR B0 (long-read 8-bit, seed score h0 >= 128) ---
     // The H arrays are seeded from the seed score h0 (H_v[0]=h0, then gap-
     // decremented down column 0 and across row 0). For a long-read seed h0 can
-    // be several hundred, which immediately overflows the signed-int8 byte
-    // state before any re-baseline event can fire. So we start each lane's
+    // be several hundred, which would overflow the unsigned [0,255] byte state
+    // before any re-baseline event can fire. So we start each lane's
     // running floor at B0[l] = max(0, h0 - REBASE_KEEP) instead of 0: the
     // wrapper seeds the H bytes from h0' = h0 - B0 = min(h0, REBASE_KEEP)
-    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 127), and
+    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 254), and
     // here we set B[l] = B0[l] so the stored bytes still mean (H_absolute - B).
     //
     // SAFETY (identical argument to the mid-DP re-baseline): the gap-prefix
@@ -2331,12 +2339,13 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         // so the two agree on B0; smithWaterman512_8 recomputes B0 via
         // bsw8_initial_floor(p[].h0, zdrop).
         const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
-        // The h0-prefix column/row seed below uses SIGNED int8 ops, so the seeded
-        // byte min(h0, REBASE_KEEP_W) must stay <= 127 (signed-positive). The
-        // routing gate (bsw8_envelope_ok) enforces zdrop <= 126; assert for any
-        // direct caller that bypasses the gate.
-        assert(REBASE_KEEP_W <= 127 &&
-               "8-bit h0-prefix seed is signed int8; REBASE_KEEP>127 (zdrop>126) -> route to 16-bit");
+        // The h0-prefix column/row seed below is unsigned-saturating [0,255], so
+        // the seeded byte min(h0, REBASE_KEEP_W) only needs to fit a uint8. The
+        // routing gate (bsw8_envelope_ok) enforces zdrop + maxStep <= 253 (so the
+        // re-baseline window REBASE_HI = 255 - maxStep > REBASE_KEEP holds);
+        // assert the byte bound for any direct caller that bypasses the gate.
+        assert(REBASE_KEEP_W <= 255 &&
+               "8-bit h0-prefix seed byte min(h0,REBASE_KEEP) must fit uint8 (zdrop<=254)");
 
         int nstart = 0, nend = numPairs;
 
@@ -2370,6 +2379,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                     int h0p = sp.h0;
                     if (h0p > REBASE_KEEP_W) h0p = REBASE_KEEP_W;
                     if (h0p < 0) h0p = 0;
+                    // Always-on uint8 guard (asserts are compiled out in release):
+                    // a direct caller that bypasses the gate with zdrop > 254 would
+                    // otherwise truncate the seed byte. In-envelope REBASE_KEEP_W <= 253,
+                    // so this never fires on the production path.
+                    if (h0p > 255) h0p = 255;
                     h0[j] = (uint8_t) h0p;
                 }
                 seq1 = seqBufRef + (int64_t)sp.idr;
@@ -2395,12 +2409,13 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 //--------------------
             __m512i h0_512 = _mm512_load_si512((__m512i*) h0);
             _mm512_store_si512((__m512i *) H2, h0_512);
-            __m512i tmp512 = _mm512_sub_epi8(h0_512, o_del512);
-            
+            // h0-prefix deletion seed, unsigned-saturating [0,255] (was signed
+            // sub_epi8 + max_epi8 floor; see smithWaterman128_8 / smithWaterman256_8).
+            __m512i tmp512 = _mm512_subs_epu8(h0_512, o_del512);
+
             for(k = 1; k < maxLen1; k++) {
-                tmp512 = _mm512_sub_epi8(tmp512, e_del512);
-                __m512i tmp512_ = _mm512_max_epi8(tmp512, zero512);
-                _mm512_store_si512((__m512i *)(H2 + k* SIMD_WIDTH8), tmp512_);
+                tmp512 = _mm512_subs_epu8(tmp512, e_del512);
+                _mm512_store_si512((__m512i *)(H2 + k* SIMD_WIDTH8), tmp512);
             }
 //-------------------
             for(j = 0; j < SIMD_WIDTH8; j++)
@@ -2432,18 +2447,17 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             }
 //------------------------
             _mm512_store_si512((__m512i *) H1, h0_512);
-            __mmask64 mask512 = _mm512_cmpgt_epi8_mask(h0_512, oe_ins512);
-            tmp512 = _mm512_sub_epi8(h0_512, oe_ins512);
-            tmp512 = _mm512_mask_blend_epi8(mask512, zero512, tmp512);
+            // h0-prefix insertion seed, unsigned-saturating [0,255]:
+            // H1[1] = max(0, h0' - oe_ins), then -e_ins per step (was signed
+            // cmpgt_mask+sub+mask_blend, then sub+max_epi8).
+            tmp512 = _mm512_subs_epu8(h0_512, oe_ins512);
             _mm512_store_si512((__m512i *) (H1 + SIMD_WIDTH8), tmp512);
 
             for(k = 2; k < maxLen2; k++)
             {
-                __m512i h1_512 = tmp512;
-                tmp512 = _mm512_sub_epi8(h1_512, e_ins512);
-                tmp512 = _mm512_max_epi8(tmp512, zero512);
+                tmp512 = _mm512_subs_epu8(tmp512, e_ins512);
                 _mm512_store_si512((__m512i *)(H1 + k*SIMD_WIDTH8), tmp512);
-            }           
+            }
 //------------------------
             /* Banding calculation in pre-processing */
             uint8_t myband[SIMD_WIDTH8] __attribute__((aligned(64)));
@@ -2594,10 +2608,10 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
     // The re-baseline machinery below is retained only as a safety net; pairs that
     // could exceed the envelope take the 16-bit path.
     // Precondition REBASE_HI > REBASE_KEEP (a non-empty window) holds for
-    // zdrop + maxStep <= 253; the routing gate enforces the tighter
-    // zdrop + maxStep <= 127 because the h0-prefix column/row seed (wrapper setup
-    // below) uses SIGNED int8 ops, so the seeded byte min(h0, REBASE_KEEP) must
-    // stay <= 127 (signed-positive).
+    // zdrop + maxStep <= 253, which is exactly what the routing gate enforces.
+    // The h0-prefix column/row seed (wrapper setup below) is unsigned-saturating
+    // [0,255] and imposes no tighter ceiling; it previously used signed int8 ops
+    // that required the seed byte <= 127 and capped zdrop at 126.
     int maxStep = (int)this->w_match;
     if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
     if (maxStep < 1) maxStep = 1;
@@ -2612,11 +2626,11 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
     // --- INITIAL SCORE FLOOR B0 (long-read 8-bit, seed score h0 >= 128) ---
     // The H arrays are seeded from the seed score h0 (H_v[0]=h0, then gap-
     // decremented down column 0 and across row 0). For a long-read seed h0 can
-    // be several hundred, which immediately overflows the signed-int8 byte
-    // state before any re-baseline event can fire. So we start each lane's
+    // be several hundred, which would overflow the unsigned [0,255] byte state
+    // before any re-baseline event can fire. So we start each lane's
     // running floor at B0[l] = max(0, h0 - REBASE_KEEP) instead of 0: the
     // wrapper seeds the H bytes from h0' = h0 - B0 = min(h0, REBASE_KEEP)
-    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 127), and
+    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 254), and
     // here we set B[l] = B0[l] so the stored bytes still mean (H_absolute - B).
     //
     // SAFETY (identical argument to the mid-DP re-baseline): the gap-prefix
@@ -4766,12 +4780,13 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         // so the two agree on B0; smithWaterman128_8 recomputes B0 via
         // bsw8_initial_floor(p[].h0, zdrop).
         const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
-        // The h0-prefix column/row seed below uses SIGNED int8 ops, so the seeded
-        // byte min(h0, REBASE_KEEP_W) must stay <= 127 (signed-positive). The
-        // routing gate (bsw8_envelope_ok) enforces zdrop <= 126; assert for any
-        // direct caller that bypasses the gate.
-        assert(REBASE_KEEP_W <= 127 &&
-               "8-bit h0-prefix seed is signed int8; REBASE_KEEP>127 (zdrop>126) -> route to 16-bit");
+        // The h0-prefix column/row seed below is unsigned-saturating [0,255], so
+        // the seeded byte min(h0, REBASE_KEEP_W) only needs to fit a uint8. The
+        // routing gate (bsw8_envelope_ok) enforces zdrop + maxStep <= 253 (so the
+        // re-baseline window REBASE_HI = 255 - maxStep > REBASE_KEEP holds);
+        // assert the byte bound for any direct caller that bypasses the gate.
+        assert(REBASE_KEEP_W <= 255 &&
+               "8-bit h0-prefix seed byte min(h0,REBASE_KEEP) must fit uint8 (zdrop<=254)");
 
         int nstart = 0, nend = numPairs;
         
@@ -4797,6 +4812,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                     int h0p = sp.h0;
                     if (h0p > REBASE_KEEP_W) h0p = REBASE_KEEP_W;
                     if (h0p < 0) h0p = 0;
+                    // Always-on uint8 guard (asserts are compiled out in release):
+                    // a direct caller that bypasses the gate with zdrop > 254 would
+                    // otherwise truncate the seed byte. In-envelope REBASE_KEEP_W <= 253,
+                    // so this never fires on the production path.
+                    if (h0p > 255) h0p = 255;
                     h0[j] = (uint8_t) h0p;
                 }
                 seq1 = seqBufRef + (int64_t)sp.idr;
@@ -4859,19 +4879,17 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             }
 //------------------------
             _mm_store_si128((__m128i *) H1, h0_128);
-            __m128i cmp128 = _mm_cmpgt_epi8(h0_128, oe_ins128);
-            tmp128 = _mm_sub_epi8(h0_128, oe_ins128);
-
-            tmp128 = _mm_blendv_epi8(zero128, tmp128, cmp128);
+            // h0-prefix insertion seed, unsigned-saturating [0,255]:
+            // H1[1] = max(0, h0' - oe_ins), then -e_ins per step. The first gap
+            // was the last signed island here (cmpgt_epi8 + sub_epi8 + blendv);
+            // the extension loop already used subs_epu8.
+            tmp128 = _mm_subs_epu8(h0_128, oe_ins128);
             _mm_store_si128((__m128i *) (H1 + SIMD_WIDTH8), tmp128);
             for(k = 2; k < maxLen2; k++)
             {
-                // __m128i h1_128 = _mm_load_si128((__m128i *) (H1 + (k-1) * SIMD_WIDTH8));
-                __m128i h1_128 = tmp128;
-                tmp128 = _mm_subs_epu8(h1_128, e_ins128);   // modif
-                // tmp128 = _mm_max_epi8(tmp128, zero128);
+                tmp128 = _mm_subs_epu8(tmp128, e_ins128);
                 _mm_store_si128((__m128i *)(H1 + k*SIMD_WIDTH8), tmp128);
-            }           
+            }
 //------------------------
             uint8_t myband[SIMD_WIDTH8] __attribute__((aligned(64)));
             uint8_t temp[SIMD_WIDTH8] __attribute__((aligned(64)));
@@ -5019,10 +5037,10 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     // The re-baseline machinery below is retained only as a safety net; pairs that
     // could exceed the envelope take the 16-bit path.
     // Precondition REBASE_HI > REBASE_KEEP (a non-empty window) holds for
-    // zdrop + maxStep <= 253; the routing gate enforces the tighter
-    // zdrop + maxStep <= 127 because the h0-prefix column/row seed (wrapper setup
-    // below) uses SIGNED int8 ops, so the seeded byte min(h0, REBASE_KEEP) must
-    // stay <= 127 (signed-positive).
+    // zdrop + maxStep <= 253, which is exactly what the routing gate enforces.
+    // The h0-prefix column/row seed (wrapper setup below) is unsigned-saturating
+    // [0,255] and imposes no tighter ceiling; it previously used signed int8 ops
+    // that required the seed byte <= 127 and capped zdrop at 126.
     int maxStep = (int)this->w_match;
     if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
     if (maxStep < 1) maxStep = 1;
@@ -5037,11 +5055,11 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     // --- INITIAL SCORE FLOOR B0 (long-read 8-bit, seed score h0 >= 128) ---
     // The H arrays are seeded from the seed score h0 (H_v[0]=h0, then gap-
     // decremented down column 0 and across row 0). For a long-read seed h0 can
-    // be several hundred, which immediately overflows the signed-int8 byte
-    // state before any re-baseline event can fire. So we start each lane's
+    // be several hundred, which would overflow the unsigned [0,255] byte state
+    // before any re-baseline event can fire. So we start each lane's
     // running floor at B0[l] = max(0, h0 - REBASE_KEEP) instead of 0: the
     // wrapper seeds the H bytes from h0' = h0 - B0 = min(h0, REBASE_KEEP)
-    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 127), and
+    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 254), and
     // here we set B[l] = B0[l] so the stored bytes still mean (H_absolute - B).
     //
     // SAFETY (identical argument to the mid-DP re-baseline): the gap-prefix

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -114,13 +114,12 @@ KSORT_INIT(mem_intv1, SMEM, intv_lt1)  // debug
  *     as a diagonal offset d = j - i in [-w, +w], which fits signed int8
  *     only for w <= 127. The default opt->w = 100 qualifies; wide-band
  *     retries (w doubling to 200/400/800) do NOT and fall back to 16-bit.
- *   - zdrop + maxStep <= 127      : keeps REBASE_KEEP = zdrop + 1 <= 127. The DP
- *     body is unsigned [0,255], but the h0-prefix column/row seed in the kernel
- *     wrappers (smithWaterman*_8 setup) still uses SIGNED int8 ops, so the seeded
- *     byte h0' = min(h0, REBASE_KEEP) must stay <= 127 (signed-positive). maxStep
- *     is the largest per-step score increment, max(w_match, w_ambig, 1) =
- *     max(opt->a, 1). (This also keeps the re-baseline window non-empty:
- *     REBASE_HI = 255 - maxStep > REBASE_KEEP.)
+ *   - zdrop + maxStep <= 253      : keeps the re-baseline window non-empty,
+ *     REBASE_HI = 255 - maxStep > REBASE_KEEP = zdrop + 1. The DP body AND the
+ *     h0-prefix column/row seed (smithWaterman*_8 setup) are both unsigned-
+ *     saturating [0,255], so the seeded byte h0' = min(h0, REBASE_KEEP) only
+ *     needs to fit a uint8. maxStep is the largest per-step score increment,
+ *     max(w_match, w_ambig, 1) = max(opt->a, 1).
  *   - h0 <= zdrop + 1             : keeps the initial floor B0 = max(0, h0 -
  *     REBASE_KEEP) == 0, so the seed score does not itself force a re-baseline.
  *   - h0 + min(len1,len2)*a < 255 - maxStep : the MAX ATTAINABLE score (seed
@@ -133,11 +132,12 @@ KSORT_INIT(mem_intv1, SMEM, intv_lt1)  // debug
  * decision. Pairs failing this envelope fall through to the existing 16-bit
  * (then scalar) buckets exactly as before. */
 #define BSW8_MAX_W 127                 /* max band: diagonal offset d=j-i must fit signed int8 */
-#define BSW8_MAX_ZDROP_STEP 127        /* keep REBASE_KEEP=zdrop+1 <= 127: the h0-prefix
-                                          column/row seed in the 8-bit wrappers uses SIGNED
-                                          int8 ops, so the seeded byte min(h0,REBASE_KEEP) must
-                                          stay signed-positive (<=127). Also keeps the re-baseline
-                                          window non-empty (REBASE_HI=255-max_step > REBASE_KEEP).
+#define BSW8_MAX_ZDROP_STEP 253        /* keep the re-baseline window non-empty:
+                                          REBASE_HI=255-max_step > REBASE_KEEP=zdrop+1, i.e.
+                                          zdrop+max_step <= 253. The DP body AND the h0-prefix
+                                          column/row seed in the 8-bit wrappers are both
+                                          unsigned-saturating [0,255], so the seed byte
+                                          min(h0,REBASE_KEEP) just needs to fit a uint8.
                                           See smithWaterman128_8 re-baseline + h0-prefix seed. */
 
 static inline int bsw8_envelope_ok(int len1, int len2, int w,

--- a/test/bandedswa_highzdrop_seed_test.cpp
+++ b/test/bandedswa_highzdrop_seed_test.cpp
@@ -1,0 +1,151 @@
+// Regression test for the unsigned [0,255] h0-prefix seed (issue #146 item:
+// "make the 8-bit h0-prefix seed unsigned").
+//
+// The 8-bit banded-SW DP body is unsigned [0,255]. The h0-prefix column/row
+// seed (smithWaterman*_8 wrapper setup) is now also unsigned-saturating
+// (subs_epu8); it previously used signed int8 ops, which required the seeded
+// byte min(h0, REBASE_KEEP) <= 127 and so capped zdrop at 126
+// (BSW8_MAX_ZDROP_STEP). With the unsigned seed the gate admits zdrop up to
+// ~252, and seed prefix bytes range over (127, 254].
+//
+// This test exercises exactly that new regime: zdrop = 200 with h0 in
+// (127, 200], so every admitted pair seeds prefix bytes > 127 — the range the
+// old signed seed could not represent. getScores8 must remain byte-identical to
+// the scalar oracle for every pair the routing gate (bsw8_envelope_ok) would
+// admit (re-baseline provably inert), so we mirror that gate here, compact the
+// admitted pairs into a tight batch, and score only that batch -- out-of-envelope
+// pairs are documented as requiring 16-bit routing and never reach the 8-bit
+// kernel. Deterministic (fixed RNG seed); exits non-zero on any score-field
+// mismatch.
+
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+#include <random>
+
+#include "bandedSWA.h"
+
+namespace {
+
+struct Out { int score, tle, gtle, qle, gscore, max_off; };
+
+// Mirror of bwamem.cpp bsw8_envelope_ok for a = maxStep = 1 (this test's
+// scoring). Only admitted pairs are required to match scalar.
+bool envelope_ok(int len1, int len2, int w, int zdrop, int h0, int maxStep) {
+    int shorter = len1 < len2 ? len1 : len2;
+    return len1 < MAX_SEQ_LEN8 && len2 < MAX_SEQ_LEN8 && len1 >= len2 &&
+           w <= 127 && zdrop + maxStep <= 253 && h0 <= zdrop + 1 &&
+           (h0 + shorter * 1) < 255 - maxStep;
+}
+
+} // namespace
+
+int main() {
+    const long n      = 50000;
+    const int  maxlen = 110;
+    const int  zdrop  = 200;        // > 126: the new regime
+    const int  h0min  = 128, h0max = 200;  // seed bytes strictly > 127
+    const int  a = 1, b = 4, ambig = -1, o = 6, e = 1, end_bonus = 5, w = 100;
+    const int  maxStep = a > 1 ? a : 1;
+    const int  STRIDE = 1280;
+
+    int8_t mat[25];
+    { int k = 0;
+      for (int i = 0; i < 4; ++i) { for (int j = 0; j < 4; ++j) mat[k++] = (i == j) ? a : -b; mat[k++] = ambig; }
+      for (int j = 0; j < 5; ++j) mat[k++] = ambig; }
+
+    BandedPairWiseSW bsw(o, e, o, e, zdrop, end_bonus, mat, a, b, 1);
+
+    std::mt19937_64 rng(12345);  // fixed seed -> deterministic
+    std::vector<uint8_t> ref((size_t)STRIDE * n, 0), qer((size_t)STRIDE * n, 0);
+    std::vector<SeqPair> pairs(n);
+    std::vector<Out> oracle(n);
+    std::uniform_int_distribution<int> lenD(20, maxlen);
+    std::uniform_int_distribution<int> hD(h0min, h0max);
+    std::uniform_int_distribution<int> unit(3, 12);
+
+    for (long c = 0; c < n; ++c) {
+        int aa = lenD(rng), bb = lenD(rng);
+        int len1 = aa > bb ? aa : bb, len2 = aa > bb ? bb : aa;  // len1 >= len2
+        int h0 = hD(rng);
+        uint8_t *s1 = &ref[(size_t)c * STRIDE];
+        uint8_t *s2 = &qer[(size_t)c * STRIDE];
+        int u = unit(rng); uint8_t ubuf[16];
+        for (int i = 0; i < u; i++) ubuf[i] = (uint8_t)(rng() % 4);
+        for (int i = 0; i < len1; i++) s1[i] = ubuf[i % u];   // tandem repeat
+        int ti = 0;
+        for (int i = 0; i < len2; i++) {                       // query: derived w/ noise
+            uint8_t base = (ti < len1) ? s1[ti] : (uint8_t)(rng() % 4);
+            if ((int)(rng() % 100) < 5) base = (uint8_t)(rng() % 4);
+            s2[i] = base;
+            if ((rng() % 40) == 0) { if (rng() & 1) ti += 2; } else ti++;
+        }
+        SeqPair &p = pairs[c];
+        p.id = c; p.len1 = len1; p.len2 = len2; p.h0 = h0;
+        p.idr = (int)((size_t)c * STRIDE); p.idq = (int)((size_t)c * STRIDE);
+        p.seqid = c; p.regid = c;
+        p.score = p.tle = p.gtle = p.qle = p.gscore = p.max_off = -1;
+        Out &O = oracle[c];
+        O.score = bsw.scalarBandedSWA(len2, s2, len1, s1, w, h0,
+                                      &O.qle, &O.tle, &O.gtle, &O.gscore, &O.max_off);
+    }
+
+    // Routing contract: only envelope-admitted pairs may traverse the 8-bit
+    // kernel — out-of-envelope pairs are documented as requiring 16-bit routing,
+    // so feeding them to getScores8 exercises an unspecified path. Mirror the
+    // gate here and compact the admitted pairs into a tight batch before
+    // scoring. Each compacted SeqPair keeps its original idr/idq, so it still
+    // references the correct slice of the shared ref/qer buffers.
+    std::vector<long> admittedIdx;
+    admittedIdx.reserve(n);
+    for (long c = 0; c < n; ++c) {
+        const SeqPair &p = pairs[c];
+        if (envelope_ok(p.len1, p.len2, w, zdrop, p.h0, maxStep)) admittedIdx.push_back(c);
+    }
+    const long admitted = (long)admittedIdx.size();
+
+    // getScores8 pads the batch to a whole number of SIMD lanes and WRITES the
+    // trailing padding lanes pairArray[numPairs .. roundup(numPairs, SIMD_WIDTH8)).
+    // Size the compact batch to that rounded capacity so the kernel's padding
+    // writes stay in-bounds (AVX2 SIMD_WIDTH8=32, AVX-512 =64; the scalar/NEON
+    // tiers round to 1/16), then bound the kernel call and comparison to the
+    // first `admitted` lanes.
+    const long round_admitted = ((admitted + SIMD_WIDTH8 - 1) / SIMD_WIDTH8) * SIMD_WIDTH8;
+    std::vector<SeqPair> apairs(round_admitted);
+    for (long k = 0; k < admitted; ++k) apairs[k] = pairs[admittedIdx[k]];
+
+    bsw.getScores8(apairs.data(), ref.data(), qer.data(), (int32_t)admitted, 1, w);
+
+    long seed_hi = 0, diffs = 0;
+    for (long k = 0; k < admitted; ++k) {
+        const SeqPair &q = apairs[k];
+        long c = admittedIdx[k];
+        int h0p = q.h0 < zdrop + 1 ? q.h0 : zdrop + 1;   // seeded byte min(h0,REBASE_KEEP)
+        if (h0p > 127) seed_hi++;
+        const Out &O = oracle[c];
+        if (O.score != q.score || O.tle != q.tle || O.gtle != q.gtle ||
+            O.qle != q.qle || O.gscore != q.gscore || O.max_off != q.max_off) {
+            if (diffs < 10)
+                fprintf(stderr,
+                    "[highzdrop-seed] DIFF c=%ld len1=%d len2=%d h0=%d | scalar %d/%d/%d/%d/%d/%d | 8 %d/%d/%d/%d/%d/%d\n",
+                    c, q.len1, q.len2, q.h0,
+                    O.score, O.tle, O.gtle, O.qle, O.gscore, O.max_off,
+                    q.score, q.tle, q.gtle, q.qle, q.gscore, q.max_off);
+            diffs++;
+        }
+    }
+
+    fprintf(stderr, "[highzdrop-seed] zdrop=%d h0=[%d,%d]: admitted=%ld (seed byte >127: %ld) diffs=%ld\n",
+            zdrop, h0min, h0max, admitted, seed_hi, diffs);
+
+    if (admitted == 0 || seed_hi == 0) {
+        fprintf(stderr, "bandedswa_highzdrop_seed_test: FAIL — fixture admitted no >127-seed pairs\n");
+        return 2;
+    }
+    if (diffs != 0) {
+        fprintf(stderr, "bandedswa_highzdrop_seed_test: FAIL — %ld getScores8/scalar mismatches\n", diffs);
+        return 1;
+    }
+    fprintf(stderr, "bandedswa_highzdrop_seed_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Makes the 8-bit banded-SW **h0-prefix seed** unsigned-saturating `[0,255]`, removing the last signed-int8 island in an otherwise-unsigned kernel and lifting the `zdrop ≤ 126` ceiling (issue #146 follow-up item).

PR #140 converted the 8-bit DP *body* to unsigned `[0,255]`, but the h0-prefix column/row seed in the `getScores8` wrappers still used signed int8 ops:
- **deletion prefix (H2):** `sub_epi8(h0', o_del)` then `max_epi8(.,0)` per step;
- **insertion prefix (H1):** `cmpgt_epi8(h0', oe_ins)` + `sub_epi8` + `blendv` for the first gap, then `sub_epi8`+`max_epi8` per step.

The signed floor required the seeded byte `min(h0, REBASE_KEEP) ≤ 127`, which is why `BSW8_MAX_ZDROP_STEP` was pinned at 127 (`zdrop ≤ 126`).

## Changes

- **Convert the seed to `subs_epu8`** in all three wrappers (`smithWaterman{256,512,128}_8`). The NEON `smithWaterman128_8` H2 prefix was already unsigned; this finishes the job (its H1 first gap, plus both prefixes in the AVX2/AVX-512 wrappers). `subs_epu8` floors at 0 inherently, so it also collapses `cmpgt+sub+blendv` → one op and `sub+max` → one op. **Byte-identical** to the signed form for the monotone-decreasing affine prefix wherever the signed form was correct (`max(0, max(0,X)−e) == max(0, X−e)`), and it removes a latent signed-wrap hazard for long prefixes.
- **Raise the routing-gate cap** `BSW8_MAX_ZDROP_STEP` 127 → 253. The binding constraint is now just the re-baseline-window bound `REBASE_HI = 255 − maxStep > REBASE_KEEP = zdrop + 1` (i.e. `zdrop + maxStep ≤ 253`), which the kernel already asserts.
- **Relax the wrapper `REBASE_KEEP_W` assert** from `≤ 127` to the uint8 bound, and add an **always-on byte clamp** (`if (h0p > 255) h0p = 255;`) before the `(uint8_t)` cast so a direct caller that bypasses the gate with `zdrop > 254` can't silently truncate the seed in a release build (asserts are compiled out). Inert on the production path (`REBASE_KEEP_W ≤ 253`). *(addresses CodeRabbit)*
- **Update the envelope / kernel docs** to describe the seed as unsigned.
- **Add `bandedswa_highzdrop_seed_test`**: `getScores8` vs the scalar oracle at `zdrop = 200` with `h0 ∈ (127, 200]`, so every admitted pair seeds prefix bytes `> 127` — the range the old signed seed could not represent. It mirrors `bsw8_envelope_ok` and compares only admitted pairs (re-baseline provably inert), and fails if the fixture admits no `>127`-seed pairs. Wired into `make test`.

## Validation — byte-identical to scalar on all four tiers, both regimes

| tier | regression (zdrop=100) | high-zdrop (zdrop=160 & 200, seed bytes >127) |
|---|---|---|
| NEON | `8 vs scalar = 0` @ maxlen 120/200/250 | 0 diffs over ~270k–294k in-envelope pairs |
| sse41 | 0 | 0 |
| avx2 | 0 | 0 |
| avx512bw | 0 | 0 |

(x86 tiers validated on a c7i.4xlarge.) `DUMMY1` (=99) is `< 128`, so its byte value is identical signed/unsigned. The committed test passes (`admitted=44860`, all seed bytes >127, `diffs=0`).

## Note

This adds a `src/bandedSWA.native.o` Makefile rule that also appears in PR #150 (#29's `bandedswa_padding_test`); if both land, the identical rule is a trivial rebase conflict.

Tracks #146.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a deterministic regression test covering high-drop-penalty “unsigned seed” scoring, comparing 8-bit results against a scalar oracle for admitted cases.
  * Updated the default test flow to build and run the new native-tier regression binary, and extended cleanup to remove it.
* **Bug Fixes**
  * Corrected 8-bit seed handling to use unsigned semantics, with stronger defensive clamping to prevent out-of-range values.
  * Widened the valid safe envelope for `zdrop`/`maxStep`, allowing more candidates into the 8-bit tier.
  * Improved 8-bit boundary initialization using unsigned saturating arithmetic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->