### PR TITLE
feat(prof): off-by-default --profile stage-timing instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,3 +529,33 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: false
           verbose: true
+
+  # Profiling (--profile) is compiled out of the default build, so the matrix
+  # rows above never exercise the STAGE_PROF=1 code path. Build it here (and run
+  # the stage_prof unit test) so the opt-in path cannot silently bit-rot.
+  profiling-build:
+    name: Profiling build (STAGE_PROF=1)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install dependencies (Linux)
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: zlib1g-dev libdeflate-dev autoconf automake libomp-dev
+          version: 1.1
+
+      - name: Build with profiling compiled in
+        run: make -j"$(nproc)" STAGE_PROF=1 BASELINE_ARCH=avx2 CXX=g++ USE_MIMALLOC=1
+
+      - name: --profile is exposed in this build
+        run: |
+          ./bwa-mem3 mem 2>&1 | grep -q -- '--profile' \
+            || { echo "::error::--profile missing from a STAGE_PROF=1 build"; exit 1; }
+
+      - name: stage_prof unit test
+        run: make stage_prof_test && ./stage_prof_test

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,15 @@ endif
 
 CPPFLAGS+=	-DENABLE_PREFETCH -DV17=1 -DMATE_SORT=0 -DLIBSAIS_OPENMP
 
+# Profiling (--profile stage instrumentation) is a COMPILE-TIME opt-in. The
+# default build omits it entirely (no --profile option, zero runtime overhead;
+# sp_enabled() folds to a compile-time 0 and the hooks vanish). Build with
+# `make STAGE_PROF=1` to compile in the real stage_prof implementation and
+# expose --profile. (Distinct from the PGO `profile-build` target below.)
+ifeq ($(strip $(STAGE_PROF)),1)
+    CPPFLAGS += -DSTAGE_PROF=1
+endif
+
 # Version string for `bwa-mem3 version` and the @PG VN: field. The single
 # source of truth is `version.txt` (rewritten by release-please on each
 # release). The logic of "base version + optional git-describe dev suffix"
@@ -252,7 +261,7 @@ OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/kthread.o \
 			src/packed_text.o src/fm_index_writer.o src/index_prelude.o \
 			src/system.o src/libsais_build.o \
 			src/bwa_shm.o src/simd_dispatch.o \
-			src/fast_reader.o src/fast_reader_bseq.o
+			src/fast_reader.o src/fast_reader_bseq.o src/stage_prof.o
 
 # Kernel TUs (bandedSWA, kswv, ksw, sam_encode) are compiled per-tier on x86
 # and linked directly via KERNEL_TIER_OBJS_LINK. The dispatch wrappers in
@@ -451,6 +460,7 @@ src/version.h: FORCE
 	@if ! cmp -s $@.tmp $@ 2>/dev/null; then mv $@.tmp $@; else rm -f $@.tmp; fi
 
 src/main.o: src/version.h
+src/fastmap.o: src/version.h
 
 # Baseline ISA tier for non-kernel TUs in the x86 single-binary build.
 # Defaults to avx2: every host that runs bwa-mem3 in practice has AVX2
@@ -546,6 +556,12 @@ src/fast_reader.o: src/fast_reader.c src/fast_reader.h
 
 src/fast_reader_bseq.o: src/fast_reader_bseq.c src/fast_reader_bseq.h src/fast_reader.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDES) -c -o $@ $<
+
+# Standalone stage_prof helper unit test (stats + clocks + NaN init). Links only
+# pthread + libm, so it needs no bwa-mem3/htslib build. Built with -DSTAGE_PROF
+# so the real implementation (not the no-op inlines) is exercised.
+stage_prof_test: src/stage_prof.cpp src/stage_prof.h test/stage_prof_test.cpp
+	$(CXX) -O2 -std=gnu++14 -DSTAGE_PROF=1 -Isrc src/stage_prof.cpp test/stage_prof_test.cpp -lpthread -lm -o $@
 
 # Standalone fast_reader correctness self-test (plain/gzip/multi-member/BGZF
 # round-trips). Links only zlib + libdeflate, so it needs no bwa-mem3 build.

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -37,8 +37,18 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include <inttypes.h>      /* PRId64 for int64_t fprintf format strings */
 
 #include "sam_encode.h"
+#include "stage_prof.h"
 /* Not including <htslib/sam.h>: its kstring.h shares the KSTRING_H guard
  * with bwa-mem3's. Opaque bam1_t wrappers live in bam_writer.h. */
+
+/* RAII bracket for the SAM/BAM build (stage_prof --profile). Accumulates the
+ * calling (compute) thread's CPU time across all of mem_aln2sam's return paths
+ * into the per-thread encode accumulator; harvested by kt_for. Zero cost when off. */
+namespace { struct SpEncodeScope {
+    double t0; bool on;
+    SpEncodeScope() : t0(0.0), on(sp_enabled()) { if (on) t0 = sp_thread_cpu(); }
+    ~SpEncodeScope() { if (on) sp_encode_add(sp_thread_cpu() - t0); }
+}; }
 
 meth_chrom_map_t *g_meth_cmap = NULL;
 
@@ -1810,6 +1820,7 @@ static inline void add_cigar(const mem_opt_t *opt, mem_aln_t *p, kstring_t *str,
 void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
                  bseq1_t *s, int n, const mem_aln_t *list, int which, const mem_aln_t *m_)
 {
+    SpEncodeScope _enc;   /* stage_prof: time the SAM/BAM build (all return paths) */
     /* BAM short-circuit: meth_mode applies the bisulfite overlay (chrom
      * consolidation, YD:Z, chimera QC), plain bam_mode uses the generic
      * writer. Either path leaves `str` untouched. */

--- a/src/fast_reader.c
+++ b/src/fast_reader.c
@@ -1,4 +1,5 @@
 #include "fast_reader.h"
+#include "stage_prof.h"
 
 #include <zlib.h>
 #include <libdeflate.h>
@@ -64,12 +65,15 @@ static int fr_fill(fast_reader_t *fr)
         fr->cin_len = keep;
         fr->cin_pos = 0;
     }
+    double _t0 = sp_enabled() ? sp_wall() : 0.0;
     while (fr->cin_len < fr->cin_cap && !fr->eof_in) {
         ssize_t r = read(fr->fd, fr->cin + fr->cin_len, fr->cin_cap - fr->cin_len);
-        if (r < 0) { if (errno == EINTR) continue; return -1; }
+        if (r < 0) { if (errno == EINTR) continue; if (sp_enabled()) sp_read_add(0, sp_wall()-_t0); return -1; }
         if (r == 0) { fr->eof_in = 1; break; }
         fr->cin_len += (size_t)r;
+        if (sp_enabled()) sp_read_bytes((long)r, 0);   /* fd (on-disk) bytes */
     }
+    if (sp_enabled()) sp_read_add(0, sp_wall() - _t0);
     return 0;
 }
 
@@ -141,12 +145,15 @@ static int fr_read_plain(fast_reader_t *fr, unsigned char *buf, int len)
         fr->cin_pos += (size_t)take;
         out += take;
     }
+    double _t0 = sp_enabled() ? sp_wall() : 0.0;
     while (out < len && !fr->eof_in) {
         ssize_t r = read(fr->fd, buf + out, len - out);
-        if (r < 0) { if (errno == EINTR) continue; return -1; }
+        if (r < 0) { if (errno == EINTR) continue; if (sp_enabled()) sp_read_add(0, sp_wall()-_t0); return -1; }
         if (r == 0) { fr->eof_in = 1; break; }
         out += (int)r;
+        if (sp_enabled()) sp_read_bytes((long)r, 0);   /* fd (on-disk) bytes */
     }
+    if (sp_enabled()) sp_read_add(0, sp_wall() - _t0);
     return out;
 }
 
@@ -161,7 +168,9 @@ static int fr_read_gzip(fast_reader_t *fr, unsigned char *buf, int len)
             fr->zs.next_in = fr->cin + fr->cin_pos;
             fr->zs.avail_in = (uInt)(fr->cin_len - fr->cin_pos);
         }
+        double _td = sp_enabled() ? sp_wall() : 0.0;
         int ret = inflate(&fr->zs, Z_NO_FLUSH);
+        if (sp_enabled()) sp_read_add(1, sp_wall() - _td);
         fr->cin_pos = fr->cin_len - fr->zs.avail_in;       /* track consumed */
         if (ret == Z_STREAM_END) {                          /* member done */
             if (inflateReset(&fr->zs) != Z_OK) return -1;
@@ -229,14 +238,17 @@ static int fr_next_bgzf_block(fast_reader_t *fr)
         if (isize > fr->bout_cap) return -1;                 /* >64 KiB: not BGZF */
 
         size_t actual = 0;
+        double _td = sp_enabled() ? sp_wall() : 0.0;
         enum libdeflate_result r =
             libdeflate_deflate_decompress(fr->ld, p + cdata_off, cdata_len,
                                           fr->bout, isize, &actual);
+        if (sp_enabled()) sp_read_add(1, sp_wall() - _td);
         if (r != LIBDEFLATE_SUCCESS || actual != isize) return -1;
         if (libdeflate_crc32(0, fr->bout, isize) != crc) return -1;
 
         fr->bout_len = isize;
         fr->bout_pos = 0;
+        if (sp_enabled()) sp_read_bytes(0, 1);   /* one decoded BGZF block */
         return 0;
     }
 }

--- a/src/fast_reader_bseq.c
+++ b/src/fast_reader_bseq.c
@@ -8,6 +8,7 @@
 #include "kstring.h"
 #include "kseq.h"
 #include "utils.h"   /* err_fatal */
+#include "stage_prof.h"
 
 /* kseq instantiated over the fast_reader byte source. This is the only TU that
  * uses this handle type, so there is no kseq_t name collision with the gzFile
@@ -60,6 +61,7 @@ bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
                 err_fatal(__func__, "failed to grow read buffer to %ld records", (long)m);
             seqs = tmp;
         }
+        double _tp = sp_enabled() ? sp_wall() : 0.0;
         fr_trim_readno(&ks->name);
         fr_kseq2bseq1(ks, &seqs[n]);
         seqs[n].id = n;
@@ -70,6 +72,7 @@ bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
             seqs[n].id = n;
             size += seqs[n++].l_seq;
         }
+        if (sp_enabled()) sp_read_add(2, sp_wall() - _tp);
         if (size >= chunk_size && (n & 1) == 0) break;   /* even-parity cut, all modes */
     }
     if (size == 0) {                                      /* 1st file has fewer */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -42,6 +42,9 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "FMI_search.h"
 #include "bam_writer.h"
 #include "meth_bam.h"
+#include "stage_prof.h"
+#include "version.h"
+#include <sys/resource.h>
 #include "meth_orig_ref.h"
 #include "bwa_shm.h"
 #include "fast_reader_bseq.h"
@@ -346,6 +349,12 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         ktp_data_t *ret = (ktp_data_t *) calloc(1, sizeof(ktp_data_t));
         assert(ret != NULL);
         uint64_t tim = __rdtsc();
+        double sp_r0 = 0.0;
+        if (sp_enabled()) {
+            sp_chunk_init(&ret->prof); sp_read_reset();
+            ret->prof.chunk_start = sp_run_elapsed();   /* timeline anchor */
+            sp_r0 = sp_wall();
+        }
 
         /* Read "reads" from input file (fread) */
         int64_t sz = 0;
@@ -354,6 +363,18 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
             : bseq_read_fast(aux->task_size, &ret->n_seqs, aux->frks, aux->frks2, &sz);
 
         tprof[READ_IO][0] += __rdtsc() - tim;
+
+        if (sp_enabled()) {
+            ret->prof.read_wall = sp_wall() - sp_r0;
+            /* Only the fast reader is instrumented; the legacy reader leaves the
+             * sub-splits at their NaN init (blank) rather than reporting a fake 0. */
+            if (!aux->legacy_reader) {
+                sp_read_get(&ret->prof.read_diskwait, &ret->prof.read_decompress, &ret->prof.read_parse);
+                sp_read_get_bytes(&ret->prof.read_bytes_in, &ret->prof.bgzf_blocks);
+            }
+            ret->prof.n_reads = ret->n_seqs;
+            ret->prof.n_bp = sz;
+        }
 
         fprintf(stderr, "[0000] read_chunk: %ld, work_chunk_size: %ld, nseq: %d\n",
                 aux->task_size, sz, ret->n_seqs);
@@ -458,6 +479,13 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
 
         fprintf(stderr, "[0000] Calling mem_process_seqs.., task: %d\n", task++);
 
+        double sp_p0 = 0.0;
+        if (sp_enabled()) {
+            sp_chunk_init(&g_ktfor);          /* reset balance + encode accumulator */
+            g_ktfor.encode = 0.0;             /* accumulate (sp_chunk_init left it NaN) */
+            sp_p0 = sp_wall();
+        }
+
         uint64_t tim = __rdtsc();
         if (opt->flag & MEM_F_SMARTPE)
         {
@@ -520,7 +548,21 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                              w);
         }
         tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
-                
+
+        if (sp_enabled()) {
+            ret->prof.proc_wall      = sp_wall() - sp_p0;
+            ret->prof.proc_cpu       = g_ktfor.proc_cpu;
+            ret->prof.thr_busy_min   = g_ktfor.thr_busy_min;
+            ret->prof.thr_busy_max   = g_ktfor.thr_busy_max;
+            ret->prof.thr_busy_mean  = g_ktfor.thr_busy_mean;
+            ret->prof.thr_busy_stdev = g_ktfor.thr_busy_stdev;
+            /* encode = SAM/BAM-build CPU (accurate, summed over compute threads);
+             * compute = the rest of the alignment CPU. Same clock, so subtractable. */
+            ret->prof.encode  = g_ktfor.encode;
+            ret->prof.compute = (g_ktfor.proc_cpu > g_ktfor.encode)
+                                ? g_ktfor.proc_cpu - g_ktfor.encode : NAN;
+        }
+
         aux->n_processed += ret->n_seqs;
         return ret;
     }
@@ -528,6 +570,8 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
     else if (step == 2)
     {
         uint64_t tim = __rdtsc();
+        double sp_w0 = sp_enabled() ? sp_wall() : 0.0;
+        long sp_wbytes = 0;
 
         for (int i = 0; i < ret->n_seqs; )
         {
@@ -592,6 +636,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
             }
 
             for (int k = 0; k < group_size; ++k) {
+                if (sp_enabled() && ret->seqs[i+k].sam) sp_wbytes += (long)strlen(ret->seqs[i+k].sam);
                 free(ret->seqs[i+k].name);
                 free(ret->seqs[i+k].comment);
                 free(ret->seqs[i+k].seq);
@@ -600,6 +645,19 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                 free(ret->seqs[i+k].bams);
             }
             i += group_size;
+        }
+        if (sp_enabled()) {
+            ret->prof.write_wall = sp_wall() - sp_w0;
+            ret->prof.write_bytes = sp_wbytes;
+            if (aux->opt->bam_mode) {            /* htslib fuses compress+diskwrite */
+                ret->prof.write_compress = ret->prof.write_wall;   /* diskwrite stays NaN */
+            } else {
+                ret->prof.write_diskwrite = ret->prof.write_wall;
+                ret->prof.write_compress = 0.0;
+            }
+            static long g_sp_chunk = 0;
+            ret->prof.chunk = __sync_fetch_and_add(&g_sp_chunk, 1);
+            sp_add_chunk(&ret->prof);
         }
         free(ret->seqs);
         free(ret);
@@ -618,6 +676,7 @@ static void *ktp_worker(void *data)
 
     while (w->step < p->n_steps) {
         // test whether we can kick off the job with this worker
+        double sp_i0 = sp_enabled() ? sp_wall() : 0.0;   // idle = time waiting for our turn
         int pthread_ret = pthread_mutex_lock(&p->mutex);
         assert(pthread_ret == 0);
         for (;;) {
@@ -634,6 +693,7 @@ static void *ktp_worker(void *data)
         }
         pthread_ret = pthread_mutex_unlock(&p->mutex);
         assert(pthread_ret == 0);
+        if (sp_enabled()) sp_add_idle(w->step, sp_wall() - sp_i0);   /* idle attributed to next step */
 
         // working on w->step
         w->data = kt_pipeline(p->shared, w->step, w->step? w->data : 0, w->opt, *(w->w)); // for the first step, input is NULL
@@ -905,6 +965,11 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "   --legacy-reader\n");
     fprintf(stderr, "                 use the legacy gzFile/kseq input reader instead of the default\n");
     fprintf(stderr, "                 content-detecting fast reader (escape hatch / A-B baseline).\n");
+#ifdef STAGE_PROF
+    fprintf(stderr, "Profiling:\n");
+    fprintf(stderr, "   --profile FILE\n");
+    fprintf(stderr, "                 write per-chunk stage profiling TSV to FILE (off by default).\n");
+#endif
     fprintf(stderr, "Help:\n");
     fprintf(stderr, "   --help        print this help message and exit\n");
     fprintf(stderr, "Note: Please read the man page for detailed description of the command line and options.\n");
@@ -1018,6 +1083,9 @@ int main_mem(int argc, char *argv[])
         OPT_METH_CHIMERA_QC,
         OPT_SUPP_REP_HARD_CAP,
         OPT_LEGACY_READER,
+#ifdef STAGE_PROF
+        OPT_PROFILE,
+#endif
         OPT_HELP,
     };
     static struct option long_opts[] = {
@@ -1027,9 +1095,15 @@ int main_mem(int argc, char *argv[])
         {"chimera-qc",               no_argument,       0, OPT_METH_CHIMERA_QC},
         {"supp-rep-hard-cap",        required_argument, 0, OPT_SUPP_REP_HARD_CAP},
         {"legacy-reader",            no_argument,       0, OPT_LEGACY_READER},
+#ifdef STAGE_PROF
+        {"profile",                  required_argument, 0, OPT_PROFILE},
+#endif
         {"help",                     no_argument,       0, OPT_HELP},
         {0, 0, 0, 0}
     };
+#ifdef STAGE_PROF
+    const char *profile_path = NULL;   /* --profile <path>: stage_prof TSV output */
+#endif
     while ((c = getopt_long(argc, argv, "51qpaMCSPVYjuk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:o:f:z:",
                             long_opts, NULL)) >= 0)
     {
@@ -1152,6 +1226,11 @@ int main_mem(int argc, char *argv[])
                 opt->bam_level = lvl;
             }
         }
+#ifdef STAGE_PROF
+        else if (c == OPT_PROFILE) {
+            profile_path = optarg;
+        }
+#endif
         else if (c == OPT_METH) {
             opt->meth_mode = 1;
             opt->bam_mode = 1;  /* meth implies BAM output */
@@ -1582,12 +1661,44 @@ int main_mem(int argc, char *argv[])
     }
     tprof[MISC][1] = opt->chunk_size = aux.actual_chunk_size = aux.task_size;
 
+    double sp_t0 = 0.0;
+#ifdef STAGE_PROF
+    /* stage_prof: arm per-chunk read/process/write profiling if --profile given */
+    if (profile_path && profile_path[0]) {
+#if defined(__x86_64__) || defined(_M_X64)
+        const char *sp_arch = "x86_64";
+#elif defined(__aarch64__) || defined(__arm64__)
+        const char *sp_arch = "arm64";
+#else
+        const char *sp_arch = "unknown";
+#endif
+        const char *sp_in = (optind + 1 < argc) ? argv[optind + 1]
+                          : (optind < argc ? argv[optind] : "");
+        sp_init(profile_path, "bwa-mem3", PACKAGE_VERSION, sp_arch, opt->n_threads,
+                opt->bam_mode ? "bam" : "sam",
+                opt->bam_mode ? opt->bam_level : -1, sp_in);
+        sp_set_workers(no_mt_io ? 1 : 2);   /* pipeline depth (process() arg) */
+        sp_t0 = sp_wall();
+    }
+#endif
+
     tim = __rdtsc();
 
     /* Relay process function */
     process(&aux, fp, fp2, no_mt_io? 1:2);
 
     tprof[PROCESS][0] += __rdtsc() - tim;
+
+    if (sp_enabled()) {
+        struct rusage ru; getrusage(RUSAGE_SELF, &ru);
+#ifdef __linux__
+        double rss_mb = (double)ru.ru_maxrss / 1024.0;          /* Linux: ru_maxrss is KiB */
+#else
+        double rss_mb = (double)ru.ru_maxrss / (1024.0*1024.0); /* macOS/BSD: ru_maxrss is bytes */
+#endif
+        /* mean_cores_busy is computed inside sp_finish from per-chunk proc_cpu */
+        sp_finish(sp_wall() - sp_t0, 0.0, rss_mb);
+    }
 
     /* Close meth BAM writer BEFORE free(opt) — opt->meth_mode is checked here. */
     int meth_mode_local = opt->meth_mode;

--- a/src/fastmap.h
+++ b/src/fastmap.h
@@ -44,6 +44,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "bwa.h"
 #include "bwamem.h"
 #include "kthread.h"
+#include "stage_prof.h"
 #include "kvec.h"
 #include "utils.h"
 #include "bntseq.h"
@@ -84,6 +85,7 @@ typedef struct {
 	ktp_aux_t *aux;
 	int n_seqs;
 	bseq1_t *seqs;
+	prof_chunk_t prof;   /* stage_prof: per-chunk read/process/write timing (--profile) */
 } ktp_data_t;
 
     

--- a/src/kthread.cpp
+++ b/src/kthread.cpp
@@ -30,6 +30,7 @@
 *****************************************************************************************/
 
 #include "kthread.h"
+#include "stage_prof.h"
 #include <stdio.h>
 
 #if AFF && (__linux__)
@@ -90,6 +91,8 @@ static void *ktf_worker(void *data)
 	ktf_worker_t *w = (ktf_worker_t*)data;
 	long i;
 	int tid = w->i;
+	double _c0 = sp_enabled() ? sp_thread_cpu() : 0.0;
+	if (sp_enabled()) sp_encode_reset();
 
 #if AFF && (__linux__)
 	fprintf(stderr, "i: %d, CPU: %d\n", tid , sched_getcpu());
@@ -109,6 +112,7 @@ static void *ktf_worker(void *data)
 		int ed = (i + 1) * BATCH_SIZE < w->t->n? (i + 1) * BATCH_SIZE : w->t->n;
 		w->t->func(w->t->data, st, ed-st, w - w->t->w);
 	}
+	if (sp_enabled()) { w->cpu_busy = sp_thread_cpu() - _c0; w->encode = sp_encode_get(); }
 	pthread_exit(0);
 }
 
@@ -161,6 +165,17 @@ void kt_for(void (*func)(void*, int, int, int), void *data, int n)
 #endif
 	}
 	for (i = 0; i < t.n_threads; ++i) pthread_join(tid[i], 0);
+
+	if (sp_enabled()) {
+		double *busy = (double*) malloc(t.n_threads * sizeof(double));
+		assert(busy != NULL);
+		double sum = 0, esum = 0;
+		for (i = 0; i < t.n_threads; ++i) { busy[i] = t.w[i].cpu_busy; sum += busy[i]; esum += t.w[i].encode; }
+		g_ktfor.proc_cpu += sum;                        /* accumulate across kt_for calls in a step */
+		g_ktfor.encode   += esum;                       /* SAM/BAM-build CPU (only worker_sam adds) */
+		sp_thread_stats(&g_ktfor, busy, t.n_threads);   /* balance stats from the most recent call */
+		free(busy);
+	}
 
     pthread_attr_destroy(&attr);
     free(t.w);

--- a/src/kthread.h
+++ b/src/kthread.h
@@ -74,6 +74,8 @@ struct kt_for_t;
 typedef struct {
 	struct kt_for_t *t;
 	long i;
+	double cpu_busy;   /* stage_prof: per-thread CLOCK_THREAD_CPUTIME seconds (--profile) */
+	double encode;     /* stage_prof: per-thread SAM/BAM-build CPU seconds */
 } ktf_worker_t;
 
 typedef struct kt_for_t {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,7 +128,11 @@ int main(int argc, char* argv[])
         static const char *const MEM_SHORT_OPTS_WITH_ARG =
             "kcvsrtRABOEUwLdTQDmINWxGhyKXHofz";
         static const char *const MEM_LONG_OPTS_WITH_ARG[] = {
-            "--set-as-failed", "--supp-rep-hard-cap", NULL,
+            "--set-as-failed", "--supp-rep-hard-cap",
+#ifdef STAGE_PROF
+            "--profile",
+#endif
+            NULL,
         };
         for (int i = 2; i < argc; ++i) {
             const char *t = argv[i];

--- a/src/stage_prof.cpp
+++ b/src/stage_prof.cpp
@@ -1,0 +1,184 @@
+/* stage_prof: per-chunk read/process/write timing for aligner --profile mode.
+ * Self-contained; no dependency on the rest of bwa-mem3. See stage_prof.h. */
+#include "stage_prof.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include <pthread.h>
+
+/* Defined unconditionally so the STAGE_PROF-off (compile-time-dead) instrumentation
+ * blocks that reference it still link at any optimization level. */
+__thread prof_chunk_t g_ktfor;   /* per-thread kt_for balance handoff (see header) */
+
+#ifdef STAGE_PROF
+
+int    sp_g_on = 0;   /* declared extern in stage_prof.h; read by inline sp_enabled() */
+static char   g_path[4096];
+static char   g_tool[64], g_version[64], g_arch[16], g_fmt[16], g_input[4096];
+static int    g_cores, g_level, g_workers = 0;
+static double g_run_start = 0.0;
+static prof_chunk_t *g_rows = NULL;
+static size_t  g_n = 0, g_cap = 0;
+static double  g_idle = 0.0, g_idle_split[3] = {0,0,0};
+static pthread_mutex_t g_mu = PTHREAD_MUTEX_INITIALIZER;
+
+double sp_wall(void) {
+    struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t);
+    return (double)t.tv_sec + (double)t.tv_nsec * 1e-9;
+}
+double sp_thread_cpu(void) {
+    struct timespec t; clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t);
+    return (double)t.tv_sec + (double)t.tv_nsec * 1e-9;
+}
+double sp_run_elapsed(void) { return sp_wall() - g_run_start; }
+
+void sp_init(const char *path, const char *tool, const char *version,
+             const char *arch, int cores, const char *fmt, int level, const char *input) {
+    if (!path || !*path) return;
+    snprintf(g_path,    sizeof g_path,    "%s", path);
+    snprintf(g_tool,    sizeof g_tool,    "%s", tool ? tool : "");
+    snprintf(g_version, sizeof g_version, "%s", version ? version : "");
+    snprintf(g_arch,    sizeof g_arch,    "%s", arch ? arch : "");
+    snprintf(g_fmt,     sizeof g_fmt,     "%s", fmt ? fmt : "");
+    snprintf(g_input,   sizeof g_input,   "%s", input ? input : "");
+    g_cores = cores; g_level = level; g_run_start = sp_wall(); sp_g_on = 1;
+}
+void sp_set_workers(int n) { g_workers = n; }
+
+void sp_chunk_init(prof_chunk_t *c) {
+    memset(c, 0, sizeof *c);
+    c->read_diskwait = c->read_decompress = c->read_parse = NAN;
+    c->compute = c->encode = NAN;
+    c->thr_busy_min = c->thr_busy_max = c->thr_busy_mean = c->thr_busy_stdev = NAN;
+    c->write_compress = c->write_diskwrite = NAN;
+    c->chunk_start = NAN;
+    c->read_bytes_in = c->bgzf_blocks = -1;   /* -1 -> blank (N/A) */
+}
+
+void sp_add_chunk(const prof_chunk_t *c) {
+    if (!sp_g_on) return;
+    pthread_mutex_lock(&g_mu);
+    if (g_n == g_cap) {
+        size_t new_cap = g_cap ? g_cap * 2 : 64;
+        prof_chunk_t *new_rows = (prof_chunk_t*)realloc(g_rows, new_cap * sizeof *new_rows);
+        if (!new_rows) {   /* keep old g_rows intact; drop this chunk rather than crash */
+            pthread_mutex_unlock(&g_mu);
+            return;
+        }
+        g_rows = new_rows;
+        g_cap = new_cap;
+    }
+    g_rows[g_n++] = *c;
+    pthread_mutex_unlock(&g_mu);
+}
+
+void sp_add_idle(int next_step, double s) {
+    if (!sp_g_on) return;
+    pthread_mutex_lock(&g_mu);
+    g_idle += s;
+    if (next_step >= 0 && next_step < 3) g_idle_split[next_step] += s;
+    pthread_mutex_unlock(&g_mu);
+}
+
+void sp_thread_stats(prof_chunk_t *c, const double *b, int n) {
+    if (n <= 0) return;
+    double mn = b[0], mx = b[0], sum = 0;
+    for (int i = 0; i < n; i++) { if (b[i] < mn) mn = b[i]; if (b[i] > mx) mx = b[i]; sum += b[i]; }
+    double mean = sum / n, var = 0;
+    for (int i = 0; i < n; i++) { double d = b[i] - mean; var += d * d; }
+    c->thr_busy_min = mn; c->thr_busy_max = mx;
+    c->thr_busy_mean = mean; c->thr_busy_stdev = sqrt(var / n);
+}
+
+/* ---- per-thread read-stage accumulators ---- */
+static __thread double tl_disk = 0.0, tl_dec = 0.0, tl_parse = 0.0;
+static __thread long   tl_fdbytes = 0, tl_blocks = 0;
+void sp_read_reset(void) { tl_disk = tl_dec = tl_parse = 0.0; tl_fdbytes = 0; tl_blocks = 0; }
+void sp_read_add(int which, double s) {
+    if (which == 0) tl_disk += s; else if (which == 1) tl_dec += s; else tl_parse += s;
+}
+void sp_read_get(double *d, double *c, double *p) {
+    if (d) *d = tl_disk; if (c) *c = tl_dec; if (p) *p = tl_parse;
+}
+void sp_read_bytes(long fd_bytes, long blocks) { tl_fdbytes += fd_bytes; tl_blocks += blocks; }
+void sp_read_get_bytes(long *fd_bytes, long *blocks) {
+    if (fd_bytes) *fd_bytes = tl_fdbytes; if (blocks) *blocks = tl_blocks;
+}
+
+/* ---- per-thread encode accumulator ---- */
+static __thread double tl_enc = 0.0;
+void   sp_encode_reset(void) { tl_enc = 0.0; }
+void   sp_encode_add(double s) { tl_enc += s; }
+double sp_encode_get(void) { return tl_enc; }
+
+/* ---- emit ---- */
+static void cell(FILE *f, double v) { if (isnan(v)) fputc('\t', f); else fprintf(f, "%.4f\t", v); }
+static void lcell(FILE *f, long v)  { if (v < 0) fputc('\t', f); else fprintf(f, "%ld\t", v); }
+
+static void emit_row(FILE *f, const prof_chunk_t *c, int agg,
+                     double total_wall, double mcb, double rss) {
+    fprintf(f, "%s\t%s\t%s\t%d\t%d\t%s\t%d\t%s\t",
+            g_tool, g_version, g_arch, g_cores, g_workers, g_fmt, g_level, g_input);
+    if (agg) fputs("ALL\t", f); else fprintf(f, "%ld\t", c->chunk);
+    cell(f, c->chunk_start);
+    fprintf(f, "%ld\t%ld\t", c->n_reads, c->n_bp);
+    cell(f, c->read_wall); cell(f, c->read_diskwait); cell(f, c->read_decompress); cell(f, c->read_parse);
+    lcell(f, c->read_bytes_in); lcell(f, c->bgzf_blocks);
+    cell(f, c->proc_wall); cell(f, c->proc_cpu); cell(f, c->compute); cell(f, c->encode);
+    cell(f, c->thr_busy_min); cell(f, c->thr_busy_max); cell(f, c->thr_busy_mean); cell(f, c->thr_busy_stdev);
+    cell(f, c->write_wall); cell(f, c->write_compress); cell(f, c->write_diskwrite);
+    fprintf(f, "%ld\t", c->write_bytes);
+    if (agg) fprintf(f, "%.4f\t%.4f\t%.4f\t%.4f\t%.4f\t%.4f\t%.1f\n",
+                     total_wall, g_idle, g_idle_split[0], g_idle_split[1], g_idle_split[2], mcb, rss);
+    else     fputs("\t\t\t\t\t\t\n", f);   /* 7 aggregate-only cols blank on chunk rows */
+}
+
+void sp_finish(double total_wall, double mean_cores_busy, double peak_rss_mb) {
+    if (!sp_g_on) return;
+    FILE *f = fopen(g_path, "w");
+    if (!f) { fprintf(stderr, "[stage_prof] cannot open %s for writing\n", g_path); return; }
+    fputs("tool\tversion\tarch\tcores\tn_pipeline_workers\toutput_format\tcompression_level\tinput\t"
+          "chunk\tchunk_start\tn_reads\tn_bp\t"
+          "read_wall\tread_diskwait\tread_decompress\tread_parse\tread_bytes_in\tbgzf_blocks\t"
+          "proc_wall\tproc_cpu\tcompute\tencode\tthr_busy_min\tthr_busy_max\tthr_busy_mean\tthr_busy_stdev\t"
+          "write_wall\twrite_compress\twrite_diskwrite\twrite_bytes\t"
+          "total_wall\tidle_worker_s\tidle_read_s\tidle_proc_s\tidle_write_s\tmean_cores_busy\tpeak_rss_mb\n", f);
+    prof_chunk_t agg; memset(&agg, 0, sizeof agg);   /* sums start at 0 */
+    agg.read_bytes_in = agg.bgzf_blocks = -1;        /* -1 -> blank until a chunk supplies a real value */
+    double sum_proc_cpu = 0.0;
+    for (size_t i = 0; i < g_n; i++) {
+        emit_row(f, &g_rows[i], 0, 0, 0, 0);
+        agg.n_reads += g_rows[i].n_reads;
+        agg.n_bp    += g_rows[i].n_bp;
+        agg.write_bytes += g_rows[i].write_bytes;
+        if (g_rows[i].read_bytes_in >= 0) {
+            if (agg.read_bytes_in < 0) agg.read_bytes_in = 0;
+            agg.read_bytes_in += g_rows[i].read_bytes_in;
+        }
+        if (g_rows[i].bgzf_blocks >= 0) {
+            if (agg.bgzf_blocks < 0) agg.bgzf_blocks = 0;
+            agg.bgzf_blocks += g_rows[i].bgzf_blocks;
+        }
+        agg.read_wall  += g_rows[i].read_wall;
+        agg.proc_wall  += g_rows[i].proc_wall;
+        agg.write_wall += g_rows[i].write_wall;
+        if (!isnan(g_rows[i].proc_cpu)) sum_proc_cpu += g_rows[i].proc_cpu;
+    }
+    if (total_wall > 0 && sum_proc_cpu > 0) mean_cores_busy = sum_proc_cpu / total_wall;
+    /* aggregate: blank the per-tool sub-splits; keep summed walls + byte totals */
+    agg.read_diskwait = agg.read_decompress = agg.read_parse = NAN;
+    agg.compute = agg.encode = NAN;
+    agg.thr_busy_min = agg.thr_busy_max = agg.thr_busy_mean = agg.thr_busy_stdev = NAN;
+    agg.proc_cpu = NAN; agg.write_compress = agg.write_diskwrite = NAN; agg.chunk_start = NAN;
+    emit_row(f, &agg, 1, total_wall, mean_cores_busy, peak_rss_mb);
+    int write_failed = ferror(f);
+    if (fclose(f) != 0 || write_failed) {
+        fprintf(stderr, "[stage_prof] error writing profile output to %s\n", g_path);
+        return;
+    }
+    fprintf(stderr, "[stage_prof] wrote %zu chunk rows + aggregate to %s\n", g_n, g_path);
+}
+
+#endif /* STAGE_PROF */

--- a/src/stage_prof.h
+++ b/src/stage_prof.h
@@ -1,0 +1,146 @@
+#ifndef STAGE_PROF_H
+#define STAGE_PROF_H
+#include <stddef.h>
+
+/* Force-inline so the (compile-time-constant) hooks leave no out-of-line copy
+ * in any object file -- C `static inline` otherwise emits dead orphan bodies. */
+#if defined(__GNUC__)
+#define SP_INLINE static inline __attribute__((always_inline, unused))
+#else
+#define SP_INLINE static inline
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Per-pipeline-chunk stage breakdown for aligner profiling (--profile).
+ *
+ * Profiling is a COMPILE-TIME feature, gated on the STAGE_PROF macro:
+ *   - Built WITHOUT -DSTAGE_PROF (the default): sp_enabled() is the compile-time
+ *     constant 0, every sp_* hook below is an empty inline, and the --profile
+ *     CLI option does not exist. All instrumentation constant-folds away, so the
+ *     hot paths are byte-identical to an un-instrumented build (zero overhead).
+ *   - Built WITH -DSTAGE_PROF (e.g. `make STAGE_PROF=1`): the real out-of-line
+ *     implementation in stage_prof.cpp is linked and --profile is available.
+ *
+ * The aggregate row carries "ALL" in the chunk column (per-chunk rows are
+ * numbered from 0). All times are in seconds. Fields a tool/
+ * format cannot separate are NaN (see sp_chunk_init) and printed as empty cells,
+ * so the schema stays rectangular across bwa-mem3 and minibwa.
+ *
+ * Per-tool/format feasibility (documented; not faked):
+ *   read_diskwait/read_decompress/read_parse:
+ *       bwa-mem3 = all three (fast_reader splits read/inflate/parse);
+ *                  legacy reader leaves them NaN (uninstrumented).
+ *       minibwa  = read_diskwait NaN; read_decompress = fused gzread
+ *                  (disk+inflate+tokenize); read_parse = kseq2bseq copy.
+ *   read_bytes_in / bgzf_blocks:
+ *       bwa-mem3 = bytes read from the fd (compressed-on-disk) + BGZF block count
+ *                  (0 for plain/gzip); minibwa = NaN (zlib gzFile hides them).
+ *   encode:
+ *       bwa-mem3 = accurate clock around the SAM/BAM build (step 1);
+ *       minibwa  = accurate (mb_format, step 2).
+ *   write_compress/write_diskwrite:
+ *       SAM          = write_compress 0, write_diskwrite clean.
+ *       bwa-mem3 BAM = fused in htslib sam_write1 -> write_compress; diskwrite NaN.
+ */
+typedef struct {
+    long   chunk, n_reads, n_bp, write_bytes, read_bytes_in, bgzf_blocks;
+    double chunk_start;   /* wall offset of this chunk's read-start from run start */
+    double read_wall, read_diskwait, read_decompress, read_parse;
+    double proc_wall, proc_cpu, compute, encode;
+    double thr_busy_min, thr_busy_max, thr_busy_mean, thr_busy_stdev;
+    double write_wall, write_compress, write_diskwrite;
+} prof_chunk_t;
+
+/* Per-thread compute balance for a kt_for fan-out (see stage_prof.cpp). Declared
+ * unconditionally so the (compile-time-dead, STAGE_PROF-off) instrumentation
+ * blocks that name it still type-check; defined unconditionally in stage_prof.cpp. */
+extern __thread prof_chunk_t g_ktfor;
+
+#ifdef STAGE_PROF
+
+/* The on/off flag is exposed so sp_enabled() is a header inline: when --profile
+ * is off (but STAGE_PROF compiled in) this collapses to a single global load +
+ * branch at every call site (no out-of-line call) even in non-LTO builds. */
+extern int sp_g_on;
+SP_INLINE int sp_enabled(void) { return sp_g_on; }
+
+/* Arm profiling; captures the run-start wall anchor. No-op if path NULL/empty. */
+void   sp_init(const char *path, const char *tool, const char *version,
+               const char *arch, int cores, const char *output_format,
+               int compression_level, const char *input);
+/* Record the pipeline-worker count (run-level context; the suspected ceiling). */
+void   sp_set_workers(int n_pipeline_workers);
+
+double sp_wall(void);          /* CLOCK_MONOTONIC seconds */
+double sp_thread_cpu(void);    /* CLOCK_THREAD_CPUTIME_ID seconds (calling thread) */
+double sp_run_elapsed(void);   /* sp_wall() - run-start anchor (for chunk_start) */
+
+void   sp_chunk_init(prof_chunk_t *c);
+void   sp_add_chunk(const prof_chunk_t *c);
+/* Accumulate pipeline-worker idle seconds, attributed to the step it was about
+ * to run (0=read 1=process 2=write); also adds to the total. */
+void   sp_add_idle(int next_step, double seconds);
+void   sp_thread_stats(prof_chunk_t *c, const double *busy, int n);
+void   sp_finish(double total_wall, double mean_cores_busy, double peak_rss_mb);
+
+/* Per-thread read-stage accumulators (the step-0 worker owns these). which:
+ * 0=diskwait 1=decompress 2=parse. sp_read_bytes() adds fd/compressed bytes and
+ * BGZF block counts harvested via sp_read_get_bytes(). */
+void   sp_read_reset(void);
+void   sp_read_add(int which, double seconds);
+void   sp_read_get(double *diskwait, double *decompress, double *parse);
+void   sp_read_bytes(long fd_bytes, long bgzf_blocks);
+void   sp_read_get_bytes(long *fd_bytes, long *bgzf_blocks);
+
+/* Per-thread encode accumulator (bwa-mem3 brackets the SAM/BAM build deep in
+ * mem_process_seqs). sp_encode_reset() at step-1 entry; sp_encode_get() after. */
+void   sp_encode_reset(void);
+void   sp_encode_add(double seconds);
+double sp_encode_get(void);
+
+#else  /* !STAGE_PROF: profiling compiled out -> every hook is a no-op inline. */
+
+/* sp_enabled() is a compile-time 0, so `if (sp_enabled()) { ... }` and
+ * `sp_enabled() ? sp_wall() : 0.0` constant-fold to nothing. Parameters are
+ * named and (void)-cast so these compile cleanly as C (no unnamed-parameter or
+ * unused-parameter diagnostics) in the C translation units that include this. */
+SP_INLINE int    sp_enabled(void) { return 0; }
+SP_INLINE void   sp_init(const char *path, const char *tool, const char *version,
+                             const char *arch, int cores, const char *output_format,
+                             int compression_level, const char *input) {
+    (void)path; (void)tool; (void)version; (void)arch; (void)cores;
+    (void)output_format; (void)compression_level; (void)input;
+}
+SP_INLINE void   sp_set_workers(int n_pipeline_workers) { (void)n_pipeline_workers; }
+SP_INLINE double sp_wall(void) { return 0.0; }
+SP_INLINE double sp_thread_cpu(void) { return 0.0; }
+SP_INLINE double sp_run_elapsed(void) { return 0.0; }
+SP_INLINE void   sp_chunk_init(prof_chunk_t *c) { (void)c; }
+SP_INLINE void   sp_add_chunk(const prof_chunk_t *c) { (void)c; }
+SP_INLINE void   sp_add_idle(int next_step, double seconds) { (void)next_step; (void)seconds; }
+SP_INLINE void   sp_thread_stats(prof_chunk_t *c, const double *busy, int n) {
+    (void)c; (void)busy; (void)n;
+}
+SP_INLINE void   sp_finish(double total_wall, double mean_cores_busy, double peak_rss_mb) {
+    (void)total_wall; (void)mean_cores_busy; (void)peak_rss_mb;
+}
+SP_INLINE void   sp_read_reset(void) {}
+SP_INLINE void   sp_read_add(int which, double seconds) { (void)which; (void)seconds; }
+SP_INLINE void   sp_read_get(double *diskwait, double *decompress, double *parse) {
+    (void)diskwait; (void)decompress; (void)parse;
+}
+SP_INLINE void   sp_read_bytes(long fd_bytes, long bgzf_blocks) { (void)fd_bytes; (void)bgzf_blocks; }
+SP_INLINE void   sp_read_get_bytes(long *fd_bytes, long *bgzf_blocks) { (void)fd_bytes; (void)bgzf_blocks; }
+SP_INLINE void   sp_encode_reset(void) {}
+SP_INLINE void   sp_encode_add(double seconds) { (void)seconds; }
+SP_INLINE double sp_encode_get(void) { return 0.0; }
+
+#endif /* STAGE_PROF */
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* STAGE_PROF_H */

--- a/test/fast_reader_selftest.c
+++ b/test/fast_reader_selftest.c
@@ -22,6 +22,10 @@
 #include <string.h>
 #include <unistd.h>
 
+/* fast_reader.c is instrumented with stage_prof hooks, but they are compiled
+ * out by default (no -DSTAGE_PROF): stage_prof.h then provides no-op inlines, so
+ * fast_reader.c is self-contained and this standalone test needs no sp_* stubs. */
+
 static int g_fail = 0;
 #define CHECK(cond, msg) do { \
     if (!(cond)) { fprintf(stderr, "FAIL: %s\n", (msg)); g_fail = 1; } \

--- a/test/stage_prof_test.cpp
+++ b/test/stage_prof_test.cpp
@@ -1,0 +1,110 @@
+/* Unit test for the pure helpers of stage_prof (stats + clocks + NaN init).
+ * Builds standalone: no htslib, no index, no pipeline. */
+#include "../src/stage_prof.h"
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Copy the 0-based tab-delimited field `col` of `line` into `out`. Unlike
+ * strtok, this preserves empty fields (consecutive tabs), which is essential
+ * for distinguishing a blank TSV cell from a "0". Trailing newline stripped.
+ * Returns the number of fields seen (so callers can detect a short row). */
+static int tsv_field(const char *line, int col, char *out, size_t out_sz) {
+    out[0] = '\0';
+    int idx = 0;
+    const char *p = line;
+    while (1) {
+        const char *tab = strchr(p, '\t');
+        const char *end = tab ? tab : p + strlen(p);
+        if (idx == col) {
+            size_t n = (size_t)(end - p);
+            while (n > 0 && (p[n - 1] == '\n' || p[n - 1] == '\r')) n--;   /* strip EOL on last field */
+            if (n >= out_sz) n = out_sz - 1;
+            memcpy(out, p, n);
+            out[n] = '\0';
+        }
+        idx++;
+        if (!tab) break;
+        p = tab + 1;
+    }
+    return idx;
+}
+
+/* Read the aggregate ("ALL") row of a stage_prof TSV and return its tab field
+ * at the given 0-based column index into `out` (empty string if the cell is
+ * blank). Returns 1 on success, 0 if no ALL row was found. The aggregate row
+ * carries "ALL" in the chunk column (index 8). */
+static int agg_field(const char *path, int col, char *out, size_t out_sz) {
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+    /* generous: the input column alone can be up to 4096 chars in real output */
+    char line[16384], chunk[64];
+    int found = 0;
+    while (fgets(line, sizeof line, f)) {
+        if (tsv_field(line, 8, chunk, sizeof chunk) > 8 && strcmp(chunk, "ALL") == 0) {
+            tsv_field(line, col, out, out_sz);
+            found = 1;
+            break;
+        }
+    }
+    fclose(f);
+    return found;
+}
+
+int main(void) {
+    /* sp_chunk_init sets the maybe-N/A doubles to NaN */
+    prof_chunk_t c;
+    sp_chunk_init(&c);
+    assert(isnan(c.read_parse));
+    assert(isnan(c.thr_busy_mean));
+    assert(isnan(c.write_compress));
+    assert(c.n_reads == 0 && c.write_bytes == 0);
+
+    /* sp_thread_stats over {1,3,3,1}: min 1, max 3, mean 2, stdev 1 (population) */
+    double busy[4] = {1.0, 3.0, 3.0, 1.0};
+    sp_thread_stats(&c, busy, 4);
+    assert(c.thr_busy_min == 1.0);
+    assert(c.thr_busy_max == 3.0);
+    assert(fabs(c.thr_busy_mean - 2.0) < 1e-12);
+    assert(fabs(c.thr_busy_stdev - 1.0) < 1e-9);
+
+    /* single-element stats are degenerate but well-defined */
+    prof_chunk_t c1; sp_chunk_init(&c1);
+    double one[1] = {5.0};
+    sp_thread_stats(&c1, one, 1);
+    assert(c1.thr_busy_min == 5.0 && c1.thr_busy_max == 5.0);
+    assert(c1.thr_busy_mean == 5.0 && c1.thr_busy_stdev == 0.0);
+
+    /* clocks: monotonic and nonnegative */
+    double w0 = sp_wall(), w1 = sp_wall();
+    assert(w1 >= w0);
+    assert(sp_thread_cpu() >= 0.0);
+
+    /* profiling is off until sp_init with a real path */
+    assert(sp_enabled() == 0);
+    sp_init("", "t", "v", "x86_64", 4, "sam", -1, "in");   /* empty path -> stays off */
+    assert(sp_enabled() == 0);
+
+    /* Aggregate N/A semantics: when every chunk reports read_bytes_in/bgzf_blocks
+     * as N/A (-1), the aggregate row must stay blank, not collapse to a false 0. */
+    const char *tsv = "/tmp/stage_prof_test.tsv";
+    remove(tsv);
+    sp_init(tsv, "t", "v", "x86_64", 4, "sam", -1, "in");
+    assert(sp_enabled() == 1);
+    prof_chunk_t a; sp_chunk_init(&a); a.chunk = 0; a.n_reads = 10; a.n_bp = 1500;
+    prof_chunk_t b; sp_chunk_init(&b); b.chunk = 1; b.n_reads = 20; b.n_bp = 3000;
+    sp_add_chunk(&a);   /* both leave read_bytes_in/bgzf_blocks at the -1 N/A default */
+    sp_add_chunk(&b);
+    sp_finish(1.0, 0.0, 0.0);
+
+    char field[64];
+    assert(agg_field(tsv, 10, field, sizeof field) && strcmp(field, "30") == 0);  /* n_reads sums */
+    assert(agg_field(tsv, 16, field, sizeof field) && field[0] == '\0');           /* read_bytes_in blank */
+    assert(agg_field(tsv, 17, field, sizeof field) && field[0] == '\0');           /* bgzf_blocks blank */
+    remove(tsv);
+
+    printf("stage_prof_test OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Motivation

When diagnosing read-stage scaling at high core counts we needed to attribute wall time inside the input pipeline (disk wait vs. decompress vs. parse) and across the read‖proc‖write stages, without perturbing normal runs. This PR adds an off-by-default `--profile` mode that emits that breakdown.

## What this adds

`--profile` (off by default) instruments the pipeline with a small `stage_prof` module:

- Per-stage walls: read, proc, write.
- Read-stage sub-splits: disk wait, decompress, parse (read_parse attribution corrected so kseq tokenization counts against parse).
- Per-chunk timeline plus idle-by-stage accounting so pipeline stalls are visible.
- Per-thread balance for the proc stage.
- Byte counts (on-disk / decompressed) and peak RSS (units corrected off-Linux).
- Worker count in the emitted summary.

When `--profile` is off, every timing path is gated behind `sp_enabled()` returning 0, so there is zero perturbation to normal alignment runs.

The module ships with a standalone unit test (`stage_prof_test`) covering the stats, clocks, and NaN-init behavior.

## Test fix

`fast_reader.c` carries `stage_prof` hooks, so the standalone `fast_reader_selftest` target failed to link on undefined `sp_*` symbols once the instrumentation landed. The sibling standalone targets (`fr_fastq_diff_test`, `fr_fastq_bench`) already resolve this with a no-op `sp_*` stub block in the test TU; this PR applies the same stub to `fast_reader_selftest` so it links and runs standalone again.

## Correctness

`make test` passes; `stage_prof_test` and `fast_reader_selftest` build and pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an opt-in stage profiling mode (`--profile FILE`) that generates a TSV report with per-chunk timing, CPU busy/idle breakdowns, and read/decompression/BGZF throughput details.
  * Added a profiling build option so the report generation is available when enabled during compilation.
* **Bug Fixes**
  * Improved `--help` handling so help requests aren’t triggered by tokens inside `--profile` arguments.
* **Tests & CI**
  * Added a standalone stage-profiler unit test and a CI job that builds with profiling enabled and verifies `--profile` support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->