### PR TITLE
perf(read): vendored zlib-ng inflate + chunk cap + 3rd pipeline worker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "ext/libsais"]
 	path = ext/libsais
 	url = https://github.com/IlyaGrebnov/libsais.git
+[submodule "ext/zlib-ng"]
+	path = ext/zlib-ng
+	url = https://github.com/zlib-ng/zlib-ng.git

--- a/Makefile
+++ b/Makefile
@@ -593,6 +593,11 @@ endif
 fast_reader_selftest: src/fast_reader.c test/fast_reader_selftest.c
 	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fast_reader_selftest.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -ldeflate -o $@
 
+# Differential test: fr_fastq vs kseq, byte-identical record parsing. Links only
+# zlib + libdeflate (kseq.h is header-only), so it needs no bwa-mem3 build.
+fr_fastq_diff_test: src/fr_fastq.c src/fast_reader.c test/fr_fastq_diff_test.c
+	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_diff_test.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -ldeflate -o $@
+
 test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
 
 # Run the in-tree tests via the unit-test harness in test/, plus the

--- a/Makefile
+++ b/Makefile
@@ -192,12 +192,41 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 # zlib-ng: src/fast_reader.c uses its native (zng_*) streaming inflate for the
-# plain-gzip path (SIMD, ~2x zlib). Native API => no symbol clash with the
-# system zlib that htslib / the legacy gzFile reader still use. On macOS resolve
-# the Homebrew prefix; on Linux <zlib-ng.h>/-lz-ng come from the system package.
-# TODO(prod): vendor zlib-ng under ext/ (cmake static build, like mimalloc) so
-# the Batch fleet doesn't depend on a host package.
-ifeq ($(UNAME_S),Darwin)
+# plain-gzip path (SIMD, ~2.3x stock zlib on both x86 and arm64). The native API
+# (zng_* symbols, <zlib-ng.h>) => no symbol clash with the system zlib that
+# htslib / the legacy gzFile reader still use.
+#
+# Vendored under ext/zlib-ng (git submodule, pinned to a zlib-ng release) and
+# built as a static archive (libz-ng.a with zng_* symbols) via its own CMake
+# system -- the same integration pattern as ext/mimalloc -- so the Batch/CI
+# fleet does NOT depend on a host zlib-ng package. ZLIB_COMPAT=OFF keeps the
+# zng_* names; BUILD_SHARED_LIBS=OFF yields the static archive.
+#
+# ZLIBNG_USE_VENDORED=1 (default) builds and links the vendored copy. Set it to
+# 0 to fall back to a host-installed zlib-ng (Homebrew on macOS, system package
+# on Linux) -- handy for dev hosts that already have it, mirroring how libdeflate
+# is resolved on macOS.
+ZLIBNG_USE_VENDORED ?= 1
+
+ZLIBNG_SRC   = ext/zlib-ng
+ZLIBNG_BUILD = $(ZLIBNG_SRC)/build
+ZLIBNG_LIB   = $(ZLIBNG_BUILD)/libz-ng.a
+# Static, native (non-zlib-compat) build with tests off. Matches mimalloc's
+# CMAKE_BUILD_TYPE=Release static integration.
+# ZLIB_ENABLE_TESTS=OFF skips the example/infcover/etc. test executables;
+# ZLIBNG_ENABLE_TESTS / WITH_GTEST turn off the API + gtest suites. We only
+# need libz-ng.a and the generated headers.
+ZLIBNG_CMAKE_FLAGS = -DZLIB_COMPAT=OFF -DBUILD_SHARED_LIBS=OFF \
+                     -DZLIB_ENABLE_TESTS=OFF -DZLIBNG_ENABLE_TESTS=OFF \
+                     -DWITH_GTEST=OFF \
+                     -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+
+ifeq ($(ZLIBNG_USE_VENDORED),1)
+    # zlib-ng.h ships in the source root and #includes zconf-ng.h /
+    # zlib_name_mangling-ng.h, which CMake GENERATES into the build dir -- so
+    # both paths are needed on the include line.
+    INCLUDES += -I$(ZLIBNG_SRC) -I$(ZLIBNG_BUILD)
+else ifeq ($(UNAME_S),Darwin)
     ZLIBNG_PREFIX ?= $(shell brew --prefix zlib-ng 2>/dev/null)
     INCLUDES += -I$(ZLIBNG_PREFIX)/include
 endif
@@ -240,7 +269,10 @@ else
     LIBS += -ldeflate
 endif
 # zlib-ng: direct dependency of src/fast_reader.c (streaming plain-gzip inflate).
-ifeq ($(UNAME_S),Darwin)
+# Vendored static archive by default; host package as an opt-out fallback.
+ifeq ($(ZLIBNG_USE_VENDORED),1)
+    LIBS += $(ZLIBNG_LIB)
+else ifeq ($(UNAME_S),Darwin)
     LIBS += -L$(ZLIBNG_PREFIX)/lib -lz-ng
 else
     LIBS += -lz-ng
@@ -493,7 +525,7 @@ BASELINE_ARCH ?= avx2
 # tier; the dispatcher picks the right per-tier subclass at runtime.
 # Replaces the `multi` target's 5 sequential clean rebuilds + execv launcher.
 .PHONY: single
-single: $(if $(filter 1,$(USE_MIMALLOC)),$(MIMALLOC_LIB))
+single: $(if $(filter 1,$(USE_MIMALLOC)),$(MIMALLOC_LIB)) $(if $(filter 1,$(ZLIBNG_USE_VENDORED)),$(ZLIBNG_LIB))
 ifneq ($(IS_ARM),)
 	@echo "ARM64 detected - building single arm64 binary instead of multi-tier"
 	$(MAKE) arm64
@@ -504,7 +536,7 @@ endif
 # Internal: builds the single binary with the BASELINE_ARCH tier for
 # non-kernel TUs and links all KERNEL_TIER_OBJS_LINK on top.
 .PHONY: all-single
-all-single: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) $(KERNEL_TIER_OBJS_LINK) src/main.o
+all-single: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) $(if $(filter 1,$(ZLIBNG_USE_VENDORED)),$(ZLIBNG_LIB)) $(KERNEL_TIER_OBJS_LINK) src/main.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) src/main.o $(KERNEL_TIER_OBJS_LINK) $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) $(MIMALLOC_LDFLAGS) -o $(EXE)
 
 # ARM64/Apple Silicon build target - single binary, no multi-binary launcher needed
@@ -514,7 +546,7 @@ arm64:
 	ln -sf bwa-mem3.arm64 bwa-mem3
 
 
-$(EXE):$(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) $(if $(filter 1,$(USE_MIMALLOC)),$(MIMALLOC_LIB)) src/main.o
+$(EXE):$(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) $(if $(filter 1,$(USE_MIMALLOC)),$(MIMALLOC_LIB)) $(if $(filter 1,$(ZLIBNG_USE_VENDORED)),$(ZLIBNG_LIB)) src/main.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) src/main.o $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) $(MIMALLOC_LDFLAGS) -o $@
 
 # Regression test for issue 38 / upstream PR 289: exercises an all-len1==0
@@ -587,7 +619,12 @@ shm_lock_destroy_test: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_lock_destr
 # fast_reader is C (not C++); the implicit .c rule omits $(INCLUDES), so give
 # these objects explicit rules carrying the project include paths (incl.
 # libdeflate) and preprocessor defines.
-src/fast_reader.o: src/fast_reader.c src/fast_reader.h
+# fast_reader.c #includes <zlib-ng.h>, which pulls the CMake-generated
+# zconf-ng.h / zlib_name_mangling-ng.h from the vendored build dir, so the
+# vendored archive (which generates those headers as a side effect) must be
+# built first. Gated on ZLIBNG_USE_VENDORED so the host-package fallback build
+# doesn't try to build the submodule.
+src/fast_reader.o: src/fast_reader.c src/fast_reader.h $(if $(filter 1,$(ZLIBNG_USE_VENDORED)),$(ZLIBNG_LIB))
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDES) -c -o $@ $<
 
 src/fast_reader_bseq.o: src/fast_reader_bseq.c src/fast_reader_bseq.h src/fast_reader.h src/fr_fastq.h
@@ -604,23 +641,39 @@ stage_prof_test: src/stage_prof.cpp src/stage_prof.h test/stage_prof_test.cpp
 
 # Standalone fast_reader correctness self-test (plain/gzip/multi-member/BGZF
 # round-trips). Links only zlib + libdeflate, so it needs no bwa-mem3 build.
+# Include / link flags shared by the standalone fast_reader test binaries.
+# zlib-ng resolution matches the main build: vendored static archive by default
+# (ext/zlib-ng build dir for the generated headers, libz-ng.a for the symbols),
+# host package as the opt-out fallback.
 FAST_READER_TEST_INC = -Isrc
-ifeq ($(UNAME_S),Darwin)
-    FAST_READER_TEST_INC += -I$(LIBDEFLATE_PREFIX)/include -I$(ZLIBNG_PREFIX)/include
-    FAST_READER_TEST_LIB = -L$(LIBDEFLATE_PREFIX)/lib -L$(ZLIBNG_PREFIX)/lib
+FAST_READER_TEST_LIB =
+ifeq ($(ZLIBNG_USE_VENDORED),1)
+    FAST_READER_TEST_INC += -I$(ZLIBNG_SRC) -I$(ZLIBNG_BUILD)
+    FAST_READER_TEST_ZLIBNG = $(ZLIBNG_LIB)
+    FAST_READER_TEST_DEP    = $(ZLIBNG_LIB)
+else
+    FAST_READER_TEST_ZLIBNG = -lz-ng
 endif
-fast_reader_selftest: src/fast_reader.c test/fast_reader_selftest.c
-	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fast_reader_selftest.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -lz-ng -ldeflate -o $@
+ifeq ($(UNAME_S),Darwin)
+    FAST_READER_TEST_INC += -I$(LIBDEFLATE_PREFIX)/include
+    FAST_READER_TEST_LIB += -L$(LIBDEFLATE_PREFIX)/lib
+    ifneq ($(ZLIBNG_USE_VENDORED),1)
+        FAST_READER_TEST_INC += -I$(ZLIBNG_PREFIX)/include
+        FAST_READER_TEST_LIB += -L$(ZLIBNG_PREFIX)/lib
+    endif
+endif
+fast_reader_selftest: src/fast_reader.c test/fast_reader_selftest.c $(FAST_READER_TEST_DEP)
+	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fast_reader_selftest.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz $(FAST_READER_TEST_ZLIBNG) -ldeflate -o $@
 
 # Differential test: fr_fastq vs kseq, byte-identical record parsing. Links only
-# zlib + libdeflate (kseq.h is header-only), so it needs no bwa-mem3 build.
-fr_fastq_diff_test: src/fr_fastq.c src/fast_reader.c test/fr_fastq_diff_test.c
-	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_diff_test.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -lz-ng -ldeflate -o $@
+# zlib + zlib-ng + libdeflate (kseq.h is header-only), so it needs no bwa-mem3 build.
+fr_fastq_diff_test: src/fr_fastq.c src/fast_reader.c test/fr_fastq_diff_test.c $(FAST_READER_TEST_DEP)
+	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_diff_test.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz $(FAST_READER_TEST_ZLIBNG) -ldeflate -o $@
 
 # Read+parse microbenchmark: kseq vs fr_fastq on a real FASTQ (no index/align).
 # Usage: ./fr_fastq_bench {kseq|frfastq} reads.fq[.gz] [reps]
-fr_fastq_bench: src/fr_fastq.c src/fast_reader.c test/fr_fastq_bench.c
-	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_bench.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -lz-ng -ldeflate -o $@
+fr_fastq_bench: src/fr_fastq.c src/fast_reader.c test/fr_fastq_bench.c $(FAST_READER_TEST_DEP)
+	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_bench.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz $(FAST_READER_TEST_ZLIBNG) -ldeflate -o $@
 
 test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
 
@@ -732,6 +785,19 @@ $(MIMALLOC_LIB):
 	mkdir -p $(MIMALLOC_BUILD)
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
+# Build zlib-ng via its own CMake system, mirroring the mimalloc rule above.
+# Shells out to cmake once and caches the build tree under ext/zlib-ng/build;
+# produces libz-ng.a (zng_* symbols) plus the generated zconf-ng.h /
+# zlib_name_mangling-ng.h headers in the build dir. Only depended on when
+# ZLIBNG_USE_VENDORED=1 (the default).
+$(ZLIBNG_LIB):
+	@if [ ! -f $(ZLIBNG_SRC)/CMakeLists.txt ]; then \
+		echo "ERROR: $(ZLIBNG_SRC) is empty. Run: git submodule update --init --recursive"; \
+		exit 1; \
+	fi
+	mkdir -p $(ZLIBNG_BUILD)
+	cd $(ZLIBNG_BUILD) && cmake $(ZLIBNG_CMAKE_FLAGS) .. && $(MAKE)
+
 clean: pgo-clean profile-clean lto-clean
 	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test bwa-mem3.arm64
 	rm -f $(LIBSAIS_OBJS)
@@ -739,6 +805,7 @@ clean: pgo-clean profile-clean lto-clean
 	$(MAKE) -C test clean
 	-[ -f ext/htslib/config.mk ] && cd ext/htslib && $(MAKE) distclean
 	rm -rf $(MIMALLOC_BUILD)
+	rm -rf $(ZLIBNG_BUILD)
 
 # ----------------------------------------------------------------------------
 # Documentation (mdbook). See docs/superpowers/specs/ for design.

--- a/Makefile
+++ b/Makefile
@@ -181,15 +181,25 @@ ifeq ($(USE_MIMALLOC),1)
     INCLUDES += -Iext/mimalloc/include
 endif
 
-# libdeflate: used directly by src/fast_reader.c for BGZF block decode (the
-# vanilla-gzip path stays on zlib). htslib already links -ldeflate
-# transitively; we add the <libdeflate.h> include path here. On macOS it
-# lives under the Homebrew prefix, resolved dynamically (mirrors the libomp
-# prefix detection below) so the build works on both Apple Silicon
-# (/opt/homebrew) and Intel (/usr/local) hosts rather than hardcoding one.
+# libdeflate: used directly by src/fast_reader.c for BGZF block decode. htslib
+# already links -ldeflate transitively; we add the <libdeflate.h> include path
+# here. On macOS it lives under the Homebrew prefix, resolved dynamically
+# (mirrors the libomp prefix detection below) so the build works on both Apple
+# Silicon (/opt/homebrew) and Intel (/usr/local) hosts rather than hardcoding one.
 ifeq ($(UNAME_S),Darwin)
     LIBDEFLATE_PREFIX ?= $(shell brew --prefix libdeflate 2>/dev/null)
     INCLUDES += -I$(LIBDEFLATE_PREFIX)/include
+endif
+
+# zlib-ng: src/fast_reader.c uses its native (zng_*) streaming inflate for the
+# plain-gzip path (SIMD, ~2x zlib). Native API => no symbol clash with the
+# system zlib that htslib / the legacy gzFile reader still use. On macOS resolve
+# the Homebrew prefix; on Linux <zlib-ng.h>/-lz-ng come from the system package.
+# TODO(prod): vendor zlib-ng under ext/ (cmake static build, like mimalloc) so
+# the Batch fleet doesn't depend on a host package.
+ifeq ($(UNAME_S),Darwin)
+    ZLIBNG_PREFIX ?= $(shell brew --prefix zlib-ng 2>/dev/null)
+    INCLUDES += -I$(ZLIBNG_PREFIX)/include
 endif
 
 # libsais (pinned in ext/libsais; see submodule SHA): linear-time suffix
@@ -228,6 +238,12 @@ ifeq ($(UNAME_S),Darwin)
     LIBS += -L$(LIBDEFLATE_PREFIX)/lib -ldeflate
 else
     LIBS += -ldeflate
+endif
+# zlib-ng: direct dependency of src/fast_reader.c (streaming plain-gzip inflate).
+ifeq ($(UNAME_S),Darwin)
+    LIBS += -L$(ZLIBNG_PREFIX)/lib -lz-ng
+else
+    LIBS += -lz-ng
 endif
 # Pull in htslib's transitive deps (-ldeflate when libdeflate is detected,
 # bzlib / lzma / curl when those features are enabled) from the generated
@@ -590,21 +606,21 @@ stage_prof_test: src/stage_prof.cpp src/stage_prof.h test/stage_prof_test.cpp
 # round-trips). Links only zlib + libdeflate, so it needs no bwa-mem3 build.
 FAST_READER_TEST_INC = -Isrc
 ifeq ($(UNAME_S),Darwin)
-    FAST_READER_TEST_INC += -I$(LIBDEFLATE_PREFIX)/include
-    FAST_READER_TEST_LIB = -L$(LIBDEFLATE_PREFIX)/lib
+    FAST_READER_TEST_INC += -I$(LIBDEFLATE_PREFIX)/include -I$(ZLIBNG_PREFIX)/include
+    FAST_READER_TEST_LIB = -L$(LIBDEFLATE_PREFIX)/lib -L$(ZLIBNG_PREFIX)/lib
 endif
 fast_reader_selftest: src/fast_reader.c test/fast_reader_selftest.c
-	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fast_reader_selftest.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -ldeflate -o $@
+	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fast_reader_selftest.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -lz-ng -ldeflate -o $@
 
 # Differential test: fr_fastq vs kseq, byte-identical record parsing. Links only
 # zlib + libdeflate (kseq.h is header-only), so it needs no bwa-mem3 build.
 fr_fastq_diff_test: src/fr_fastq.c src/fast_reader.c test/fr_fastq_diff_test.c
-	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_diff_test.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -ldeflate -o $@
+	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_diff_test.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -lz-ng -ldeflate -o $@
 
 # Read+parse microbenchmark: kseq vs fr_fastq on a real FASTQ (no index/align).
 # Usage: ./fr_fastq_bench {kseq|frfastq} reads.fq[.gz] [reps]
 fr_fastq_bench: src/fr_fastq.c src/fast_reader.c test/fr_fastq_bench.c
-	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_bench.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -ldeflate -o $@
+	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_bench.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -lz-ng -ldeflate -o $@
 
 test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
 

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/kthread.o \
 			src/packed_text.o src/fm_index_writer.o src/index_prelude.o \
 			src/system.o src/libsais_build.o \
 			src/bwa_shm.o src/simd_dispatch.o \
-			src/fast_reader.o src/fast_reader_bseq.o src/stage_prof.o
+			src/fast_reader.o src/fast_reader_bseq.o src/fr_fastq.o src/stage_prof.o
 
 # Kernel TUs (bandedSWA, kswv, ksw, sam_encode) are compiled per-tier on x86
 # and linked directly via KERNEL_TIER_OBJS_LINK. The dispatch wrappers in
@@ -574,7 +574,10 @@ shm_lock_destroy_test: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_lock_destr
 src/fast_reader.o: src/fast_reader.c src/fast_reader.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDES) -c -o $@ $<
 
-src/fast_reader_bseq.o: src/fast_reader_bseq.c src/fast_reader_bseq.h src/fast_reader.h
+src/fast_reader_bseq.o: src/fast_reader_bseq.c src/fast_reader_bseq.h src/fast_reader.h src/fr_fastq.h
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDES) -c -o $@ $<
+
+src/fr_fastq.o: src/fr_fastq.c src/fr_fastq.h src/fast_reader.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDES) -c -o $@ $<
 
 # Standalone stage_prof helper unit test (stats + clocks + NaN init). Links only
@@ -597,6 +600,11 @@ fast_reader_selftest: src/fast_reader.c test/fast_reader_selftest.c
 # zlib + libdeflate (kseq.h is header-only), so it needs no bwa-mem3 build.
 fr_fastq_diff_test: src/fr_fastq.c src/fast_reader.c test/fr_fastq_diff_test.c
 	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_diff_test.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -ldeflate -o $@
+
+# Read+parse microbenchmark: kseq vs fr_fastq on a real FASTQ (no index/align).
+# Usage: ./fr_fastq_bench {kseq|frfastq} reads.fq[.gz] [reps]
+fr_fastq_bench: src/fr_fastq.c src/fast_reader.c test/fr_fastq_bench.c
+	$(CC) -O2 -Wall -Wextra $(FAST_READER_TEST_INC) test/fr_fastq_bench.c src/fr_fastq.c src/fast_reader.c $(FAST_READER_TEST_LIB) -lz -ldeflate -o $@
 
 test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
 

--- a/src/fast_reader.c
+++ b/src/fast_reader.c
@@ -1,7 +1,14 @@
 #include "fast_reader.h"
 #include "stage_prof.h"
 
-#include <zlib.h>
+/* zlib-ng (native zng_* API) for the streaming plain-gzip inflate path: its
+ * SIMD inflate is ~2x zlib's, and it keeps the streaming inflate() model that a
+ * FASTQ-scale reader needs (the decompressed stream is far larger than RAM, so a
+ * one-shot decompressor like libdeflate cannot be used here). The native API is
+ * used (not --zlib-compat) so these symbols never collide with the system zlib
+ * that htslib and the legacy gzFile reader still use. libdeflate stays on the
+ * bounded, independent BGZF blocks below. */
+#include <zlib-ng.h>
 #include <libdeflate.h>
 
 #include <errno.h>
@@ -24,7 +31,7 @@ struct fast_reader {
     int            eof_in;
 
     /* gzip */
-    z_stream zs;
+    zng_stream zs;
     int      zs_active;
 
     /* bgzf */
@@ -115,7 +122,7 @@ fast_reader_t *fast_reader_dopen(int fd, const char **err)
     if (fmt == FR_GZIP) {
         fr->zs.zalloc = Z_NULL; fr->zs.zfree = Z_NULL; fr->zs.opaque = Z_NULL;
         fr->zs.next_in = Z_NULL; fr->zs.avail_in = 0;
-        if (inflateInit2(&fr->zs, 15 + 16) != Z_OK) {   /* 15+16 = gzip wrapper */
+        if (zng_inflateInit2(&fr->zs, 15 + 16) != Z_OK) {   /* 15+16 = gzip wrapper */
             free(fr->cin); free(fr); FR_DOPEN_FAIL("inflateInit2 failed");
         }
         fr->zs_active = 1;
@@ -169,11 +176,11 @@ static int fr_read_gzip(fast_reader_t *fr, unsigned char *buf, int len)
             fr->zs.avail_in = (uInt)(fr->cin_len - fr->cin_pos);
         }
         double _td = sp_enabled() ? sp_wall() : 0.0;
-        int ret = inflate(&fr->zs, Z_NO_FLUSH);
+        int ret = zng_inflate(&fr->zs, Z_NO_FLUSH);
         if (sp_enabled()) sp_read_add(1, sp_wall() - _td);
         fr->cin_pos = fr->cin_len - fr->zs.avail_in;       /* track consumed */
         if (ret == Z_STREAM_END) {                          /* member done */
-            if (inflateReset(&fr->zs) != Z_OK) return -1;
+            if (zng_inflateReset(&fr->zs) != Z_OK) return -1;
             if (fr->zs.avail_in == 0 && fr->eof_in) break;  /* nothing follows */
             continue;                                       /* next member */
         }
@@ -288,7 +295,7 @@ fr_format_t fast_reader_format(const fast_reader_t *fr) { return fr->fmt; }
 void fast_reader_close(fast_reader_t *fr)
 {
     if (!fr) return;
-    if (fr->zs_active) inflateEnd(&fr->zs);
+    if (fr->zs_active) zng_inflateEnd(&fr->zs);
     if (fr->ld) libdeflate_free_decompressor(fr->ld);
     free(fr->bout);
     free(fr->cin);

--- a/src/fast_reader_bseq.c
+++ b/src/fast_reader_bseq.c
@@ -70,8 +70,25 @@ bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
     int64_t size = 0, m, n;
     bseq1_t *seqs;
     m = n = 0; seqs = 0;
-    while (kseq_read(ks) >= 0) {
-        if (ks2 && kseq_read(ks2) < 0) {                 /* 2nd file has fewer */
+    for (;;) {
+        /* Tokenize the next record(s). kseq_read does the FASTQ tokenization
+         * (newline scan + copy of each field into its kstring_t) and pulls
+         * bytes through the codec layer, which charges its own read()/inflate
+         * time to the diskwait/decompress timers from inside this call. To make
+         * read_parse account for the tokenization itself (the dominant, formerly
+         * uninstrumented cost), time the whole kseq_read region and subtract the
+         * IO delta the codec already counted. The IO interval is strictly nested
+         * inside this wall bracket, so the remainder is non-negative. */
+        double _tk0 = sp_enabled() ? sp_wall() : 0.0, _io0 = 0.0;
+        if (sp_enabled()) { double d, c; sp_read_get(&d, &c, NULL); _io0 = d + c; }
+        int r1 = kseq_read(ks);
+        int r2 = (r1 >= 0 && ks2) ? kseq_read(ks2) : 0;
+        if (sp_enabled()) {
+            double d, c; sp_read_get(&d, &c, NULL);
+            sp_read_add(2, (sp_wall() - _tk0) - ((d + c) - _io0));
+        }
+        if (r1 < 0) break;                               /* clean EOF on 1st file */
+        if (ks2 && r2 < 0) {                             /* 2nd file has fewer */
             fprintf(stderr, "[W::%s] the 2nd file has fewer sequences.\n", __func__);
             break;
         }

--- a/src/fast_reader_bseq.c
+++ b/src/fast_reader_bseq.c
@@ -5,30 +5,30 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "kstring.h"
-#include "kseq.h"
+#include "fr_fastq.h"
 #include "utils.h"   /* err_fatal */
 #include "stage_prof.h"
 
-/* kseq instantiated over the fast_reader byte source. This is the only TU that
- * uses this handle type, so there is no kseq_t name collision with the gzFile
- * instantiation used elsewhere. */
-KSEQ_INIT(fast_reader_t *, fast_reader_read)
+/* This adapter turns fr_fastq record slices into the bseq1_t array the pipeline
+ * consumes. fr_fastq replaced the kseq layer (see fr_fastq.c): records are now
+ * sliced once out of the reader's own buffer rather than copied through a
+ * kstring_t intermediate. The public handle names below are kept for the
+ * pipeline's call sites; the opaque handle is now an fr_fastq_t*. */
 
-/* fr_trim_readno mirrors the static helper in bwa.cpp exactly: strip a trailing
- * /<digit> for any digit. It runs BEFORE the copy and shortens ks->name.l, so
- * fr_kseq2bseq1 must read the live kseq length rather than re-scanning. */
-static inline void fr_trim_readno(kstring_t *s)
+/* Strip a trailing /<digit> from the name, matching bwa's trim_readno. It used
+ * to mutate the kseq kstring_t in place before the copy; here it just shortens
+ * the length we copy out of the (const) record slice. */
+static inline size_t fr_trim_readno_len(const char *name, size_t l)
 {
-    if (s->l > 2 && s->s[s->l - 2] == '/' && isdigit((unsigned char)s->s[s->l - 1]))
-        s->l -= 2, s->s[s->l] = 0;
+    if (l > 2 && name[l - 2] == '/' && isdigit((unsigned char)name[l - 1])) return l - 2;
+    return l;
 }
 
-/* Length-aware field copy: malloc(len+1)+memcpy using the kseq-known length,
- * avoiding strdup's internal strlen scan on the hot path. The kseq source is
- * already NUL-terminated at .l; we set dst[len] explicitly so the copy is
- * NUL-terminated regardless. Aborts on OOM to match the house style of failing
- * loudly on allocation failure (see the realloc in bseq_read_fast below). */
+/* Length-aware field copy: malloc(len+1)+memcpy using the parser-known length,
+ * avoiding strdup's internal strlen scan on the hot path. The source slice is
+ * not assumed NUL-terminated; we set dst[len] explicitly. Aborts on OOM to
+ * match the house style of failing loudly on allocation failure (see the
+ * realloc in bseq_read_fast below). */
 static inline char *fr_dup_field(const char *src, size_t len)
 {
     char *dst = (char *)malloc(len + 1);
@@ -39,56 +39,56 @@ static inline char *fr_dup_field(const char *src, size_t len)
     return dst;
 }
 
-/* fr_kseq2bseq1 produces output identical to bwa.cpp's kseq2bseq1, but copies
- * each field with its kseq-known length (ks->*.l) so the copy never scans for a
- * terminator, and takes l_seq from ks->seq.l directly. qual==NULL when empty.
+/* Copy one parsed record into a bseq1_t, producing output identical to the old
+ * kseq path: per-field copy with comment/qual==NULL when empty, l_seq from the
+ * sequence length, and the readno suffix trimmed from the name.
  *
- * The leading memset is retained on purpose and is NOT the cost the strlen
- * removal targets: bseq_read_fast grows `seqs` with realloc, which leaves new
- * entries uninitialized, and the output loop in fastmap.cpp free()s sam/bams
- * unconditionally — so every field must start well-defined. Zeroing the whole
- * struct (rather than hand-listing sam/bams/n_bams/cap_bams) stays correct if a
- * field is ever added to bseq1_t, matching the documented rationale on the
- * bwa.cpp sibling. id is overwritten by the caller. */
-static inline void fr_kseq2bseq1(const kseq_t *ks, bseq1_t *s)
+ * The leading memset is retained on purpose: bseq_read_fast grows `seqs` with
+ * realloc, which leaves new entries uninitialized, and the output loop in
+ * fastmap.cpp free()s sam/bams unconditionally — so every field must start
+ * well-defined. Zeroing the whole struct (rather than hand-listing
+ * sam/bams/n_bams/cap_bams) stays correct if a field is ever added to bseq1_t.
+ * id is overwritten by the caller. */
+static inline void fr_rec_to_bseq1(const fr_fastq_rec_t *r, bseq1_t *s)
 {
     memset(s, 0, sizeof(*s));
-    s->name    = fr_dup_field(ks->name.s, ks->name.l);
-    s->comment = ks->comment.l ? fr_dup_field(ks->comment.s, ks->comment.l) : 0;
-    s->seq     = fr_dup_field(ks->seq.s, ks->seq.l);
-    s->qual    = ks->qual.l ? fr_dup_field(ks->qual.s, ks->qual.l) : 0;
-    s->l_seq   = (int)ks->seq.l;
+    size_t name_l = fr_trim_readno_len(r->name, r->name_l);
+    s->name    = fr_dup_field(r->name, name_l);
+    s->comment = r->comment_l ? fr_dup_field(r->comment, r->comment_l) : 0;
+    s->seq     = fr_dup_field(r->seq, r->seq_l);
+    s->qual    = r->qual_l ? fr_dup_field(r->qual, r->qual_l) : 0;
+    s->l_seq   = (int)r->seq_l;
 }
 
-void *fast_kseq_init(fast_reader_t *fr) { return kseq_init(fr); }
+void *fast_kseq_init(fast_reader_t *fr) { return fr_fastq_init(fr); }
 
-void fast_kseq_destroy(void *ks) { if (ks) kseq_destroy((kseq_t *)ks); }
+void fast_kseq_destroy(void *p) { fr_fastq_destroy((fr_fastq_t *)p); }
 
 bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s)
 {
-    kseq_t *ks = (kseq_t *)ks1_, *ks2 = (kseq_t *)ks2_;
+    fr_fastq_t *p1 = (fr_fastq_t *)ks1_, *p2 = (fr_fastq_t *)ks2_;
     int64_t size = 0, m, n;
     bseq1_t *seqs;
     m = n = 0; seqs = 0;
     for (;;) {
-        /* Tokenize the next record(s). kseq_read does the FASTQ tokenization
-         * (newline scan + copy of each field into its kstring_t) and pulls
-         * bytes through the codec layer, which charges its own read()/inflate
-         * time to the diskwait/decompress timers from inside this call. To make
-         * read_parse account for the tokenization itself (the dominant, formerly
-         * uninstrumented cost), time the whole kseq_read region and subtract the
-         * IO delta the codec already counted. The IO interval is strictly nested
-         * inside this wall bracket, so the remainder is non-negative. */
+        /* Tokenize the next record(s). fr_fastq_next scans record boundaries and
+         * pulls bytes through the codec layer, which charges its read()/inflate
+         * time to the diskwait/decompress timers from inside this call. Time the
+         * whole region and subtract that IO delta so read_parse accounts for the
+         * tokenization (boundary scan + any multi-line compaction). The IO
+         * interval is strictly nested inside the wall bracket, so the remainder
+         * is non-negative. */
         double _tk0 = sp_enabled() ? sp_wall() : 0.0, _io0 = 0.0;
         if (sp_enabled()) { double d, c; sp_read_get(&d, &c, NULL); _io0 = d + c; }
-        int r1 = kseq_read(ks);
-        int r2 = (r1 >= 0 && ks2) ? kseq_read(ks2) : 0;
+        fr_fastq_rec_t r1, r2;
+        int g1 = fr_fastq_next(p1, &r1);
+        int g2 = (g1 == 1 && p2) ? fr_fastq_next(p2, &r2) : 0;
         if (sp_enabled()) {
             double d, c; sp_read_get(&d, &c, NULL);
             sp_read_add(2, (sp_wall() - _tk0) - ((d + c) - _io0));
         }
-        if (r1 < 0) break;                               /* clean EOF on 1st file */
-        if (ks2 && r2 < 0) {                             /* 2nd file has fewer */
+        if (g1 != 1) break;                              /* clean EOF or malformed 1st file */
+        if (p2 && g2 != 1) {                             /* 2nd file has fewer */
             fprintf(stderr, "[W::%s] the 2nd file has fewer sequences.\n", __func__);
             break;
         }
@@ -105,13 +105,11 @@ bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
             seqs = tmp;
         }
         double _tp = sp_enabled() ? sp_wall() : 0.0;
-        fr_trim_readno(&ks->name);
-        fr_kseq2bseq1(ks, &seqs[n]);
+        fr_rec_to_bseq1(&r1, &seqs[n]);
         seqs[n].id = n;
         size += seqs[n++].l_seq;
-        if (ks2) {
-            fr_trim_readno(&ks2->name);
-            fr_kseq2bseq1(ks2, &seqs[n]);
+        if (p2) {
+            fr_rec_to_bseq1(&r2, &seqs[n]);
             seqs[n].id = n;
             size += seqs[n++].l_seq;
         }
@@ -119,7 +117,8 @@ bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
         if (size >= chunk_size && (n & 1) == 0) break;   /* even-parity cut, all modes */
     }
     if (size == 0) {                                      /* 1st file has fewer */
-        if (ks2 && kseq_read(ks2) >= 0)
+        fr_fastq_rec_t rr;
+        if (p2 && fr_fastq_next(p2, &rr) == 1)
             fprintf(stderr, "[W::%s] the 1st file has fewer sequences.\n", __func__);
     }
     *n_ = n;

--- a/src/fast_reader_bseq.c
+++ b/src/fast_reader_bseq.c
@@ -15,23 +15,49 @@
  * instantiation used elsewhere. */
 KSEQ_INIT(fast_reader_t *, fast_reader_read)
 
-/* trim_readno / kseq2bseq1 mirror the static helpers in bwa.cpp exactly:
- * strip a trailing /<digit> for any digit; per-field strdup; qual==NULL when
- * empty; zero the struct first (the output loop free()s every field). */
+/* fr_trim_readno mirrors the static helper in bwa.cpp exactly: strip a trailing
+ * /<digit> for any digit. It runs BEFORE the copy and shortens ks->name.l, so
+ * fr_kseq2bseq1 must read the live kseq length rather than re-scanning. */
 static inline void fr_trim_readno(kstring_t *s)
 {
     if (s->l > 2 && s->s[s->l - 2] == '/' && isdigit((unsigned char)s->s[s->l - 1]))
         s->l -= 2, s->s[s->l] = 0;
 }
 
+/* Length-aware field copy: malloc(len+1)+memcpy using the kseq-known length,
+ * avoiding strdup's internal strlen scan on the hot path. The kseq source is
+ * already NUL-terminated at .l; we set dst[len] explicitly so the copy is
+ * NUL-terminated regardless. Aborts on OOM to match the house style of failing
+ * loudly on allocation failure (see the realloc in bseq_read_fast below). */
+static inline char *fr_dup_field(const char *src, size_t len)
+{
+    char *dst = (char *)malloc(len + 1);
+    if (dst == NULL)
+        err_fatal(__func__, "failed to allocate %zu bytes for a read field", len + 1);
+    memcpy(dst, src, len);
+    dst[len] = '\0';
+    return dst;
+}
+
+/* fr_kseq2bseq1 produces output identical to bwa.cpp's kseq2bseq1, but copies
+ * each field with its kseq-known length (ks->*.l) so the copy never scans for a
+ * terminator, and takes l_seq from ks->seq.l directly. qual==NULL when empty.
+ *
+ * The leading memset is retained on purpose and is NOT the cost the strlen
+ * removal targets: bseq_read_fast grows `seqs` with realloc, which leaves new
+ * entries uninitialized, and the output loop in fastmap.cpp free()s sam/bams
+ * unconditionally — so every field must start well-defined. Zeroing the whole
+ * struct (rather than hand-listing sam/bams/n_bams/cap_bams) stays correct if a
+ * field is ever added to bseq1_t, matching the documented rationale on the
+ * bwa.cpp sibling. id is overwritten by the caller. */
 static inline void fr_kseq2bseq1(const kseq_t *ks, bseq1_t *s)
 {
     memset(s, 0, sizeof(*s));
-    s->name    = strdup(ks->name.s);
-    s->comment = ks->comment.l ? strdup(ks->comment.s) : 0;
-    s->seq     = strdup(ks->seq.s);
-    s->qual    = ks->qual.l ? strdup(ks->qual.s) : 0;
-    s->l_seq   = strlen(s->seq);
+    s->name    = fr_dup_field(ks->name.s, ks->name.l);
+    s->comment = ks->comment.l ? fr_dup_field(ks->comment.s, ks->comment.l) : 0;
+    s->seq     = fr_dup_field(ks->seq.s, ks->seq.l);
+    s->qual    = ks->qual.l ? fr_dup_field(ks->qual.s, ks->qual.l) : 0;
+    s->l_seq   = (int)ks->seq.l;
 }
 
 void *fast_kseq_init(fast_reader_t *fr) { return kseq_init(fr); }

--- a/src/fast_reader_bseq.h
+++ b/src/fast_reader_bseq.h
@@ -1,7 +1,7 @@
-/* Adapter: kseq parser over a fast_reader, producing bseq1_t chunks with the
- * exact contract of bseq_read_orig (same chunking, parity, trim, per-field
- * allocation). Kept in its own translation unit because kseq.h can only be
- * instantiated for one handle type per TU. */
+/* Adapter: fr_fastq parser over a fast_reader, producing bseq1_t chunks with
+ * the exact contract of bseq_read_orig (same chunking, parity, trim, per-field
+ * allocation) — byte-identical to the former kseq path. The handle names below
+ * are kept for the pipeline call sites; the opaque handle is an fr_fastq_t*. */
 #ifndef FAST_READER_BSEQ_H
 #define FAST_READER_BSEQ_H
 
@@ -12,18 +12,17 @@
 extern "C" {
 #endif
 
-/* Create a kseq bound to an already-open fast_reader, returned as an opaque
- * kseq_t*. `fr` must be non-NULL and outlive the returned handle (the kseq
+/* Create a parser bound to an already-open fast_reader, returned as an opaque
+ * handle. `fr` must be non-NULL and outlive the returned handle (the parser
  * borrows it; it does not take ownership and fast_kseq_destroy does NOT close
- * the underlying fast_reader). Returns the handle; never returns NULL on the
- * caller-visible path (the underlying kseq_init allocates with calloc and the
- * fast_reader is assumed valid). */
+ * the underlying fast_reader). Never returns NULL on the caller-visible path
+ * (it aborts on allocation failure). */
 void *fast_kseq_init(fast_reader_t *fr);
 
-/* Destroy a handle from fast_kseq_init. `ks` may be NULL (no-op). Frees only
- * the kseq buffers; the caller still owns and must close the fast_reader the
+/* Destroy a handle from fast_kseq_init. `p` may be NULL (no-op). Frees only the
+ * parser buffers; the caller still owns and must close the fast_reader the
  * handle was bound to. */
-void  fast_kseq_destroy(void *ks);
+void  fast_kseq_destroy(void *p);
 
 /* Mirror of bseq_read_orig, reading from fast_reader-backed kseq handles.
  * Reads up to ~chunk_size bytes of sequence (cut on an even record boundary)

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1661,6 +1661,17 @@ int main_mem(int argc, char *argv[])
     }
     tprof[MISC][1] = opt->chunk_size = aux.actual_chunk_size = aux.task_size;
 
+    /* Pipeline depth. The 3-step pipeline (read / process / write) is gated by
+     * how many of those steps can run at once. With 2 workers only 2 of the 3
+     * run concurrently, so the single I/O-side worker serialises read(N+1) and
+     * write(N-1) around the compute worker; at high thread counts that
+     * read+write chain, not compute, binds the wall. A 3rd worker lets
+     * read || process || write triple-overlap. It is not oversubscription: the
+     * step mutex still admits only one worker into the compute step at a time,
+     * so the extra worker only ever does single-threaded I/O. Cost is one more
+     * chunk in flight. -1 (no_mt_io) forces single-threaded I/O as before. */
+    const int pipe_workers = no_mt_io ? 1 : (opt->n_threads > 2 ? 3 : opt->n_threads);
+
     double sp_t0 = 0.0;
 #ifdef STAGE_PROF
     /* stage_prof: arm per-chunk read/process/write profiling if --profile given */
@@ -1677,7 +1688,7 @@ int main_mem(int argc, char *argv[])
         sp_init(profile_path, "bwa-mem3", PACKAGE_VERSION, sp_arch, opt->n_threads,
                 opt->bam_mode ? "bam" : "sam",
                 opt->bam_mode ? opt->bam_level : -1, sp_in);
-        sp_set_workers(no_mt_io ? 1 : 2);   /* pipeline depth (process() arg) */
+        sp_set_workers(pipe_workers);   /* pipeline depth (process() arg) */
         sp_t0 = sp_wall();
     }
 #endif
@@ -1685,7 +1696,7 @@ int main_mem(int argc, char *argv[])
     tim = __rdtsc();
 
     /* Relay process function */
-    process(&aux, fp, fp2, no_mt_io? 1:2);
+    process(&aux, fp, fp2, pipe_workers);
 
     tprof[PROCESS][0] += __rdtsc() - tim;
 

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1653,11 +1653,28 @@ int main_mem(int argc, char *argv[])
     }
 #endif
 
-    if (fixed_chunk_size > 0)
+    if (fixed_chunk_size > 0) {
+        /* -K: the user pinned the batch size (for reproducibility) — honor it
+         * exactly, never cap. */
         aux.task_size = fixed_chunk_size;
-    else {
-        //aux.task_size = 10000000 * opt->n_threads; //aux.actual_chunk_size;
-        aux.task_size = opt->chunk_size * opt->n_threads; //aux.actual_chunk_size;
+    } else {
+        /* Default batch size is chunk_size (~10M bases) per thread. That keeps
+         * each thread well-fed, but at very high -t it makes a single chunk
+         * enormous (10M * 192 ~= 1.9G bases), so the input is only ~3-4 chunks
+         * and the pipeline starves: the first chunk's read and the last chunk's
+         * write don't overlap anything, leaving cores idle (fill/drain). Cap the
+         * default so high -t still produces enough chunks to keep read/compute/
+         * write overlapped, while keeping each chunk far above the ~33k-pairs
+         * floor below which per-chunk overhead (pestat/barriers) starts to bite.
+         * Output stays identical for -t small enough that the cap doesn't engage
+         * (scaled <= cap); above that, batch composition changes exactly as -K
+         * would (validated to leave proper-pair rate unchanged). The cap is
+         * overridable via BWA_MEM3_CHUNK_CAP (bases; <=0 disables, for sweeps). */
+        int64_t cap = 256000000;
+        const char *cap_env = getenv("BWA_MEM3_CHUNK_CAP");
+        if (cap_env && *cap_env) cap = (int64_t)atoll(cap_env);
+        int64_t scaled = (int64_t)opt->chunk_size * (int64_t)opt->n_threads;
+        aux.task_size = (cap > 0 && scaled > cap) ? cap : scaled;
     }
     tprof[MISC][1] = opt->chunk_size = aux.actual_chunk_size = aux.task_size;
 

--- a/src/fr_fastq.c
+++ b/src/fr_fastq.c
@@ -1,0 +1,246 @@
+/* fr_fastq: single-copy FASTQ/FASTA parser over a fast_reader byte source.
+ *
+ * Strategy: keep a large refillable buffer and guarantee the *whole* current
+ * record is resident before handing back field slices. For the dominant case
+ * (single-line FASTQ/FASTA) every field is then a contiguous run in that buffer,
+ * so the caller copies each field exactly once (no kstring_t intermediate).
+ * Multi-line seq/qual are the only case that needs concatenation; those are
+ * compacted into a small scratch buffer, matching what kseq did anyway.
+ *
+ * The grammar mirrors kseq exactly for realistic inputs (see the differential
+ * test test/fr_fastq_diff_test.c). Pathological shapes that never occur in real
+ * FASTQ (e.g. a bare "\r" line inside a sequence) are out of scope; the
+ * --legacy-reader path retains exact kseq behavior for anyone who needs it.
+ */
+#include "fr_fastq.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FR_FASTQ_BUF_INIT (1u << 20)   /* 1 MiB; a record almost always fits */
+#define FR_FASTQ_READ_MAX (1u << 20)   /* cap a single fast_reader_read */
+
+/* scan_record return sentinel: the record is not yet fully buffered. */
+#define FR_UNDERRUN (-3)
+
+struct fr_fastq {
+    fast_reader_t *fr;             /* borrowed byte source */
+    unsigned char *buf;            /* refillable read buffer */
+    size_t cap, beg, end;          /* capacity, parse cursor, valid byte count */
+    int    eof;                    /* fast_reader_read returned 0 */
+    int    err;                    /* fast_reader_read returned -1 (decode error) */
+    /* scratch for assembling multi-line seq/qual (allocation persists across
+     * records; the used length is recomputed per record). */
+    unsigned char *seq_scr;  size_t seq_scr_cap;
+    unsigned char *qual_scr; size_t qual_scr_cap;
+};
+
+static void *xrealloc(void *p, size_t n)
+{
+    void *q = realloc(p, n);
+    if (q == NULL) { abort(); }   /* OOM on the read path is unrecoverable */
+    return q;
+}
+
+fr_fastq_t *fr_fastq_init(fast_reader_t *fr)
+{
+    fr_fastq_t *p = (fr_fastq_t *)calloc(1, sizeof(*p));
+    if (p == NULL) abort();
+    p->fr  = fr;
+    p->cap = FR_FASTQ_BUF_INIT;
+    /* Test-only: shrink the initial buffer so the differential test can drive
+     * mid-record underruns and buffer growth at every byte boundary. Never set
+     * in production; the buffer still grows to fit any record either way. */
+    const char *tc = getenv("FR_FASTQ_TEST_BUFSZ");
+    if (tc && *tc) { long v = atol(tc); if (v > 0) p->cap = (size_t)v; }
+    p->buf = (unsigned char *)xrealloc(NULL, p->cap);
+    return p;
+}
+
+void fr_fastq_destroy(fr_fastq_t *p)
+{
+    if (!p) return;
+    free(p->buf); free(p->seq_scr); free(p->qual_scr);
+    free(p);
+}
+
+/* Pull more bytes in: drop the consumed prefix [0, beg), then read into the
+ * tail, growing the buffer if a single record fills it. Returns bytes read
+ * (0 at EOF, -1 on decode error). */
+static int fr_refill(fr_fastq_t *p)
+{
+    if (p->beg > 0) {
+        memmove(p->buf, p->buf + p->beg, p->end - p->beg);
+        p->end -= p->beg;
+        p->beg  = 0;
+    }
+    if (p->end == p->cap) {        /* record larger than the buffer: grow */
+        p->cap *= 2;
+        p->buf  = (unsigned char *)xrealloc(p->buf, p->cap);
+    }
+    size_t want = p->cap - p->end;
+    if (want > FR_FASTQ_READ_MAX) want = FR_FASTQ_READ_MAX;
+    int got = fast_reader_read(p->fr, p->buf + p->end, (int)want);
+    if (got < 0) { p->err = 1; return -1; }
+    if (got == 0) p->eof = 1;
+    else          p->end += (size_t)got;
+    return got;
+}
+
+/* Append n bytes to a scratch buffer, growing as needed. */
+static void scr_put(unsigned char **bufp, size_t *capp, size_t *lenp,
+                    const unsigned char *src, size_t n)
+{
+    if (*lenp + n > *capp) {
+        size_t ncap = *capp ? *capp : 256;
+        while (ncap < *lenp + n) ncap *= 2;
+        *bufp = (unsigned char *)xrealloc(*bufp, ncap);
+        *capp = ncap;
+    }
+    memcpy(*bufp + *lenp, src, n);
+    *lenp += n;
+}
+
+/* Length of a line's content with a single trailing '\r' dropped, matching
+ * kseq's KS_SEP_LINE rule: strip only when the copied run (which includes the
+ * '\r') is longer than one byte. */
+static size_t line_content_len(const unsigned char *s, size_t raw_len)
+{
+    if (raw_len > 1 && s[raw_len - 1] == '\r') return raw_len - 1;
+    return raw_len;
+}
+
+/* Attempt to parse one record entirely out of the resident buffer.
+ *   1           -> *rec filled, *new_beg = byte after the record
+ *   0           -> clean EOF
+ *   -2          -> malformed (matches kseq_read's -2)
+ *   FR_UNDERRUN -> the record is not fully buffered yet (caller refills) */
+static int scan_record(fr_fastq_t *p, fr_fastq_rec_t *rec, size_t *new_beg)
+{
+    const unsigned char *b = p->buf;
+    const size_t end = p->end;
+
+    /* Phase 1: skip to a header line. Junk/blank lines before it are consumed
+     * for good, so advance beg past them. */
+    while (p->beg < end && b[p->beg] != '>' && b[p->beg] != '@') p->beg++;
+    if (p->beg >= end) return p->eof ? 0 : FR_UNDERRUN;
+
+    const int is_fastq_marker = (b[p->beg] == '@');
+    size_t i = p->beg + 1;        /* first byte after the header char */
+
+    /* name: up to the first whitespace (kseq KS_SEP_SPACE). */
+    size_t name_s = i;
+    while (i < end && !isspace(b[i])) i++;
+    if (i >= end && !p->eof) return FR_UNDERRUN;
+    size_t name_e = i;
+
+    /* comment: present iff the name stopped at a non-newline whitespace. */
+    size_t com_s = name_e, com_e = name_e;
+    size_t after_header;          /* first byte of the line below the header */
+    if (i < end && b[i] != '\n') {
+        size_t cs = i + 1, j = cs;
+        while (j < end && b[j] != '\n') j++;
+        if (j >= end && !p->eof) return FR_UNDERRUN;
+        com_s = cs;
+        com_e = cs + line_content_len(b + cs, j - cs);
+        after_header = (j < end) ? j + 1 : end;
+    } else {
+        after_header = (i < end) ? i + 1 : end;
+    }
+
+    /* seq: sequence lines (newlines stripped) until the next header or '+'. */
+    size_t k = after_header;
+    size_t seq_s = after_header, seq_e = after_header;  /* single-line fast path */
+    size_t seq_len = 0; int seq_lines = 0;
+    unsigned char term = 0;       /* 0 = EOF, else '>' '@' '+' */
+    for (;;) {
+        if (k >= end) { if (p->eof) break; else return FR_UNDERRUN; }
+        unsigned char c = b[k];
+        if (c == '>' || c == '@' || c == '+') { term = c; break; }
+        if (c == '\n') { k++; continue; }        /* skip empty lines */
+        size_t ls = k;
+        while (k < end && b[k] != '\n') k++;
+        if (k >= end && !p->eof) return FR_UNDERRUN;
+        size_t clen = line_content_len(b + ls, k - ls);
+        if (seq_lines == 0) { seq_s = ls; seq_e = ls + clen; }
+        else {
+            if (seq_lines == 1) {                /* promote first line to scratch */
+                size_t l = 0;
+                scr_put(&p->seq_scr, &p->seq_scr_cap, &l, b + seq_s, seq_e - seq_s);
+                seq_len = l;
+            }
+            scr_put(&p->seq_scr, &p->seq_scr_cap, &seq_len, b + ls, clen);
+        }
+        if (seq_lines == 0) seq_len = clen;
+        seq_lines++;
+        if (k < end) k++;                        /* step past '\n' */
+    }
+
+    rec->name    = (const char *)(b + name_s);
+    rec->name_l  = name_e - name_s;
+    rec->comment = (const char *)(b + com_s);
+    rec->comment_l = com_e - com_s;
+    if (seq_lines <= 1) { rec->seq = (const char *)(b + seq_s); }
+    else                { rec->seq = (const char *)p->seq_scr; }
+    rec->seq_l = seq_len;
+
+    if (term != '+') {            /* FASTA (or EOF): no quality */
+        (void)is_fastq_marker;
+        rec->qual = NULL; rec->qual_l = 0;
+        *new_beg = k;             /* leave the next header unconsumed */
+        return 1;
+    }
+
+    /* skip the '+' separator line. */
+    size_t pl = k;
+    while (pl < end && b[pl] != '\n') pl++;
+    if (pl >= end && !p->eof) return FR_UNDERRUN;
+    if (pl >= end) return -2;     /* '+' line with no newline and no quality */
+    size_t m = pl + 1;
+
+    /* qual: quality lines accumulated until they reach the sequence length
+     * (kseq reads at least one line, then stops once qual.l >= seq.l). */
+    size_t qual_s = m, qual_e = m, qual_len = 0; int qual_lines = 0;
+    for (;;) {
+        if (m >= end) { if (p->eof) break; else return FR_UNDERRUN; }
+        size_t ls = m;
+        while (m < end && b[m] != '\n') m++;
+        if (m >= end && !p->eof) return FR_UNDERRUN;
+        size_t clen = line_content_len(b + ls, m - ls);
+        if (qual_lines == 0) { qual_s = ls; qual_e = ls + clen; }
+        else {
+            if (qual_lines == 1) {
+                size_t l = 0;
+                scr_put(&p->qual_scr, &p->qual_scr_cap, &l, b + qual_s, qual_e - qual_s);
+                qual_len = l;
+            }
+            scr_put(&p->qual_scr, &p->qual_scr_cap, &qual_len, b + ls, clen);
+        }
+        if (qual_lines == 0) qual_len = clen;
+        qual_lines++;
+        if (m < end) m++;                        /* step past '\n' */
+        if (qual_len >= seq_len) break;
+    }
+    if (qual_len != seq_len) return -2;          /* kseq: seq.l != qual.l */
+
+    if (qual_lines <= 1) { rec->qual = (const char *)(b + qual_s); }
+    else                 { rec->qual = (const char *)p->qual_scr; }
+    rec->qual_l = qual_len;
+    *new_beg = m;
+    return 1;
+}
+
+int fr_fastq_next(fr_fastq_t *p, fr_fastq_rec_t *rec)
+{
+    for (;;) {
+        size_t new_beg = p->beg;
+        int r = scan_record(p, rec, &new_beg);
+        if (r != FR_UNDERRUN) {
+            if (r == 1) p->beg = new_beg;
+            return r;
+        }
+        if (fr_refill(p) < 0) return -2;         /* decode error: stop the batch */
+        /* on EOF, scan_record will now resolve (no more underruns possible). */
+    }
+}

--- a/src/fr_fastq.c
+++ b/src/fr_fastq.c
@@ -111,6 +111,15 @@ static size_t line_content_len(const unsigned char *s, size_t raw_len)
     return raw_len;
 }
 
+/* Index of the next '\n' in b[from..end), or `end` if none. memchr is the
+ * libc-vectorised newline scan (NEON/SSE/AVX) — the sequence and quality lines
+ * are the dominant scan cost, so this is where the speedup lives. */
+static inline size_t find_nl(const unsigned char *b, size_t from, size_t end)
+{
+    const unsigned char *nl = (const unsigned char *)memchr(b + from, '\n', end - from);
+    return nl ? (size_t)(nl - b) : end;
+}
+
 /* Attempt to parse one record entirely out of the resident buffer.
  *   1           -> *rec filled, *new_beg = byte after the record
  *   0           -> clean EOF
@@ -139,8 +148,7 @@ static int scan_record(fr_fastq_t *p, fr_fastq_rec_t *rec, size_t *new_beg)
     size_t com_s = name_e, com_e = name_e;
     size_t after_header;          /* first byte of the line below the header */
     if (i < end && b[i] != '\n') {
-        size_t cs = i + 1, j = cs;
-        while (j < end && b[j] != '\n') j++;
+        size_t cs = i + 1, j = find_nl(b, cs, end);
         if (j >= end && !p->eof) return FR_UNDERRUN;
         com_s = cs;
         com_e = cs + line_content_len(b + cs, j - cs);
@@ -160,7 +168,7 @@ static int scan_record(fr_fastq_t *p, fr_fastq_rec_t *rec, size_t *new_beg)
         if (c == '>' || c == '@' || c == '+') { term = c; break; }
         if (c == '\n') { k++; continue; }        /* skip empty lines */
         size_t ls = k;
-        while (k < end && b[k] != '\n') k++;
+        k = find_nl(b, k, end);
         if (k >= end && !p->eof) return FR_UNDERRUN;
         size_t clen = line_content_len(b + ls, k - ls);
         if (seq_lines == 0) { seq_s = ls; seq_e = ls + clen; }
@@ -193,8 +201,7 @@ static int scan_record(fr_fastq_t *p, fr_fastq_rec_t *rec, size_t *new_beg)
     }
 
     /* skip the '+' separator line. */
-    size_t pl = k;
-    while (pl < end && b[pl] != '\n') pl++;
+    size_t pl = find_nl(b, k, end);
     if (pl >= end && !p->eof) return FR_UNDERRUN;
     if (pl >= end) return -2;     /* '+' line with no newline and no quality */
     size_t m = pl + 1;
@@ -205,7 +212,7 @@ static int scan_record(fr_fastq_t *p, fr_fastq_rec_t *rec, size_t *new_beg)
     for (;;) {
         if (m >= end) { if (p->eof) break; else return FR_UNDERRUN; }
         size_t ls = m;
-        while (m < end && b[m] != '\n') m++;
+        m = find_nl(b, m, end);
         if (m >= end && !p->eof) return FR_UNDERRUN;
         size_t clen = line_content_len(b + ls, m - ls);
         if (qual_lines == 0) { qual_s = ls; qual_e = ls + clen; }

--- a/src/fr_fastq.h
+++ b/src/fr_fastq.h
@@ -1,0 +1,69 @@
+/* fr_fastq: a single-copy FASTQ/FASTA parser over a fast_reader byte source.
+ *
+ * Replaces the kseq layer on the read hot path. kseq copies every field twice
+ * (codec buffer -> kstring_t, then kstring_t -> bseq1_t); this parser slices
+ * records directly out of its own refillable buffer so the caller copies each
+ * field exactly once (or, for #2, defers the copy to a worker thread).
+ *
+ * The grammar matches kseq's exactly so output is byte-identical:
+ *   - record starts at '>' (FASTA) or '@' (FASTQ); leading junk before the
+ *     first header is skipped, as are blank lines between records;
+ *   - name = bytes up to the first whitespace; comment = the rest of that line
+ *     (empty if the name ran to end-of-line), with a single trailing '\r'
+ *     dropped when the line has more than one byte;
+ *   - seq = the sequence line(s), newlines removed, up to the next header or
+ *     the '+' separator; CRLF endings are normalised the same way kseq does;
+ *   - qual (FASTQ only) = quality line(s) accumulated until they match the
+ *     sequence length.
+ *
+ * Slice pointers returned by fr_fastq_next() reference parser-internal storage
+ * and are valid only until the next fr_fastq_next() / fr_fastq_destroy() call.
+ */
+#ifndef FR_FASTQ_H
+#define FR_FASTQ_H
+
+#include <stddef.h>
+
+#include "fast_reader.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct fr_fastq fr_fastq_t;
+
+/* One parsed record. Lengths are exact; pointers are NOT guaranteed to be
+ * NUL-terminated. comment_l == 0 means "no comment" (mirrors kseq's
+ * comment.l == 0). qual_l == 0 means no quality (FASTA, or an empty record);
+ * downstream should treat comment/qual as absent when their length is 0, which
+ * reproduces fr_kseq2bseq1's `comment.l ? ... : 0` / `qual.l ? ... : 0`. */
+typedef struct {
+    const char *name;    size_t name_l;
+    const char *comment; size_t comment_l;
+    const char *seq;     size_t seq_l;
+    const char *qual;    size_t qual_l;
+} fr_fastq_rec_t;
+
+/* Bind a parser to an already-open fast_reader. `fr` is borrowed: it must
+ * outlive the parser and is NOT closed by fr_fastq_destroy. Aborts on OOM. */
+fr_fastq_t *fr_fastq_init(fast_reader_t *fr);
+
+/* Free the parser's buffers. `p` may be NULL. Does not close the fast_reader. */
+void fr_fastq_destroy(fr_fastq_t *p);
+
+/* Parse the next record into *rec.
+ *   returns 1  -> a record was parsed; slices in *rec are valid until the next call
+ *   returns 0  -> clean end of input
+ *   returns -2 -> either a malformed record (matches kseq_read's -2: a '+' line
+ *                 with no quality, or a quality string whose length never reaches
+ *                 the sequence length) OR an upstream decode/read failure from the
+ *                 underlying fast_reader. The caller cannot distinguish the two and
+ *                 stops the batch in both cases, as the kseq path did via
+ *                 `kseq_read(...) >= 0`. */
+int fr_fastq_next(fr_fastq_t *p, fr_fastq_rec_t *rec);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FR_FASTQ_H */

--- a/test/fr_fastq_bench.c
+++ b/test/fr_fastq_bench.c
@@ -1,0 +1,131 @@
+/* Read+parse microbenchmark: kseq path vs fr_fastq path, on a real FASTQ.
+ *
+ * Isolates exactly what the single-copy parser changed — decompress (identical
+ * in both modes) + tokenize + field copy into bseq1-style allocations — with no
+ * index load or alignment, so it runs in ~1s/rep and the delta between modes is
+ * the parse change alone.
+ *
+ *   mode kseq    : kseq_read + (trim_readno + per-field copy), then free
+ *   mode frfastq : fr_fastq_next + (trim_readno + per-field copy), then free
+ *
+ * Build:
+ *   cc -O2 -Wall -Wextra -Isrc test/fr_fastq_bench.c src/fr_fastq.c src/fast_reader.c \
+ *      -lz -ldeflate -o fr_fastq_bench
+ * Run:  ./fr_fastq_bench {kseq|frfastq} reads.fq.gz [reps]
+ */
+#include "fast_reader.h"
+#include "fr_fastq.h"
+#include "kseq.h"
+
+#include <ctype.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+KSEQ_INIT(fast_reader_t *, fast_reader_read)
+
+int    sp_enabled(void) { return 0; }
+double sp_wall(void) { return 0.0; }
+void   sp_read_add(int w, double s) { (void)w; (void)s; }
+void   sp_read_bytes(long a, long b) { (void)a; (void)b; }
+
+static double now(void)
+{
+    struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t);
+    return (double)t.tv_sec + (double)t.tv_nsec * 1e-9;
+}
+
+/* Mirror the real per-field copy: malloc(l+1)+memcpy, no strlen. */
+static char *dup_field(const char *s, size_t l)
+{
+    char *d = (char *)malloc(l + 1);
+    if (!d) abort();
+    memcpy(d, s, l); d[l] = '\0';
+    return d;
+}
+static size_t trim_readno_len(const char *name, size_t l)
+{
+    if (l > 2 && name[l - 2] == '/' && isdigit((unsigned char)name[l - 1])) return l - 2;
+    return l;
+}
+
+/* Consume one batch's worth of allocations exactly as the pipeline would: name,
+ * comment, seq, qual malloc'd then freed. Returns reads + bases via *nb. */
+static long run_kseq(const char *path, long *bases)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) { perror("open"); exit(2); }
+    const char *err = NULL;
+    fast_reader_t *fr = fast_reader_dopen(fd, &err);
+    if (!fr) { fprintf(stderr, "open fail: %s\n", err ? err : "?"); exit(2); }
+    kseq_t *ks = kseq_init(fr);
+    long n = 0, bp = 0;
+    while (kseq_read(ks) >= 0) {
+        size_t nl = trim_readno_len(ks->name.s, ks->name.l);
+        char *name = dup_field(ks->name.s, nl);
+        char *comment = ks->comment.l ? dup_field(ks->comment.s, ks->comment.l) : NULL;
+        char *seq = dup_field(ks->seq.s, ks->seq.l);
+        char *qual = ks->qual.l ? dup_field(ks->qual.s, ks->qual.l) : NULL;
+        bp += (long)ks->seq.l; n++;
+        free(name); free(comment); free(seq); free(qual);
+    }
+    kseq_destroy(ks); fast_reader_close(fr);
+    *bases = bp; return n;
+}
+
+static long run_frfastq(const char *path, long *bases)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) { perror("open"); exit(2); }
+    const char *err = NULL;
+    fast_reader_t *fr = fast_reader_dopen(fd, &err);
+    if (!fr) { fprintf(stderr, "open fail: %s\n", err ? err : "?"); exit(2); }
+    fr_fastq_t *p = fr_fastq_init(fr);
+    long n = 0, bp = 0;
+    fr_fastq_rec_t r;
+    while (fr_fastq_next(p, &r) == 1) {
+        size_t nl = trim_readno_len(r.name, r.name_l);
+        char *name = dup_field(r.name, nl);
+        char *comment = r.comment_l ? dup_field(r.comment, r.comment_l) : NULL;
+        char *seq = dup_field(r.seq, r.seq_l);
+        char *qual = r.qual_l ? dup_field(r.qual, r.qual_l) : NULL;
+        bp += (long)r.seq_l; n++;
+        free(name); free(comment); free(seq); free(qual);
+    }
+    fr_fastq_destroy(p); fast_reader_close(fr);
+    *bases = bp; return n;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 3) { fprintf(stderr, "usage: %s {kseq|frfastq} reads.fq[.gz] [reps]\n", argv[0]); return 2; }
+    const char *mode = argv[1], *path = argv[2];
+    int reps = 5;
+    if (argc > 3) {
+        char *end = NULL;
+        long v = strtol(argv[3], &end, 10);
+        if (!end || *end != '\0' || v < 1 || v > INT_MAX) {
+            fprintf(stderr, "invalid reps: %s\n", argv[3]);
+            return 2;
+        }
+        reps = (int)v;
+    }
+    int use_kseq = strcmp(mode, "kseq") == 0;
+    if (!use_kseq && strcmp(mode, "frfastq") != 0) { fprintf(stderr, "bad mode\n"); return 2; }
+
+    double best = 1e30; long n = 0, bp = 0;
+    for (int i = 0; i < reps; i++) {
+        double t0 = now();
+        n = use_kseq ? run_kseq(path, &bp) : run_frfastq(path, &bp);
+        double dt = now() - t0;
+        if (dt < best) best = dt;
+        fprintf(stderr, "  rep %d: %.4fs  (%.1f Mreads/s)\n", i, dt, n / dt / 1e6);
+    }
+    fprintf(stdout, "%-8s best=%.4fs  reads=%ld  bp=%ld  %.2f Mreads/s  %.1f MB/s\n",
+            mode, best, n, bp, n / best / 1e6, bp / best / 1e6);
+    return 0;
+}

--- a/test/fr_fastq_bench.c
+++ b/test/fr_fastq_bench.c
@@ -77,7 +77,19 @@ static long run_kseq(const char *path, long *bases)
     *bases = bp; return n;
 }
 
-static long run_frfastq(const char *path, long *bases)
+/* malloc(l+1) + free, no memcpy: isolates allocation cost. A single touch
+ * keeps the optimizer from eliding the allocation. */
+static volatile char g_sink;
+static void alloc_field(size_t l)
+{
+    char *d = (char *)malloc(l + 1);
+    if (!d) abort();
+    d[0] = (char)l; g_sink = d[0];
+    free(d);
+}
+
+/* level: 0 = scan only, 1 = scan + alloc (no copy), 2 = scan + alloc + copy. */
+static long run_frfastq(const char *path, long *bases, int level)
 {
     int fd = open(path, O_RDONLY);
     if (fd < 0) { perror("open"); exit(2); }
@@ -89,12 +101,21 @@ static long run_frfastq(const char *path, long *bases)
     fr_fastq_rec_t r;
     while (fr_fastq_next(p, &r) == 1) {
         size_t nl = trim_readno_len(r.name, r.name_l);
-        char *name = dup_field(r.name, nl);
-        char *comment = r.comment_l ? dup_field(r.comment, r.comment_l) : NULL;
-        char *seq = dup_field(r.seq, r.seq_l);
-        char *qual = r.qual_l ? dup_field(r.qual, r.qual_l) : NULL;
+        if (level == 2) {
+            char *name = dup_field(r.name, nl);
+            char *comment = r.comment_l ? dup_field(r.comment, r.comment_l) : NULL;
+            char *seq = dup_field(r.seq, r.seq_l);
+            char *qual = r.qual_l ? dup_field(r.qual, r.qual_l) : NULL;
+            free(name); free(comment); free(seq); free(qual);
+        } else if (level == 1) {
+            alloc_field(nl);
+            if (r.comment_l) alloc_field(r.comment_l);
+            alloc_field(r.seq_l);
+            if (r.qual_l) alloc_field(r.qual_l);
+        } else {
+            g_sink = (char)(nl ^ r.seq_l ^ r.qual_l); /* force the slices to be read */
+        }
         bp += (long)r.seq_l; n++;
-        free(name); free(comment); free(seq); free(qual);
     }
     fr_fastq_destroy(p); fast_reader_close(fr);
     *bases = bp; return n;
@@ -114,13 +135,18 @@ int main(int argc, char **argv)
         }
         reps = (int)v;
     }
+    /* modes: kseq | frfastq(=copy) | fr_scan | fr_alloc | fr_copy */
     int use_kseq = strcmp(mode, "kseq") == 0;
-    if (!use_kseq && strcmp(mode, "frfastq") != 0) { fprintf(stderr, "bad mode\n"); return 2; }
+    int level = 2;
+    if (strcmp(mode, "fr_scan") == 0)  level = 0;
+    else if (strcmp(mode, "fr_alloc") == 0) level = 1;
+    else if (strcmp(mode, "fr_copy") == 0 || strcmp(mode, "frfastq") == 0) level = 2;
+    else if (!use_kseq) { fprintf(stderr, "bad mode\n"); return 2; }
 
     double best = 1e30; long n = 0, bp = 0;
     for (int i = 0; i < reps; i++) {
         double t0 = now();
-        n = use_kseq ? run_kseq(path, &bp) : run_frfastq(path, &bp);
+        n = use_kseq ? run_kseq(path, &bp) : run_frfastq(path, &bp, level);
         double dt = now() - t0;
         if (dt < best) best = dt;
         fprintf(stderr, "  rep %d: %.4fs  (%.1f Mreads/s)\n", i, dt, n / dt / 1e6);

--- a/test/fr_fastq_diff_test.c
+++ b/test/fr_fastq_diff_test.c
@@ -224,7 +224,7 @@ static size_t make_fuzz_payload(char *out, size_t cap)
         out[n++] = fasta ? '>' : '@';
         int namelen = 1 + (int)rnd(20);
         for (int j = 0; j < namelen; j++) out[n++] = (char)('a' + rnd(26));
-        if (rnd(2)) { out[n++] = (char)('/' + rnd(2) * ('1' - '/')); } /* sometimes /x style */
+        if (rnd(2)) { out[n++] = '/'; out[n++] = (char)('1' + rnd(2)); } /* sometimes /1 or /2 */
         if (rnd(3) == 0) { out[n++] = ' '; int cl = (int)rnd(15); for (int j = 0; j < cl; j++) out[n++] = (char)('A' + rnd(40)); }
         out[n++] = '\n';
         int seqlen = (int)rnd(40);

--- a/test/fr_fastq_diff_test.c
+++ b/test/fr_fastq_diff_test.c
@@ -1,0 +1,294 @@
+/* Differential test: fr_fastq must parse byte-identically to kseq.
+ *
+ * kseq is the oracle. For each payload in a deliberately adversarial corpus
+ * (single/multi-line FASTQ and FASTA, comments, CRLF, blank lines, missing
+ * trailing newline, leading junk, truncated quality), we parse the same bytes
+ * through kseq and through fr_fastq and assert that every record's
+ * name/comment/seq/qual (length AND bytes) matches, and that both stop after
+ * the same number of records (so the -2 malformed cut lines up too).
+ *
+ * Build (standalone — only fr_fastq + fast_reader, no bwa-mem3 link):
+ *   cc -I src test/fr_fastq_diff_test.c src/fr_fastq.c src/fast_reader.c \
+ *      -lz -ldeflate -o fr_fastq_diff_test
+ */
+#include "fast_reader.h"
+#include "fr_fastq.h"
+#include "kseq.h"
+
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+KSEQ_INIT(fast_reader_t *, fast_reader_read)
+
+/* fast_reader.c is instrumented with stage_prof hooks; stub them out so this
+ * standalone parser test links without the bwa-mem3 object graph. sp_enabled()
+ * returning 0 disables every timing path inside fast_reader.c. */
+int    sp_enabled(void) { return 0; }
+double sp_wall(void) { return 0.0; }
+void   sp_read_add(int which, double seconds) { (void)which; (void)seconds; }
+void   sp_read_bytes(long fd_bytes, long bgzf_blocks) { (void)fd_bytes; (void)bgzf_blocks; }
+
+static int g_fail = 0;
+
+/* A field copied out of a parser (both kseq and fr_fastq reuse their buffers
+ * across records, so each record's bytes must be snapshotted immediately). */
+typedef struct { char *s; size_t l; int present; } field_t;
+typedef struct { field_t name, comment, seq, qual; } rec_t;
+
+static field_t dup_field(const char *s, size_t l, int present)
+{
+    field_t f;
+    f.l = l; f.present = present;
+    f.s = (char *)malloc(l + 1);
+    assert(f.s != NULL);
+    if (l) memcpy(f.s, s, l);
+    f.s[l] = '\0';
+    return f;
+}
+
+static void free_rec(rec_t *r)
+{
+    free(r->name.s); free(r->comment.s); free(r->seq.s); free(r->qual.s);
+}
+
+/* Double the record array with overflow- and realloc-failure checks. Both
+ * parsers grow `recs` identically, so this keeps the growth path safe in one
+ * place: a doubling that wraps int, or a byte count that exceeds SIZE_MAX, or a
+ * realloc that fails, all abort rather than under-allocate or leak the original. */
+static rec_t *grow_recs(rec_t *recs, int *cap)
+{
+    int next = (*cap == 0) ? 16 : (*cap * 2);
+    if (next <= *cap) abort();                            /* int overflow */
+    if ((size_t)next > SIZE_MAX / sizeof(*recs)) abort(); /* size overflow */
+    rec_t *tmp = (rec_t *)realloc(recs, (size_t)next * sizeof(*recs));
+    if (!tmp) abort();                                    /* realloc failure */
+    *cap = next;
+    return tmp;
+}
+
+/* Parse via kseq. Mirrors bseq_read_fast's `kseq_read(...) >= 0` stop. */
+static rec_t *parse_kseq(const char *path, int *n_out)
+{
+    int fd = open(path, O_RDONLY);
+    assert(fd >= 0);
+    const char *err = NULL;
+    fast_reader_t *fr = fast_reader_dopen(fd, &err);
+    assert(fr != NULL);
+    kseq_t *ks = kseq_init(fr);
+
+    int cap = 16, n = 0;
+    rec_t *recs = (rec_t *)malloc((size_t)cap * sizeof(*recs));
+    assert(recs != NULL);
+    while (kseq_read(ks) >= 0) {
+        if (n == cap) recs = grow_recs(recs, &cap);
+        recs[n].name    = dup_field(ks->name.s, ks->name.l, 1);
+        recs[n].comment = dup_field(ks->comment.s ? ks->comment.s : "", ks->comment.l, ks->comment.l > 0);
+        recs[n].seq     = dup_field(ks->seq.s, ks->seq.l, 1);
+        recs[n].qual    = dup_field(ks->qual.s ? ks->qual.s : "", ks->qual.l, ks->qual.l > 0);
+        n++;
+    }
+    kseq_destroy(ks);
+    fast_reader_close(fr);
+    *n_out = n;
+    return recs;
+}
+
+/* Parse via fr_fastq. Mirrors the same stop (next() != 1). */
+static rec_t *parse_fr(const char *path, int *n_out)
+{
+    int fd = open(path, O_RDONLY);
+    assert(fd >= 0);
+    const char *err = NULL;
+    fast_reader_t *fr = fast_reader_dopen(fd, &err);
+    assert(fr != NULL);
+    fr_fastq_t *p = fr_fastq_init(fr);
+
+    int cap = 16, n = 0;
+    rec_t *recs = (rec_t *)malloc((size_t)cap * sizeof(*recs));
+    assert(recs != NULL);
+    fr_fastq_rec_t rec;
+    while (fr_fastq_next(p, &rec) == 1) {
+        if (n == cap) recs = grow_recs(recs, &cap);
+        recs[n].name    = dup_field(rec.name, rec.name_l, 1);
+        recs[n].comment = dup_field(rec.comment ? rec.comment : "", rec.comment_l, rec.comment_l > 0);
+        recs[n].seq     = dup_field(rec.seq, rec.seq_l, 1);
+        recs[n].qual    = dup_field(rec.qual ? rec.qual : "", rec.qual_l, rec.qual_l > 0);
+        n++;
+    }
+    fr_fastq_destroy(p);
+    fast_reader_close(fr);
+    *n_out = n;
+    return recs;
+}
+
+static int field_eq(const field_t *a, const field_t *b)
+{
+    /* Only length + bytes matter for byte-identical bseq1_t: a 0-length field
+     * and an absent field both produce a NULL bseq1 pointer downstream. */
+    if (a->l != b->l) return 0;
+    return memcmp(a->s, b->s, a->l) == 0;
+}
+
+static void report_field(const char *which, int rec, const field_t *k, const field_t *f)
+{
+    if (field_eq(k, f)) return;
+    fprintf(stderr, "    rec %d %-7s MISMATCH: kseq(l=%zu)='%s'  fr(l=%zu)='%s'\n",
+            rec, which, k->l, k->s, f->l, f->s);
+}
+
+static void run_case(const char *name, const char *payload, size_t len)
+{
+    char path[] = "/tmp/fr_fastq_diff_XXXXXX";
+    int fd = mkstemp(path);
+    assert(fd >= 0);
+    { size_t off = 0; while (off < len) { ssize_t w = write(fd, payload + off, len - off); assert(w > 0); off += (size_t)w; } }
+    close(fd);
+
+    int nk = 0, nf = 0;
+    rec_t *k = parse_kseq(path, &nk);
+    rec_t *f = parse_fr(path, &nf);
+
+    int ok = 1;
+    if (nk != nf) { ok = 0; fprintf(stderr, "    record count: kseq=%d fr=%d\n", nk, nf); }
+    int n = nk < nf ? nk : nf;
+    for (int i = 0; i < n; i++) {
+        int rec_ok = field_eq(&k[i].name, &f[i].name) && field_eq(&k[i].comment, &f[i].comment)
+                  && field_eq(&k[i].seq, &f[i].seq) && field_eq(&k[i].qual, &f[i].qual);
+        if (!rec_ok) {
+            ok = 0;
+            report_field("name", i, &k[i].name, &f[i].name);
+            report_field("comment", i, &k[i].comment, &f[i].comment);
+            report_field("seq", i, &k[i].seq, &f[i].seq);
+            report_field("qual", i, &k[i].qual, &f[i].qual);
+        }
+    }
+    fprintf(stderr, "%s: %s (%d records)\n", ok ? "ok  " : "FAIL", name, nk);
+    if (!ok) g_fail = 1;
+
+    for (int i = 0; i < nk; i++) free_rec(&k[i]);
+    for (int i = 0; i < nf; i++) free_rec(&f[i]);
+    free(k); free(f);
+    unlink(path);
+}
+
+typedef struct { const char *name; const char *payload; size_t len; } case_t;
+
+#define LIT(name, lit) { (name), (lit), sizeof(lit) - 1 }
+
+static const case_t CASES[] = {
+    LIT("basic single-line FASTQ",
+        "@r1\nACGTACGT\n+\nIIIIIIII\n"
+        "@r2\nTTTTGGGG\n+\nFFFFFFFF\n"
+        "@r3\nCCCCAAAA\n+\n########\n"),
+    LIT("readno suffixes /1 /2",
+        "@read1/1\nACGT\n+\nIIII\n@read1/2\nTTGG\n+\nFFFF\n"),
+    LIT("with comment",
+        "@r1 here is a comment\nACGT\n+\nIIII\n@r2 1:N:0:ACGT\nTTGG\n+\nFFFF\n"),
+    LIT("multiple spaces before comment", "@r1   spaced comment\nACGT\n+\nIIII\n"),
+    LIT("tab before comment",             "@r1\tfield2\tfield3\nACGT\n+\nIIII\n"),
+    LIT("empty comment (trailing space)", "@r1 \nACGT\n+\nIIII\n"),
+    LIT("FASTA single-line",              ">s1\nACGTACGT\n>s2\nTTTTGGGG\n"),
+    LIT("FASTA multi-line seq",           ">s1 desc\nACGT\nTTGG\nCCAA\n>s2\nGGGG\nTTTT\n"),
+    LIT("multi-line FASTQ seq and qual",  "@r1\nACGT\nTTGG\n+\nIIII\nFFFF\n@r2\nCCCC\n+\nHHHH\n"),
+    LIT("CRLF line endings",              "@r1\r\nACGT\r\n+\r\nIIII\r\n@r2\r\nTTGG\r\n+\r\nFFFF\r\n"),
+    LIT("blank lines between records",    "@r1\nACGT\n+\nIIII\n\n@r2\nTTGG\n+\nFFFF\n"),
+    LIT("no trailing newline",            "@r1\nACGT\n+\nIIII\n@r2\nTTGG\n+\nFFFF"),
+    LIT("leading junk before first header", "; comment line\n# another\n@r1\nACGT\n+\nIIII\n"),
+    LIT("lowercase and N in seq",         "@r1\nacgtNNNNACGT\n+\nIIIIIIIIIIII\n"),
+    LIT("qual chars include @ and +",     "@r1\nACGTACGT\n+\n@@++!!~~\n@r2\nTTTTGGGG\n+\n++++@@@@\n"),
+    LIT("plus line with trailing text",   "@r1\nACGT\n+r1 same name\nIIII\n"),
+    LIT("truncated final qual (kseq -2)", "@r1\nACGT\n+\nIIII\n@r2\nACGTACGT\n+\nIIII\n"),
+    LIT("single record, no comment, exact", "@only\nA\n+\nI\n"),
+};
+
+/* Deterministic LCG so the fuzz corpus is reproducible across runs. */
+static unsigned long g_rng = 0x9e3779b97f4a7c15UL;
+static unsigned rnd(unsigned mod) { g_rng = g_rng * 6364136223846793005UL + 1; return (unsigned)((g_rng >> 33) % mod); }
+
+/* Build a payload of random-but-valid FASTQ/FASTA records: varied name, seq and
+ * qual lengths (qual always matches seq), optional comments, occasional FASTA
+ * records. Exercises every field-length boundary against kseq. */
+static size_t make_fuzz_payload(char *out, size_t cap)
+{
+    static const char BASES[] = "ACGTNacgtn";
+    static const char QUALS[] = "!#$%&()*+,-./0123456789:;<=>?@ABCDEFGHIIIII";
+    size_t n = 0;
+    while (n + 1024 < cap) {
+        int fasta = (rnd(5) == 0);
+        out[n++] = fasta ? '>' : '@';
+        int namelen = 1 + (int)rnd(20);
+        for (int j = 0; j < namelen; j++) out[n++] = (char)('a' + rnd(26));
+        if (rnd(2)) { out[n++] = (char)('/' + rnd(2) * ('1' - '/')); } /* sometimes /x style */
+        if (rnd(3) == 0) { out[n++] = ' '; int cl = (int)rnd(15); for (int j = 0; j < cl; j++) out[n++] = (char)('A' + rnd(40)); }
+        out[n++] = '\n';
+        int seqlen = (int)rnd(40);
+        for (int j = 0; j < seqlen; j++) out[n++] = BASES[rnd(sizeof BASES - 1)];
+        out[n++] = '\n';
+        if (!fasta) {
+            out[n++] = '+'; out[n++] = '\n';
+            for (int j = 0; j < seqlen; j++) out[n++] = QUALS[rnd(sizeof QUALS - 1)];
+            out[n++] = '\n';
+        }
+    }
+    return n;
+}
+
+int main(void)
+{
+    const int NCASES = (int)(sizeof(CASES) / sizeof(CASES[0]));
+
+    /* A moderate payload spanning many records, used to stress buffer refills
+     * (small enough to stay fast even at a 1-byte buffer). */
+    size_t big_cap = 200u << 10;
+    char *big = (char *)malloc(big_cap);
+    assert(big != NULL);
+    size_t big_n = 0;
+    for (int i = 0; big_n + 256 < big_cap; i++)
+        big_n += (size_t)snprintf(big + big_n, big_cap - big_n,
+            "@read%d/1 comment %d here\nACGTACGTNNNNacgtACGT\n+\nIIIIIIIIIIIIIIIIIIII\n", i, i);
+
+    /* Run the whole corpus at the default buffer, then at a ladder of tiny
+     * buffer sizes (via the FR_FASTQ_TEST_BUFSZ hook) so every record straddles
+     * the buffer end and the underrun/compact/grow path is exercised at every
+     * byte alignment. */
+    const long bufszs[] = { 0, 1, 2, 3, 5, 7, 16, 64, 4096 };
+    for (size_t bi = 0; bi < sizeof(bufszs) / sizeof(bufszs[0]); bi++) {
+        char val[32];
+        if (bufszs[bi] == 0) unsetenv("FR_FASTQ_TEST_BUFSZ");
+        else { snprintf(val, sizeof val, "%ld", bufszs[bi]); setenv("FR_FASTQ_TEST_BUFSZ", val, 1); }
+        fprintf(stderr, "--- buffer size: %s ---\n", bufszs[bi] ? val : "default(1MiB)");
+        for (int i = 0; i < NCASES; i++)
+            run_case(CASES[i].name, CASES[i].payload, CASES[i].len);
+        run_case("refill-stress payload", big, big_n);
+    }
+
+    free(big);
+
+    /* Deterministic fuzz: many randomly-sized records, diffed at the default
+     * buffer and a couple of tiny ones so field-length boundaries land at every
+     * offset relative to a refill. */
+    {
+        size_t fcap = 256u << 10;
+        char *fz = (char *)malloc(fcap);
+        assert(fz != NULL);
+        size_t fn = make_fuzz_payload(fz, fcap);
+        const long fbufs[] = { 0, 1, 3, 7, 64 };
+        for (size_t bi = 0; bi < sizeof(fbufs) / sizeof(fbufs[0]); bi++) {
+            char val[32];
+            if (fbufs[bi] == 0) unsetenv("FR_FASTQ_TEST_BUFSZ");
+            else { snprintf(val, sizeof val, "%ld", fbufs[bi]); setenv("FR_FASTQ_TEST_BUFSZ", val, 1); }
+            fprintf(stderr, "--- fuzz @ buffer %s ---\n", fbufs[bi] ? val : "default");
+            run_case("fuzz corpus", fz, fn);
+        }
+        free(fz);
+    }
+
+    fprintf(stderr, "\n%s\n", g_fail ? "DIFFERENTIAL TEST FAILED" : "ALL CASES IDENTICAL");
+    return g_fail ? 1 : 0;
+}


### PR DESCRIPTION
Stacked on #152 (profiling instrumentation); review/merge that first.

## Motivation
On production-representative plain-gzip input (20M read pairs → hg38), the read stage is the scaling wall at high core counts. The stage is single-threaded gzip inflate: as cores increase, alignment (`proc`) finishes faster but the one decompression thread does not, so `read_wall` exceeds `proc` and the aligner stalls waiting for input; thread efficiency collapses. This stack makes bwa-mem3 compute-bound again on plain gzip.

The `--profile` stage-timing instrumentation used to diagnose this (`read_wall` vs `proc`, idle-by-stage, per-thread balance) lands in the stacked base PR (#152), not here.

## The change
- Single-copy FASTQ/FASTA parser (`fr_fastq`) — parses directly into `bseq1_t`, dropping the kseq intermediate copy and `strlen` scans; boundary scan vectorised with `memchr`. Differentially tested byte-identical against kseq.
- 3rd pipeline worker at `-t > 2` — overlaps read‖proc‖write.
- Default chunk-size cap (`BWA_MEM3_CHUNK_CAP`, default 256M) — removes pipeline fill/drain at high `-t`.
- zlib-ng streaming inflate for the plain-gzip path (`src/fast_reader.c`, native `zng_*` API, `ZLIB_COMPAT=OFF` so no clash with the system zlib htslib uses; bounded ≤64KB BGZF blocks stay on libdeflate).
- zlib-ng vendored under `ext/` (static, mirrors `ext/mimalloc`; `ZLIBNG_USE_VENDORED=1` default, `=0` host fallback).

## Benchmarks
zlib-ng inflate ~2.3× faster than stock zlib on BOTH arches — adopted unconditionally:

| Arch | Host | zlib-ng vs stock (inflate) |
|---|---|---|
| x86_64 | c7a (EPYC Genoa) | 2.35× |
| arm64 (NEON) | c8g (Graviton4) | 2.27× |

Full stack @192 cores, plain gzip, 20M pairs → hg38:

| Metric | Baseline | This stack | Δ |
|---|---|---|---|
| Total wall | 70.4 s | 46.3 s | −34% |
| read_wall | 62 s | 42 s | now below proc (44.6 s) → compute-bound |
| Thread efficiency | 51% | 77% | +26 pts |

Chunk cap −10% @192c (256M sweet spot, swept 0/64M/128M/256M/512M); 3rd worker −2.8% @96c, flat at 32c/192c.

## Correctness
Byte-identical SAM: fr_fastq-vs-kseq differential test (multi-line/CRLF/BGZF/gzip-member-spanning/fuzz) + SHA-identical on real HG002 WGS. `make test` passes (2.88M assertions). Vendored zlib-ng re-verified e2e (gzipped FASTQ → phiX, 100% mapped/properly-paired).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for gzip/zlib-ng via a configurable zlib-ng build option (vendored or system-installed).

* **Performance**
  * Improved FASTA/FASTQ parsing for streaming inputs.
  * Enhanced multi-threaded batching and pipeline I/O concurrency tuning.
  * Chunk sizing can now be capped via `BWA_MEM3_CHUNK_CAP` (optional).

* **Tests**
  * Added differential parsing tests and a parsing benchmark for FASTQ/FASTA correctness and speed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->