### PR TITLE
fix(kthread): drive kt_for with a persistent worker pool (fixes multi-chunk SIGSEGV under mimalloc v3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,7 @@ ifneq ($(strip $(DISABLE_BATCHED_MATESW)),)
     CPPFLAGS += -DDISABLE_BATCHED_MATESW=$(DISABLE_BATCHED_MATESW)
 endif
 
-.PHONY:all myall arm64 clean depend single all-single print-mimalloc-config kswv_nrow_zero_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test test test-injection FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean docs docs-serve docs-cli docs-clean docs-install-tools
+.PHONY:all myall arm64 clean depend single all-single print-mimalloc-config kswv_nrow_zero_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test kt_for_pool_test test test-injection FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean docs docs-serve docs-cli docs-clean docs-install-tools
 .SUFFIXES:.cpp .o
 
 .cpp.o:
@@ -568,6 +568,9 @@ shm_pack_round_trip_test: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_pack_ro
 shm_lock_destroy_test: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_lock_destroy_test.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/shm_lock_destroy_test.o $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) -o $@
 
+kt_for_pool_test: $(BWA_LIB) $(HTS_LIB) test/kt_for_pool_test.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/kt_for_pool_test.o $(BWA_LIB) $(LIBS) -o $@
+
 # fast_reader is C (not C++); the implicit .c rule omits $(INCLUDES), so give
 # these objects explicit rules carrying the project include paths (incl.
 # libdeflate) and preprocessor defines.
@@ -604,13 +607,14 @@ test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
 # Note: depends on `bwa-mem3` so version_banner.sh has a binary to grep —
 # previously `test:` only built the test harness binaries, not the main
 # executable.
-test: test-binaries kswv_nrow_zero_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_lock_destroy_test bwa-mem3
+test: test-binaries kswv_nrow_zero_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_lock_destroy_test kt_for_pool_test bwa-mem3
 	./test/bwa_mem3_tests_unit
 	./test/bwa_mem3_tests_integration
 	./kswv_nrow_zero_test
 	./bandedswa_padding_test
 	./bandedswa_highzdrop_seed_test
 	./shm_section_find_test
+	./kt_for_pool_test
 	./shm_lock_destroy_test
 	BWA_MEM3=./bwa-mem3 ./test/regression/version_banner.sh
 
@@ -636,6 +640,9 @@ test/shm_section_find_test.o: test/shm_section_find_test.cpp
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 test/shm_lock_destroy_test.o: test/shm_lock_destroy_test.cpp
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
+
+test/kt_for_pool_test.o: test/kt_for_pool_test.cpp
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 # Archive both the baseline (unmangled) kernel objects from $(OBJS) and the
@@ -704,7 +711,7 @@ $(MIMALLOC_LIB):
 	cd $(MIMALLOC_BUILD) && cmake $(MIMALLOC_CMAKE_FLAGS) .. && $(MAKE)
 
 clean: pgo-clean profile-clean lto-clean
-	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test bwa-mem3.arm64
+	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test kt_for_pool_test bwa-mem3.arm64
 	rm -f $(LIBSAIS_OBJS)
 	rm -f src/*.gcno src/*.gcda
 	$(MAKE) -C test clean

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -868,6 +868,10 @@ static int process(void *shared, gzFile gfp, gzFile gfp2, int pipe_threads)
     free(aux_.workers);
     /***** pipeline ends ******/
 
+    /* Retire the kt_for() worker pool (created lazily on the first chunk).
+     * No kt_for() calls remain past this point. */
+    kt_pool_destroy();
+
     fprintf(stderr, "[0000] Computation ends..\n");
 
     /* Dealloc per-worker scratch buffers allocated in the header section */

--- a/src/kthread.cpp
+++ b/src/kthread.cpp
@@ -32,6 +32,9 @@
 #include "kthread.h"
 #include "stage_prof.h"
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
 
 #if AFF && (__linux__)
 extern int affy[256];
@@ -85,10 +88,13 @@ static inline long steal_work(kt_for_t *t)
 	return k*BATCH_SIZE >= t->n? -1 : k;
 }
 
-/******** Current working code *********/
-static void *ktf_worker(void *data)
+/* The per-thread work loop: strided dispatch followed by work-stealing.
+ * Extracted from the old per-call thread body so it can be driven by a
+ * persistent pool worker (see below). Distribution is byte-for-byte the
+ * legacy behaviour; tid passed to func() is the worker's slot index
+ * (w - w->t->w). */
+static void ktf_run(ktf_worker_t *w)
 {
-	ktf_worker_t *w = (ktf_worker_t*)data;
 	long i;
 	int tid = w->i;
 	double _c0 = sp_enabled() ? sp_thread_cpu() : 0.0;
@@ -97,14 +103,13 @@ static void *ktf_worker(void *data)
 #if AFF && (__linux__)
 	fprintf(stderr, "i: %d, CPU: %d\n", tid , sched_getcpu());
 #endif
-	
+
 	for (;;) {
 		i = __sync_fetch_and_add(&w->i, w->t->n_threads);
 		int st = i * BATCH_SIZE;
 		if (st >= w->t->n) break;
 		int ed = (i + 1) * BATCH_SIZE < w->t->n? (i + 1) * BATCH_SIZE : w->t->n;
-		// w->t->func(w->t->data, st, ed-st, tid);
-        w->t->func(w->t->data, st, ed-st, w - w->t->w);
+		w->t->func(w->t->data, st, ed-st, w - w->t->w);
 	}
 
 	while ((i = steal_work(w->t)) >= 0) {
@@ -113,71 +118,171 @@ static void *ktf_worker(void *data)
 		w->t->func(w->t->data, st, ed-st, w - w->t->w);
 	}
 	if (sp_enabled()) { w->cpu_busy = sp_thread_cpu() - _c0; w->encode = sp_encode_get(); }
-	pthread_exit(0);
+}
+
+/* ---------------------------------------------------------------------------
+ * Persistent worker pool for kt_for().
+ *
+ * The original kt_for() spawned n worker pthreads on every call and joined
+ * them at the end. bwa-mem3 calls kt_for() three times per chunk (worker_bwt /
+ * worker_aln / worker_sam) across many chunks, so a per-thread scratch buffer
+ * (e.g. mmc->enc_qdb[tid]) is malloc()'d by one chunk's worker thread and then
+ * realloc()'d by a *different* OS thread on a later chunk — the first thread
+ * has already exited. That cross-thread realloc of an abandoned-heap block is
+ * mishandled by mimalloc v3.x and silently corrupts the heap, crashing with
+ * SIGSEGV several chunks later (it is benign under glibc / mimalloc v2.x, which
+ * is why no sanitizer flags it).
+ *
+ * A persistent pool keeps the same n worker threads alive for the whole run, so
+ * worker slot `tid` is always the same OS thread: every realloc of that slot's
+ * buffers happens on the thread that allocated them — no cross-thread realloc.
+ * It also removes the per-chunk thread create/join overhead.
+ * ------------------------------------------------------------------------- */
+typedef struct {
+	int started;
+	int n_threads;
+	pthread_t *threads;
+	ktf_worker_t *w;          /* per-worker steal state (n_threads entries) */
+	kt_for_t job;             /* current job: func / data / n / w           */
+	pthread_mutex_t mtx;
+	pthread_cond_t cv_go;     /* signalled when a new generation is posted  */
+	pthread_cond_t cv_done;   /* signalled when the last worker finishes    */
+	long generation;          /* bumped once per kt_for() call              */
+	int n_left;               /* workers not yet done with `generation`     */
+	int shutdown;
+} kt_pool_t;
+
+static kt_pool_t g_kt_pool = {0};
+
+static void *kt_pool_worker(void *arg)
+{
+	long k = (long)(intptr_t)arg;
+	long seen = 0;
+	for (;;) {
+		pthread_mutex_lock(&g_kt_pool.mtx);
+		while (g_kt_pool.generation == seen && !g_kt_pool.shutdown)
+			pthread_cond_wait(&g_kt_pool.cv_go, &g_kt_pool.mtx);
+		if (g_kt_pool.shutdown) { pthread_mutex_unlock(&g_kt_pool.mtx); break; }
+		seen = g_kt_pool.generation;
+		pthread_mutex_unlock(&g_kt_pool.mtx);
+
+		ktf_run(&g_kt_pool.w[k]);
+
+		pthread_mutex_lock(&g_kt_pool.mtx);
+		if (--g_kt_pool.n_left == 0) pthread_cond_signal(&g_kt_pool.cv_done);
+		pthread_mutex_unlock(&g_kt_pool.mtx);
+	}
+	return NULL;
+}
+
+static void kt_pool_init(int n_threads)
+{
+	g_kt_pool.n_threads = n_threads;
+	g_kt_pool.threads = (pthread_t*) malloc(n_threads * sizeof(pthread_t));
+	g_kt_pool.w       = (ktf_worker_t*) malloc(n_threads * sizeof(ktf_worker_t));
+	if (g_kt_pool.threads == NULL || g_kt_pool.w == NULL) {
+		perror("Allocation of kt_for worker pool failed");
+		exit(EXIT_FAILURE);
+	}
+	pthread_mutex_init(&g_kt_pool.mtx, NULL);
+	pthread_cond_init(&g_kt_pool.cv_go, NULL);
+	pthread_cond_init(&g_kt_pool.cv_done, NULL);
+	g_kt_pool.generation = 0;
+	g_kt_pool.n_left = 0;
+	g_kt_pool.shutdown = 0;
+
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+#ifdef __APPLE__
+	/* Prefer P-cores on Apple Silicon for compute-intensive alignment work. */
+	int pcore_count = get_pcore_count();
+	if (pcore_count > 0)
+		pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INITIATED, 0);
+#endif
+	for (int i = 0; i < n_threads; ++i) {
+#if AFF && (__linux__)
+		cpu_set_t cpus;
+		CPU_ZERO(&cpus);
+		CPU_SET(affy[i], &cpus);
+		pthread_attr_setaffinity_np(&attr, sizeof(cpu_set_t), &cpus);
+#endif
+		/* A failed worker would leave kt_for() waiting on cv_done for a
+		 * completion that never arrives (deadlock), so fail loudly instead.
+		 * pthread_create() returns the error code directly rather than via
+		 * errno, so report it with strerror(rc), not perror(). */
+		int rc = pthread_create(&g_kt_pool.threads[i], &attr, kt_pool_worker, (void*)(intptr_t)i);
+		if (rc != 0) {
+			fprintf(stderr, "ERROR: kt_for worker pool: pthread_create failed (worker %d): %s\n", i, strerror(rc));
+			exit(EXIT_FAILURE);
+		}
+	}
+	pthread_attr_destroy(&attr);
+	g_kt_pool.started = 1;
+}
+
+/* Tear the pool down (joins the workers). Safe to call when no pool exists. */
+void kt_pool_destroy(void)
+{
+	if (!g_kt_pool.started) return;
+	pthread_mutex_lock(&g_kt_pool.mtx);
+	g_kt_pool.shutdown = 1;
+	pthread_cond_broadcast(&g_kt_pool.cv_go);
+	pthread_mutex_unlock(&g_kt_pool.mtx);
+	for (int i = 0; i < g_kt_pool.n_threads; ++i)
+		pthread_join(g_kt_pool.threads[i], NULL);
+	free(g_kt_pool.threads);
+	free(g_kt_pool.w);
+	pthread_mutex_destroy(&g_kt_pool.mtx);
+	pthread_cond_destroy(&g_kt_pool.cv_go);
+	pthread_cond_destroy(&g_kt_pool.cv_done);
+	memset(&g_kt_pool, 0, sizeof(g_kt_pool));
 }
 
 void kt_for(void (*func)(void*, int, int, int), void *data, int n)
 {
-	int i;
-	kt_for_t t;
-	pthread_t *tid;
 	worker_t *w = (worker_t*) data;
-	t.func = func, t.data = data, t.n_threads = w->nthreads, t.n = n;
-	t.w = (ktf_worker_t*) malloc (t.n_threads * sizeof(ktf_worker_t));
-    assert(t.w != NULL);
-	tid = (pthread_t*) malloc (t.n_threads * sizeof(pthread_t));
-    assert(tid != NULL);
-	for (i = 0; i < t.n_threads; ++i)
-		t.w[i].t = &t, t.w[i].i = i;
+	int n_threads = w->nthreads;
+	if (n_threads < 1) n_threads = 1;  /* nthreads is int16_t; never spin up a 0/negative pool */
 
-	pthread_attr_t attr;
-    pthread_attr_init(&attr);
-
-#ifdef __APPLE__
-    /* Set QoS to USER_INITIATED for compute-intensive alignment work
-     * This hints to the scheduler to prefer P-cores (performance cores)
-     * over E-cores (efficiency cores) on Apple Silicon */
-    static int pcore_count = -2;  /* -2 = not yet queried */
-    if (pcore_count == -2) {
-        pcore_count = get_pcore_count();
-    }
-
-    /* Only set QoS on Apple Silicon (pcore_count > 0) */
-    if (pcore_count > 0) {
-        pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INITIATED, 0);
-    }
-#endif
-
-	// printf("getcpu: %d\n", sched_getcpu());
-	for (i = 0; i < t.n_threads; ++i) {
-#if AFF && (__linux__)
-		cpu_set_t cpus;
-		CPU_ZERO(&cpus);
-		// CPU_SET(i, &cpus);
-		CPU_SET(affy[i], &cpus);
-		pthread_attr_setaffinity_np(&attr, sizeof(cpu_set_t), &cpus);
-		pthread_create(&tid[i], &attr, ktf_worker, &t.w[i]);
-#elif defined(__APPLE__)
-        /* Use attr with QoS settings on Apple */
-        pthread_create(&tid[i], &attr, ktf_worker, &t.w[i]);
-#else
-		pthread_create(&tid[i], NULL, ktf_worker, &t.w[i]);
-#endif
+	/* kt_for() is only ever called from the serialized step-1 of kt_pipeline
+	 * (one chunk in flight at a time), so lazy init here is race-free, and
+	 * n_threads (= opt->n_threads) is constant for the whole run. Rebuild the
+	 * pool defensively if that invariant ever changes. */
+	if (!g_kt_pool.started)
+		kt_pool_init(n_threads);
+	else if (g_kt_pool.n_threads != n_threads) {
+		kt_pool_destroy();
+		kt_pool_init(n_threads);
 	}
-	for (i = 0; i < t.n_threads; ++i) pthread_join(tid[i], 0);
 
+	pthread_mutex_lock(&g_kt_pool.mtx);
+	g_kt_pool.job.func = func;
+	g_kt_pool.job.data = data;
+	g_kt_pool.job.n = n;
+	g_kt_pool.job.n_threads = n_threads;
+	g_kt_pool.job.w = g_kt_pool.w;
+	for (int i = 0; i < n_threads; ++i) {
+		g_kt_pool.w[i].t = &g_kt_pool.job;
+		g_kt_pool.w[i].i = i;
+	}
+	g_kt_pool.n_left = n_threads;
+	++g_kt_pool.generation;
+	pthread_cond_broadcast(&g_kt_pool.cv_go);
+	while (g_kt_pool.n_left > 0)
+		pthread_cond_wait(&g_kt_pool.cv_done, &g_kt_pool.mtx);
+	pthread_mutex_unlock(&g_kt_pool.mtx);
+
+	/* All workers are done with this generation (n_left == 0) and will not
+	 * touch their per-slot stats again until the next kt_for() call, so the
+	 * pool's worker slots can be read without the lock here. */
 	if (sp_enabled()) {
-		double *busy = (double*) malloc(t.n_threads * sizeof(double));
+		double *busy = (double*) malloc(n_threads * sizeof(double));
 		assert(busy != NULL);
 		double sum = 0, esum = 0;
-		for (i = 0; i < t.n_threads; ++i) { busy[i] = t.w[i].cpu_busy; sum += busy[i]; esum += t.w[i].encode; }
+		for (int i = 0; i < n_threads; ++i) { busy[i] = g_kt_pool.w[i].cpu_busy; sum += busy[i]; esum += g_kt_pool.w[i].encode; }
 		g_ktfor.proc_cpu += sum;                        /* accumulate across kt_for calls in a step */
 		g_ktfor.encode   += esum;                       /* SAM/BAM-build CPU (only worker_sam adds) */
-		sp_thread_stats(&g_ktfor, busy, t.n_threads);   /* balance stats from the most recent call */
+		sp_thread_stats(&g_ktfor, busy, n_threads);     /* balance stats from the most recent call */
 		free(busy);
 	}
-
-    pthread_attr_destroy(&attr);
-    free(t.w);
-	free(tid);
 }

--- a/src/kthread.h
+++ b/src/kthread.h
@@ -89,4 +89,8 @@ typedef struct kt_for_t {
 
 void kt_pipeline(int n_threads, int (*func)(void*), void *shared_data, int n_steps);
 void kt_for(void (*func)(void*,int,int,int), void *data, int n);
+/* Tear down the persistent kt_for() worker pool (joins the worker threads).
+ * Call once after the last kt_for()/kt_pipeline() of a run; a no-op if the pool
+ * was never created. */
+void kt_pool_destroy(void);
 #endif

--- a/test/kt_for_pool_test.cpp
+++ b/test/kt_for_pool_test.cpp
@@ -1,0 +1,118 @@
+// Regression test for the kt_for() persistent worker pool.
+//
+// bwa-mem3 calls kt_for() three times per chunk (worker_bwt / worker_aln /
+// worker_sam) across many chunks. Per-worker scratch buffers (e.g.
+// mmc->enc_qdb[tid]) persist across chunks and are grown with realloc(). If
+// kt_for() spawned a fresh set of pthreads on every call (the historical
+// behaviour), the buffer for slot `tid` would be allocated by one chunk's
+// worker thread and realloc'd by a *different* OS thread on the next chunk —
+// after the first thread exited. mimalloc v3.x mishandles that cross-thread
+// realloc of an abandoned-heap block and corrupts the heap (benign under glibc
+// and mimalloc v2.x, so no sanitizer flags it), crashing several chunks later.
+//
+// The fix makes kt_for() drive a persistent worker pool, so worker slot `tid`
+// is always the same OS thread: every realloc of that slot's buffers happens on
+// the thread that allocated them. This test asserts exactly that invariant —
+// the same OS thread services a given slot across successive kt_for() calls.
+// It passes with the pool and fails with per-call threads.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <pthread.h>
+#include <unistd.h>
+
+#include "kthread.h"
+#include "bwamem.h"   // worker_t
+#include "macro.h"    // BATCH_SIZE
+
+static const int NT = 4;
+static pthread_t g_seen[2][NT];
+static int       g_seen_ok[2][NT];  // 1 once slot t has been observed on call c
+static int       g_call = 0;
+
+// Sums the work items (len) handed to the callback, so the edge-case phase can
+// check that a recreated single-thread pool runs all the work and that a
+// zero-item call is a clean no-op rather than a hang.
+static long g_processed = 0;
+static void count_work(void *data, int st, int len, int tid) {
+    (void)data; (void)st; (void)tid;
+    __sync_fetch_and_add(&g_processed, (long)len);
+}
+
+// kt_for() invokes this as func(data, st, len, tid). `tid` is the worker slot
+// index; record which OS thread is servicing that slot on this call. The brief
+// sleep keeps all NT workers busy on their own strided batch simultaneously so
+// none finishes early and steals another slot's work — that keeps the
+// slot->thread mapping stable for this test (work-stealing is irrelevant to the
+// invariant under test: thread persistence across kt_for() calls).
+static void record_slot_thread(void *data, int st, int len, int tid) {
+    (void)data; (void)st; (void)len;
+    if (tid >= 0 && tid < NT) {
+        g_seen[g_call][tid] = pthread_self();
+        g_seen_ok[g_call][tid] = 1;
+    }
+    usleep(20000);  // 20 ms: long enough to overlap all workers, trivial total
+}
+
+int main(void) {
+    // kt_for() reads only ->nthreads from its data argument. worker_t is large
+    // (per-thread buffer arrays), so allocate it on the heap.
+    worker_t *w = (worker_t *) calloc(1, sizeof(worker_t));
+    if (w == NULL) { fprintf(stderr, "calloc failed\n"); return 2; }
+    w->nthreads = NT;
+
+    // n = NT * BATCH_SIZE gives exactly one strided batch per worker slot, so
+    // every slot's thread runs record_slot_thread() at least once.
+    const int n = NT * BATCH_SIZE;
+
+    g_call = 0; kt_for(record_slot_thread, w, n);
+    g_call = 1; kt_for(record_slot_thread, w, n);
+
+    kt_pool_destroy();
+
+    // Edge cases. kt_pool_destroy() above tore down the NT-thread pool, so the
+    // next kt_for() lazily builds a fresh one — exercising destroy->recreate and,
+    // with nthreads=1, the single-thread pool path.
+    w->nthreads = 1;
+    g_processed = 0;
+    kt_for(count_work, w, BATCH_SIZE);
+    if (g_processed != (long)BATCH_SIZE) {
+        fprintf(stderr, "FAIL: recreated single-thread pool processed %ld items, expected %d\n",
+                g_processed, BATCH_SIZE);
+        return 1;
+    }
+    // Zero work items must be a clean no-op (no work run, no deadlock).
+    g_processed = 0;
+    kt_for(count_work, w, 0);
+    if (g_processed != 0) {
+        fprintf(stderr, "FAIL: kt_for(n=0) processed %ld items, expected 0 (no-op)\n", g_processed);
+        return 1;
+    }
+
+    kt_pool_destroy();
+    free(w);
+
+    int fail = 0;
+    for (int t = 0; t < NT; ++t) {
+        if (!g_seen_ok[0][t] || !g_seen_ok[1][t]) {
+            fprintf(stderr, "slot %d was not observed in both kt_for() calls "
+                    "-> cannot confirm thread persistence\n", t);
+            fail = 1;
+            continue;
+        }
+        if (!pthread_equal(g_seen[0][t], g_seen[1][t])) {
+            fprintf(stderr,
+                    "slot %d ran on different OS threads across kt_for() calls "
+                    "-> pool is not persistent (cross-thread realloc would occur)\n", t);
+            fail = 1;
+        }
+    }
+    if (fail) {
+        fprintf(stderr, "FAIL: kt_for() is not reusing a persistent worker pool\n");
+        return 1;
+    }
+    printf("OK: kt_for() reuses a persistent worker pool "
+           "(same OS thread services each slot across calls)\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

`bwa-mem3 mem` SIGSEGVs partway through any multi-chunk paired-end alignment (≥3 pipeline chunks) — e.g. `bwa-mem3 mem -t 12 hg38.fa R1.fq R2.fq` on a full WGS/CMRG run. It dies at the start of a later chunk's seeding (`mem_kernel1_core` → `realloc(enc_qdb[tid])`), and `-K 2000000000` (single batch) is clean. The crash is **mimalloc-v3-specific**: it does not reproduce under glibc, the system allocator, AddressSanitizer, libgmalloc, mimalloc guard pages/padding, or **mimalloc v2.x** — only mimalloc v3.x (which is what we vendor) crashes.

## Root cause

`kt_for()` is called three times per chunk (`worker_bwt` / `worker_aln` / `worker_sam`) and previously **spawned a fresh set of pthreads on every call and joined them at the end**. The per-worker `mem_cache` scratch buffers (`enc_qdb[tid]`, `matchArray[tid]`, `min_intv_ar[tid]`, …) persist across chunks and grow with `realloc()`. So a buffer for slot `tid` is `malloc`'d by one chunk's worker thread and then `realloc`'d by a **different OS thread** on the next chunk — after the first thread has already exited.

mimalloc v3.x mishandles that cross-thread `realloc` of an abandoned-heap block and corrupts heap metadata; the corruption surfaces as a SIGSEGV a few chunks later (≥3 chunks is enough to build the cross-thread reuse). There is **no out-of-bounds access** in bwa-mem3 — which is why no sanitizer flags it — so this is a pure mimalloc-v3 regression. A 25-line standalone reproducer confirms it (crashes 3/3 on mimalloc v3.3.0/v3.3.2, clean on v2.3.2):

```c
/* realloc of a block whose allocating thread has exited — bwa-mem3's per-chunk
 * kt_for worker pattern. v3.x: SIGSEGV. v2.x: clean. */
#include <pthread.h>
#include <stdlib.h>
#include <string.h>
static void *g; 
typedef struct { size_t sz; int first; } arg_t;
static void *w(void *p){ arg_t*a=p; g = a->first ? malloc(a->sz) : realloc(g,a->sz);
                         if(g) memset(g,0xAB,a->sz); return 0; }
int main(void){
  size_t s[]={130594,130594,130608,130600,130620,130594,130700,130594,130608,130594};
  for(int c=0;c<4000;c++) for(int i=0;i<10;i++){
    arg_t a={s[i]+(c&63),(c==0&&i==0)}; pthread_t t;
    pthread_create(&t,0,w,&a); pthread_join(t,0); }      /* thread exits -> heap abandoned */
  free(g); return 0;
}
```

## Fix

Make `kt_for()` drive a **persistent worker pool** instead of creating/joining threads per call. The same `n` worker threads stay alive for the whole run, so worker slot `tid` is always the same OS thread and every `realloc` of a slot's buffers happens on the thread that allocated them — no cross-thread realloc. Work distribution (strided dispatch + `steal_work`) and the `tid` passed to callbacks are byte-for-byte identical to before; this also removes the per-chunk thread create/join overhead. The pool is created lazily on the first `kt_for()` and torn down (`kt_pool_destroy()`) at the end of `process()`.

mimalloc stays at v3.3.0 (submodule unchanged).

## Verification

- Minimal repro (768 repetitive 2×250 pairs, `-K` to force 3 small chunks): was 100% crash → **5/5 clean** at `-t 1` and `-t 12`.
- Full CMRG repro (`-t 12`, default chunking): exit 0, all chunks, **3,753,429 SAM records**, output **byte-identical** to a mimalloc-v2.3.2 baseline (sorted alignment diff is empty).
- `test/kt_for_pool_test.cpp` (new, wired into `make test`): asserts `kt_for()` services each worker slot on the same OS thread across successive calls — passes with the pool, fails with per-call threads.

## Follow-up

Worth reporting the cross-thread-`realloc` regression upstream to microsoft/mimalloc (the standalone repro above is self-contained); once a fixed v3 is available we can drop the pool requirement if desired, though the pool is a net win on its own (no per-chunk thread churn).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `kt_for()` now uses a persistent worker pool across repeated calls to improve performance.
  * Added `kt_pool_destroy()` to explicitly tear down the pool after the final workload.

* **Bug Fixes**
  * Improved shutdown/lifecycle handling to ensure the worker pool is retired cleanly during teardown.

* **Tests**
  * Added a regression test covering persistent worker slot-to-OS-thread mapping, correct behavior after teardown (including recreation), and `n=0` as a safe no-op.

* **Chores**
  * Updated build and clean targets to compile and run the new `kt_for_pool_test`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->