### PR TITLE
docs(perf): what drives the speedup, full perf-PR catalog, and fix the stale RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,11 +2,33 @@ version: 2
 
 build:
   os: ubuntu-24.04
+  # A tool entry is required by the Read the Docs schema even when the build is
+  # driven entirely by `commands`. We do not actually use Python — it is the
+  # lightest always-available toolchain to satisfy the requirement. mdbook and
+  # mdbook-mermaid are installed from prebuilt release binaries below.
   tools:
-    rust: "1.91"
+    python: "3.12"
   commands:
-    - cargo install mdbook --version 0.5.2 --locked
-    - cargo install mdbook-mermaid --locked
-    - cd docs && mdbook build
+    # Install pinned mdbook + mdbook-mermaid from prebuilt release binaries.
+    #
+    # These pins MUST stay in lockstep with .github/workflows/docs.yml. That CI
+    # job pins BOTH mdbook (0.5.2) and mdbook-mermaid (0.17.0); the previous
+    # version of this file pinned only mdbook and ran `cargo install
+    # mdbook-mermaid` with no version, so Read the Docs floated to whatever
+    # mdbook-mermaid was newest on crates.io. When a newer mdbook-mermaid that
+    # is incompatible with mdbook 0.5.2 ships, the RTD build breaks while CI
+    # stays green — leaving the published site stale (e.g. missing the
+    # whats-different/equivalence page added later). Prebuilt binaries also avoid
+    # a multi-minute source compile on every build and drop the brittle rust
+    # toolchain pin entirely.
+    #
+    # Each binary is downloaded to a file, verified against its pinned SHA-256,
+    # and only then extracted — so a corrupted or tampered download fails the
+    # build with a checksum error instead of being run. The `&&` chain makes any
+    # step's failure (curl, checksum, or tar) abort the command.
+    - mkdir -p bin
+    - curl -fsSL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz -o bin/mdbook.tar.gz && echo "084e4342ba564db270108763e404a7d1f309d932651a22484e93c0dc1a071f6d  bin/mdbook.tar.gz" | sha256sum -c - && tar -xzf bin/mdbook.tar.gz -C bin
+    - curl -fsSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.17.0/mdbook-mermaid-v0.17.0-x86_64-unknown-linux-gnu.tar.gz -o bin/mdbook-mermaid.tar.gz && echo "8aced70d781830fb0e81988f081c4abdd49e056a001ae2f1e4d484e1f6385c57  bin/mdbook-mermaid.tar.gz" | sha256sum -c - && tar -xzf bin/mdbook-mermaid.tar.gz -C bin
+    - cd docs && PATH="$PWD/../bin:$PATH" mdbook build
     - mkdir -p _readthedocs/html
     - cp -r docs/book/. _readthedocs/html/

--- a/docs/src/performance/overview.md
+++ b/docs/src/performance/overview.md
@@ -4,19 +4,114 @@ Performance claims in this section are benchmarked, not asserted. The canonical 
 
 ## What drives bwa-mem3's performance
 
-bwa-mem3 inherits the SIMD-vectorized alignment kernels of bwa-mem2 and adds several improvements of its own. The headline gains relative to a stock bwa-mem2 build fall into four categories.
+There is no single "the speedup." bwa-mem3 inherits bwa-mem2's SIMD-vectorized
+core and layers on a series of independent improvements, each targeting a
+different bottleneck in the align pipeline. How much any one of them helps —
+and therefore the total — depends heavily on the workload: read length, error
+rate, reference size, thread count, CPU architecture (AVX2 vs AVX-512 vs NEON),
+and whether the index is cold or warm in the page cache. A short-read whole-genome
+run is dominated by seeding and FM-index walks; a long-read or high-error run
+spends most of its cycles in the Smith–Waterman kernels; a many-sample run can be
+bottlenecked on header ingestion or decompression. The drivers below group by
+*what part of the machine or algorithm they fix*. For real, reproducible numbers
+on specific hardware, always defer to [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench)
+rather than any single anecdote here.
 
-**Vectorized alignment kernels.** The Smith-Waterman and banded-SWA kernels (kswv, bandedSWA) are compiled against the widest SIMD ISA the current CPU supports — SSE4.1 through AVX-512BW on x86, or native NEON on ARM. On Apple Silicon, native NEON intrinsics replaced the sse2neon shim in the two hottest kernels, delivering roughly 10% additional throughput over the pure-translation baseline. See [SIMD dispatch matrix](simd-dispatch.md) for the full picture.
+For the full per-change list with PR links and status, see
+[What's Different — Performance improvements](../whats-different/performance.md).
 
-**libsais FM-index construction.** The indexing step uses the linear-time suffix-array/BWT construction library libsais in place of the original quadratic-time approach. This cuts `bwa-mem3 index` wall time substantially on large references. See [What's Different — Performance improvements](../whats-different/performance.md) for the corresponding PR details.
+### 1. Getting more out of the machine (SIMD / microarchitecture)
 
-**mimalloc allocator.** bwa-mem3 vendors and statically links [mimalloc](https://github.com/microsoft/mimalloc), replacing the system `malloc`/`free` for all allocations. On Linux the library is injected via `--whole-archive`; on macOS it uses dyld interposition. The allocator shows consistent throughput gains on multi-threaded workloads because mimalloc avoids the lock contention in glibc's `ptmalloc` at high thread counts. See [User Guide — Memory allocator](../user-guide/allocator.md) for details.
+The alignment kernels (`kswv` mate-rescue, `bandedSWA`) are compiled for the
+widest SIMD ISA the host supports — SSE4.1 through AVX-512BW on x86, native NEON
+on ARM — and selected at runtime by an in-process dispatcher (a single binary
+that picks the right kernel per host, [#83](https://github.com/fg-labs/bwa-mem3/pull/83))
+rather than the older multi-binary `execv` launcher.
 
-**Profile-Guided Optimization (PGO).** The build system provides `make pgo-generate` and `make pgo-use` targets that compile an instrumented binary, gather branch-probability and call-frequency profiles from a representative workload, and then recompile with those profiles applied. On Apple Silicon the measured gain is approximately 3%; on x86 the gain depends on the workload mix. PGO is opt-in and is not applied to the default `make` output. See [PGO build](pgo.md) for the full workflow.
+- **Native NEON kernels** replaced the `sse2neon` translation shim in the two
+  hottest kernels on ARM, worth roughly **10% additional throughput** on Apple
+  Silicon over the pure-translation baseline.
+- **AVX2 as the x86 baseline** ([#84](https://github.com/fg-labs/bwa-mem3/pull/84)):
+  restoring the non-kernel translation units to `-mavx2` recovered ~**+15%** user
+  time on `wgs-5M` / ~**+11%** on `wes-5M` that had been lost when the baseline
+  briefly dropped to SSE4.1 — hot non-kernel paths (chain extension, FM-index BWT
+  walks, mate scoring) auto-vectorize at 256-bit width again.
+- **Capping AVX-512BW auto-vectorization at 256-bit** ([#86](https://github.com/fg-labs/bwa-mem3/pull/86))
+  avoids the frequency downclock that wide 512-bit auto-vec code triggers on some
+  x86 parts, where the wider vectors cost more in clock than they return.
+- **Per-strip L1 prefetches** added to the 8-/16-bit `kswv` kernels that lacked
+  them ([#70](https://github.com/fg-labs/bwa-mem3/pull/70), bringing them in line
+  with `kswv512_16`) stop the inner SW loop from stalling on first-touch L1
+  misses.
+- **A recovered 8-bit banded SW path** for reads ≥128 bp
+  ([#140](https://github.com/fg-labs/bwa-mem3/pull/140) and follow-ups) keeps
+  long-read alignment in the cheaper 8-bit lane width where it is valid.
 
-## Consolidated mapping speedups
+See the [SIMD dispatch matrix](simd-dispatch.md) for the full ISA picture.
 
-PR [#58](https://github.com/fg-labs/bwa-mem3/pull/58) and the related lockstep SMEM-batching work ([#33](https://github.com/fg-labs/bwa-mem3/pull/33)) reduced per-read overhead in the main mapping loop beyond what upstream bwa-mem2 carries. The batch `-H` ingestion improvement ([#49](https://github.com/fg-labs/bwa-mem3/pull/49)) further reduces header-processing latency for large sample sets.
+### 2. Fixing bad patterns in the hot path (algorithmic rewrites)
+
+Several gains come simply from rewriting code that did more work than it needed
+to — the "rewrites wind up fixing bad patterns" effect — without changing where
+reads map.
+
+- **Lockstep SMEM batching** ([#33](https://github.com/fg-labs/bwa-mem3/pull/33),
+  widened from 8 to 16 reads in [#75](https://github.com/fg-labs/bwa-mem3/pull/75)):
+  advances several reads' seed walks in interleaved order so the out-of-order
+  engine overlaps the random `cp_occ` checkpoint-array cache misses of one read
+  with the compute of another. Measured ~**−6% wall time** on 150 bp WGS, with the
+  hot `cp_occ` load share dropping from 65.5% to 53.3% of seeding time.
+- **O(n²) → O(n) header ingestion** ([#49](https://github.com/fg-labs/bwa-mem3/pull/49)):
+  the `-H` path re-ran `strlen` + `realloc` per line; batching the read took a
+  ~70 MB / 1.5 M-line header from **>10 minutes to under a second** before
+  alignment even starts.
+- **Closed-form ungapped scoring** when there are no mismatches
+  ([#77](https://github.com/fg-labs/bwa-mem3/pull/77)) replaces a per-base
+  Kadane-style walk with a direct store.
+- **On-stack sort buffers for small arrays** ([#78](https://github.com/fg-labs/bwa-mem3/pull/78))
+  removes a per-read `malloc`/`free` that was dominating the sort of the typical
+  5–30-element alignment-region arrays.
+- **Inlining `backwardExt`** ([#88](https://github.com/fg-labs/bwa-mem3/pull/88))
+  eliminates a struct-by-value ABI pass that gcc 12+ could not optimize away,
+  recovering (and beating) the older compiler's baseline.
+- **`pdqsort` with stable tie-breaks** at the dedup-patch sort sites
+  ([#123](https://github.com/fg-labs/bwa-mem3/pull/123)).
+- The **consolidated mapping-speedup audit** ([#58](https://github.com/fg-labs/bwa-mem3/pull/58))
+  bundles tuning across the ksw2 band loop, SMEM batching, suffix-array lookup
+  prefetch, and SAM record building — historically the single largest wall-time
+  step in `main`.
+
+### 3. Indexing
+
+`bwa-mem3 index` builds the FM-index with the linear-time
+[libsais](https://github.com/IlyaGrebnov/libsais) library
+([#57](https://github.com/fg-labs/bwa-mem3/pull/57)) instead of the older
+sais-lite, cutting both wall time and peak memory while producing a
+byte-identical index (existing indexes need no rebuild). Construction also skips
+the wasted zero-initialization of unpack and suffix-array buffers
+([#80](https://github.com/fg-labs/bwa-mem3/pull/80)), which on a doubled-human
+input avoided tens of GiB of write-then-overwrite zero-fill.
+
+### 4. Memory allocation and I/O
+
+- **mimalloc**, vendored and statically linked by default
+  ([#19](https://github.com/fg-labs/bwa-mem3/pull/19)), replaces the system
+  allocator and avoids glibc `ptmalloc`'s lock contention at high thread counts —
+  a consistent multi-threaded throughput win. See
+  [User Guide — Memory allocator](../user-guide/allocator.md).
+- **Faster read ingestion**: a content-detecting FASTQ fast path over libdeflate
+  BGZF ([#128](https://github.com/fg-labs/bwa-mem3/pull/128), merged) cuts the
+  cost of decompressing and parsing input, which matters most when the aligner
+  would otherwise be I/O- or parse-bound. A vendored zlib-ng inflate path with an
+  added pipeline worker ([#153](https://github.com/fg-labs/bwa-mem3/pull/153)) is
+  **proposed but not yet merged** and extends the same idea.
+
+### 5. Build-time optimization (PGO)
+
+The build provides opt-in `make pgo-generate` / `make pgo-use` targets that
+recompile with branch-probability and call-frequency profiles gathered from a
+representative workload — ~**3%** on Apple Silicon, workload-dependent on x86.
+PGO is not applied to the default `make` output. See [PGO build](pgo.md).
 
 ## Reference numbers across architectures
 

--- a/docs/src/performance/overview.md
+++ b/docs/src/performance/overview.md
@@ -46,6 +46,17 @@ rather than the older multi-binary `execv` launcher.
 - **A recovered 8-bit banded SW path** for reads ≥128 bp
   ([#140](https://github.com/fg-labs/bwa-mem3/pull/140) and follow-ups) keeps
   long-read alignment in the cheaper 8-bit lane width where it is valid.
+- **Per-ISA SW kernel hand-tuning.** A NEON pass
+  ([#160](https://github.com/fg-labs/bwa-mem3/pull/160)) replaced the multi-instruction
+  `sse2neon` "all lanes zero" tests in the hot band-narrowing scans with a single
+  `vmaxvq` horizontal reduction; an AVX2 pass
+  ([#161](https://github.com/fg-labs/bwa-mem3/pull/161)) relieved the port-5
+  `vpblendvb`/`vpshufb` bottleneck that ceilings the inner loop on Zen3. Both are
+  byte-identical to the prior output.
+- **AVX2 16-bit mate rescue** ([#162](https://github.com/fg-labs/bwa-mem3/pull/162)):
+  AVX2-only hosts (e.g. Zen3, which run the AVX2 default) previously fell back to
+  scalar `ksw_align2` for 16-bit mate rescue because only NEON and AVX-512 had a
+  batched 16-bit `kswv`; `kswv256_16` closes that gap.
 
 See the [SIMD dispatch matrix](simd-dispatch.md) for the full ISA picture.
 
@@ -90,7 +101,9 @@ sais-lite, cutting both wall time and peak memory while producing a
 byte-identical index (existing indexes need no rebuild). Construction also skips
 the wasted zero-initialization of unpack and suffix-array buffers
 ([#80](https://github.com/fg-labs/bwa-mem3/pull/80)), which on a doubled-human
-input avoided tens of GiB of write-then-overwrite zero-fill.
+input avoided tens of GiB of write-then-overwrite zero-fill, and right-sizes the
+SA-entry staging buffers to the actual write count rather than the uncapped
+SA-interval sum ([#157](https://github.com/fg-labs/bwa-mem3/pull/157)).
 
 ### 4. Memory allocation and I/O
 
@@ -102,9 +115,14 @@ input avoided tens of GiB of write-then-overwrite zero-fill.
 - **Faster read ingestion**: a content-detecting FASTQ fast path over libdeflate
   BGZF ([#128](https://github.com/fg-labs/bwa-mem3/pull/128), merged) cuts the
   cost of decompressing and parsing input, which matters most when the aligner
-  would otherwise be I/O- or parse-bound. A vendored zlib-ng inflate path with an
-  added pipeline worker ([#153](https://github.com/fg-labs/bwa-mem3/pull/153)) is
-  **proposed but not yet merged** and extends the same idea.
+  would otherwise be I/O- or parse-bound. A vendored zlib-ng inflate path with a
+  third pipeline worker ([#153](https://github.com/fg-labs/bwa-mem3/pull/153),
+  merged) extends the same idea: it cuts the read stage ~**2.2×** on gzip input
+  and, because the serial read stage becomes a larger share of the wall as the
+  compute stage parallelizes, improves end-to-end wall by up to **−7.8%** at 96
+  cores. The accompanying `--profile` stage-timing mode
+  ([#152](https://github.com/fg-labs/bwa-mem3/pull/152)) is what attributes wall
+  time across the read‖proc‖write stages to surface exactly this effect.
 
 ### 5. Build-time optimization (PGO)
 

--- a/docs/src/whats-different/performance.md
+++ b/docs/src/whats-different/performance.md
@@ -1,10 +1,17 @@
 # Performance Improvements
 
 This page covers the performance work carried in bwa-mem3 on top of upstream
-bwa-mem2. Every change listed here preserves byte-identical SAM/BAM output vs
-the upstream baseline it was benchmarked against.
+bwa-mem2. Almost every change listed here is a pure throughput or memory win
+that preserves the aligner's output; the one exception is the deterministic
+tie-break ordering in [#123](https://github.com/fg-labs/bwa-mem3/pull/123),
+which can reorder equal-scoring alignments relative to upstream (see
+[Equivalence with bwa-mem2](equivalence.md) for the full, audited list of where
+bwa-mem3 output diverges).
 
-For current benchmark numbers across architectures and workloads, see
+For a reader-friendly grouping of *what drives the speedup* — by machine
+architecture, hot-path rewrite, indexing, allocation/I/O, and build-time — see
+[Performance → Overview](../performance/overview.md). For current benchmark
+numbers across architectures and workloads, see
 [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench), the canonical
 source of truth for benchmark methodology and results.
 
@@ -91,13 +98,59 @@ are maintained at [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench).
 
 ## Changes catalog
 
-| Item | bwa-mem3 PR | Upstream PR/issue | Status |
-|------|-------------|-------------------|--------|
-| Lockstep SMEM batching | [#33](https://github.com/fg-labs/bwa-mem3/pull/33) | — | fork-only |
-| Batched `-H` header ingestion | [#49](https://github.com/fg-labs/bwa-mem3/pull/49) | [bwa-mem2#204](https://github.com/bwa-mem2/bwa-mem2/pull/204) | fork-only (upstream PR open) |
-| Large header performance (issue) | — | [issue #37](https://github.com/fg-labs/bwa-mem3/issues/37) | closed by #49 |
-| libsais FM-index construction | [#57](https://github.com/fg-labs/bwa-mem3/pull/57) | — | fork-only |
-| Consolidated mapping speedups | [#58](https://github.com/fg-labs/bwa-mem3/pull/58) | — | fork-only |
+The mechanism column says, in one line, *why it is faster*. The stage column
+groups changes by where in the pipeline they act: **seed** (SMEM/FM-index
+walks), **sw** (Smith–Waterman / banded kernels), **index** (`bwa-mem3 index`),
+**i/o** (read decompression + header ingestion), **mem** (allocation),
+**dispatch** (SIMD/runtime selection), or **sort**.
+
+### Merged
+
+| Item | Stage | Mechanism | bwa-mem3 PR | Upstream |
+|------|-------|-----------|-------------|----------|
+| mimalloc by default | mem | Vendored + statically linked allocator; avoids glibc `ptmalloc` lock contention at high thread counts | [#19](https://github.com/fg-labs/bwa-mem3/pull/19) | — |
+| Lockstep SMEM batching | seed | Interleaves several reads' seed walks so the OoO engine overlaps `cp_occ` cache misses across reads | [#33](https://github.com/fg-labs/bwa-mem3/pull/33) | — |
+| Batched `-H` header ingestion | i/o | One-pass buffered read; fixes O(n²) `strlen`+`realloc` per line (>10 min → <1 s on large headers) | [#49](https://github.com/fg-labs/bwa-mem3/pull/49) | [bwa-mem2#204](https://github.com/bwa-mem2/bwa-mem2/pull/204) (open); closes [#37](https://github.com/fg-labs/bwa-mem3/issues/37) |
+| libsais FM-index construction | index | Linear-time suffix-array/BWT build; less wall time + memory; byte-identical index | [#57](https://github.com/fg-labs/bwa-mem3/pull/57) | — |
+| Consolidated mapping speedups | seed/sw | Multi-phase hot-path audit across ksw2 band loop, SMEM batching, SAL prefetch, SAM building | [#58](https://github.com/fg-labs/bwa-mem3/pull/58) | — |
+| kswv per-strip L1 prefetches | sw | Adds the per-strip L1 prefetches that `kswv512_16` already had to the four `kswv` kernels that lacked them; stops first-touch L1 stalls | [#70](https://github.com/fg-labs/bwa-mem3/pull/70) | — |
+| `SMEM_LOCKSTEP_N` 8 → 16 | seed | Wider lockstep batch exposes more memory-level parallelism on modern cores | [#75](https://github.com/fg-labs/bwa-mem3/pull/75) | — |
+| Closed-form ungapped HIT | sw | Replaces the per-base Kadane walk with a direct store when `total_mis == 0` | [#77](https://github.com/fg-labs/bwa-mem3/pull/77) | — |
+| On-stack ksort buffer | sort | Removes a per-call `malloc` for small arrays (typical n = 5–30 alignment regions) | [#78](https://github.com/fg-labs/bwa-mem3/pull/78) | — |
+| Skip zero-init in libsais build | index | Drops value-initialization of unpack + SA buffers later fully overwritten (tens of GiB of zero-fill avoided) | [#80](https://github.com/fg-labs/bwa-mem3/pull/80) | — |
+| Single-binary SIMD dispatch | dispatch | Replaces the multi-binary `execv` launcher with in-process per-host kernel selection | [#83](https://github.com/fg-labs/bwa-mem3/pull/83) | — |
+| x86 baseline → avx2 | dispatch/sw | Restores 256-bit auto-vec on non-kernel TUs (~+15% wgs / +11% wes vs the sse41 baseline) | [#84](https://github.com/fg-labs/bwa-mem3/pull/84) | — |
+| Cap avx512bw autovec at 256-bit | dispatch/sw | Avoids the 512-bit auto-vec frequency downclock on some x86 parts (the PR also adds an unrelated `bwa_shm` `/dev/shm` preflight) | [#86](https://github.com/fg-labs/bwa-mem3/pull/86) | — |
+| Inline `backwardExt` | seed | Forces inlining at the hot SMEM call sites; kills a struct-by-value ABI pass gcc 12+ couldn't elide | [#88](https://github.com/fg-labs/bwa-mem3/pull/88) | — |
+| SIMD host-floor precheck | dispatch | Fails fast with a clear message when a host lacks the build's required ISA (safe multi-arch deployment) | [#95](https://github.com/fg-labs/bwa-mem3/pull/95) | — |
+| Stable tie-breaks + pdqsort | sort | Deterministic alnreg ordering and `pdqsort` at the dedup-patch sort sites (see equivalence note above) | [#123](https://github.com/fg-labs/bwa-mem3/pull/123) | — |
+| FASTQ reader fast path | i/o | Content-detecting reader over libdeflate BGZF for faster input decompression/parse | [#128](https://github.com/fg-labs/bwa-mem3/pull/128) | — |
+| Recover 8-bit banded SW (≥128 bp) | sw | Keeps long reads in the cheaper 8-bit lane width where valid | [#140](https://github.com/fg-labs/bwa-mem3/pull/140) | — |
+| Gotoh gaps from H | sw | Derives extension gaps from H (standard Gotoh) rather than M in the recovered 8-bit path | [#141](https://github.com/fg-labs/bwa-mem3/pull/141) | — |
+| Drop dead `qlen[]` param | sw | Removes an unread parameter from the three 8-bit kernels (cleanup; compile-output-identical) | [#143](https://github.com/fg-labs/bwa-mem3/pull/143) | — |
+
+### Open / in progress
+
+These are not yet merged to `main`; tracked together under the long-read
+banded-SW effort ([#146](https://github.com/fg-labs/bwa-mem3/issues/146)) and the
+read-I/O pipeline work.
+
+| Item | Stage | Mechanism | bwa-mem3 PR |
+|------|-------|-----------|-------------|
+| Short-circuit re-baseline scan | sw | Skips the inert per-row re-baseline scan in the banded kernel | [#147](https://github.com/fg-labs/bwa-mem3/pull/147) |
+| Vectorize epilogue side-channel | sw | Vectorizes the per-row epilogue side-channel loop | [#149](https://github.com/fg-labs/bwa-mem3/pull/149) |
+| Unsigned 8-bit h0-prefix seed | sw | Widens the 8-bit h0-prefix seed to unsigned `[0,255]` | [#151](https://github.com/fg-labs/bwa-mem3/pull/151) |
+| zlib-ng inflate + 3rd worker | i/o | Vendored zlib-ng inflate path with chunk cap and an added pipeline worker | [#153](https://github.com/fg-labs/bwa-mem3/pull/153) |
+| Bound getScores prefetch reads | sw | Bounds `getScores8/16` prefetch reads to the padding contract (hardening) | [#150](https://github.com/fg-labs/bwa-mem3/pull/150) |
+| Remove dead SW code paths | sw | Deletes unreachable `SORT_PAIRS` / non-CORE / SSE2-polyfill code (no behavior change) | [#148](https://github.com/fg-labs/bwa-mem3/pull/148) |
+| Long-read kernel parity test | sw | Promotes the 8-bit/16-bit byte-identity harness into a CI doctest | [#144](https://github.com/fg-labs/bwa-mem3/pull/144) |
+
+Two correctness fixes underpin the long-read SW and high-throughput work rather
+than adding speed themselves: SMEM read positions widened `int16_t` → `int32_t`
+to stop a long-read `SIGSEGV` ([#142](https://github.com/fg-labs/bwa-mem3/pull/142),
+merged), and a persistent `kt_for` worker pool that fixes a multi-chunk
+`SIGSEGV` under mimalloc v3 ([#154](https://github.com/fg-labs/bwa-mem3/pull/154),
+open).
 
 ---
 

--- a/docs/src/whats-different/performance.md
+++ b/docs/src/whats-different/performance.md
@@ -1,8 +1,9 @@
 # Performance Improvements
 
 This page covers the performance work carried in bwa-mem3 on top of upstream
-bwa-mem2. Almost every change listed here is a pure throughput or memory win
-that preserves the aligner's output; the one exception is the deterministic
+bwa-mem2. Almost every change listed here is a throughput, memory, or
+supporting (test/hardening/cleanup) change that preserves the aligner's output;
+the one exception is the deterministic
 tie-break ordering in [#123](https://github.com/fg-labs/bwa-mem3/pull/123),
 which can reorder equal-scoring alignments relative to upstream (see
 [Equivalence with bwa-mem2](equivalence.md) for the full, audited list of where
@@ -102,7 +103,10 @@ The mechanism column says, in one line, *why it is faster*. The stage column
 groups changes by where in the pipeline they act: **seed** (SMEM/FM-index
 walks), **sw** (Smith–Waterman / banded kernels), **index** (`bwa-mem3 index`),
 **i/o** (read decompression + header ingestion), **mem** (allocation),
-**dispatch** (SIMD/runtime selection), or **sort**.
+**dispatch** (SIMD/runtime selection), **sort**, or **prof** (off-by-default
+profiling). A `/test` suffix (e.g. `sw/test`) marks a test or contract-locking
+change for that stage; a slash between two stages (e.g. `dispatch/sw`) means the
+change spans both.
 
 ### Merged
 

--- a/docs/src/whats-different/performance.md
+++ b/docs/src/whats-different/performance.md
@@ -128,29 +128,37 @@ walks), **sw** (Smith–Waterman / banded kernels), **index** (`bwa-mem3 index`)
 | Recover 8-bit banded SW (≥128 bp) | sw | Keeps long reads in the cheaper 8-bit lane width where valid | [#140](https://github.com/fg-labs/bwa-mem3/pull/140) | — |
 | Gotoh gaps from H | sw | Derives extension gaps from H (standard Gotoh) rather than M in the recovered 8-bit path | [#141](https://github.com/fg-labs/bwa-mem3/pull/141) | — |
 | Drop dead `qlen[]` param | sw | Removes an unread parameter from the three 8-bit kernels (cleanup; compile-output-identical) | [#143](https://github.com/fg-labs/bwa-mem3/pull/143) | — |
+| Long-read kernel parity test | sw/test | Promotes the 8-bit/16-bit byte-identity harness into a CI doctest | [#144](https://github.com/fg-labs/bwa-mem3/pull/144) | — |
+| Short-circuit re-baseline scan | sw | Skips the inert per-row re-baseline scan in the banded kernel | [#147](https://github.com/fg-labs/bwa-mem3/pull/147) | — |
+| Remove dead SW code paths | sw | Deletes unreachable `SORT_PAIRS` / non-CORE / SSE2-polyfill code (no behavior change) | [#148](https://github.com/fg-labs/bwa-mem3/pull/148) | — |
+| Vectorize epilogue side-channel | sw | Vectorizes the per-row epilogue side-channel loop | [#149](https://github.com/fg-labs/bwa-mem3/pull/149) | — |
+| Bound getScores prefetch reads | sw | Bounds `getScores8/16` prefetch reads to the padding contract (hardening) | [#150](https://github.com/fg-labs/bwa-mem3/pull/150) | — |
+| Unsigned 8-bit h0-prefix seed | sw | Widens the 8-bit h0-prefix seed to unsigned `[0,255]` | [#151](https://github.com/fg-labs/bwa-mem3/pull/151) | — |
+| `--profile` stage timing | prof | Off-by-default read/proc/write + disk/decompress/parse breakdown for diagnosing pipeline scaling (no overhead when off) | [#152](https://github.com/fg-labs/bwa-mem3/pull/152) | — |
+| zlib-ng inflate + 3rd worker | i/o | Vendored zlib-ng inflate path with chunk cap and an added pipeline worker (~2.2× faster read stage; up to −7.8% wall at 96 cores) | [#153](https://github.com/fg-labs/bwa-mem3/pull/153) | — |
+| Right-size SA staging buffers | index | Sizes the `pos_ar`/`map_ar` staging buffers to the actual `min(s, max_occ)` write count instead of the uncapped SA-interval sum | [#157](https://github.com/fg-labs/bwa-mem3/pull/157) | — |
+| `gtle` contract test | sw/test | Enforces `gtle` byte-identity when `gscore > 0`; documents the `gscore == 0` query-end tail divergence | [#158](https://github.com/fg-labs/bwa-mem3/pull/158) | — |
+| NEON SW tuning | sw | Replaces `sse2neon` all-zero `movemask` tests with single-instruction `vmaxvq` horizontal reductions in the hot SW scans | [#160](https://github.com/fg-labs/bwa-mem3/pull/160) | — |
+| AVX2 SW tuning | sw | Relieves the port-5 `vpblendvb`/`vpshufb` bottleneck in the two SW kernels (byte-identical, Zen3-verified) | [#161](https://github.com/fg-labs/bwa-mem3/pull/161) | — |
+| AVX2 16-bit `kswv256_16` | sw | Adds the AVX2 16-bit mate-rescue kernel so AVX2 hosts no longer fall back to scalar `ksw_align2` for 16-bit rescue | [#162](https://github.com/fg-labs/bwa-mem3/pull/162) | — |
+| NEON `movemask` parity test | sw/test | Scalar-vs-NEON unit test for the `movemask` helpers; guards the #160 rewrite against silent mask collapse | [#164](https://github.com/fg-labs/bwa-mem3/pull/164) | — |
 
 ### Open / in progress
 
-These are not yet merged to `main`; tracked together under the long-read
-banded-SW effort ([#146](https://github.com/fg-labs/bwa-mem3/issues/146)) and the
-read-I/O pipeline work.
+Not yet merged to `main`:
 
 | Item | Stage | Mechanism | bwa-mem3 PR |
 |------|-------|-----------|-------------|
-| Short-circuit re-baseline scan | sw | Skips the inert per-row re-baseline scan in the banded kernel | [#147](https://github.com/fg-labs/bwa-mem3/pull/147) |
-| Vectorize epilogue side-channel | sw | Vectorizes the per-row epilogue side-channel loop | [#149](https://github.com/fg-labs/bwa-mem3/pull/149) |
-| Unsigned 8-bit h0-prefix seed | sw | Widens the 8-bit h0-prefix seed to unsigned `[0,255]` | [#151](https://github.com/fg-labs/bwa-mem3/pull/151) |
-| zlib-ng inflate + 3rd worker | i/o | Vendored zlib-ng inflate path with chunk cap and an added pipeline worker | [#153](https://github.com/fg-labs/bwa-mem3/pull/153) |
-| Bound getScores prefetch reads | sw | Bounds `getScores8/16` prefetch reads to the padding contract (hardening) | [#150](https://github.com/fg-labs/bwa-mem3/pull/150) |
-| Remove dead SW code paths | sw | Deletes unreachable `SORT_PAIRS` / non-CORE / SSE2-polyfill code (no behavior change) | [#148](https://github.com/fg-labs/bwa-mem3/pull/148) |
-| Long-read kernel parity test | sw | Promotes the 8-bit/16-bit byte-identity harness into a CI doctest | [#144](https://github.com/fg-labs/bwa-mem3/pull/144) |
+| AVX2 8-bit wrapper prefetch | sw | Adds the missing next-batch ref/query software-prefetch to `smithWatermanBatchWrapper8` — the lone SW wrapper that lacked it (follow-up to #161) | [#163](https://github.com/fg-labs/bwa-mem3/pull/163) |
 
-Two correctness fixes underpin the long-read SW and high-throughput work rather
-than adding speed themselves: SMEM read positions widened `int16_t` → `int32_t`
-to stop a long-read `SIGSEGV` ([#142](https://github.com/fg-labs/bwa-mem3/pull/142),
-merged), and a persistent `kt_for` worker pool that fixes a multi-chunk
-`SIGSEGV` under mimalloc v3 ([#154](https://github.com/fg-labs/bwa-mem3/pull/154),
-open).
+Several correctness and crash fixes underpin the long-read SW, indexing, and
+high-throughput work rather than adding speed themselves: SMEM read positions
+widened `int16_t` → `int32_t` to stop a long-read `SIGSEGV`
+([#142](https://github.com/fg-labs/bwa-mem3/pull/142), merged); a persistent
+`kt_for` worker pool that fixes a multi-chunk `SIGSEGV` under mimalloc v3
+([#154](https://github.com/fg-labs/bwa-mem3/pull/154), merged); and `mem_lim`
+widened to `int64` to stop an SA-staging buffer overflow on highly repetitive
+seeds ([#156](https://github.com/fg-labs/bwa-mem3/pull/156), merged).
 
 ---
 


### PR DESCRIPTION
## Why

Two things Jeff raised in Slack about bwa-mem3:

1. The published page <https://bwa-mem3.readthedocs.io/en/latest/whats-different/equivalence.html> "doesn't look right" (it 404s in every browser).
2. There's no good single place explaining **what drives bwa-mem3's speedup**.

This draft PR addresses both.

## 1. The stale Read the Docs site (the "doesn't look right" link)

**Root cause confirmed via the public RTD API — it is a one-setting misconfiguration, not a build failure and not a dead webhook.**

### Symptom
The live `latest` site is frozen at late April. `whats-different/equivalence` (added in #124, merged 2026-06-04) 404s — exactly the dead link Jeff hit — and the site is ~72 commits behind `main`. `mdbook build` of current `main` succeeds locally, so the content is fine.

### Root cause
The RTD project's **configured default branch is `master`, but this repo's default branch is `main`** (there is no `master` branch). From `GET /api/v3/projects/bwa-mem3/`:

| RTD setting | Value | Reality |
|---|---|---|
| `default_branch` | **`master`** | repo has no `master`; default is `main` |
| `default_version` | `latest` | — |
| project `modified` | 2026-04-30 | untouched since import |

Versions (`/api/v3/projects/bwa-mem3/versions/`):

| version | active | built | tracks |
|---|---|---|---|
| `latest` | ✅ | last built `41e1f3c` on **2026-04-29** | branch `main` |
| `main` | ❌ inactive | never built | branch `main` |
| `stable` / `v0.2.0` | ✅ | tag `1e94a8e` (2026-05-13) | tag |

RTD's `latest` version resolves to the project's `default_branch`. Because that points at the non-existent `master`, pushes to `main` map to **no active buildable version** (`latest` chases the phantom `master`; the auto-discovered `main` version is inactive). The RTD GitHub App is healthy — installed org-wide on 2026-04-29, not suspended, subscribed to `push`, `updated_at` 2026-06-18 — so it **is** receiving every push to `main`; they just build nothing. `latest` therefore stayed at `41e1f3c` (RTD's one-time on-import build), and everything merged since — including #124's equivalence page — was never published.

This also accounts for every other signal: no classic repo webhook (modern App flow), no RTD commit statuses on any `main` commit (RTD isn't configured to post them here), and "builds succeed whenever they actually run" (the import build was green — the build *recipe* was never the problem).

### The fix (RTD dashboard, ~30 s — needs dashboard access)
> ⚠️ I can't change this (no RTD token; the dashboard is 403 without auth). Please:
> 1. **Admin → Settings → Default branch:** change `master` → `main` (or blank it to fall back to the repo default). Save.
> 2. **Builds → "Build version: latest"** to force an immediate rebuild; confirm `…/en/latest/whats-different/equivalence.html` resolves. After this, pushes to `main` auto-build again.

### What this PR still contributes
The `.readthedocs.yaml` change is **not** the cause fix, but it's worth keeping: it installs **both** `mdbook` (0.5.2) and `mdbook-mermaid` (0.17.0) from **prebuilt release binaries pinned to the exact CI versions**, so RTD and `.github/workflows/docs.yml` stay in lockstep and a future floating `mdbook-mermaid` (the old config ran `cargo install mdbook-mermaid` unpinned) can't silently break builds. It also drops the brittle `rust: "1.91"` pin and the multi-minute source compile.

## 2. "What drives the speedup" — narrative overview

`performance/overview.md` previously listed only four drivers. It's rewritten into five reader-facing groups, each leading with the plain-English reason it's faster, with PR citations and an explicit "it depends on the workload" caveat:

- **Getting more out of the machine** — widest-ISA SIMD kernels, in-process dispatch (#83), native NEON (~10% on Apple Silicon), AVX2 baseline (#84), 256-bit avx512 cap (#86), kswv prefetch (#70), recovered 8-bit long-read SW (#140), per-ISA SW hand-tuning (#160/#161), and the AVX2 16-bit `kswv256_16` rescue kernel (#162).
- **Fixing bad patterns in the hot path** — lockstep SMEM batching (#33/#75), O(n²)→O(n) header ingestion (#49), closed-form ungapped (#77), on-stack sort (#78), inlined `backwardExt` (#88), pdqsort (#123), consolidated audit (#58).
- **Indexing** — libsais (#57), zero-init skip (#80), right-sized SA staging buffers (#157).
- **Allocation & I/O** — mimalloc (#19), FASTQ fast path (#128), zlib-ng inflate + 3rd worker (#153), `--profile` stage timing (#152).
- **Build-time** — PGO.

## 3. Full perf-PR catalog (merged + open)

`whats-different/performance.md`: the catalog is a complete **merged + open** table (mechanism, pipeline stage, PR, upstream), current as of the 2026-06-18→06-20 merges. The seven PRs previously listed "open / in progress" (#144, #147, #148, #149, #150, #151, #153) are merged, and the newly-landed perf work (#152, #157, #158, #160, #161, #162, #164) is added. The only still-open perf PR is the AVX2 8-bit wrapper prefetch (#163). The intro also corrects the stale "every change is byte-identical" claim — the deterministic tie-break ordering (#123) is the one output-affecting exception, cross-linked to the equivalence page.

## Verification

- `mdbook build` (pinned 0.5.2 / mermaid 0.17.0) succeeds; all three pages render and every cross-link resolves.
- Catalog cross-checked against `gh pr list --state merged/open`: the status column matches current `main`.
- RTD root cause read directly from the public `app.readthedocs.org/api/v3` project + versions endpoints (no auth needed for read); repo default branch and absence of `master` confirmed via `gh`.
- Prebuilt-binary recipe validated locally: both release URLs return 200 and the tar layout is `bin/mdbook` + `bin/mdbook-mermaid`.

## Notes for reviewers

- The #153 (zlib-ng) numbers cited in the docs come from the authoritative single-socket scaling sweep posted in the PR comments (c8g.24xlarge, ~2.2× read stage, up to −7.8% wall at 96 cores).
- Draft because the RTD fix needs a dashboard owner to flip `default_branch` to `main` and trigger a `latest` rebuild (box above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized the performance overview into five workload-dependent categories: SIMD/microarchitecture, hot-path algorithmic improvements, indexing, memory/I/O, and build-time optimization (PGO).
  * Updated the performance comparison and “changes catalog” with clearer stage/mechanism breakdowns, an explicit note about a documented output divergence, and expanded tracking of merged and open items, plus other non-speed correctness/crash fixes.
* **Chores**
  * Updated the Read the Docs build configuration to use a pinned Python version and prebuilt `mdbook` artifacts with checksum verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->