### PR TITLE
fix(fmi): widen mem_lim to int64 and guard SA-entry allocations

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -858,7 +858,9 @@ void FMI_search::getSMEMsAllPosOneThread(uint8_t *enc_qdb,
                                          SMEM *matchArray,
                                          int64_t *__numTotalSmem)
 {
-    int32_t *query_pos_array = (int32_t *)_mm_malloc(numReads * sizeof(int32_t), 64);
+    size_t query_pos_bytes = (size_t)numReads * sizeof(int32_t);
+    int32_t *query_pos_array = (int32_t *)_mm_malloc(query_pos_bytes, 64);
+    assert_not_null(query_pos_array, query_pos_bytes, query_pos_bytes);
 
     int32_t i;
     for(i = 0; i < numReads; i++)
@@ -1591,8 +1593,16 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
 {
     
     // uint32_t i;
-    int32_t totalCoordCount = 0;
-    int32_t mem_lim = 0, id = 0;
+    // totalCoordCount and id (below) both count entries staged into the int64
+    // coordArray/pos_ar/map_ar buffers and are paired with the int64 mem_lim,
+    // so keep them int64 to avoid truncating the running offset.
+    int64_t totalCoordCount = 0;
+    // mem_lim sums the (uncapped) SA-interval sizes smem.s, which for a highly
+    // repetitive seed can approach the genome length and overflow int32 on its
+    // own. A wrapped value undersizes the pos_ar/map_ar allocation below and
+    // corrupts the heap, so accumulate in int64. id indexes those buffers and
+    // is paired with mem_lim, so widen it too.
+    int64_t mem_lim = 0, id = 0;
     
     for(int i = 0; i < count; i++)
     {
@@ -1601,8 +1611,11 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
         mem_lim += smem.s;
     }
 
-    int64_t *pos_ar = (int64_t *) _mm_malloc( mem_lim * sizeof(int64_t), 64);
-    int64_t *map_ar = (int64_t *) _mm_malloc( mem_lim * sizeof(int64_t), 64);
+    size_t sa_ar_bytes = (size_t)mem_lim * sizeof(int64_t);
+    int64_t *pos_ar = (int64_t *) _mm_malloc( sa_ar_bytes, 64);
+    assert_not_null(pos_ar, sa_ar_bytes, sa_ar_bytes);
+    int64_t *map_ar = (int64_t *) _mm_malloc( sa_ar_bytes, 64);
+    assert_not_null(map_ar, sa_ar_bytes, (size_t)2 * sa_ar_bytes);
 
     for(int i = 0; i < count; i++)
     {
@@ -1650,7 +1663,9 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
         j++;
     }
         
-    int lim = j, all_quit = 0;
+    // all_quit counts up to id (int64); lim stays int (bounded by sa_batch_size).
+    int lim = j;
+    int64_t all_quit = 0;
     while (all_quit < id)
     {
         


### PR DESCRIPTION
## Summary

Two related hardening fixes in `src/FMI_search.cpp`, both surfaced while auditing the file's `_mm_malloc` convention.

### 1. `mem_lim` int32 overflow (the substantive fix)

`get_sa_entries_prefetch` sizes its `pos_ar`/`map_ar` staging buffers from `mem_lim`, which sums the **uncapped** SA-interval sizes (`smem.s`) across all SMEMs in a read group:

```c
int32_t mem_lim = 0;
for (...) mem_lim += smem.s;            // smem.s is int64_t
int64_t *pos_ar = _mm_malloc(mem_lim * sizeof(int64_t), 64);
```

`smem.s` is an `int64_t` SA-interval size. A single highly repetitive seed can carry an interval size approaching the reference length (~3×10⁹ for GRCh38), which overflows `int32` on its own and wraps to a small or negative value. The allocation is then undersized while the actual number of writes stays bounded by `max_occ` per SMEM — so the staging loop overruns the buffer and corrupts the heap.

Fix: accumulate `mem_lim` (and its paired buffer index `id`) in `int64_t`.

### 2. Three missing `assert_not_null` guards

The file pairs every `_mm_malloc` with `assert_not_null` so an allocation failure prints a labeled "Allocation of X GB … failed" message and exits, rather than dereferencing NULL. Three of the 14 calls lacked it:

- `query_pos_array` in `getSMEMsAllPosOneThread`
- `pos_ar` / `map_ar` in `get_sa_entries_prefetch`

All three are written through immediately after allocation, so on OOM they would segfault instead of reporting the labeled error. Added the guards to match the convention. No leaks were involved — all three buffers were already freed.

## Scope

Only `get_sa_entries_prefetch` heap-stages SA entries; the other `get_sa_entries` overloads write directly to the caller's buffer, so the `mem_lim` change needed no replication.

A related **over-allocation** in the same function (`mem_lim` sums uncapped `s` but writes are capped at `min(s, max_occ)`) is intentionally left out — it changes sizing semantics and is tracked as a follow-up PR.

## Verification

`c++ -fsyntax-only -std=c++17` is clean (only pre-existing `%ld`/`int64_t` format warnings, untouched by this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected memory allocation sizing in search processing by computing required byte sizes in a wider integer type to avoid overflow.
  * Improved internal buffer indexing and staging calculations by widening related counters, preventing truncation and ensuring consistent allocation and bounds during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->