### PR TITLE
perf(fmi): size SA-entry staging buffers to the exact write count

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -1597,18 +1597,19 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
     // coordArray/pos_ar/map_ar buffers and are paired with the int64 mem_lim,
     // so keep them int64 to avoid truncating the running offset.
     int64_t totalCoordCount = 0;
-    // mem_lim sums the (uncapped) SA-interval sizes smem.s, which for a highly
-    // repetitive seed can approach the genome length and overflow int32 on its
-    // own. A wrapped value undersizes the pos_ar/map_ar allocation below and
-    // corrupts the heap, so accumulate in int64. id indexes those buffers and
-    // is paired with mem_lim, so widen it too.
+    // mem_lim is the exact number of entries the staging loop below writes:
+    // each SMEM contributes min(smem.s, max_occ) (the inner loop stops at
+    // c < max_occ). Summing min(s, max_occ) instead of the uncapped interval
+    // size s both right-sizes the pos_ar/map_ar allocation -- repetitive seeds
+    // have s up to the reference length but still write only max_occ entries --
+    // and keeps every term bounded by max_occ so the int64 sum cannot run away.
+    // id indexes those buffers and is paired with mem_lim, so it is int64 too.
     int64_t mem_lim = 0, id = 0;
-    
+
     for(int i = 0; i < count; i++)
     {
-        int32_t c = 0;
         SMEM smem = smemArray[i];
-        mem_lim += smem.s;
+        mem_lim += (smem.s > max_occ) ? max_occ : smem.s;
     }
 
     size_t sa_ar_bytes = (size_t)mem_lim * sizeof(int64_t);


### PR DESCRIPTION
> **Stacked on #156** (base branch is `fix/fmi-alloc-guards`, not `main`). Review/merge #156 first; this PR's diff will retarget to `main` automatically once #156 lands.

## Summary

Follow-up to #156. That PR made `get_sa_entries_prefetch`'s `mem_lim` accumulator `int64` so the `pos_ar`/`map_ar` allocation can no longer overflow. This PR fixes the *other* half of the same expression: the buffers are sized from the sum of the **uncapped** SA-interval sizes (`smem.s`), but the staging loop only ever writes `min(smem.s, max_occ)` entries per SMEM:

```c
for (j = smem.k; (j < hi) && (c < max_occ); j += step, c++)   // c < max_occ caps the writes
```

So for a read group containing highly repetitive seeds — where `s` can approach the reference length (~3×10⁹ for GRCh38) while only `max_occ` (typically a few hundred) entries are actually staged — the two `int64` buffers were over-allocated by orders of magnitude.

## Change

Sum `min(s, max_occ)` instead of `s`:

```c
mem_lim += (smem.s > max_occ) ? max_occ : smem.s;
```

This right-sizes the allocation to exactly the number of entries written. As a side benefit it bounds every term by `max_occ`, so the (already `int64`, per #156) sum stays clear of overflow by construction rather than just by width.

Also drops a stray unused `int32_t c = 0;` from the counting loop (the live `c` is declared in the staging loop below).

## Correctness

Output is unchanged. The buffers were only ever indexed up to the write count, and the new size is still ≥ that count for every SMEM, so a tighter-but-sufficient allocation produces byte-identical results. `c++ -fsyntax-only -std=c++17` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed integer overflow vulnerability in memory buffer allocation that prevented heap corruption during data structure construction.
* Enhanced allocation sizing calculations to ensure stable operation with highly repetitive input patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->