### PR TITLE
perf(bsw): AVX2 SIMD tuning for the Smith-Waterman kernels

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -338,45 +338,8 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
 //------------------------------------------------------------------------------
 // MACROs
 // ------------------------ vec-8 ---------------------------------------------
-// ZSCORE8 is unused in smithWaterman256_8 (z-drop replaced by wide scalar);
-// retained here in case a future 256-bit tier reinstates it.
-#define ZSCORE8(i4_256, y4_256)                                         \
-    {                                                                   \
-        __m256i tmpi = _mm256_sub_epi8(i4_256, x256);                   \
-        __m256i tmpj = _mm256_sub_epi8(y4_256, y256);                   \
-        cmp = _mm256_cmpgt_epi8(tmpi, tmpj);                            \
-        score256 = _mm256_sub_epi8(maxScore256, maxRS1);                \
-        __m256i insdel = _mm256_blendv_epi8(e_ins256, e_del256, cmp);   \
-        __m256i sub_a256 = _mm256_sub_epi8(tmpi, tmpj);                 \
-        __m256i sub_b256 = _mm256_sub_epi8(tmpj, tmpi);                 \
-        tmp = _mm256_blendv_epi8(sub_b256, sub_a256, cmp);              \
-        tmp = _mm256_sub_epi8(score256, tmp);                           \
-        cmp = _mm256_cmpgt_epi8(tmp, zdrop256);                         \
-        exit0 = _mm256_blendv_epi8(exit0, zero256, cmp);                \
-    }
 
 
-#define MAIN_CODE8(s1, s2, h00, h11, e11, f11, f21, zero256,  maxScore256, e_ins256, oe_ins256, e_del256, oe_del256, y256, maxRS) \
-    {                                                                   \
-        __m256i cmp11 = _mm256_cmpeq_epi8(s1, s2);                      \
-        __m256i sbt11 = _mm256_blendv_epi8(mismatch256, match256, cmp11); \
-        __m256i tmp256 = _mm256_max_epu8(s1, s2);                       \
-        /*tmp256 = _mm256_cmpeq_epi8(tmp256, val102);*/                 \
-        sbt11 = _mm256_blendv_epi8(sbt11, w_ambig_256, tmp256);         \
-        __m256i m11 = _mm256_add_epi8(h00, sbt11);                      \
-        cmp11 = _mm256_cmpeq_epi8(h00, zero256);                        \
-        m11 = _mm256_blendv_epi8(m11, zero256, cmp11);                  \
-        h11 = _mm256_max_epi8(m11, e11);                                \
-        h11 = _mm256_max_epi8(h11, f11);                                \
-        __m256i temp256 = _mm256_sub_epi8(h11, oe_ins256);              \
-        __m256i val256  = _mm256_max_epi8(temp256, zero256);            \
-        e11 = _mm256_sub_epi8(e11, e_ins256);                           \
-        e11 = _mm256_max_epi8(val256, e11);                             \
-        temp256 = _mm256_sub_epi8(h11, oe_del256);                      \
-        val256  = _mm256_max_epi8(temp256, zero256);                    \
-        f21 = _mm256_sub_epi8(f11, e_del256);                           \
-        f21 = _mm256_max_epi8(val256, f21);                             \
-    }
 
 // ------------------------ vec 16 --------------------------------------------------
 #define _mm256_blendv_epi16(a,b,c)              \
@@ -399,26 +362,6 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
     }
 
 
-#define MAIN_CODE16(s1, s2, h00, h11, e11, f11, f21, zero256,  maxScore256, e_ins256, oe_ins256, e_del256, oe_del256, y256, maxRS) \
-    {                                                                   \
-        __m256i cmp11 = _mm256_cmpeq_epi16(s1, s2);                     \
-        __m256i sbt11 = _mm256_blendv_epi16(mismatch256, match256, cmp11); \
-        __m256i tmp256 = _mm256_max_epu16(s1, s2);                      \
-        sbt11 = _mm256_blendv_epi16(sbt11, w_ambig_256, tmp256);        \
-        __m256i m11 = _mm256_add_epi16(h00, sbt11);                     \
-        cmp11 = _mm256_cmpeq_epi16(h00, zero256);                       \
-        m11 = _mm256_blendv_epi16(m11, zero256, cmp11);                 \
-        h11 = _mm256_max_epi16(m11, e11);                               \
-        h11 = _mm256_max_epi16(h11, f11);                               \
-        __m256i temp256 = _mm256_sub_epi16(h11, oe_ins256);             \
-        __m256i val256  = _mm256_max_epi16(temp256, zero256);           \
-        e11 = _mm256_sub_epi16(e11, e_ins256);                          \
-        e11 = _mm256_max_epi16(val256, e11);                            \
-        temp256 = _mm256_sub_epi16(h11, oe_del256);                     \
-        val256  = _mm256_max_epi16(temp256, zero256);                   \
-        f21 = _mm256_sub_epi16(f11, e_del256);                          \
-        f21 = _mm256_max_epi16(val256, f21);                            \
-    }
 
 // --- PR 17/16: AVX2 LUT primitive ---
 // pmat256 must have the 16-byte LUT broadcast into both 128-bit halves
@@ -888,11 +831,7 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
 {
     __m256i match256     = _mm256_set1_epi8(this->w_match);
     __m256i mismatch256  = _mm256_set1_epi8(this->w_mismatch);
-    __m256i gapOpen256   = _mm256_set1_epi8(this->w_open);
-    __m256i gapExtend256 = _mm256_set1_epi8(this->w_extend);
-    __m256i gapOE256     = _mm256_set1_epi8(this->w_open + this->w_extend);
     __m256i w_ambig_256  = _mm256_set1_epi8(this->w_ambig); // ambig penalty
-    __m256i five256      = _mm256_set1_epi8(5);
 
     // PR 16: pmat LUT, broadcast into both 128-bit halves (shuffle_epi8 is
     // lane-wise on AVX2 — each half shuffles against its own half of pmat256).
@@ -1835,11 +1774,7 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
 {
     __m256i match256     = _mm256_set1_epi16(this->w_match);
     __m256i mismatch256  = _mm256_set1_epi16(this->w_mismatch);
-    __m256i gapOpen256   = _mm256_set1_epi16(this->w_open);
-    __m256i gapExtend256 = _mm256_set1_epi16(this->w_extend);
-    __m256i gapOE256     = _mm256_set1_epi16(this->w_open + this->w_extend);
     __m256i w_ambig_256  = _mm256_set1_epi16(this->w_ambig);    // ambig penalty
-    __m256i five256      = _mm256_set1_epi16(5);
 
     __m256i e_del256    = _mm256_set1_epi16(this->e_del);
     __m256i oe_del256   = _mm256_set1_epi16(this->o_del + this->e_del);

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -1206,12 +1206,11 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
 
             __m256i bmaxRS = maxRS1;
             maxRS1 =_mm256_max_epu8(maxRS1, h11);
-            // UNSIGNED >: maxRS1 = max_epu8(.,h11) >= bmaxRS always, so
-            // (maxRS1 >u bmaxRS) == (maxRS1 != bmaxRS). Signed cmpgt_epi8 here
-            // mis-read scores >127 (long reads) as negative.
-            __m256i cmpA = _mm256_xor_si256(_mm256_cmpeq_epi8(maxRS1, bmaxRS), ff256);
-            __m256i cmpB =_mm256_cmpeq_epi8(maxRS1, h11);
-            cmpA = _mm256_or_si256(cmpA, cmpB);
+            // "new row-max" argmax mask. maxRS1 = max(bmaxRS,h11), so
+            // (maxRS1 != bmaxRS) is a strict subset of (maxRS1 == h11) (both
+            // mean h11 >= bmaxRS); the OR was redundant. cmpeq(maxRS1,h11) is
+            // the exact combined mask — bit-identical, drops a cmpeq+xor+or.
+            __m256i cmpA = _mm256_cmpeq_epi8(maxRS1, h11);
             cmp1 = _mm256_cmpgt_epi8(j256, tail256);
             cmp1 = _mm256_or_si256(cmp1, cmp2);
             cmpA = _mm256_blendv_epi8(y1_256, j256, cmpA);
@@ -2030,11 +2029,13 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
             h10 = _mm256_andnot_si256(cmp1, h10);
             f21 = _mm256_andnot_si256(cmp1, f21);
             
-            __m256i bmaxRS = maxRS1;                                        
-            maxRS1 =_mm256_max_epi16(maxRS1, h11);                          
-            __m256i cmpA = _mm256_cmpgt_epi16(maxRS1, bmaxRS);                  
-            __m256i cmpB =_mm256_cmpeq_epi16(maxRS1, h11);                  
-            cmpA = _mm256_or_si256(cmpA, cmpB);
+            __m256i bmaxRS = maxRS1;
+            maxRS1 =_mm256_max_epi16(maxRS1, h11);
+            // "new row-max" argmax mask. maxRS1 = max(bmaxRS,h11), so
+            // cmpgt(maxRS1,bmaxRS) is a strict subset of cmpeq(maxRS1,h11)
+            // (both mean h11 >= bmaxRS); the OR was redundant. cmpeq(maxRS1,h11)
+            // is the exact combined mask — bit-identical, drops a cmpgt+or.
+            __m256i cmpA = _mm256_cmpeq_epi16(maxRS1, h11);
             cmp1 = _mm256_cmpgt_epi16(j256, tail256); // change
             cmp1 = _mm256_or_si256(cmp1, cmp2);         // change
             cmpA = _mm256_blendv_epi16(y1_256, j256, cmpA);

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -2052,17 +2052,20 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
             if (j >= minq)
             {
                 __m256i cmp = _mm256_cmpeq_epi16(j256, qlen256);
+                // Both blendv pairs below fall back to the same operand under
+                // exit0 then cmp, so each collapses to one select against the
+                // fused mask (cmp & exit0): saves 2 port-5 blendv per qualifying
+                // cell. Bit-identical — lane masks are uniform 0xFFFF/0x0000.
+                __m256i sel = _mm256_and_si256(cmp, exit0);
                 __m256i max_gh = _mm256_max_epi16(gscore, h11);
                 __m256i cmp_gh = _mm256_cmpgt_epi16(gscore, h11);
-                __m256i tmp256_1 = _mm256_blendv_epi16(i1_256, max_ie256, cmp_gh);
+                __m256i cand_ie = _mm256_blendv_epi16(i1_256, max_ie256, cmp_gh);
 
-                __m256i tmp256_t = _mm256_blendv_epi16(max_ie256, tmp256_1, cmp);
-                tmp256_1 = _mm256_blendv_epi16(max_ie256, tmp256_t, exit0);             
+                __m256i tmp256_1 = _mm256_blendv_epi16(max_ie256, cand_ie, sel);
 
-                max_gh = _mm256_blendv_epi16(gscore, max_gh, exit0);
-                max_gh = _mm256_blendv_epi16(gscore, max_gh, cmp);              
+                max_gh = _mm256_blendv_epi16(gscore, max_gh, sel);
 
-                cmp = _mm256_cmpgt_epi16(j256, tail256); 
+                cmp = _mm256_cmpgt_epi16(j256, tail256);
                 max_gh = _mm256_blendv_epi16(max_gh, gscore, cmp);
                 max_ie256 = _mm256_blendv_epi16(tmp256_1, max_ie256, cmp);
                 gscore = max_gh;            

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -395,7 +395,7 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
         tmp = _mm256_blendv_epi16(sub_b256, sub_a256, cmp);             \
         tmp = _mm256_sub_epi16(score256, tmp);                          \
         cmp = _mm256_cmpgt_epi16(tmp, zdrop256);                            \
-        exit0 = _mm256_blendv_epi16(exit0, zero256, cmp);               \
+        exit0 = _mm256_andnot_si256(cmp, exit0);               \
     }
 
 
@@ -445,7 +445,7 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
         __m256i sbt_neg = _mm256_max_epi8(_mm256_sub_epi8(zero256, sbt11), zero256); \
         __m256i m11 = _mm256_subs_epu8(_mm256_adds_epu8(h00, sbt_pos), sbt_neg); \
         __m256i cmp11 = _mm256_cmpeq_epi8(h00, zero256);                \
-        m11 = _mm256_blendv_epi8(m11, zero256, cmp11);  /* h00==0 -> local restart */ \
+        m11 = _mm256_andnot_si256(cmp11, m11);  /* h00==0 -> local restart */ \
         h11 = _mm256_max_epu8(m11, e11);                                \
         h11 = _mm256_max_epu8(h11, f11);                                \
         /* gap-open from H (standard Gotoh), unsigned-saturating */      \
@@ -469,7 +469,7 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
     {                                                                   \
         __m256i m11 = _mm256_add_epi16(h00, sbt11);                     \
         __m256i cmp11 = _mm256_cmpeq_epi16(h00, zero256);               \
-        m11 = _mm256_blendv_epi16(m11, zero256, cmp11);                 \
+        m11 = _mm256_andnot_si256(cmp11, m11);                 \
         h11 = _mm256_max_epi16(m11, e11);                               \
         h11 = _mm256_max_epi16(h11, f11);                               \
         __m256i temp256 = _mm256_sub_epi16(h11, oe_ins256);             \
@@ -1143,8 +1143,8 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
             if (cval == 0x00) break;
             __m256i cmp2 = _mm256_cmpgt_epi8(pj256, tail256);
             cmp1 = _mm256_or_si256(cmp1, cmp2);
-            h256 = _mm256_blendv_epi8(h256, zero256, cmp1);
-            f256 = _mm256_blendv_epi8(f256, zero256, cmp1);
+            h256 = _mm256_andnot_si256(cmp1, h256);
+            f256 = _mm256_andnot_si256(cmp1, f256);
 
             _mm256_store_si256((__m256i *)(F + l * SIMD_WIDTH8), f256);
             _mm256_store_si256((__m256i *)(H_h + l * SIMD_WIDTH8), h256);
@@ -1163,7 +1163,7 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         cmpht = _mm256_cmpgt_epi8(head256, tail256);
         cmpim = _mm256_or_si256(cmpim, cmpht);
 
-        exit0 = _mm256_blendv_epi8(exit0, zero256, cmpim);
+        exit0 = _mm256_andnot_si256(cmpim, exit0);
 
 #if RDT
         tim1 = __rdtsc();
@@ -1201,8 +1201,8 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
             __m256i cmp1 = _mm256_cmpgt_epi8(head256, pj256);
             __m256i cmp2 = _mm256_cmpgt_epi8(pj256, tail256);
             cmp1 = _mm256_or_si256(cmp1, cmp2);
-            h10 = _mm256_blendv_epi8(h10, zero256, cmp1);
-            f21 = _mm256_blendv_epi8(f21, zero256, cmp1);
+            h10 = _mm256_andnot_si256(cmp1, h10);
+            f21 = _mm256_andnot_si256(cmp1, f21);
 
             __m256i bmaxRS = maxRS1;
             maxRS1 =_mm256_max_epu8(maxRS1, h11);
@@ -1243,7 +1243,7 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         __m256i cmp1 = _mm256_cmpgt_epi8(head256, j256);
         __m256i cmp2 = _mm256_cmpgt_epi8(j256, tail256);
         cmp1 = _mm256_or_si256(cmp1, cmp2);
-        h10 = _mm256_blendv_epi8(h10, zero256, cmp1);
+        h10 = _mm256_andnot_si256(cmp1, h10);
 
         _mm256_store_si256((__m256i *)(H_h + j * SIMD_WIDTH8), h10);
         _mm256_store_si256((__m256i *)(F + j * SIMD_WIDTH8), zero256);
@@ -1256,7 +1256,7 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         cval = _mm256_movemask_epi8(tmp);
         if (cval == 0xFFFFFFFF) break;
 
-        exit0 = _mm256_blendv_epi8(exit0, zero256,  tmp);
+        exit0 = _mm256_andnot_si256(tmp, exit0);
 
         __m256i score256 = _mm256_max_epu8(maxScore256, maxRS1);
         maxScore256 = _mm256_blendv_epi8(maxScore256, score256, exit0);
@@ -1971,8 +1971,8 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
             //__m256i cmp2 = _mm256_cmpgt_epi16(pj256, tail256);
             __m256i cmp2 = _mm256_cmpgt_epi16(j256, tail256);
             cmp1 = _mm256_or_si256(cmp1, cmp2);
-            h256 = _mm256_blendv_epi16(h256, zero256, cmp1);
-            f256 = _mm256_blendv_epi16(f256, zero256, cmp1);
+            h256 = _mm256_andnot_si256(cmp1, h256);
+            f256 = _mm256_andnot_si256(cmp1, f256);
             
             _mm256_store_si256((__m256i *)(F + l * SIMD_WIDTH16), f256);
             _mm256_store_si256((__m256i *)(H_h + l * SIMD_WIDTH16), h256);
@@ -1993,7 +1993,7 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         cmpht = _mm256_cmpgt_epi16(head256, tail256);
         cmpim = _mm256_or_si256(cmpim, cmpht);
 
-        exit0 = _mm256_blendv_epi16(exit0, zero256, cmpim);
+        exit0 = _mm256_andnot_si256(cmpim, exit0);
 
         
 #if RDT
@@ -2027,8 +2027,8 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
             __m256i cmp2 = _mm256_cmpgt_epi16(head256, pj256);
             __m256i cmp1 = _mm256_cmpgt_epi16(pj256, tail256);
             cmp1 = _mm256_or_si256(cmp1, cmp2);
-            h10 = _mm256_blendv_epi16(h10, zero256, cmp1);
-            f21 = _mm256_blendv_epi16(f21, zero256, cmp1);
+            h10 = _mm256_andnot_si256(cmp1, h10);
+            f21 = _mm256_andnot_si256(cmp1, f21);
             
             __m256i bmaxRS = maxRS1;                                        
             maxRS1 =_mm256_max_epi16(maxRS1, h11);                          
@@ -2071,7 +2071,7 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         __m256i cmp2 = _mm256_cmpgt_epi16(head256, j256);
         __m256i cmp1 = _mm256_cmpgt_epi16(j256, tail256);
         cmp1 = _mm256_or_si256(cmp1, cmp2);
-        h10 = _mm256_blendv_epi16(h10, zero256, cmp1);
+        h10 = _mm256_andnot_si256(cmp1, h10);
         
         _mm256_store_si256((__m256i *)(H_h + j * SIMD_WIDTH16), h10);
         _mm256_store_si256((__m256i *)(F + j * SIMD_WIDTH16), zero256);
@@ -2082,7 +2082,7 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         uint32_t cval = _mm256_movemask_epi8(tmp) & dmask32;
         if (cval == dmask32) break;
 
-        exit0 = _mm256_blendv_epi16(exit0, zero256,  tmp);
+        exit0 = _mm256_andnot_si256(tmp, exit0);
 
         __m256i score256 = _mm256_max_epi16(maxScore256, maxRS1);
         maxScore256 = _mm256_blendv_epi16(maxScore256, score256, exit0);

--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -1255,10 +1255,6 @@ static inline __m256i avx2_widen_u8_hi(__m256i v)
 
 /* Signed 16-bit compares are provided directly by AVX2 (_mm256_cmpgt_epi16,
  * _mm256_cmpeq_epi16). No cmplt / cmpge; synthesize. */
-static inline __m256i avx2_cmplt_s16(__m256i a, __m256i b)
-{
-    return _mm256_cmpgt_epi16(b, a);
-}
 static inline __m256i avx2_cmpgt_s16(__m256i a, __m256i b)
 {
     return _mm256_cmpgt_epi16(a, b);

--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -1348,10 +1348,10 @@ int kswv::kswv256_u8(uint8_t seq1SoA[],
     // Per-strip L1 prefetches mirroring the AVX-512 8-bit and 16-bit kernels.
     // The 8-bit AVX2 path was missing them; without these the inner loop
     // stalls on L1 misses for F/H1/seq for the first several rows.
-    _mm_prefetch((const char*) (F + SIMD_WIDTH8), _MM_HINT_NTA);
-    _mm_prefetch((const char*) seq2SoA, _MM_HINT_NTA);
+    _mm_prefetch((const char*) (F + SIMD_WIDTH8), _MM_HINT_T0);
+    _mm_prefetch((const char*) seq2SoA, _MM_HINT_T1);
     _mm_prefetch((const char*) seq1SoA, _MM_HINT_NTA);
-    _mm_prefetch((const char*) (H1 + SIMD_WIDTH8), _MM_HINT_NTA);
+    _mm_prefetch((const char*) (H1 + SIMD_WIDTH8), _MM_HINT_T0);
 
     for (int i = 0; i <= ncol; i++) {
         _mm256_storeu_si256((__m256i*)(H0   + i * SIMD_WIDTH8), zero_vec);
@@ -2031,10 +2031,10 @@ int kswv::kswv512_u8(uint8_t seq1SoA[],
     // PR #58; without them the inner loop stalls on L1 misses for F/H1/seq
     // for the first several rows. Identical hint shape; load addresses
     // scaled to SIMD_WIDTH8 (64 bytes per row).
-    _mm_prefetch((const char*) (F + SIMD_WIDTH8), _MM_HINT_NTA);
-    _mm_prefetch((const char*) seq2SoA, _MM_HINT_NTA);
+    _mm_prefetch((const char*) (F + SIMD_WIDTH8), _MM_HINT_T0);
+    _mm_prefetch((const char*) seq2SoA, _MM_HINT_T1);
     _mm_prefetch((const char*) seq1SoA, _MM_HINT_NTA);
-    _mm_prefetch((const char*) (H1 + SIMD_WIDTH8), _MM_HINT_NTA);
+    _mm_prefetch((const char*) (H1 + SIMD_WIDTH8), _MM_HINT_T0);
 
     for (int i=0; i <=ncol; i++)
     {
@@ -2576,11 +2576,11 @@ int kswv::kswv512_16(int16_t seq1SoA[],
     int16_t *F      = F16 + tid * SIMD_WIDTH16 * this->maxQerLen;
     int16_t *rowMax = rowMax16 + tid * SIMD_WIDTH16 * this->maxRefLen;
     
-    _mm_prefetch((const char*) (F + SIMD_WIDTH16), _MM_HINT_NTA);
-    _mm_prefetch((const char*) seq2SoA, _MM_HINT_NTA);
+    _mm_prefetch((const char*) (F + SIMD_WIDTH16), _MM_HINT_T0);
+    _mm_prefetch((const char*) seq2SoA, _MM_HINT_T1);
     _mm_prefetch((const char*) seq1SoA, _MM_HINT_NTA);
-    _mm_prefetch((const char*) (H1 + SIMD_WIDTH16), _MM_HINT_NTA);
-    _mm_prefetch((const char*) (F + SIMD_WIDTH16), _MM_HINT_NTA);
+    _mm_prefetch((const char*) (H1 + SIMD_WIDTH16), _MM_HINT_T0);
+    _mm_prefetch((const char*) (F + SIMD_WIDTH16), _MM_HINT_T0);
 
     for (int i=ncol; i >= 0; i--) {
         _mm512_store_si512((__m512*) (H0 + i * SIMD_WIDTH16), zero512);


### PR DESCRIPTION
## Summary

Hand-tuning pass over the **AVX2** paths of the two Smith-Waterman kernels (`BandedPairWiseSW` extension and `kswv` rescue), the sibling to the NEON pass in #160. AVX2 has no mask registers, so every conditional is a `vpblendvb` (2 µops, port-5 only) that contends with the LUT `_mm256_shuffle_epi8` — port 5 is the inner-loop ceiling, and the findings here relieve it. Everything is confined to AVX2 code (other tiers untouched) and validated **byte-identical** on real Zen3 hardware (per-pair score checksums matched across every commit).

Why AVX2 and not AVX-512: `simd_dispatch.cpp` records that `avx2→avx512bw` is a measured wash (c7a −2.2%, c7i −0.7%), so bwa-mem3 ships **AVX2 as the default x86 kernel**. It's the tier nearly every x86 run actually uses.

## Measured impact (c6a.4xlarge, Zen3, native AVX2; n=20000, reps=5, best-of)

**Extension (`bandedSWA`):**

| workload | baseline (Mc/s) | this branch | net |
|----------|------|------|------|
| 100 bp, band=100 | 6599 | 6908 | +4.7% |
| 150 bp, band=100 | 6397 | 6810 | +6.5% |
| 250 bp, band=100 | 6104 | 6556 | +7.4% |
| 150 bp, band=400 | 6280 | 6658 | +6.0% |
| 250 bp, band=400 | 7586 | 8070 | +6.4% |
| 500 bp, band=400 | 9040 | 9790 | +8.3% |

Per-commit: the `blendv→andnot` change carries +3-4% at every length; the gscore-epilogue fusion adds +2-5% on the 16-bit path (most on long reads). The argmax/prefetch/hygiene commits are flat (correctness/cleanup).

**Rescue (`kswv`):** neutral — see the note on commit 1 below.

## Commits (suggested reading order: 1, then 2)

1. **`blendv zero-selects → andnot` (extension kernels)** — the port-5 win. `blendv(x, 0, mask) == andnot(mask, x)`; `andnot` issues on ports 0/1/5 instead of port-5-only. Converts every live zero-select in `smithWaterman256_8/16`, including the per-cell `m11` local-restart in `MAIN_CODE8_CORE`/`MAIN_CODE16_CORE` (the hottest blendv).

   **Course-correction worth calling out:** the same transform was tried in `kswv256_u8` and **measured a consistent ~2-3% regression on Zen3** (andnot perturbs inner-loop register allocation there for no benefit). The stacked per-commit benchmarking caught it; the rescue kernel is deliberately left on `blendv`. Same idiom, opposite result in the two kernels — a good reminder to measure, not assume.

2. **fuse gscore-epilogue blendv pairs (`smithWaterman256_16`)** — two `blendv` pairs share a fallback operand under `exit0` then `cmp`, collapsing to one select against `cmp & exit0`. −2 blendv/cell on the query-end tail.

3. **drop redundant argmax compare (both extension kernels)** — the "new row-max" mask was `(maxRS1 ▷ bmaxRS) | (maxRS1 == h11)`; since `maxRS1 = max(bmaxRS, h11)` the first term is a strict subset of the second, so the single `cmpeq(maxRS1, h11)` is the exact combined mask. Bit-identical, no tie-break change.

4. **fix prefetch locality hints (x86 kswv)** — `F`/`H1`/`seq2SoA` are loop-resident but were prefetched `_MM_HINT_NTA` (stream-don't-retain); switch to T0/T1, leave read-once `seq1SoA` at NTA. Mirrors the NEON fix in #160. One-shot warm-up, so neutral; committed for hint correctness across ISAs.

5. **hygiene** — delete the dead `ZSCORE8`/`MAIN_CODE8`/`MAIN_CODE16` macros (also a gap-from-H + stale-signed footgun), dead scoring constants, and an unused helper. Deliberately excluded `loadu→load` (a wash on modern x86, and a misaligned `_mm256_load` faults at runtime) and the FP→int band division (10 sites, marginal, rounding-edge risk). Other tiers' equivalent dead macros are left for a separate cleanup — this PR is AVX2-scoped.

## Testing

- **Validated on c6a (Zen3)**, the bench-fleet AVX2 baseline, via a bwa-mem3-only microbench (no minibwa) with `BWAMEM3_FORCE_TIER=avx2`. Each commit was stacked and benchmarked individually.
- **Byte-identity:** an FNV-1a score checksum over every pair matched across all six states (baseline + 5 commits) on every workload.
- Both files syntax-check clean under `-mavx2` and `-mavx512bw` (no AVX-512 code paths changed except the kswv prefetch hints in commit 4, which are also corrected there).

## Notes

- A natural follow-up surfaced during review: there is **no AVX2 16-bit `kswv` kernel** — `getScores16` falls back to scalar on AVX2-only hosts, where NEON and AVX-512 both have one. That's a feature (porting `kswv512_16` down), tracked separately, potentially a larger lever than this tuning pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal kernel operations for sequence alignment to improve efficiency and reduce code redundancy.
  * Adjusted memory access patterns to optimize cache utilization across different processing tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->