### PR TITLE
docs: recommend a recent compiler on aarch64, with measured NEON numbers

### DIFF
--- a/docs/src/best-practices/build.md
+++ b/docs/src/best-practices/build.md
@@ -31,6 +31,36 @@ the non-kernel TU compile baseline with `BASELINE_ARCH=` (default
 See [SIMD dispatch matrix](../performance/simd-dispatch.md) for the full list
 of targets and which kernels each vectorizes.
 
+## Use a recent compiler (especially on ARM)
+
+Use the newest C++ compiler available, and on ARM/aarch64 prefer a recent
+`clang`. The compiler matters more on ARM than on x86: the aarch64 build runs
+its SIMD through the [sse2neon](../developer-guide/neon-port.md) translation
+layer rather than hand-written intrinsics, so codegen quality — and therefore
+throughput — depends heavily on the compiler **and its version**.
+
+Measured on AWS Graviton4 (`c8g.4xlarge`, 16 cores), hg38, 5M read pairs,
+`make arm64`, best-of-3 CPU-seconds:
+
+| Compiler | CPU-seconds | vs gcc 15.2 |
+|---|---:|---:|
+| gcc 15.2 | 1779 | — |
+| clang 22.1 | 1679 | ~6% faster |
+
+Two takeaways:
+
+- **clang generally emits better NEON than gcc** for sse2neon-translated code —
+  about 6% fewer CPU-seconds here.
+- **Compiler *version* matters as much as the vendor.** A larger ~18%
+  clang-over-gcc gap has been reported against an older gcc (~13); against a
+  modern gcc (15.2) it narrows to ~6%, because recent gcc closed most of the
+  NEON-codegen gap. Bumping the gcc version is often most of the win even
+  without switching to clang.
+
+If you build the arm64 binary with clang, note the OpenMP runtime changes from
+`libgomp` to `libomp` (`llvm-openmp`) — see
+[Multi-architecture deployment](multi-arch-deployment.md).
+
 ## Profile-Guided Optimization (PGO)
 
 PGO typically yields 3–5% throughput improvement on real workloads.  It is opt-in — the standard
@@ -99,6 +129,16 @@ make pgo-generate PGO_ARCH=avx2
 ./bwa-mem3.pgo-instr.avx2 mem -t 16 ref.fa R1.fq.gz R2.fq.gz > /dev/null
 make pgo-use PGO_ARCH=avx2
 # Deploy: bwa-mem3.pgo.avx2
+```
+
+On ARM/aarch64 (Apple Silicon, AWS Graviton), build with a recent `clang` and
+apply PGO on top:
+
+```bash
+make pgo-generate PGO_ARCH=arm64 CXX=clang++
+./bwa-mem3.pgo-instr mem -t 16 ref.fa R1.fq.gz R2.fq.gz > /dev/null
+make pgo-use PGO_ARCH=arm64 CXX=clang++
+# Deploy: bwa-mem3.pgo
 ```
 
 ---

--- a/docs/src/best-practices/multi-arch-deployment.md
+++ b/docs/src/best-practices/multi-arch-deployment.md
@@ -38,6 +38,13 @@ docker buildx build --platform linux/amd64,linux/arm64 \
   -t <registry>/<image>:<tag> --push .
 ```
 
+> **Building the arm64 layer with clang?** A recent `clang` produces faster
+> NEON code than `gcc` on aarch64 (see
+> [Best Practices → Build](build.md#use-a-recent-compiler-especially-on-arm)).
+> If you switch the arm64 build to clang, swap the OpenMP runtime: clang links
+> `libomp` (LLVM) rather than `libgomp`, so the runtime stage needs `libomp5`
+> (or `llvm-openmp`) in place of `libgomp1`.
+
 AWS Batch, GCP Batch, Kubernetes, and containerd all read the manifest list and pull the correct layer based on the host's architecture. The submitter references one tag; the runtime picks the right binary automatically.
 
 ## Verifying at runtime

--- a/docs/src/developer-guide/neon-port.md
+++ b/docs/src/developer-guide/neon-port.md
@@ -15,6 +15,8 @@ The translation is not zero-cost for all operations. Two patterns that sse2neon 
 - `_mm_movemask_epi16` — used heavily in `bandedSWA.cpp` to extract the sign bit of each 16-bit lane. The native implementation shifts right by 15, narrows to 8-bit with `vmovn_u16`, and reduces with position-weighted `vaddv_u8`.
 - `_mm_blendv_epi16_fast` — a bitwise select on 16-bit lanes using `vbslq_s16`. Replaces the three-operation OR/AND/ANDNOT sequence sse2neon emits for `_mm_blendv_epi8`.
 
+Because the bulk of the ARM SIMD path is compiler-translated rather than hand-written intrinsics, codegen quality is unusually sensitive to the compiler and its version — a recent `clang` or `gcc` closes most of the gap to a hypothetical full native port. See [Best Practices → Build](../best-practices/build.md#use-a-recent-compiler-especially-on-arm) for measured numbers and the recommendation.
+
 ### Memory alignment
 
 Apple Silicon uses 128-byte cache lines (versus 64 bytes on x86). `simd_compat.h` overrides `_mm_malloc` on ARM to call `posix_memalign` with a minimum alignment of 128 bytes for all SIMD allocations. `CACHE_LINE_BYTES` is set to `128` in `macro.h` when `APPLE_SILICON=1`.


### PR DESCRIPTION
## What

Adds a build best-practice: use a recent compiler, and on ARM/aarch64 prefer a recent `clang`. The aarch64 build routes its SIMD through the sse2neon translation layer rather than hand-written intrinsics, so codegen quality — and throughput — depends heavily on the compiler *and its version*, much more so than on x86.

## Why / measurements

Measured on AWS Graviton4 (`c8g.4xlarge`, 16 cores), hg38, 5M read pairs, `make arm64`, best-of-3 CPU-seconds (same binary config, both NEON-only — compiler is the only variable):

| Compiler | CPU-seconds | vs gcc 15.2 |
|---|---:|---:|
| gcc 15.2 | 1779 | — |
| clang 22.1 | 1679 | ~6% faster |

Two takeaways captured in the docs:

- clang generally emits better NEON than gcc for sse2neon-translated code (~6% here).
- Compiler *version* matters as much as vendor: a larger ~18% clang-over-gcc gap reported elsewhere is mostly an old-gcc (~13) artifact — modern gcc (15.2) closed most of the NEON-codegen gap, so bumping the gcc version is often most of the win even without switching to clang.

## Changes (three placements, no duplicated tables)

- `best-practices/build.md` — new "Use a recent compiler (especially on ARM)" section with the actionable rule + the measured table, placed alongside the other build-time perf knobs (arch target, PGO, mimalloc). The page's `## Summary` gains a matching ARM build line so its bottom-line stays consistent.
- `developer-guide/neon-port.md` — one sentence appended to the existing "sse2neon shim" subsection (the natural place, since it already explains translation quality is compiler-dependent), linking to the build page. Deliberately *not* a second benchmark table — that page's existing table measures a different axis (which kernels are native NEON).
- `best-practices/multi-arch-deployment.md` — a short note next to the example Dockerfile (which installs `libgomp1`): building the arm64 layer with clang needs `libomp5`/`llvm-openmp` instead of `libgomp1`, since clang links LLVM's OpenMP runtime.

## Verification

- `mdbook build` clean.
- Confirmed the generated anchor `use-a-recent-compiler-especially-on-arm` matches both cross-links (from `neon-port.md` and `multi-arch-deployment.md`).
- The documented ARM PGO commands (`PGO_ARCH=arm64 CXX=clang++` → `bwa-mem3.pgo-instr` / `bwa-mem3.pgo`) match the Makefile's output naming.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced build best practices with compiler recommendations optimized for ARM architecture deployments
  * Added performance benchmarking data comparing different compiler options
  * Updated deployment instructions for multi-architecture builds
  * Added guidance on compiler selection impact for ARM performance optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->