### PR TITLE
docs(settings-profiles): note repeat-aggregating downstream caveat for -m 10

### DIFF
--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -84,6 +84,8 @@ low-MAPQ deep-rescue tail: the mapped count only ever *decreases* (it never newl
 previously-unmapped read), and the handful of reads whose placement does change net to ≈0 recall
 against golden truth.
 
+One caveat: this golden-truth metric scores a single best placement per read, so it does not capture downstream tools that *aggregate over repeats* — depth-based CNV, SV/mobile-element calling in repetitive regions, or repeat-region methylation. If your pipeline relies on which repeat copy is reported (rather than just the confident, MAPQ-high tier), validate `-m 10` against your own analysis rather than assuming neutrality.
+
 Numbers are from [bwa-mem3-bench](../related-projects/bwa-mem3-bench.md) on 5 M-read real datasets
 plus a multi-contig holodeck golden-truth ablation; consult the bench for methodology and current
 figures.


### PR DESCRIPTION
The `-m 10` recommendation on the settings-profiles page is backed by a golden-truth ablation whose accuracy metric scores a *single best placement per read*. That metric does not capture downstream tools that **aggregate over repeats** — depth-based CNV, SV/mobile-element calling in repetitive regions, or repeat-region methylation.

This adds one paragraph advising that pipelines relying on which repeat copy is reported (rather than just the confident, MAPQ-high tier) validate `-m 10` against their own analysis rather than assuming the near-neutral accuracy result transfers.

### Why

An independent re-measurement (HG002 WGS-1M) corroborates the existing page: capping `max_matesw` 50→10 changes ~2.25% of records, but **96.3% of reads that move have MAPQ 0** and only ~91 MAPQ≥30 reads per 2M move — i.e. the change is concentrated in the ambiguous repeat tail. That is exactly the tier a repeat-aggregating analysis would consume, so the single-best-placement "≈0 net recall" result understates the impact for those use cases. Pure documentation; no code or behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification to settings documentation explaining placement metric limitations and providing guidance for validating configurations in workflows sensitive to repeat region analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->