### PR TITLE
feat(mem): --min-ext-len opt-in filter to skip extension of short seeds

### DIFF
--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -43,6 +43,7 @@ speed/accuracy trade-off. Current recommended deviations:
 |---|---|---|---|
 | `-m` (mate-rescue depth) | 50 | **10** | ~11–22% less alignment CPU; near-neutral accuracy (see below) |
 | `-s` (Pass-2 re-seed width), **`--meth` only** | 10 | **0** | ~20% less alignment CPU; near-neutral accuracy (see below) |
+| `--min-ext-len` (skip short-seed extension), **standard-error reads** | 0 | **30** | ~10–20% less alignment CPU; accuracy change confined to the already-low-confidence tail (see below) |
 
 This table will grow as we benchmark additional tunings; each entry is gated on the same
 "measurably faster, near-neutral accuracy" bar.
@@ -127,6 +128,43 @@ repetitive inputs where the redundant Pass-2 candidate set is largest.
 A selective fallback — skip Pass-2 globally but re-seed only low-confidence reads — was evaluated and
 **does not help**: in the multi-contig regime it would re-seed ~13% of reads yet recovers about as
 many placements as it sacrifices (net within noise), so there is no cheap middle ground.
+
+## Why we recommend `--min-ext-len 30` (standard-error reads)
+
+`--min-ext-len INT` drops seeds shorter than `INT` bp before banded Smith–Waterman, so their
+extension never runs (off by default, `0` → byte-identical to baseline). Extension is ~60% of `mem`
+CPU and almost all of it is spent on short seeds — seeds ≤40 bp hold ~90% of all banded-SW *cells*
+yet are ~99% wasted, because long seeds already resolve via the ungapped fast-path. Skipping them
+thins the extension stage without touching seeding or chaining.
+
+**The accuracy change is confined to reads that were already low-confidence.** On real HG002 1M PE
+WGS at `--min-ext-len 30`, 0.40% of reads change, and profiling every one of them against the
+population shows the cost lands entirely on reads that were *already* marginal — heavily soft-clipped
+partial alignments (median 95 of 150 bp clipped), high edit distance, or multi-mappers. **Zero**
+confidently, uniquely mapped reads (MAPQ ≥ 60, NM ≤ 1, no soft-clip) regress. Like `-m 10`, the
+mapped count only ever *decreases* (≈0.11% newly unmapped; it essentially never newly maps a
+previously-unmapped read), and the reads whose locus changes are repeat/paralog churn with
+sub-2-mismatch score deltas — about 1 in 4 of which the filter actually *improves*. On simulated
+clean Illumina and indel-rich data the change is nil-to-positive even at larger thresholds.
+
+**In exchange, alignment CPU drops ~10–20% single-thread**, largest on data carrying many short
+seeds (real WGS sees more than idealized simulated reads). Because the speedup thins extension rather
+than speeding seeding — and seeding dominates the wall — the wall-clock gain is smaller than the
+~90% banded-SW *cell* reduction would suggest.
+
+**Contraindication — very high per-base error.** On degraded-chemistry or cross-species libraries
+(per-base error well above modern Illumina), every seed is short, so some correct alignments depend
+*solely* on short seeds and the cost rises sharply (e.g. at 2–15% simulated substitution error, F1
+−0.2% at `30`, growing to −1.4% at `40` and a cliff at `50`). Keep `--min-ext-len` low or off for
+such data. **Indels and structural variants are *not* a contraindication** — an indel splits a read
+into two still-long exact segments that the fast-path handles, so indel-rich data is free.
+
+`30` is the accuracy-safe knee; `40`–`50` give a little more speed on known-clean data but trade
+accuracy as divergence rises. The CPU win is confirmed cross-architecture: on Graviton4/Linux
+(c8g) the same single-thread sweep gives realistic **+15.8%** and HG002 **+20.5%** (T=0→T=30),
+matching macOS — the filter is algorithmic, so it ports. Remaining before this graduates from
+"recommended for standard-error reads" to an unqualified default: a multi-thread + broader
+[bwa-mem3-bench](../related-projects/bwa-mem3-bench.md) run (all current figures are single-thread).
 
 ## Speed: drop-in and recommended
 

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -209,6 +209,25 @@ chain.
 Discards chains with fewer than `INT` seeded bases. Raising this filters out
 very short, low-confidence chains.
 
+#### `--min-ext-len INT` — skip Smith-Waterman extension of short seeds
+
+Off by default (`0`) → output byte-identical to baseline. When `INT > 0`, seeds
+shorter than `INT` bp are dropped before banded Smith-Waterman, so their
+extension never runs. Short seeds carry the large majority of extension work but
+rarely change the final alignment (long seeds resolve via the ungapped
+fast-path), so skipping them trims alignment CPU — roughly 10–20 % single-thread
+on Illumina WGS, more on data with many short seeds.
+
+`30` is the recommended value: on real HG002 WGS it gives ~20 % lower alignment
+CPU while any accuracy change is confined to reads that were already
+low-confidence (heavily soft-clipped, high edit distance, or multi-mapping) —
+confidently, uniquely mapped reads are unaffected. Larger values (40–50) are
+also accuracy-safe on known-clean data but trade accuracy on divergent data.
+Keep it low or off for libraries with very high per-base error (degraded
+chemistry, cross-species); indels and structural variants are *not* a
+contraindication. See
+[Features — short-seed extension filter](../whats-different/features.md#--min-ext-len-short-seed-extension-filter).
+
 #### `-h INT[,INT]` — secondary alignment reporting
 
 If there are fewer than `INT` hits with score exceeding `FLOAT` (see `-z`)

--- a/docs/src/whats-different/features.md
+++ b/docs/src/whats-different/features.md
@@ -160,6 +160,48 @@ all 11 SAM columns and all aux tags. See
 [Best Practices → Output format](../best-practices/output-format.md) for the
 recommended pipeline.
 
+## `--min-ext-len` short-seed extension filter
+
+`--min-ext-len INT` opts into skipping banded Smith-Waterman extension of seeds
+shorter than `INT` bp. Off by default (`0`) → output byte-identical to baseline.
+
+Smith-Waterman extension is ~60 % of `bwa-mem3 mem` CPU, and almost all of it is
+spent on short seeds: seeds ≤40 bp hold roughly **90 % of all banded-SW cells**
+yet are ~99 % wasted, because long seeds already resolve via the ungapped
+fast-path at near-zero cost. `--min-ext-len` drops the short seeds before
+extension (`mem_chain_drop_short_seeds`, a stable in-place compaction of each
+chain's seeds, called from `mem_flt_chained_seeds` in `src/bwamem.cpp`), so their
+extension never runs while seeding and chaining are untouched.
+
+Measured single-thread on hg38:
+
+- **Real HG002 1M PE WGS: ~20 % lower alignment CPU at `--min-ext-len 30`.** The
+  accuracy effect is confined to reads that were already low-confidence — 0.40 %
+  of reads change (mostly partial, heavily soft-clipped, or repeat/multi-mapping
+  reads); **zero** confidently and uniquely mapped reads (MAPQ ≥ 60, NM ≤ 1,
+  no soft-clip) regress.
+- Simulated clean Illumina and indel-rich data: free (F1 unchanged or slightly
+  better, even at larger thresholds).
+- The only workload with a real accuracy cost is very high per-base error
+  (degraded chemistry, cross-species) — there, every seed is short, so some
+  correct alignments depend solely on short seeds. Indels and structural variants
+  are *not* a contraindication: an indel leaves two still-long exact segments
+  that the fast-path handles.
+- Confirmed cross-architecture: Graviton4/Linux reproduces the win (realistic
+  +15.8 %, HG002 +20.5 %), matching macOS — the speedup is algorithmic, not
+  microarch tuning.
+
+`30` is the recommended opt-in value (accuracy-safe across clean, indel-rich, and
+moderately-divergent data); `40`–`50` are also safe on known-clean data but cost
+accuracy as divergence rises. Because the speedup is thinning the extension stage
+— not faster seeding — the wall-clock gain is smaller than the cell-count
+reduction would suggest (seeding, which the filter does not touch, dominates
+runtime). See
+[CLI → mem `--min-ext-len`](../cli/mem.md#--min-ext-len-int--skip-smith-waterman-extension-of-short-seeds)
+and
+[Settings profiles](../best-practices/settings-profiles.md#why-we-recommend---min-ext-len-30-standard-error-reads)
+for the recommended operating point.
+
 ---
 
 ## Changes catalog
@@ -173,6 +215,7 @@ recommended pipeline.
 | `shm --meth` symmetry | [#67](https://github.com/fg-labs/bwa-mem3/pull/67) | — | fork-only |
 | `HN:i` hit count tag | [#42](https://github.com/fg-labs/bwa-mem3/pull/42) | [lh3/bwa#438](https://github.com/lh3/bwa/pull/438) | fork-only (analogous to bwa aln) |
 | `--bam=LEVEL` direct BAM output | [#12](https://github.com/fg-labs/bwa-mem3/pull/12) | — | fork-only |
+| `--min-ext-len` short-seed extension filter | _pending_ | — | fork-only (opt-in, off by default) |
 
 ---
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -255,6 +255,7 @@ mem_opt_t *mem_opt_init()
     o->max_mem_intv = 20;
 
     o->min_seed_len = 19;
+    o->min_ext_len = 0;   // off by default -> byte-identical to baseline
     o->split_width = 10;
     o->max_occ = 500;
     o->max_chain_gap = 10000;
@@ -627,6 +628,22 @@ void mem_print_chain(const bntseq_t *bns, mem_chain_v *chn)
     }
 }
 
+// Skip-short-seed extension filter: drop seeds shorter than min_ext_len from a
+// chain in place, so they are never extended (their banded Smith-Waterman is
+// skipped downstream). Stable compaction -- surviving seeds keep their order.
+// Returns the new seed count. min_ext_len <= 0 is a no-op, which keeps default
+// output byte-identical to baseline.
+int mem_chain_drop_short_seeds(mem_chain_t *c, int min_ext_len)
+{
+    if (min_ext_len <= 0) return c->n;
+    int j, k;
+    for (j = k = 0; j < c->n; ++j)
+        if (c->seeds[j].len >= min_ext_len)
+            c->seeds[k++] = c->seeds[j];
+    c->n = k;
+    return c->n;
+}
+
 void mem_flt_chained_seeds(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
                            bseq1_t *seq_, int n_chn, mem_chain_t *a)
 {
@@ -641,6 +658,12 @@ void mem_flt_chained_seeds(const mem_opt_t *opt, const bntseq_t *bns, const uint
         mem_chain_t *c = &a[i];
         const uint8_t *query = (uint8_t*) seq_[c->seqid].seq;
         int l_query = seq_[c->seqid].l_seq;
+
+        // Skip-short-seed extension filter (opt->min_ext_len). Placed BEFORE the
+        // MEM_SEEDSW_COEF screen `continue` below, which is skipped for typical
+        // read lengths -- dropping seeds inside that loop would no-op on the main
+        // workload. Off (min_ext_len==0): no-op, output byte-identical.
+        mem_chain_drop_short_seeds(c, opt->min_ext_len);
 
         double min_l = opt->min_chain_weight?
         MEM_HSP_COEF * opt->min_chain_weight : MEM_MINSC_COEF * log(l_query);

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -88,6 +88,7 @@ typedef struct mem_opt_t {
     int T;                  // output score threshold; only affecting output
     int flag;               // see MEM_F_* macros
     int min_seed_len;       // minimum seed length
+    int min_ext_len;        // seeds shorter than this are not extended (0 = off)
     int min_chain_weight;
     int max_chain_extend;
     float split_factor;     // split into a seed if MEM is longer than min_seed_len*split_factor
@@ -276,6 +277,11 @@ const bwtintv_v *smem_next(smem_i *itr);
 
 mem_opt_t *mem_opt_init(void);
 void mem_fill_scmat(int a, int b, int8_t mat[25]);
+
+// Skip-short-seed extension filter: drop seeds shorter than min_ext_len from a
+// chain in place (stable; surviving seeds keep their order). Returns the new
+// seed count. min_ext_len <= 0 is a no-op. See mem_opt_t::min_ext_len.
+int mem_chain_drop_short_seeds(mem_chain_t *c, int min_ext_len);
 
 void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
                  bseq1_t *s, mem_alnreg_v *a, int extra_flag, const mem_aln_t *m);

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1087,6 +1087,7 @@ int main_mem(int argc, char *argv[])
         OPT_METH_CHIMERA_QC,
         OPT_SUPP_REP_HARD_CAP,
         OPT_LEGACY_READER,
+        OPT_MIN_EXT_LEN,
 #ifdef STAGE_PROF
         OPT_PROFILE,
 #endif
@@ -1094,6 +1095,7 @@ int main_mem(int argc, char *argv[])
     };
     static struct option long_opts[] = {
         {"bam",                      optional_argument, 0, OPT_BAM},
+        {"min-ext-len",              required_argument, 0, OPT_MIN_EXT_LEN},
         {"meth",                     no_argument,       0, OPT_METH},
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
         {"chimera-qc",               no_argument,       0, OPT_METH_CHIMERA_QC},
@@ -1112,6 +1114,7 @@ int main_mem(int argc, char *argv[])
                             long_opts, NULL)) >= 0)
     {
         if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
+        else if (c == OPT_MIN_EXT_LEN) opt->min_ext_len = atoi(optarg), opt0.min_ext_len = 1;
         else if (c == '1') no_mt_io = 1;
         else if (c == 'x') mode = optarg;
         else if (c == 'w') opt->w = atoi(optarg), opt0.w = 1;

--- a/test/unit/test_min_ext_len.cpp
+++ b/test/unit/test_min_ext_len.cpp
@@ -1,0 +1,107 @@
+// Unit tests for the --min-ext-len short-seed extension filter
+// (mem_chain_drop_short_seeds). The filter drops seeds shorter than the
+// threshold from a chain so they are never extended; min_ext_len <= 0 is a
+// no-op (default), which keeps output byte-identical to baseline.
+
+#include "doctest/doctest.h"
+#include "bwamem.h"
+
+#include <vector>
+
+namespace {
+
+// Build a chain from a list of seed lengths, run the filter, and return the
+// lengths of the surviving seeds in order. Backing storage is owned by the
+// caller-supplied vector so the chain's seed pointer stays valid for the call.
+std::vector<int> drop_short(std::vector<mem_seed_t> &seeds, int min_ext_len)
+{
+    mem_chain_t c{};
+    c.n = static_cast<int32_t>(seeds.size());
+    c.m = static_cast<int32_t>(seeds.size());
+    c.seeds = seeds.empty() ? nullptr : seeds.data();
+
+    const int new_n = mem_chain_drop_short_seeds(&c, min_ext_len);
+    CHECK(new_n == c.n);
+
+    std::vector<int> out;
+    out.reserve(static_cast<size_t>(c.n));
+    for (int i = 0; i < c.n; ++i) out.push_back(c.seeds[i].len);
+    return out;
+}
+
+std::vector<mem_seed_t> make_seeds(const std::vector<int> &lens)
+{
+    std::vector<mem_seed_t> seeds(lens.size());  // mem_seed_t ctor sets defaults
+    for (size_t i = 0; i < lens.size(); ++i) {
+        seeds[i].len = lens[i];
+        seeds[i].rbeg = static_cast<int64_t>(i) * 1000;  // distinct, to track order
+        seeds[i].qbeg = static_cast<int32_t>(i);
+    }
+    return seeds;
+}
+
+}  // namespace
+
+TEST_CASE("min_ext_len=0 is a no-op (byte-identical default)"
+          * doctest::test_suite("unit/min_ext_len"))
+{
+    auto seeds = make_seeds({10, 50, 19, 100});
+    CHECK(drop_short(seeds, 0) == std::vector<int>{10, 50, 19, 100});
+}
+
+TEST_CASE("negative threshold is also a no-op"
+          * doctest::test_suite("unit/min_ext_len"))
+{
+    auto seeds = make_seeds({10, 50, 19, 100});
+    CHECK(drop_short(seeds, -5) == std::vector<int>{10, 50, 19, 100});
+}
+
+TEST_CASE("drops seeds shorter than threshold and preserves order"
+          * doctest::test_suite("unit/min_ext_len"))
+{
+    auto seeds = make_seeds({10, 50, 19, 100, 30});
+    // 10 and 19 dropped; 50, 100, 30 kept in original order.
+    CHECK(drop_short(seeds, 30) == std::vector<int>{50, 100, 30});
+}
+
+TEST_CASE("preserves full seed records, not just lengths"
+          * doctest::test_suite("unit/min_ext_len"))
+{
+    auto seeds = make_seeds({10, 50, 19, 100});  // rbeg = 0, 1000, 2000, 3000
+    mem_chain_t c{};
+    c.n = c.m = static_cast<int32_t>(seeds.size());
+    c.seeds = seeds.data();
+
+    REQUIRE(mem_chain_drop_short_seeds(&c, 30) == 2);
+    // Survivors are the original index-1 and index-3 seeds, copied whole:
+    CHECK(c.seeds[0].len == 50);   CHECK(c.seeds[0].rbeg == 1000);
+    CHECK(c.seeds[1].len == 100);  CHECK(c.seeds[1].rbeg == 3000);
+}
+
+TEST_CASE("boundary: seed length == threshold is kept (>=)"
+          * doctest::test_suite("unit/min_ext_len"))
+{
+    auto seeds = make_seeds({29, 30, 31});
+    CHECK(drop_short(seeds, 30) == std::vector<int>{30, 31});
+}
+
+TEST_CASE("all seeds shorter than threshold -> empty chain"
+          * doctest::test_suite("unit/min_ext_len"))
+{
+    auto seeds = make_seeds({10, 19, 25});
+    CHECK(drop_short(seeds, 30).empty());
+}
+
+TEST_CASE("all seeds at least threshold -> all kept"
+          * doctest::test_suite("unit/min_ext_len"))
+{
+    auto seeds = make_seeds({30, 40, 150});
+    CHECK(drop_short(seeds, 30) == std::vector<int>{30, 40, 150});
+}
+
+TEST_CASE("empty chain stays empty"
+          * doctest::test_suite("unit/min_ext_len"))
+{
+    std::vector<mem_seed_t> seeds;  // n == 0
+    CHECK(drop_short(seeds, 30).empty());
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `bwa-mem3 mem` option `--min-ext-len INT` that skips banded Smith-Waterman extension of seeds shorter than `INT` bp. **Default `0` = off → output byte-identical to baseline**, so merging changes nothing for existing pipelines. The recommended opt-in value is **`--min-ext-len 30`**, which gives roughly **10–20% lower single-thread alignment CPU** on Illumina WGS with the accuracy effect confined to reads that were already low-confidence.

## What it does

Smith-Waterman extension is ~60% of `mem` CPU, and almost all of it is spent on short seeds: seeds ≤40 bp hold ~90% of all banded-SW *cells* yet are ~99% wasted, because long seeds already resolve via the ungapped fast-path at near-zero cost. `--min-ext-len` drops the short seeds from each chain before extension so their banded-SW never runs, while seeding and chaining are left untouched.

Implementation is a small, stable in-place compaction helper `mem_chain_drop_short_seeds()` (in `src/bwamem.cpp`), called from `mem_flt_chained_seeds` **before** the `MEM_SEEDSW_COEF` screen `continue` gate — that gate is skipped for typical read lengths, so dropping seeds inside the screen loop would silently no-op on the main workload. When `min_ext_len <= 0` the helper early-returns before touching the chain, which is what makes the default byte-identical.

## Why opt-in, off by default

The speedup is a workload-dependent accuracy/speed trade, not a free lunch on every input, so it ships off and is documented as a recommended setting rather than a new default. It is byte-identical when off, so there is zero risk to existing callers.

## Validation

Measured single-thread, uncompressed BAM, median of interleaved reps, on hg38. "Compute" is whole-run user+sys CPU.

T-sweep (compute speedup vs F1, vs the byte-identical T=0 baseline):

| regime | T=30 | T=40 | T=50 |
|---|---|---|---|
| easy (sim 150 bp Illumina) | +11.3% CPU, ΔF1 +0.001 | +13.8%, +0.007 | +15.0%, +0.007 |
| indel-heavy (sim, 37% indels) | +13.5% CPU, ΔF1 +0.009 | +18.7%, −0.004 | +22.2%, −0.031 |
| substitution-divergent (sim, 2–15% error) | +20.7% CPU, ΔF1 −0.197 | +30.2%, −1.360 | +38.1%, −4.591 |
| **HG002 1M WGS (real)** | **+20.8% CPU** | — | — |

`T=30` is the accuracy-safe knee: the `30 → 40` step costs ~7× the F1 for ~1.3× the speed on divergent data, and `50` falls off a cliff. **Indels are benign** (free even at `T=50`) — an indel splits a read into two still-long exact segments the fast-path handles; the only regime with a real cost is high per-base error (degraded chemistry / cross-species), where every seed is short.

## Accuracy characterization (HG002 real data, AS-aware)

No truth on real data, so the strict signal is the primary alignment-score (AS) regression. At `--min-ext-len 30`, 0.40% of reads change, and profiling every regressed read shows the cost lands entirely on reads that were already marginal: **zero** confidently and uniquely mapped reads (MAPQ ≥ 60, NM ≤ 1, no soft-clip) regress. The two mechanisms are newly-unmapped partial alignments (median 95 of 150 bp soft-clipped, anchored only on a short seed) and repeat/paralog churn (99% of AS-changed reads moved between near-tied loci with sub-2-mismatch deltas; ~1 in 4 actually improved). Real WGS also speeds up *more* than the idealized simulated "easy" set (+20.8% vs +11.3%), because real reads carry more short seeds — the simulation was conservative.

## Cross-architecture

The win ports cleanly to Graviton4/Linux (c8g.4xlarge, AL2023, single-thread, median of 3 reps): realistic **+15.8%**, HG002 **+20.5%** (T=0 → T=30), with SMEM flat across T and banded-SW down 51–59%. This is algorithmic (skipped work), not a host- or microarch-specific artifact.

## Testing

- New unit test `test/unit/test_min_ext_len.cpp` (doctest, synthetic) covers the no-op default, the `>=` threshold boundary, order preservation, whole-record copy, and the empty / all-kept / all-dropped chains. `./test/bwa_mem3_tests_unit --test-suite="unit/min_ext_len"` → 8 cases / 19 assertions pass; the full unit suite (57 cases) is green.
- Byte-identity when off verified end-to-end: default vs `--min-ext-len 0` differ only in the `@PG CL:` line; all alignment records are identical.
- Functional smoke confirms the filter is active (a large threshold drops all seeds on short reads).

## Docs

Documented in the mdbook in three places: the CLI `mem` flag reference (Filtering), the opt-in Features catalog, and the recommended Settings profile (with the speed/accuracy trade, the `T=30` recommendation, and the high-per-base-error contraindication).

## Notes / follow-ups

- All figures above are single-thread. A multi-thread run and a broader bwa-mem3-bench pass are the remaining validation before this could graduate from "recommended for standard-error reads" to an unqualified default; it is shipped opt-in until then.
- Suggested reading order: `src/bwamem.cpp` (the `mem_chain_drop_short_seeds` helper and its call site) first, then `src/fastmap.cpp` (CLI wiring) and `test/unit/test_min_ext_len.cpp`, then the docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--min-ext-len` option to skip Smith-Waterman extension for seeds below specified threshold, delivering ~10–20% single-thread performance improvement with minimal accuracy impact on confident alignments.

* **Documentation**
  * Documented the new `--min-ext-len` option with performance guidance, accuracy considerations, and recommended settings in CLI and best-practices references.

* **Tests**
  * Added unit tests for short-seed extension filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->