### PR TITLE
docs(book): recommend -y 0 (drop 3rd-round seeding) as an opt-in speed knob

### DIFF
--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -33,7 +33,7 @@ No extra flags. Use this when you are:
 ## Recommended profile
 
 ```bash
-bwa-mem3 mem -t <N> -m 10 ref.fa R1.fq R2.fq > out.sam
+bwa-mem3 mem -t <N> -m 10 -y 0 ref.fa R1.fq R2.fq > out.sam
 ```
 
 Use this for new pipelines, or once a drop-in migration is validated and you want bwa-mem3's best
@@ -42,6 +42,7 @@ speed/accuracy trade-off. Current recommended deviations:
 | flag | default (drop-in) | recommended | effect |
 |---|---|---|---|
 | `-m` (mate-rescue depth) | 50 | **10** | ~11–22% less alignment CPU; near-neutral accuracy (see below) |
+| `-y` (3rd-round seeding occurrence) | 20 | **0** | ~11–30% less alignment CPU; F1 near-neutral across regimes (within ±0.02; better on divergent/repeat — see below) |
 | `-s` (Pass-2 re-seed width), **`--meth` only** | 10 | **0** | ~20% less alignment CPU; near-neutral accuracy (see below) |
 | `--min-ext-len` (skip short-seed extension), **standard-error reads** | 0 | **30** | ~10–20% less alignment CPU; accuracy change confined to the already-low-confidence tail (see below) |
 
@@ -51,7 +52,7 @@ This table will grow as we benchmark additional tunings; each entry is gated on 
 For a bisulfite (`--meth`) pipeline the recommended invocation is therefore:
 
 ```bash
-bwa-mem3 mem -t <N> --meth -m 10 -s 0 ref.fa R1.fq R2.fq > out.sam
+bwa-mem3 mem -t <N> --meth -m 10 -s 0 -y 0 ref.fa R1.fq R2.fq > out.sam
 ```
 
 ## Why we recommend `-m 10`
@@ -90,6 +91,48 @@ One caveat: this golden-truth metric scores a single best placement per read, so
 Numbers are from [bwa-mem3-bench](../related-projects/bwa-mem3-bench.md) on 5 M-read real datasets
 plus a multi-contig holodeck golden-truth ablation; consult the bench for methodology and current
 figures.
+
+## Why we recommend `-y 0`
+
+bwa-mem seeds in up to three rounds: (1) SMEMs, (2) reseeding long SMEMs (`-r`), and (3) an
+occurrence-bounded "seed strategy" round (`-y`) that, for every read position, grows an exact match
+until it occurs fewer than `-y` (default 20) times in the genome and emits it. Round 3 is a
+repeat-region safety net. `-y 0` disables it entirely.
+
+**It is net-useless-to-harmful, even in the repeats it was built for.** We swept `-y 0` (and the
+more-aggressive `-y 0 -r 10`, see below) against the stock default across four golden-truth regimes
+(holodeck, read-name truth) and on real WES + WGS:
+
+| regime | ΔF1 (`-y 0` − default) | ΔF1 (`-y 0 -r 10` − default) | ΔF1 in the MAPQ-0 (repeat) bin (`-y 0` / `-y 0 -r 10`) |
+|---|---|---|---|
+| easy (150 bp, default error) | −0.010 | −0.001 | −0.14 / −0.04 |
+| substitution-divergent (2–15%) | **+0.008** | −0.074 | **+0.13** / −0.07 |
+| indel-rich (37 % indels) | −0.016 | −0.017 | −0.02 / −0.03 |
+| **repeat-enriched** (reads simulated from RepeatMasker, 49 % of hg38) | **+0.007** | +0.004 | **+0.16** / −0.02 |
+
+The tiny easy/indel deltas are ≤0.016 in absolute F1; on the divergent and *repeat-enriched* regimes —
+where round 3 is supposed to earn its keep — removing it makes F1 **better**. Mechanism: its
+low-occurrence (<20-hit) seeds add spurious near-tied repeat candidates that slightly degrade
+placement; dropping them lets the correct unique anchor win. (The regime sweep was on standard,
+non-`--meth` reads; `-y 0` is a generic seeding change and is recommended for `--meth` on the same
+basis, but was not separately F1-measured there.)
+
+**On real data the confident core is untouched.** On 20 M real WES+WGS reads, **zero** confidently and
+uniquely mapped reads (MAPQ ≥ 60, NM ≤ 1, no soft-clip) became unmapped under `-y 0`, and 3–4 per 10 M
+lost any alignment score. Every regression lands on the already-low-confidence tail (base MAPQ ≈ 0,
+heavily soft-clipped or high-NM), and round 3 was so often producing *worse* primaries that removing it
+*improves* a large share of as many reads as it perturbs (on WES, 3,194 reads improve vs 3,784 that
+worsen).
+
+**In exchange, alignment CPU drops ~11–30 % single-thread**, larger on data with more repeat content
+(WGS > WES). The win is confirmed cross-architecture (Graviton4/Linux: realistic +29.9 %, HG002 WGS
++19.8 %, matching macOS) — it cuts cold-memory seeding work, not arithmetic, so it ports.
+
+**More aggressive (clean-data only): also drop round 2 with `-y 0 -r 10`.** That roughly halves
+alignment CPU (~50–63 %), but round 2 *is* genuine split-read/divergence sensitivity — it costs
+−0.074 F1 on divergent data (the `-y 0 -r 10` column above, concentrated in the repeat/multimapper
+bin). Use `-y 0 -r 10` only on known-clean, low-divergence libraries; `-y 0` alone is the
+broadly-safe recommendation.
 
 ## Why we recommend `-s 0` under `--meth`
 

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -315,13 +315,22 @@ extension continues after a score drop.
 
 #### `-r FLOAT` — re-seeding factor
 
-Seeds longer than `-k * FLOAT` are re-seeded internally to find sub-seeds.
-Lowering this produces more seeds and higher sensitivity at greater cost.
+Seeds longer than `-k * FLOAT` are re-seeded internally to find sub-seeds (bwa-mem's
+second seeding round). Lowering this produces more seeds and higher sensitivity at
+greater cost; **raising it** (e.g. `-r 10`) suppresses the round, which — combined with
+`-y 0` — roughly halves alignment CPU on clean, low-divergence data. Round 2 is genuine
+split-read/divergence sensitivity, so it costs accuracy on divergent libraries; see
+[Settings profiles](../best-practices/settings-profiles.md#why-we-recommend--y-0).
 
 #### `-y INT` — third-round seed occurrence threshold
 
-Seed occurrence threshold for the third round of seeding. Rarely needs
-adjustment outside highly repetitive genomes.
+bwa-mem's third seeding round: for each read position, grow an exact match until it
+occurs fewer than `INT` times in the genome (default 20), then emit it as a seed — a
+repeat-region safety net. **`-y 0` disables the round entirely**, which benchmarks
+F1-near-neutral across all tested regimes (within ±0.02; better on repeat-enriched and
+divergent data) while cutting ~11–30 % of alignment CPU. Recommended for the speed/accuracy
+profile — see
+[Settings profiles → `-y 0`](../best-practices/settings-profiles.md#why-we-recommend--y-0).
 
 ## Notes / Gotchas
 


### PR DESCRIPTION
## Summary

Adds `-y 0` to bwa-mem3's **recommended settings profile** as an opt-in speed knob: it disables bwa-mem's third seeding round, cutting **~11–30% of single-thread alignment CPU** with F1 near-neutral across every regime tested — *better* on divergent and repeat-enriched data. Also documents the more-aggressive `-y 0 -r 10` (drop rounds 2+3) for clean-data workflows. **Docs only — `-y` and `-r` are existing stock flags, no code change**, and the stock defaults are unchanged.

This follows the same opt-in pattern as `-m 10`, `-s 0`, and `--min-ext-len 30` (#169): recommended-profile knobs, off by default, to be considered for default in a future major release.

## Why

A seeding micro-benchmark found bwa-mem3 emits ~5× more SMEMs and ~4× more suffix-array lookups per read than minibwa — entirely from bwa-mem's multi-round seeding (round-2 reseed/split via `-r`, round-3 occurrence-bounded "seed strategy" via `-y`). Each extra SA lookup is a cold-DRAM miss, which is the aligner's dominant cost. Round 3 turns out to be net-useless-to-harmful.

## Validation (golden-truth F1 + real WES/WGS + cross-arch)

`-y 0` vs the stock default, holodeck read-name truth across four regimes:

| regime | ΔF1 | ΔF1 in MAPQ-0 (repeat) bin |
|---|---|---|
| easy (150 bp) | −0.010 | −0.14 |
| substitution-divergent (2–15%) | **+0.008** | **+0.13** |
| indel-rich (37% indels) | −0.016 | −0.02 |
| **repeat-enriched** (reads from RepeatMasker, 49% of hg38) | **+0.007** | **+0.16** |

The decisive result: on the **repeat-enriched** regime — round 3's entire design purpose — removing it makes F1 *better*, because its ≤19-hit seeds add spurious near-tied repeat candidates that slightly degrade placement.

**Real data (20M WES+WGS reads, AS-aware):** **zero** confidently/uniquely mapped reads (MAPQ≥60, NM≤1, no soft-clip) became unmapped under `-y 0`; 3–4 per 10M lost any score. Every regression lands on the already-low-confidence tail.

**CPU & portability:** WES −11% / WGS −22% whole-aligner CPU (seeding stage ~halves); Graviton4/Linux replicates (realistic +29.9%, HG002 WGS +19.8%, matching macOS) — it cuts cold-memory seeding work, not arithmetic, so it ports.

**`-y 0 -r 10`** (the aggressive variant) roughly halves alignment CPU (~50–63%) but round 2 is genuine split-read/divergence sensitivity (−0.07% F1 on divergent), so it's scoped to known-clean libraries.

Full methodology and per-phase results are in the repo reports (`reports/2026-06-21-seeding-gap-diagnostic.md`, `reports/2026-06-21-reseed-reduction-validation.md`).

## Changes

- `best-practices/settings-profiles.md`: add `-y 0` to the recommended-deviations table + invocations, with a "Why we recommend `-y 0`" section (regime evidence, real-data who-regresses, Graviton, and the `-y 0 -r 10` clean-data variant).
- `cli/mem.md`: expand the thin `-y` and `-r` flag docs to explain the seeding rounds and point to the recommendation.

## Testing

- `mdbook build` clean; cross-link anchors verified against the generated HTML.
- Self-reviewed via `/coderabbitai-review` + `coderabbit --agent` CLI; findings addressed (meth-invocation consistency; "F1 near-neutral" phrasing to match the mixed-but-tiny regime deltas).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated recommended `bwa-mem3 mem` configuration profiles to include `-y 0`, documenting CPU reduction and F1/accuracy impacts (including standard and `--meth` pipelines)
  * Added a new subsection explaining why `-y 0` is recommended, with benchmark/empirical comparisons across alignment regimes and optional more aggressive settings (`-y 0 -r 10`)
  * Expanded CLI documentation for `-r` and `-y` flags, including how `-r` interacts with `-y 0` and the associated performance/accuracy tradeoffs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->