### PR TITLE
docs(book): document the libdeflate build prerequisite (incl. AL2023)

### DIFF
--- a/docs/src/best-practices/multi-arch-deployment.md
+++ b/docs/src/best-practices/multi-arch-deployment.md
@@ -19,14 +19,14 @@ FROM ubuntu:24.04 AS build
 RUN apt-get update && apt-get install -y \
     build-essential git cmake pkg-config \
     autoconf automake autoconf-archive libtool \
-    zlib1g-dev
+    zlib1g-dev libdeflate-dev
 WORKDIR /src
 RUN git clone --recursive https://github.com/fg-labs/bwa-mem3 .
 RUN make -j
 
 FROM ubuntu:24.04
 COPY --from=build /src/bwa-mem3 /usr/local/bin/bwa-mem3
-RUN apt-get update && apt-get install -y libgomp1 zlib1g \
+RUN apt-get update && apt-get install -y libgomp1 zlib1g libdeflate0 \
  && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["bwa-mem3"]
 ```

--- a/docs/src/developer-guide/building.md
+++ b/docs/src/developer-guide/building.md
@@ -9,6 +9,7 @@ This page documents every build target available in the Makefile and what each p
 - CMake 3.12+ (required only when `USE_MIMALLOC=1`, which is the default).
 - autoconf, automake, autoconf-archive, libtool, pkg-config — `ext/htslib`'s build runs `autoreconf -i && ./configure` and locates zlib via `pkg-config`.
 - zlib development headers — htslib links against zlib.
+- libdeflate development headers — `src/fast_reader.c` uses libdeflate for BGZF block decode (htslib also links it transitively). Debian/Ubuntu: `libdeflate-dev`; RHEL/Fedora: `libdeflate-devel`; macOS: `brew install libdeflate` (the Makefile auto-detects the Homebrew prefix or honours `LIBDEFLATE_PREFIX`). **Amazon Linux 2023 ships no `libdeflate-devel`** — build *and install* it from source (e.g. libdeflate v1.22): `cmake -B build -DCMAKE_INSTALL_PREFIX=/usr/local -DLIBDEFLATE_BUILD_SHARED_LIB=OFF`, then `cmake --build build && sudo cmake --install build`, and set `LIBRARY_PATH=/usr/local/lib64:/usr/local/lib` (CMake installs to `lib` or `lib64` depending on the distro) before `make`.
 - OpenMP runtime — libsais uses OpenMP for parallel suffix-array construction. Linux + GCC: libgomp ships with the compiler, nothing extra to install. Linux + Clang: `libomp-dev` (Debian) / `libomp-devel` (RHEL). macOS: `brew install libomp`; the Makefile auto-detects the Homebrew prefix or honours `LIBOMP_PREFIX`.
 - Git submodules initialised: `git submodule update --init --recursive`.
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -27,6 +27,7 @@ bwa-mem3 vendors several libraries as git submodules. Building from source requi
 | autoconf, automake, autoconf-archive, libtool | `ext/htslib` runs `autoreconf -i && ./configure` during build | any recent |
 | pkg-config | htslib's `configure` uses it to locate zlib | any recent |
 | zlib development headers | htslib links against zlib | any recent |
+| libdeflate development headers | `src/fast_reader.c` uses libdeflate for BGZF block decode | any recent |
 | OpenMP runtime | `ext/libsais` uses OpenMP for parallel suffix-array construction | see notes below |
 | CMake 3.12+ | building bundled mimalloc (default; skip if you pass `USE_MIMALLOC=0`) | 3.12+ |
 
@@ -42,7 +43,7 @@ bwa-mem3 vendors several libraries as git submodules. Building from source requi
 sudo apt-get install \
     build-essential git cmake pkg-config \
     autoconf automake autoconf-archive libtool \
-    zlib1g-dev \
+    zlib1g-dev libdeflate-dev \
     libomp-dev          # only needed if building with Clang
 ```
 
@@ -51,9 +52,17 @@ sudo apt-get install \
 sudo dnf install \
     gcc gcc-c++ make git cmake pkgconf-pkg-config \
     autoconf automake autoconf-archive libtool \
-    zlib-devel \
+    zlib-devel libdeflate-devel \
     libomp-devel        # only needed if building with Clang
 ```
+
+> **Amazon Linux 2023 has no `libdeflate-devel`.** The `dnf install` above will fail on that one
+> package. Build *and install* libdeflate from source instead (e.g. v1.22): configure with
+> `cmake -B build -DCMAKE_INSTALL_PREFIX=/usr/local -DLIBDEFLATE_BUILD_SHARED_LIB=OFF`, then
+> `cmake --build build && sudo cmake --install build` to put the headers and static library under
+> `/usr/local`. CMake installs the library to `lib` or `lib64` depending on the distro, so set
+> `LIBRARY_PATH=/usr/local/lib64:/usr/local/lib` (covering both) before running bwa-mem3's `make`.
+> Other RHEL/Fedora releases have the package.
 
 **macOS (Homebrew):**
 ```bash
@@ -61,7 +70,7 @@ xcode-select --install   # Apple Clang + git + make
 brew install \
     cmake pkg-config \
     autoconf automake autoconf-archive libtool \
-    libomp
+    libdeflate libomp
 ```
 
 > **What happens if a prereq is missing.** The Makefile fails fast with an actionable error: a missing `libomp` on macOS, a missing `autoreconf`, or a missing `cmake` each produce a one-line hint pointing at the install command above. There is no need to install everything optimistically — install only what the error message asks for if you prefer.


### PR DESCRIPTION
## Summary

Documents the **libdeflate build prerequisite**, which `src/fast_reader.c` links for BGZF block decode but which the build docs never listed. A fresh Linux box without `libdeflate-dev` / `libdeflate-devel` fails to build with a raw `cannot find -ldeflate` linker error, and the documented multi-arch Docker recipe was broken (build stage missing the dev package; runtime stage missing the dynamic `.so`). Docs only.

## Changes

- **`getting-started/installation.md`** — add libdeflate to the dependency table and to the apt / dnf / brew install blocks.
- **`developer-guide/building.md`** — add it to the Prerequisites list.
- **`best-practices/multi-arch-deployment.md`** — Dockerfile: `libdeflate-dev` in the build stage, `libdeflate0` in the runtime stage (the binary links libdeflate dynamically, so the runtime image needs the shared lib).

## Amazon Linux 2023

Called out explicitly: **AL2023 ships no `libdeflate-devel`** — the `dnf install` fails on that one package, so build libdeflate from source (v1.22 via CMake, `-DCMAKE_INSTALL_PREFIX=/usr/local -DLIBDEFLATE_BUILD_SHARED_LIB=OFF`) and put `/usr/local/lib64` on `LIBRARY_PATH`. This is the exact gap that throwaway Graviton/AL2023 build hosts hit twice during recent benchmarking.

## Testing

`mdbook build` clean. Self-reviewed via `/coderabbitai-review` (caught the multi-arch Docker build+runtime gap, fixed) + `coderabbit --agent` CLI (0 findings).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation and build prerequisites to include **libdeflate** development headers, with correct package names for Debian/Ubuntu, RHEL/Fedora/Amazon Linux, and macOS.
  * Revised the multi-architecture Dockerfile example to install **libdeflate** in both build and runtime stages.
  * Added an Amazon Linux 2023 workaround explaining how to build and install libdeflate from source when prebuilt packages are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->