### PR TITLE
ci(docs): fail the docs build on dead internal links via mdbook-linkcheck2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,22 +32,34 @@ jobs:
           path: |
             ~/.cargo/bin/mdbook
             ~/.cargo/bin/mdbook-mermaid
-          key: cargo-mdbook-0.5.2-mermaid-0.17.0-${{ runner.os }}-v1
+            ~/.cargo/bin/mdbook-linkcheck2
+          key: cargo-mdbook-0.5.2-mermaid-0.17.0-linkcheck2-0.12.2-${{ runner.os }}-v1
 
       - name: Install mdbook + plugins
         run: |
           want_mdbook=0.5.2
           want_mermaid=0.17.0
-          have_mdbook="$(mdbook --version 2>/dev/null | awk '{print $2}' || true)"
+          want_linkcheck2=0.12.2
+          # mdbook prints "mdbook v0.5.2" (note the leading 'v'); strip it so the
+          # comparison against want_mdbook matches and the install does not rerun
+          # every time. mdbook-mermaid and mdbook-linkcheck2 emit plain versions.
+          have_mdbook="$(mdbook --version 2>/dev/null | awk '{print $2}' | sed 's/^v//' || true)"
           have_mermaid="$(mdbook-mermaid --version 2>/dev/null | awk '{print $2}' || true)"
+          have_linkcheck2="$(mdbook-linkcheck2 --version 2>/dev/null | awk '{print $2}' || true)"
           if [ "$have_mdbook" != "$want_mdbook" ]; then
             cargo install mdbook --version "$want_mdbook" --locked --force
           fi
           if [ "$have_mermaid" != "$want_mermaid" ]; then
             cargo install mdbook-mermaid --version "$want_mermaid" --locked --force
           fi
+          # Broken-link checker backend (see docs/book.toml). The fork supports
+          # mdBook 0.5; the original mdbook-linkcheck does not.
+          if [ "$have_linkcheck2" != "$want_linkcheck2" ]; then
+            cargo install mdbook-linkcheck2 --version "$want_linkcheck2" --locked --force
+          fi
           mdbook --version
           mdbook-mermaid --version
+          mdbook-linkcheck2 --version
 
       - name: Build bwa-mem3
         run: make

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,23 +4,31 @@ build:
   os: ubuntu-24.04
   # A tool entry is required by the Read the Docs schema even when the build is
   # driven entirely by `commands`. We do not actually use Python — it is the
-  # lightest always-available toolchain to satisfy the requirement. mdbook and
-  # mdbook-mermaid are installed from prebuilt release binaries below.
+  # lightest always-available toolchain to satisfy the requirement. mdbook,
+  # mdbook-mermaid, and mdbook-linkcheck2 are installed from prebuilt release
+  # binaries below (there is no rust toolchain here, so `cargo install` is not
+  # an option).
   tools:
     python: "3.12"
   commands:
     # Install pinned mdbook + mdbook-mermaid from prebuilt release binaries.
     #
     # These pins MUST stay in lockstep with .github/workflows/docs.yml. That CI
-    # job pins BOTH mdbook (0.5.2) and mdbook-mermaid (0.17.0); the previous
-    # version of this file pinned only mdbook and ran `cargo install
-    # mdbook-mermaid` with no version, so Read the Docs floated to whatever
-    # mdbook-mermaid was newest on crates.io. When a newer mdbook-mermaid that
-    # is incompatible with mdbook 0.5.2 ships, the RTD build breaks while CI
+    # job pins mdbook (0.5.2), mdbook-mermaid (0.17.0), and mdbook-linkcheck2
+    # (0.12.2); the previous version of this file pinned only mdbook and ran
+    # `cargo install mdbook-mermaid` with no version, so Read the Docs floated to
+    # whatever mdbook-mermaid was newest on crates.io. When a newer mdbook-mermaid
+    # that is incompatible with mdbook 0.5.2 ships, the RTD build breaks while CI
     # stays green — leaving the published site stale (e.g. missing the
     # whats-different/equivalence page added later). Prebuilt binaries also avoid
     # a multi-minute source compile on every build and drop the brittle rust
     # toolchain pin entirely.
+    #
+    # mdbook-linkcheck2 is the broken-link checker backend (see docs/book.toml).
+    # We use the fork rather than the original mdbook-linkcheck because the
+    # original is pinned to the mdBook 0.4 backend API and cannot parse mdBook
+    # 0.5's RenderContext. mdBook discovers it as the `linkcheck2` backend by
+    # finding `mdbook-linkcheck2` on PATH (bin/ is prepended below).
     #
     # Each binary is downloaded to a file, verified against its pinned SHA-256,
     # and only then extracted — so a corrupted or tampered download fails the
@@ -29,6 +37,9 @@ build:
     - mkdir -p bin
     - curl -fsSL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz -o bin/mdbook.tar.gz && echo "084e4342ba564db270108763e404a7d1f309d932651a22484e93c0dc1a071f6d  bin/mdbook.tar.gz" | sha256sum -c - && tar -xzf bin/mdbook.tar.gz -C bin
     - curl -fsSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.17.0/mdbook-mermaid-v0.17.0-x86_64-unknown-linux-gnu.tar.gz -o bin/mdbook-mermaid.tar.gz && echo "8aced70d781830fb0e81988f081c4abdd49e056a001ae2f1e4d484e1f6385c57  bin/mdbook-mermaid.tar.gz" | sha256sum -c - && tar -xzf bin/mdbook-mermaid.tar.gz -C bin
+    - curl -fsSL https://github.com/marxin/mdbook-linkcheck2/releases/download/v0.12.2/mdbook-linkcheck2-x86_64-unknown-linux-gnu.tar.gz -o bin/mdbook-linkcheck2.tar.gz && echo "c68bba37dd07887d308a8c1ccab56aef8250793196e35c0fe517b9c7fbc44c48  bin/mdbook-linkcheck2.tar.gz" | sha256sum -c - && tar -xzf bin/mdbook-linkcheck2.tar.gz -C bin && chmod +x bin/mdbook-linkcheck2
     - cd docs && PATH="$PWD/../bin:$PATH" mdbook build
+    # With the linkcheck2 output backend configured, mdBook writes the HTML site
+    # to book/html/ (rather than book/), so copy from there.
     - mkdir -p _readthedocs/html
-    - cp -r docs/book/. _readthedocs/html/
+    - cp -r docs/book/html/. _readthedocs/html/

--- a/Makefile
+++ b/Makefile
@@ -863,6 +863,9 @@ docs-clean:
 docs-install-tools:
 	cargo install mdbook --version 0.5.2 --locked
 	cargo install mdbook-mermaid --version 0.17.0 --locked
+	# Broken-link checker backend (see docs/book.toml). The mdbook-linkcheck2
+	# fork supports mdBook 0.5; the original mdbook-linkcheck does not.
+	cargo install mdbook-linkcheck2 --version 0.12.2 --locked
 
 # Profile-Guided Optimization (PGO) targets.
 #

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-Release notes for 0.3.0 and later live in [`CHANGELOG.md`](./CHANGELOG.md) and the [GitHub Releases](https://github.com/fg-labs/bwa-mem3/releases) page. The 0.2.0 entry below is preserved as historical context.
+Release notes for 0.3.0 and later live in [`CHANGELOG.md`](https://github.com/fg-labs/bwa-mem3/blob/main/CHANGELOG.md) and the [GitHub Releases](https://github.com/fg-labs/bwa-mem3/releases) page. The 0.2.0 entry below is preserved as historical context.
 
 Release 0.2.0 (2026-05-13)
 ---------------------------------

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -31,3 +31,25 @@ runnable = false
 
 [preprocessor.mermaid]
 command = "mdbook-mermaid"
+
+# Broken-link checker. Configuring this as an output backend makes `mdbook build`
+# (which both CI and Read the Docs run) fail when an internal link points at a page
+# that does not exist. mdBook on its own only *warns* on dead internal links, so a
+# broken cross-reference can ship to the published site unnoticed.
+#
+# We use the mdbook-linkcheck2 fork rather than the original mdbook-linkcheck: the
+# original is pinned to the mdBook 0.4 backend API and cannot parse mdBook 0.5's
+# RenderContext (this book builds with mdBook 0.5.2). See .readthedocs.yaml and
+# .github/workflows/docs.yml for the pinned install.
+#
+# `follow-web-links = false`: do not hit the network -- external links are out of
+# scope here and following them makes the build slow, flaky, and offline-broken.
+#
+# The default warning-policy is intentional: bracketed literal text in the captured
+# CLI `--help` snippets (e.g. `[P]`, `[=LEVEL]`, `[proto]`) is reported as a non-fatal
+# "incomplete link" warning, while genuine dead links remain hard errors.
+#
+# NOTE: configuring a second output backend makes mdBook write the HTML site to
+# book/html/ rather than book/ -- the Read the Docs copy step accounts for this.
+[output.linkcheck2]
+follow-web-links = false

--- a/docs/src/developer-guide/building.md
+++ b/docs/src/developer-guide/building.md
@@ -163,11 +163,13 @@ Removes only the mdbook build output (`docs/book/`). Covered in [Developer Guide
 
 | Target | Action |
 |---|---|
-| `make docs` | Build the mdbook into `docs/book/` |
+| `make docs` | Build the mdbook into `docs/book/html/` |
 | `make docs-serve` | Live-preview at `http://localhost:3000` |
 | `make docs-cli` | Capture `--help` output for each subcommand into `docs/_generated/cli/` |
 | `make docs-clean` | Remove `docs/book/` |
-| `make docs-install-tools` | `cargo install` mdbook + three plugins |
+| `make docs-install-tools` | `cargo install` mdbook, mdbook-mermaid, and mdbook-linkcheck2 |
+
+The build runs the [mdbook-linkcheck2](https://github.com/marxin/mdbook-linkcheck2) backend, which **fails the build on a dead internal link** (a link to a page that does not exist). This guards against broken cross-references reaching the published site — mdBook on its own only warns. External (web) links are not checked, and bracketed literal text in the captured CLI snippets (e.g. `[P]`) is reported only as a non-fatal warning. Because a second output backend is configured, the HTML site is written to `docs/book/html/` rather than `docs/book/`.
 
 ---
 


### PR DESCRIPTION
## Summary

Port of [fulcrumgenomics/fgumi#457](https://github.com/fulcrumgenomics/fgumi/pull/457) to this repo. `bwa-mem3` uses the same mdBook + Read the Docs documentation stack as fgumi and has the same gap: **mdBook only *warns* on broken internal links**, so a dead cross-reference can ship to the published site unnoticed (this is the same class of bug as fgumi#456 — a link to a page that mdBook never renders).

This configures the [`mdbook-linkcheck2`](https://github.com/marxin/mdbook-linkcheck2) backend so that `mdbook build` — run by **both** the `docs` CI workflow (`make docs`) and Read the Docs — **fails** on a dead internal link.

### Why the `mdbook-linkcheck2` fork rather than `mdbook-linkcheck`

This book builds with mdBook 0.5.2. The original `mdbook-linkcheck` (last released 0.7.7, Oct 2022) is built against the mdBook **0.4** backend API and cannot parse mdBook 0.5's `RenderContext` (it dies with `missing field 'sections'`). The maintained `marxin/mdbook-linkcheck2` fork tracks mdBook 0.5 and ships a prebuilt `x86_64-unknown-linux-gnu` binary, which matters for Read the Docs (see below).

## Changes

- **`docs/book.toml`** — add `[output.linkcheck2]` with `follow-web-links = false`.
- **`.readthedocs.yaml`** — install `mdbook-linkcheck2` 0.12.2 from a SHA-256-verified prebuilt binary, matching the existing `mdbook` / `mdbook-mermaid` install pattern. RTD here has **no rust toolchain** (it was deliberately dropped), so `cargo install` is not an option — the prebuilt binary is required. Also copy the published site from `docs/book/html/` instead of `docs/book/`.
- **`.github/workflows/docs.yml`** — install and cache `mdbook-linkcheck2` (via `cargo install`, consistent with the existing mdbook/mermaid install) so the CI docs build gates on dead links **pre-merge**.
- **`Makefile`** — add `mdbook-linkcheck2` to `docs-install-tools`.
- **`docs/src/developer-guide/building.md`** — document the link-check behavior and the new `docs/book/html/` output directory.

## Behavior (default `warning-policy`)

- **Genuine dead internal links are hard errors** — e.g. a link to `getting-started/does-not-exist.md` fails the build with exit 101.
- **Bracketed literal text in the captured CLI snippets is a non-fatal warning** — strings like `[P]`, `[=LEVEL]`, `[proto]` are CommonMark "shortcut reference links" with no definition; linkcheck2 reports them as `Potential incomplete link` warnings (8 currently) but does not fail the build.

## The `docs/book/html/` relocation

Configuring a second mdBook output backend (here: html + linkcheck2; mermaid is a *preprocessor* and does not count) makes mdBook write the HTML site to `book/html/` rather than `book/`. The RTD copy step is updated accordingly. The `make docs` / CI path does not copy `book/`, so no change was needed there; `make docs-clean` already removes the whole `docs/book/` tree.

## Verification

Ran the build locally with both plugins installed:

- `cd docs && mdbook build` → exit 0 (8 non-fatal bracket warnings, no errors).
- HTML lands at `docs/book/html/index.html`; `cp -r docs/book/html/. <site>/` yields a correct site root with no stray `linkcheck2/` directory.
- Injecting a broken link (`[x](getting-started/does-not-exist.md)`) → `error: File not found`, exit 101. Gate confirmed.
- Both edited YAML files parse cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation builds now include a pinned broken-link checker (`mdbook-linkcheck2`), causing the mdBook build to fail on dead internal links.

* **Documentation**
  * Docs output and deployment now use the `docs/book/html/` directory.
  * Developer documentation updated to reflect the new link-checking build behavior and the available docs tool targets.

* **Chores / Maintenance**
  * Documentation tooling installation is now version-pinned and verified for consistent builds.
  * Updated the `NEWS.md` link to point to the external changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->