### PR TITLE
perf(mem): pac-fetch the reference from .pac instead of loading/building .0123

### DIFF
--- a/docs/_generated/cli/index.txt
+++ b/docs/_generated/cli/index.txt
@@ -9,4 +9,8 @@ Usage: bwa-mem3 index [-p prefix] [-t N] [--max-memory SIZE] [--tmp-dir PATH] [-
   --meth             build a BS-aware dual index. Writes the original-alphabet
                      index at <in.fasta>.* plus a converted seed FM-index at
                      <in.fasta>.meth.* (used by `bwa-mem3 mem --meth`).
+  --emit-unpacked-ref also write the unpacked `<prefix>.0123` reference. Off by
+                     default: `mem` pac-fetches bases from `.pac`, so `.0123`
+                     is never read. Enable only for an external consumer that
+                     still requires it (e.g. bwa-mem2); ~8x the size of `.pac`.
   -h, --help         print this help message and exit

--- a/docs/src/cli/index-cmd.md
+++ b/docs/src/cli/index-cmd.md
@@ -37,12 +37,12 @@ bwa-mem3 index --max-memory 16G --tmp-dir /scratch ref.fa
 ### `-p STR` — output prefix
 
 By default, index files are written alongside `<in.fasta>` using the FASTA
-path as a prefix (e.g. `ref.fa.bwt.2bit.64`, `ref.fa.0123`, etc.). Use `-p`
+path as a prefix (e.g. `ref.fa.bwt.2bit.64`, `ref.fa.pac`, etc.). Use `-p`
 to write them to a different base path, such as a dedicated index directory:
 
 ```sh
 bwa-mem3 index -p /idx/hg38 ref.fa
-# writes /idx/hg38.bwt.2bit.64, /idx/hg38.0123, …
+# writes /idx/hg38.bwt.2bit.64, /idx/hg38.pac, …
 # align with: bwa-mem3 mem /idx/hg38 R1.fq R2.fq
 ```
 
@@ -69,6 +69,21 @@ Scratch directory for intermediate files when memory is partitioned. Defaults
 to `$TMPDIR`. Point this at a fast local disk (NVMe or ramdisk) to minimize
 wall-clock time when `--max-memory` forces partitioned construction.
 
+### `--emit-unpacked-ref` — also write `<prefix>.0123`
+
+Off by default. `bwa-mem3 mem` reconstructs reference bases from the packed
+`.pac` on demand (*pac-fetch*), so the unpacked `.0123` (~8× the `.pac`; ~6.4 GB
+on hg38) is never read and is not built. Enable this flag only when an external
+consumer still requires the file — for example, sharing an index with
+[bwa-mem2](../related-projects/bwa-mem2.md), which loads `.0123` directly:
+
+```sh
+bwa-mem3 index --emit-unpacked-ref ref.fa   # additionally writes ref.fa.0123
+```
+
+For `--meth` the flag applies to the **original** index only; the `.meth` seed
+index never needs an unpacked reference.
+
 ### `--meth` — build a methylation (dual) index
 
 Builds a **dual index**: the normal FM-index over the original FASTA (at the bare
@@ -76,9 +91,13 @@ prefix), plus a converted **seed** FM-index under the `.meth` prefix, built over
 per-strand-converted FASTA `<in.fasta>.meth.fa` (`f`-prefixed C→T and `r`-prefixed
 G→A doubled contigs). All files are placed alongside the original FASTA.
 
-The seed index omits the unpacked `.meth.0123` reference: `mem --meth` extends
-against the original reference, never the seed, so the seed's unpacked bases are
-never read. Not building it saves ~13 GB of disk (and RSS) on hg38.
+By default, neither index writes an unpacked `.0123`: `mem --meth` extends against
+the original reference (whose bases it pac-fetches from `.pac`), never the seed, so
+the original `.0123` (~6.4 GB) is unnecessary and the seed's unpacked bases are
+never read at all (~13 GB). Not building either saves ~19 GB of disk on hg38; the
+runtime RSS reduction comes from avoiding the original `.0123` load (~6.4 GB).
+(`--emit-unpacked-ref` overrides this for the **original** index only; the
+`.meth` seed never needs one.)
 
 Pass the **original** FASTA prefix to all three `index`, `shm`, and `mem` commands;
 the `.meth` seed index is located automatically when `--meth` is present.
@@ -87,13 +106,14 @@ the `.meth` seed index is located automatically when `--meth` is present.
 
 > **Tip — Index once, align many times**
 >
-> A standard hg38 index is ~18 GB of index files on disk and takes several
+> A standard hg38 index is ~11 GB of index files on disk and takes several
 > minutes to build. A `--meth` build adds the seed index on top — the doubled
-> seed FM-index (~21 GB) plus its packed `.pac` (~1.6 GB) — for roughly **40 GB**
-> of index files (~47 GB including the converted `.meth.fa`). That is a little
-> over double the plain footprint, not triple: the seed's unpacked `.0123`
-> (~13 GB) is no longer built. Build once and store on shared storage; all
-> alignment jobs on the same reference share the files.
+> seed FM-index (~21 GB) plus its packed `.pac` (~1.6 GB) — for roughly **34 GB**
+> of index files (~37 GB including the converted `.meth.fa`). That is a little
+> over double the plain footprint, not triple: by default no unpacked `.0123` is
+> built for either index (`--emit-unpacked-ref` adds it for the original only).
+> Build once and store on shared storage; all alignment jobs on the same reference
+> share the files.
 >
 > **Note — a `--meth` index is a superset, not a separate index**
 >

--- a/docs/src/cli/shm.md
+++ b/docs/src/cli/shm.md
@@ -65,9 +65,12 @@ plain `<idxbase>` to all three commands; the `.meth` suffix is handled
 transparently.
 
 The staged seed segment is **seed-only**: it holds the seed FM-index and contig
-metadata (BNS) but omits the packed reference (PAC) and the unpacked reference
-(`.0123`), because `mem --meth` extends against the original reference and never
-reads the seed's bases. This trims ~14.5 GB from the staged segment on hg38.
+metadata (BNS) but omits the packed reference (PAC), because `mem --meth` extends
+against the original reference and never reads the seed's bases. This trims
+~1.6 GB from the staged segment on hg38. (The unpacked `.0123` reference is never
+staged for **any** index — plain or seed — because `mem` pac-fetches reference
+bases from `.pac` on demand; that saves the seed's ~13 GB and the original's
+~6.4 GB versus staging `.0123`.)
 
 ## Notes / Gotchas
 

--- a/docs/src/getting-started/quick-align.md
+++ b/docs/src/getting-started/quick-align.md
@@ -8,19 +8,21 @@ This page walks through the two-command workflow: index the reference once, then
 bwa-mem3 index ref.fa
 ```
 
-This produces five index files alongside `ref.fa`:
+This produces four index files alongside `ref.fa`:
 
 | File | Description |
 |------|-------------|
 | `ref.fa.bwt.2bit.64` | FM-index in 2-bit packed format |
-| `ref.fa.0123` | 2-bit packed reference sequence |
 | `ref.fa.amb` | Ambiguous base positions |
 | `ref.fa.ann` | Sequence name and length annotations |
-| `ref.fa.pac` | Packed 4-bit reference sequence |
+| `ref.fa.pac` | 2-bit packed reference sequence |
+
+(No `ref.fa.0123` is written: `mem` reconstructs reference bases from `.pac` on
+demand. Pass `index --emit-unpacked-ref` if a tool such as bwa-mem2 needs it.)
 
 Indexing hg38 takes roughly 2-3 minutes and requires approximately 60 GB of peak disk space
-during creation (including temporary/intermediate files); the final FM-index stored on disk
-is roughly 28 GB. The index is read once per `mem` invocation; for workloads that align many
+during creation (including temporary/intermediate files); the final index stored on disk
+is roughly 11 GB. The index is read once per `mem` invocation; for workloads that align many
 samples, load it into shared memory first (see [Quick start: shared-memory index](quick-shm.md)).
 
 ## Align paired-end reads

--- a/docs/src/getting-started/quick-meth.md
+++ b/docs/src/getting-started/quick-meth.md
@@ -24,7 +24,7 @@ This builds the normal 4-letter index at the bare prefix **plus** a converted se
 
 | File(s) | Description |
 |---------|-------------|
-| `ref.fa.0123`, `ref.fa.amb`, `ref.fa.ann`, `ref.fa.bwt.2bit.64`, `ref.fa.pac` | Normal index over the original reference (used for scoring/extension). |
+| `ref.fa.amb`, `ref.fa.ann`, `ref.fa.bwt.2bit.64`, `ref.fa.pac` | Normal index over the original reference (used for scoring/extension; bases are pac-fetched from `.pac`, so no `.0123` is built). |
 | `ref.fa.meth.fa` | Per-strand C→T / G→A converted FASTA (`f`/`r` doubled contigs). |
 | `ref.fa.meth.*` | FM-index over the converted FASTA (used only for **seeding**). |
 

--- a/docs/src/methylation/conversion.md
+++ b/docs/src/methylation/conversion.md
@@ -103,14 +103,18 @@ original base calls.
 
 `bwa-mem3 index --meth ref.fa` writes **two** indexes:
 
-- the normal 4-letter index at the bare prefix (`ref.fa.0123`, `.amb`, `.ann`,
+- the normal 4-letter index at the bare prefix (`ref.fa.amb`, `.ann`,
   `.bwt.2bit.64`, `.pac`) — used for scoring/extension against the original
   reference, and
 - the converted **seed** index `ref.fa.meth.*` (built over a per-strand-converted
   FASTA `ref.fa.meth.fa` with the `f`/`r` doubled contigs) — used only for
-  seeding. The seed index omits the unpacked `.meth.0123` reference: seeding uses
-  the seed FM-index and scoring/extension uses the original reference, so the
-  seed's unpacked bases are never read (saving ~13 GB of disk and RSS on hg38).
+  seeding.
+
+Neither index writes an unpacked `.0123`: seeding uses the seed FM-index, and
+scoring/extension pac-fetches the original reference's bases from `ref.fa.pac` on
+demand. So the original `.0123` (~6.4 GB) is unnecessary and the seed's unpacked
+bases are never read (~13 GB) — saving ~19 GB of disk on hg38, while the runtime
+RSS reduction comes from avoiding the original `.0123` load (~6.4 GB).
 
 This dual-index layout differs from bwameth.py, which builds a single
 `ref.fa.bwameth.c2t` doubled reference and aligns entirely against it. A legacy

--- a/docs/src/related-projects/bwa-mem2.md
+++ b/docs/src/related-projects/bwa-mem2.md
@@ -18,7 +18,11 @@ the last:
    format conventions, and the `.bwt` / `.pac` / `.ann` / `.amb` index layout.
 2. **bwa-mem2** (Vasimuddin et al., Intel) — Replaced scalar inner loops with SIMD
    kernels; introduced the compact `.bwt.2bit.64` and `.0123` index formats;
-   retained full output compatibility with bwa-mem.
+   retained full output compatibility with bwa-mem. (bwa-mem3 reads the same
+   formats but no longer **builds** the unpacked `.0123` by default — it
+   pac-fetches reference bases from `.pac`. If you want to share a bwa-mem3 index
+   with bwa-mem2, which loads `.0123` directly, build it with
+   `bwa-mem3 index --emit-unpacked-ref`.)
 3. **bwa-mem3** (Fulcrum Genomics fork) — Carries correctness fixes, performance
    improvements, new features (bisulfite alignment, mimalloc, ARM Neon), and
    expanded architecture support on top of the bwa-mem2 codebase. See

--- a/docs/src/user-guide/indexing.md
+++ b/docs/src/user-guide/indexing.md
@@ -10,18 +10,33 @@ built once and reused indefinitely.
 bwa-mem3 index ref.fa
 ```
 
-The command writes five files alongside the input FASTA:
+The command writes four files alongside the input FASTA:
 
 | File | Contents |
 |------|----------|
 | `ref.fa.bwt.2bit.64` | Burrows-Wheeler Transform, 2-bit packed, 64-bit offsets |
-| `ref.fa.0123` | Forward sequence, 2-bit packed |
 | `ref.fa.amb` | Coordinates and counts of ambiguous (N) bases |
 | `ref.fa.ann` | Sequence names and lengths |
-| `ref.fa.pac` | Forward sequence, 4-bit packed |
+| `ref.fa.pac` | Forward sequence, 2-bit packed (one base per 2 bits) |
 
 The `.bwt.2bit.64` file dominates disk usage. For the human reference (hg38),
-expect roughly 28 GB total across all five files.
+expect roughly 11 GB total across all four files.
+
+> **Note — no `.0123` by default**
+>
+> Earlier releases (and bwa-mem2) also wrote `ref.fa.0123`, an *unpacked*
+> forward+reverse reference (~8× the `.pac`; ~6.4 GB on hg38). bwa-mem3 no longer
+> builds it: `mem` reconstructs the bases it needs directly from the packed
+> `.pac` on demand (*pac-fetch*), so `.0123` is never read. Output is byte-for-byte
+> identical. Pass `--emit-unpacked-ref` to `index` if you need the file for an
+> external tool that still requires it (e.g. bwa-mem2):
+>
+> ```sh
+> bwa-mem3 index --emit-unpacked-ref ref.fa   # also writes ref.fa.0123
+> ```
+>
+> At run time, `BWAMEM3_REF_PAC_FETCH=0` reloads `.0123` instead of pac-fetching
+> (only on an index that still has the file); it exists for A/B verification.
 
 ## Methylation index (`--meth`)
 
@@ -36,7 +51,6 @@ prefix. The seed index is built over a per-strand-converted FASTA
 
 ```text
 # normal index over the original reference (used for scoring/extension)
-ref.fa.0123
 ref.fa.amb
 ref.fa.ann
 ref.fa.bwt.2bit.64
@@ -49,17 +63,23 @@ ref.fa.meth.bwt.2bit.64
 ref.fa.meth.pac
 ```
 
-> **Note — the seed index has no `.0123`**
+> **Note — neither index ships a `.0123`**
 >
-> The seed index deliberately omits the unpacked `.meth.0123` reference. `mem
-> --meth` seeds against the seed FM-index but scores/extends against the
-> **original** reference, so it never reads the seed's unpacked bases. Skipping
-> it saves ~13 GB of disk — and ~13 GB of resident memory at run time — on hg38.
+> By default, neither the original index nor the `.meth` seed index writes an
+> unpacked `.0123`. `mem --meth` seeds against the seed FM-index but scores/extends
+> against the **original** reference, whose bases it pac-fetches from
+> `ref.fa.pac` — so the original `.0123` (~6.4 GB) is unnecessary, and the seed's
+> unpacked bases are never read at all (~13 GB). Skipping both saves ~19 GB of
+> disk on hg38, while the runtime RSS reduction comes from avoiding the original
+> `.0123` load. (`--emit-unpacked-ref`
+> applies to the original index only, for bwa-mem2 compatibility; the seed never
+> needs one.)
 
 The `.meth` seed FM-index is roughly twice the size of the normal FM-index (its
-contigs are doubled), so a `--meth` build is larger than a plain build but less
-than 3× (the seed `.0123` is skipped). For hg38, budget on the order of 50 GB of
-disk for the combined dual index plus the intermediate `ref.fa.meth.fa`.
+contigs are doubled), so a `--meth` build is larger than a plain build but well
+under 3× (by default no `.0123` is written; `--emit-unpacked-ref` adds it for the
+original index only). For hg38, budget on the order of 35 GB
+of disk for the combined dual index plus the intermediate `ref.fa.meth.fa`.
 
 > **Tip — Pass the original FASTA to mem, not the seed index**
 >

--- a/docs/src/user-guide/indexing.md
+++ b/docs/src/user-guide/indexing.md
@@ -35,8 +35,7 @@ expect roughly 11 GB total across all four files.
 > bwa-mem3 index --emit-unpacked-ref ref.fa   # also writes ref.fa.0123
 > ```
 >
-> At run time, `BWAMEM3_REF_PAC_FETCH=0` reloads `.0123` instead of pac-fetching
-> (only on an index that still has the file); it exists for A/B verification.
+> `mem` ignores any `.0123` present and always pac-fetches from `.pac`.
 
 ## Methylation index (`--meth`)
 

--- a/docs/src/user-guide/memory-and-data-types.md
+++ b/docs/src/user-guide/memory-and-data-types.md
@@ -24,12 +24,10 @@ for a given reference and does not change with `-t` or `-K`.
 directly from the packed `.pac` on demand (*pac-fetch*), so the unpacked
 `.0123` reference (~6.4 GB on hg38) is **neither loaded nor required on disk** —
 the `.pac` already holds the same bases at one-quarter the size. This is the
-default and is byte-for-byte identical to loading `.0123`. The escape hatch
-`BWAMEM3_REF_PAC_FETCH=0` restores the old behavior of loading `.0123` (only on
-an index that still has the file; see [indexing](indexing.md)), and is intended
-only for A/B verification. On hg38 (5M read pairs, `-t 16`) pac-fetch lowered
-peak RSS by **~6.2 GB** for a plain alignment and **~6.3 GB** for `--meth`, at
-neutral-to-slightly-faster wall time.
+only reference path and is byte-for-byte identical to the historical `.0123`
+load. On hg38 (5M read pairs, `-t 16`) pac-fetch lowered peak RSS by **~6.2 GB**
+for a plain alignment and **~6.3 GB** for `--meth`, at neutral-to-slightly-faster
+wall time.
 
 **Per-batch working set.** On top of the index, each in-flight batch holds the
 reads, their seeds, candidate alignment regions, and the reference windows used

--- a/docs/src/user-guide/memory-and-data-types.md
+++ b/docs/src/user-guide/memory-and-data-types.md
@@ -15,10 +15,21 @@ Peak resident memory during `bwa-mem3 mem` is the sum of two parts:
 peak RSS  ≈  resident index  +  per-batch working set
 ```
 
-**Resident index.** The FM-index, packed reference, and related structures are
-loaded once and shared across all threads (there is no per-thread copy). For
-hg38 the resident index baseline is roughly **21 GB**. This is fixed for a given
-reference and does not change with `-t` or `-K`.
+**Resident index.** The FM-index, packed reference (`.pac`), and related
+structures are loaded once and shared across all threads (there is no per-thread
+copy). For hg38 the resident index baseline is roughly **15 GB**. This is fixed
+for a given reference and does not change with `-t` or `-K`.
+
+`mem` reconstructs the reference bases it needs for scoring and extension
+directly from the packed `.pac` on demand (*pac-fetch*), so the unpacked
+`.0123` reference (~6.4 GB on hg38) is **neither loaded nor required on disk** —
+the `.pac` already holds the same bases at one-quarter the size. This is the
+default and is byte-for-byte identical to loading `.0123`. The escape hatch
+`BWAMEM3_REF_PAC_FETCH=0` restores the old behavior of loading `.0123` (only on
+an index that still has the file; see [indexing](indexing.md)), and is intended
+only for A/B verification. On hg38 (5M read pairs, `-t 16`) pac-fetch lowered
+peak RSS by **~6.2 GB** for a plain alignment and **~6.3 GB** for `--meth`, at
+neutral-to-slightly-faster wall time.
 
 **Per-batch working set.** On top of the index, each in-flight batch holds the
 reads, their seeds, candidate alignment regions, and the reference windows used
@@ -29,18 +40,20 @@ larger.
 ### Methylation (`--meth`) mode
 
 `--meth` loads a **dual index**: the doubled seed FM-index for seeding plus the
-**original** reference's packed (`.pac`) and unpacked (`.0123`) bases for
-scoring/extension. The seed FM-index is roughly twice the size of a plain
-FM-index (its contigs are doubled), so the resident index for hg38 is on the
-order of **28 GB** (seed FM-index ~21 GB + original `.0123` ~6 GB + original
-`.pac` ~1 GB), versus ~21 GB for a plain alignment.
+**original** reference's packed `.pac` for scoring/extension. The seed FM-index
+is roughly twice the size of a plain FM-index (its contigs are doubled), so the
+resident index for hg38 is on the order of **22 GB** (seed FM-index ~21 GB +
+original `.pac` ~1 GB), versus ~17 GB for a plain alignment.
 
+As with plain alignment, the original reference's bases are pac-fetched from its
+`.pac` — the original unpacked `.0123` (~6.4 GB) is **neither built nor loaded**.
 The seed index's own unpacked `.0123` (~13 GB) and packed `.pac` (~1.6 GB) are
-**neither built nor loaded** — `mem --meth` extends against the original
+likewise **neither built nor loaded** — `mem --meth` extends against the original
 reference, never the seed, so the seed's bases are never read. (Earlier `--meth`
-builds loaded both, costing ~14.5 GB of extra RSS.) Under `bwa-mem3 shm --meth`
-the staged seed segment is likewise seed-only, omitting the seed PAC and
-`.0123`. The per-batch levers below (`-K`, `-t`) apply unchanged.
+builds loaded the original `.0123` plus both seed files, costing ~20 GB of extra
+RSS in total.) Under `bwa-mem3 shm --meth` the staged seed segment is likewise
+seed-only, omitting the seed PAC and `.0123`. The per-batch levers below (`-K`,
+`-t`) apply unchanged.
 
 ## Effective batch size: `-K` and the `-t` multiplier
 
@@ -75,7 +88,7 @@ budget like this:
 per-batch budget  ≈  memory cap  −  resident index  −  headroom
 ```
 
-For hg38 under a 28 GB cap, that is roughly `28 − 21 − a couple GB ≈ a few GB`
+For hg38 under a 22 GB cap, that is roughly `22 − 15 − a couple GB ≈ a few GB`
 for the per-batch working set — not much. The levers, in order of preference:
 
 1. **Lower `-K`.** `-K 1000000` keeps the per-batch working set well under 1 GB
@@ -86,7 +99,7 @@ for the per-batch working set — not much. The levers, in order of preference:
    adjusting `-K` first so you keep your cores busy.
 3. **Use `bwa-mem3 shm`** if you run several samples on one host: the index is
    mapped from a shared segment and its pages are shared across processes, so the
-   ~21 GB index is paid once rather than per process. See
+   ~15 GB index is paid once rather than per process. See
    [Quick start: shared-memory index](../getting-started/quick-shm.md).
 
 > **Tip — a silent OOM looks like a truncated BAM**

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -119,9 +119,10 @@ class FMI_search: public indexEle
      * fastmap reuses this so it doesn't have to re-attach for the ref string. */
     uint8_t *shm_attached_base()     const { return shm_base; }
 
-    /* emit_unpacked_ref=false skips writing the unpacked `<prefix>.0123`
-     * (used by the D3 --meth seed index, which is never extended against). */
-    int build_index(bool emit_unpacked_ref = true);
+    /* emit_unpacked_ref defaults false: skip writing the unpacked `<prefix>.0123`.
+     * `mem` pac-fetches the original reference from `.pac`, so `.0123` is never
+     * read; pass true only to emit it for an external consumer (e.g. bwa-mem2). */
+    int build_index(bool emit_unpacked_ref = false);
     /* load_pac=false skips loading the 2-bit packed reference (BNS only). D3
      * --meth uses this for the SEED index: seeding needs the FM-index + bns
      * (for the seed->original remap) but never the seed pac — extension/scoring

--- a/src/bntseq.cpp
+++ b/src/bntseq.cpp
@@ -527,6 +527,19 @@ void bns_fetch_seq_into(const bntseq_t *bns, const uint8_t *pac,
 	assert(*end - *beg == *len_out); // assertion failure should never happen
 }
 
+// pac-fetch scratch buffer (used by bns_get_seq_v2's ref_string==NULL path).
+// Thread-local so each worker reconstructs windows into its own buffer; the
+// destructor frees it at thread exit (via __cxa_thread_atexit), so a worker
+// thread's buffer is not leaked when the thread terminates — without it,
+// LeakSanitizer flags one live allocation per worker thread.
+namespace {
+struct PacFetchScratch {
+    uint8_t *buf = nullptr;
+    int64_t  cap = 0;
+    ~PacFetchScratch() { free(buf); }
+};
+}  // namespace
+
 // Zero-copy v2 variants. Identical semantics to bns_get_seq / bns_fetch_seq
 // except they return a pointer into the caller-supplied `ref_string` (the
 // .0123 reference materialized at startup) rather than a malloc'd copy. The
@@ -536,9 +549,53 @@ uint8_t *bns_get_seq_v2(int64_t l_pac, const uint8_t *pac, int64_t beg, int64_t 
                         int64_t *len, uint8_t *ref_string, uint8_t *seqb)
 {
 	uint8_t *seq = 0;
-	if (ref_string == NULL) { // guard against UB pointer arithmetic on NULL
-		*len = 0;
-		return 0;
+	if (ref_string == NULL) {
+		/* pac-fetch: the unpacked `.0123` was not loaded. Reconstruct the window
+		 * by unpacking the ORIGINAL `.pac` on demand (bns_get_seq_into: forward
+		 * 2-bit unpack; reverse-strand window = reverse + complement) — byte-
+		 * identical to the `.0123` it replaces.
+		 *
+		 * CONTRACT (single live window): the returned pointer aliases a per-thread
+		 * scratch that this thread's NEXT call overwrites. Every caller must
+		 * consume (or copy) the window before fetching again on the same thread —
+		 * exactly the zero-copy `.0123` contract. All current consumers honor it
+		 * (extension consumes rseq within the chain iteration; both mate-rescue
+		 * sites copy the window into seqBufRef immediately). This is a convention,
+		 * NOT enforceable as an in-function assert (the function cannot observe a
+		 * caller's later deref). The NDEBUG poison-fill below is a best-effort
+		 * detector: it 0xFF's the prior window so a stale read trips the byte-
+		 * identity / BAM-cmp golden gate rather than silently mis-scoring.
+		 * seqb (the caller's scratch) is intentionally left untouched. */
+		static thread_local PacFetchScratch t_pf;
+		int64_t b = beg, e = end;
+		if (e < b) { int64_t t = b; b = e; e = t; }
+		if (e > l_pac<<1) e = l_pac<<1;
+		if (b < 0) b = 0;
+		int64_t need = e - b;
+		if (need <= 0) { *len = 0; return 0; }
+		/* A window bridging the forward/reverse boundary yields nothing (the
+		 * legacy `.0123` path returns empty without allocating; bns_get_seq_into
+		 * likewise sets len=0 and writes no bytes). Short-circuit BEFORE the
+		 * realloc so a bad bridge query can't grow t_pf.buf toward the doubled
+		 * reference (~6.4 GB on hg38) just to return an empty window. */
+		if (b < l_pac && e > l_pac) { *len = 0; return 0; }
+		if (need > t_pf.cap) {
+			/* Grow via a temp so a failed realloc neither leaks the old buffer nor
+			 * leaves the buffer NULL with cap > 0 (which would deref NULL below).
+			 * Matches the perror+exit idiom used for the .pac realloc in this file. */
+			uint8_t *nb = (uint8_t*)realloc(t_pf.buf, (size_t)need);
+			if (nb == NULL) { perror("Reallocation of pac-fetch buffer failed"); exit(EXIT_FAILURE); }
+			t_pf.buf = nb; t_pf.cap = need;
+		}
+		(void)seqb;
+#ifndef NDEBUG
+		if (t_pf.buf && t_pf.cap > 0) memset(t_pf.buf, 0xFF, (size_t)t_pf.cap); /* poison prior window */
+#endif
+		/* Fetch with the already-clamped [b, e) so the bytes written stay in
+		 * lock-step with `need` (the buffer size). bns_get_seq_into re-derives
+		 * the same clamp, so this is byte-identical to passing [beg, end). */
+		bns_get_seq_into(l_pac, pac, b, e, t_pf.buf, len);
+		return (*len > 0) ? t_pf.buf : 0;
 	}
 	if (end < beg) end ^= beg, beg ^= end, end ^= beg; // if end is smaller, swap
 	if (end > l_pac<<1) end = l_pac<<1;

--- a/src/bntseq.h
+++ b/src/bntseq.h
@@ -115,12 +115,20 @@ extern "C" {
 	                        int64_t *beg, int64_t mid, int64_t *end, int *rid,
 	                        uint8_t *dst, int64_t *len_out);
 	// Zero-copy v2 variants used by mem_chain2aln_across_reads_V2 and the
-	// mem_matesw_batch_* path. Return a pointer into the pre-unpacked
-	// `ref_string` (the .0123 reference materialized at startup); no
-	// allocation, callers must NOT free the returned pointer. The seqb
-	// scratch arg is currently unused by both v2 variants (kept for
-	// signature parity with their original definition); pass any buffer
-	// or NULL.
+	// mem_matesw_batch_* path. Callers must NOT free the returned pointer.
+	//
+	// Two lifetime regimes, selected by `ref_string`:
+	//   - ref_string != NULL: returns a pointer into the pre-unpacked `.0123`
+	//     reference materialized at startup. Stable for the run; any number of
+	//     windows may be held live at once.
+	//   - ref_string == NULL (pac-fetch): the `.0123` was not loaded, so the
+	//     window is reconstructed on demand from `pac` into a PER-THREAD scratch
+	//     buffer. SINGLE LIVE WINDOW — the returned pointer aliases scratch that
+	//     this thread's NEXT v2 call overwrites, so each caller must consume (or
+	//     copy) the window before fetching again on the same thread. Do NOT cache
+	//     multiple pac-fetch windows across calls.
+	// The seqb scratch arg is currently unused by both v2 variants (kept for
+	// signature parity with their original definition); pass any buffer or NULL.
 	uint8_t *bns_get_seq_v2(int64_t l_pac, const uint8_t *pac, int64_t beg, int64_t end,
 	                        int64_t *len, uint8_t *ref_string, uint8_t *seqb);
 	uint8_t *bns_fetch_seq_v2(const bntseq_t *bns, const uint8_t *pac,

--- a/src/bwa.h
+++ b/src/bwa.h
@@ -116,12 +116,15 @@ extern "C" {
 							 int64_t rb, int64_t re, int *score,
 							 int *n_cigar, int *NM);
 
-	/* emit_unpacked_ref=0 skips writing `<prefix>.0123` (D3 --meth seed index —
-	 * never extended against, so the unpacked seed ref is dead weight). `int`
-	 * (not bool) and a C++-only default keep this declaration valid C: bwa.h is
-	 * inside extern "C" and is transitively included by fast_reader_bseq.c. */
+	/* emit_unpacked_ref=0 (the default) skips writing `<prefix>.0123`. `mem`
+	 * pac-fetches the original reference from `<prefix>.pac` on demand
+	 * (bns_get_seq_v2), so the unpacked `.0123` (~8x the `.pac`) is never read
+	 * and not worth building. Pass 1 only to emit it for an external consumer
+	 * that still requires the unpacked file (e.g. bwa-mem2). `int` (not bool)
+	 * and a C++-only default keep this declaration valid C: bwa.h is inside
+	 * extern "C" and is transitively included by fast_reader_bseq.c. */
 #ifdef __cplusplus
-	int bwa_idx_build(const char *fa, const char *prefix, int emit_unpacked_ref = 1);
+	int bwa_idx_build(const char *fa, const char *prefix, int emit_unpacked_ref = 0);
 #else
 	int bwa_idx_build(const char *fa, const char *prefix, int emit_unpacked_ref);
 #endif

--- a/src/bwa_shm.cpp
+++ b/src/bwa_shm.cpp
@@ -901,25 +901,27 @@ static int resolve_meth_prefix(const char *prefix, char out[PATH_MAX])
     return 0;
 }
 
-/* If `<prefix>.0123` is absent but `<prefix>.meth.0123` is present, the user
- * likely meant `--meth`. Print a hint and return 1. Returns 0 when no hint
- * applies (let the regular stage path produce its own error). */
+/* If the plain FM-index `<prefix>.bwt.2bit.64` is absent but the seed index
+ * `<prefix>.meth.bwt.2bit.64` is present, the user likely meant `--meth`. Print
+ * a hint and return 1. Returns 0 when no hint applies (let the regular stage
+ * path produce its own error). Probes `.bwt.2bit.64`, not `.0123`: the unpacked
+ * `.0123` is no longer built by default (mem pac-fetches from `.pac`), so a
+ * complete plain index has no `.0123` — only `.bwt.2bit.64` is a reliable
+ * "index present" sentinel. */
 static int hint_missing_meth_flag(const char *prefix)
 {
-    char zer_path[PATH_MAX];
-    path_concat2(zer_path, prefix, ".0123");
+    char fmi_path[PATH_MAX];
+    path_concat2(fmi_path, prefix, ".bwt.2bit.64");
     struct stat st;
-    if (stat(zer_path, &st) == 0) return 0;        /* literal index present */
+    if (stat(fmi_path, &st) == 0) return 0;        /* plain index present */
     if (errno != ENOENT) return 0;                 /* I/O error: defer */
 
-    /* Detect the seed index by its FM-index file: the seed `.meth.0123` is no
-     * longer built (it is never read by `mem --meth`), so probe `.meth.bwt.2bit.64`. */
     char meth_fmi[PATH_MAX];
     path_concat2(meth_fmi, prefix, ".meth.bwt.2bit.64");
     if (stat(meth_fmi, &st) != 0) return 0;        /* no meth seed index either */
 
     std::fprintf(stderr,
-        "[E::main_shm] no FMI at '%s.0123' but a meth seed index is present at "
+        "[E::main_shm] no FMI at '%s.bwt.2bit.64' but a meth seed index is present at "
         "'%s.meth.*'\n"
         "             did you mean `bwa-mem3 shm --meth %s`?\n",
         prefix, prefix, prefix);

--- a/src/bwa_shm.cpp
+++ b/src/bwa_shm.cpp
@@ -315,27 +315,15 @@ int bwa_shm_compute(const char *prefix, bwa_shm_layout_t *layout, bool bns_only)
         return -1;
     }
 
-    /* 3. Stat <prefix>.0123 for its size. Skipped for a bns_only (D3 --meth
-     * seed) segment: the seed `.0123` is not staged and need not exist. */
-    if (bns_only) {
-        layout->ref_string_len = 0;
-    } else {
-        char zer_path[PATH_MAX];
-        path_concat2(zer_path, prefix, ".0123");
-        struct stat zst;
-        if (stat(zer_path, &zst) != 0) {
-            fprintf(stderr, "[E::%s] stat(%s) failed: %s\n",
-                    __func__, zer_path, strerror(errno));
-            bwa_shm_layout_free(layout);
-            return -1;
-        }
-        if (zst.st_size <= 0) {
-            fprintf(stderr, "[E::%s] %s is empty\n", __func__, zer_path);
-            bwa_shm_layout_free(layout);
-            return -1;
-        }
-        layout->ref_string_len = (int64_t)zst.st_size;
-    }
+    /* 3. REF_STRING (.0123) is NEVER staged. `mem` pac-fetches the original
+     * reference from `.pac` on demand (bns_get_seq_v2), so the unpacked `.0123`
+     * is never read from shm — for meth OR plain. Zero-length REF_STRING section
+     * for every index → −6.4 GB per staged segment on hg38, and the `.0123` need
+     * not exist on disk (commit "stop building .0123"). This is DECOUPLED from
+     * `bns_only`: that flag still gates PAC below — the seed --meth segment drops
+     * PAC too, but plain/original segments KEEP PAC (pac-fetch reads it). The
+     * `.0123` is not stat'd, so staging works on an index that doesn't have it. */
+    layout->ref_string_len = 0;
 
     /* 4. BNS_NAMES section size: walk anns[]. */
     int64_t bns_names_bytes = 0;

--- a/src/bwtindex.cpp
+++ b/src/bwtindex.cpp
@@ -85,10 +85,12 @@ static int meth_c2t_is_fresh(const char *in_fa, const char *out_fa)
 }
 
 /* D3 BS-seq index layout. `index --meth` builds TWO indexes from `fa`:
- *   1. The ORIGINAL-alphabet index `<fa>.{pac,ann,amb,0123,bwt.2bit.64}` — real chrom
+ *   1. The ORIGINAL-alphabet index `<fa>.{pac,ann,amb,bwt.2bit.64}` — real chrom
  *      names + original bases. This is the extension/scoring reference and the basis
  *      for variant-callable `mem --meth` output. (Identical to a normal `index`.)
- *   2. A converted SEED index `<fa>.meth.{pac,ann,amb,0123,bwt.2bit.64}`, built over a
+ *      `mem` pac-fetches its bases from `.pac`, so no `.0123` is written (see
+ *      bwa_idx_build's emit_unpacked_ref default).
+ *   2. A converted SEED index `<fa>.meth.{pac,ann,amb,bwt.2bit.64}`, built over a
  *      per-strand-converted FASTA `<fa>.meth.fa` (two contigs per chromosome:
  *      `>r<name>` = G->A reverse-strand target, `>f<name>` = C->T forward-strand
  *      target). 3-letter seeding requires per-strand conversion because C->T and
@@ -96,11 +98,13 @@ static int meth_c2t_is_fresh(const char *in_fa, const char *out_fa)
  *      SA-intervals, which are then remapped to original coordinates for chaining and
  *      extension. The `.meth` separation is by file PREFIX (not by changing the global
  *      CP_FILENAME_SUFFIX, which serves every index). */
-static int meth_index_build(const char *fa)
+static int meth_index_build(const char *fa, int emit_unpacked_ref)
 {
-    /* 1. Original-alphabet index (extension reference). */
+    /* 1. Original-alphabet index (extension reference). emit_unpacked_ref applies
+     * to the original only (its `.0123` is the legacy bwa-mem2 extension target);
+     * the seed index never needs an unpacked ref (step 2b passes false). */
     fprintf(stderr, "[bwa_index:--meth] building original index for %s ...\n", fa);
-    if (bwa_idx_build(fa, fa) != 0) {
+    if (bwa_idx_build(fa, fa, emit_unpacked_ref) != 0) {
         fprintf(stderr, "ERROR: bwa_idx_build failed on original %s\n", fa);
         return 5;
     }
@@ -171,9 +175,10 @@ static int meth_index_build(const char *fa)
         return 1;
     }
     fprintf(stderr, "[bwa_index:--meth] building seed index %s.* ...\n", meth_prefix);
-    /* emit_unpacked_ref=false: the seed `.0123` is never read by `mem --meth`
-     * (extension uses the original reference), so don't write it (~13 GB on
-     * hg38). The seed `.pac` + `.bwt.2bit.64` + `.ann`/`.amb` are still built. */
+    /* emit_unpacked_ref=false (also the default now): the seed `.0123` is never
+     * read by `mem --meth` (extension uses the original reference), so don't
+     * write it (~13 GB on hg38). Kept explicit for documentation; the seed
+     * `.pac` + `.bwt.2bit.64` + `.ann`/`.amb` are still built. */
     if (bwa_idx_build(conv_fa, meth_prefix, /*emit_unpacked_ref=*/false) != 0) {
         fprintf(stderr, "ERROR: bwa_idx_build failed on seed index %s\n", conv_fa);
         return 5;
@@ -212,6 +217,10 @@ static void index_usage(void)
 	        "  --meth             build a BS-aware dual index. Writes the original-alphabet\n"
 	        "                     index at <in.fasta>.* plus a converted seed FM-index at\n"
 	        "                     <in.fasta>.meth.* (used by `bwa-mem3 mem --meth`).\n"
+	        "  --emit-unpacked-ref also write the unpacked `<prefix>.0123` reference. Off by\n"
+	        "                     default: `mem` pac-fetches bases from `.pac`, so `.0123`\n"
+	        "                     is never read. Enable only for an external consumer that\n"
+	        "                     still requires it (e.g. bwa-mem2); ~8x the size of `.pac`.\n"
 	        "  -h, --help         print this help message and exit\n");
 }
 
@@ -220,14 +229,16 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 	int c;
 	char *prefix = 0;
 	int meth = 0;
+	int emit_unpacked_ref = 0;     // 0 => don't write <prefix>.0123 (mem pac-fetches)
 	int64_t user_max_memory = 0;   // 0 => auto default
 	int     user_threads    = 0;   // 0 => auto default
 	static struct option long_opts[] = {
-		{"meth",       no_argument,       0, 1000},
-		{"max-memory", required_argument, 0, 1001},
-		{"tmp-dir",    required_argument, 0, 1002},
-		{"threads",    required_argument, 0, 't'},
-		{"help",       no_argument,       0, 'h'},
+		{"meth",              no_argument,       0, 1000},
+		{"max-memory",        required_argument, 0, 1001},
+		{"tmp-dir",           required_argument, 0, 1002},
+		{"emit-unpacked-ref", no_argument,       0, 1003},
+		{"threads",           required_argument, 0, 't'},
+		{"help",              no_argument,       0, 'h'},
 		{0, 0, 0, 0}
 	};
 	while ((c = getopt_long(argc, argv, "p:t:h", long_opts, NULL)) >= 0) {
@@ -255,6 +266,8 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 			user_max_memory = mem;
 		} else if (c == 1002) {
 			setenv("BWA_INDEX_TMPDIR", optarg, 1);
+		} else if (c == 1003) {
+			emit_unpacked_ref = 1;
 		} else if (c == 'h') {
 			index_usage();
 			return 0;
@@ -315,10 +328,10 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 			fprintf(stderr, "ERROR: --meth does not accept -p (outputs <in.fasta>.* and <in.fasta>.meth.*)\n");
 			return 1;
 		}
-		return meth_index_build(argv[optind]);
+		return meth_index_build(argv[optind], emit_unpacked_ref);
 	}
 	if (prefix == 0) prefix = argv[optind];
-	return bwa_idx_build(argv[optind], prefix);
+	return bwa_idx_build(argv[optind], prefix, emit_unpacked_ref);
 }
 
 int bwa_idx_build(const char *fa, const char *prefix, int emit_unpacked_ref)

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1613,7 +1613,15 @@ int main_mem(int argc, char *argv[])
      * batched extension partitions a mixed PE batch by hypothesis; mate rescue
      * routes meth pairs through the scalar ksw_align2 path). The projected read is
      * used only for seeding against the `.meth` FM-index. */
-    if (opt->meth_mode && meth_orig_ref_prefix != NULL) {
+    /* pac-fetch (default ON): reconstruct the ORIGINAL reference from its `.pac`
+     * on demand (bns_get_seq_v2's ref_string==NULL path) instead of loading the
+     * unpacked `.0123` (~6.4 GB on hg38). Byte-identical, perf-neutral. The
+     * escape hatch BWAMEM3_REF_PAC_FETCH=0 reloads the legacy `.0123` (only
+     * succeeds on an index that still carries the file). */
+    int ref_pac_fetch;
+    { const char *e = getenv("BWAMEM3_REF_PAC_FETCH");
+      ref_pac_fetch = !(e != NULL && e[0] == '0'); }
+    if (opt->meth_mode && meth_orig_ref_prefix != NULL && !ref_pac_fetch) {
         int64_t orig_rlen = 0;
         int     orig_is_shm = 0;   /* original .0123 is never in shm; force disk */
         aux.meth_orig_ref_string =
@@ -1622,7 +1630,7 @@ int main_mem(int argc, char *argv[])
         if (aux.meth_orig_ref_string == NULL) {
             fprintf(stderr,
                     "ERROR: --meth could not load the original reference '%s.0123' "
-                    "(needed for extension).\n", meth_orig_ref_prefix);
+                    "(BWAMEM3_REF_PAC_FETCH=0 requires it).\n", meth_orig_ref_prefix);
             meth_orig_ref_free_handles(&aux);
             delete aux.fmi;
             free(opt);
@@ -1632,6 +1640,10 @@ int main_mem(int argc, char *argv[])
         fprintf(stderr,
                 "[bwa-mem3:--meth] original reference .0123 loaded for extension "
                 "(%ld bp).\n", (long)orig_rlen);
+    } else if (opt->meth_mode && meth_orig_ref_prefix != NULL) {
+        fprintf(stderr,
+                "[bwa-mem3:--meth] pac-fetch: original .0123 NOT loaded; unpacking "
+                "original bases from .pac on demand.\n");
     }
 
     // reading ref string (from shm if FMI attached, else from .0123 file)

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1621,6 +1621,25 @@ int main_mem(int argc, char *argv[])
     int ref_pac_fetch;
     { const char *e = getenv("BWAMEM3_REF_PAC_FETCH");
       ref_pac_fetch = !(e != NULL && e[0] == '0'); }
+    /* The legacy reload (BWAMEM3_REF_PAC_FETCH=0) reads `<prefix>.0123`, which is
+     * no longer built by default (bwa_idx_build's emit_unpacked_ref). If the user
+     * asks for it but the file is absent, fall back to pac-fetch rather than
+     * aborting — the two paths are byte-identical, so an old script or muscle-
+     * memory env setting still runs. The escape hatch only does anything on an
+     * index that was built (or rebuilt) with the unpacked `.0123` present. */
+    if (!ref_pac_fetch) {
+        const char *probe_prefix = (opt->meth_mode && meth_orig_ref_prefix != NULL)
+                                       ? meth_orig_ref_prefix : ref_prefix;
+        char probe_0123[PATH_MAX];
+        int pn = snprintf(probe_0123, sizeof(probe_0123), "%s.0123", probe_prefix);
+        if (pn > 0 && (size_t)pn < sizeof(probe_0123) && access(probe_0123, R_OK) != 0) {
+            fprintf(stderr,
+                    "* BWAMEM3_REF_PAC_FETCH=0 requested but '%s' is absent "
+                    "(index built without it); falling back to pac-fetch.\n",
+                    probe_0123);
+            ref_pac_fetch = 1;
+        }
+    }
     if (opt->meth_mode && meth_orig_ref_prefix != NULL && !ref_pac_fetch) {
         int64_t orig_rlen = 0;
         int     orig_is_shm = 0;   /* original .0123 is never in shm; force disk */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1005,71 +1005,6 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "Note: Please read the man page for detailed description of the command line and options.\n");
 }
 
-/* Resolve `<prefix>.0123` to a `uint8_t *` view of the ref string. If
- * `shm_base` is non-NULL, the FMI loader already attached this segment;
- * resolve REF_STRING via that single mapping. Otherwise fall back to the
- * disk slurp. The two paths must agree: if FMI came from disk, ref string
- * must come from disk too, so we never call `bwa_shm_attach` here. */
-static uint8_t *load_ref_string(const char *prefix, uint8_t *shm_base,
-                                int64_t *rlen_out, int *is_shm_out)
-{
-    *is_shm_out = 0;
-    *rlen_out   = 0;
-
-    if (shm_base != NULL) {
-        uint64_t off = 0, sz = 0;
-        if (bwa_shm_section_find(shm_base, BWA_SHM_SEC_REF_STRING, &off, &sz) != 0) {
-            fprintf(stderr,
-                "ERROR: shm segment for '%s' is missing REF_STRING; aborting.\n"
-                "       The segment was staged by an older bwa-mem3; drop and re-stage.\n",
-                prefix);
-            exit(EXIT_FAILURE);
-        }
-        *is_shm_out = 1;
-        *rlen_out   = (int64_t)sz;
-        fprintf(stderr, "* Reference genome attached from shm: %lld bytes\n",
-                (long long)sz);
-        return shm_base + off;
-    }
-
-    /* Disk path. */
-    char binary_seq_file[PATH_MAX];
-    int n = snprintf(binary_seq_file, sizeof(binary_seq_file), "%s.0123", prefix);
-    if (n < 0 || (size_t)n >= sizeof(binary_seq_file)) {
-        fprintf(stderr, "Error: reference prefix too long for path: %s\n", prefix);
-        return NULL;
-    }
-
-    fprintf(stderr, "* Binary seq file = %s\n", binary_seq_file);
-    FILE *fr = fopen(binary_seq_file, "r");
-    if (fr == NULL) {
-        fprintf(stderr, "Error: can't open %s input file\n", binary_seq_file);
-        return NULL;
-    }
-    int64_t rlen = 0;
-    if (fseek(fr, 0, SEEK_END) != 0) {
-        fprintf(stderr, "Error: fseek failed on %s\n", binary_seq_file);
-        fclose(fr);
-        return NULL;
-    }
-    rlen = ftell(fr);
-    if (rlen <= 0) {
-        fprintf(stderr, "Error: %s is empty or unseekable (ftell=%lld)\n",
-                binary_seq_file, (long long)rlen);
-        fclose(fr);
-        return NULL;
-    }
-    uint8_t *buf = (uint8_t*) _mm_malloc(rlen, 64);
-    assert_not_null(buf, rlen, rlen);
-    bwamem_madv_hugepage(buf, rlen);
-    rewind(fr);
-    err_fread_noeof(buf, 1, rlen, fr);
-    fclose(fr);
-
-    *rlen_out = rlen;
-    return buf;
-}
-
 /* D3 (--meth) only: load the ORIGINAL reference's bns + pac (un-converted, real
  * chrom names) from `prefix` as resident handles for the future extension/scoring
  * phase, distinct from the seed FM-index. Mirrors indexEle::bwa_idx_load_ele's
@@ -1114,9 +1049,10 @@ static void meth_orig_ref_free_handles(ktp_aux_t *aux)
 {
     if (aux->meth_orig_pac != NULL) { free(aux->meth_orig_pac); aux->meth_orig_pac = NULL; }
     if (aux->meth_orig_bns != NULL) { bns_destroy(aux->meth_orig_bns); aux->meth_orig_bns = NULL; }
-    /* D3 (--meth, PR-3): the original .0123 ref_string is always _mm_malloc'd by
-     * load_ref_string's disk path (we pass shm_base=NULL), so it is never a shm
-     * alias — free it with _mm_free unconditionally. */
+    /* D3 (--meth): meth_orig_ref_string is NULL under pac-fetch (the only path
+     * now — the original reference is unpacked from `.pac` on demand, never
+     * materialized). This NULL-safe free is retained defensively; if it is ever
+     * non-NULL it would be an _mm_malloc'd buffer, freed with _mm_free. */
     if (aux->meth_orig_ref_string != NULL) {
         _mm_free(aux->meth_orig_ref_string);
         aux->meth_orig_ref_string = NULL;
@@ -1604,68 +1540,27 @@ int main_mem(int argc, char *argv[])
      * pipeline now runs end to end. Seeds generated against the `.meth` seed
      * FM-index are remapped to ORIGINAL coordinates + an OT/OB hypothesis inside
      * mem_chain_seeds (see meth_seed_to_orig), and chaining/extension/pairing/
-     * mate-rescue/output all operate against the ORIGINAL bns/pac/.0123 carried
-     * on worker_t::meth_orig_*. Load the ORIGINAL unpacked reference here (the
-     * seed `.0123` is still loaded below as `ref_string`, but is unused after the
-     * remap; kept for the non-meth code path's invariants).
+     * mate-rescue/output all operate against the ORIGINAL bns/pac carried on
+     * worker_t::meth_orig_* (the original reference bases are pac-fetched from
+     * `.pac` on demand; no unpacked `.0123` is loaded for either the seed or the
+     * original — see below).
      * Extension and mate-rescue score the ORIGINAL read against the original
      * reference with the per-hypothesis asymmetric OT/OB matrix (PR-4 + A1: the
      * batched extension partitions a mixed PE batch by hypothesis; mate rescue
      * routes meth pairs through the scalar ksw_align2 path). The projected read is
      * used only for seeding against the `.meth` FM-index. */
-    /* pac-fetch (default ON): reconstruct the ORIGINAL reference from its `.pac`
-     * on demand (bns_get_seq_v2's ref_string==NULL path) instead of loading the
-     * unpacked `.0123` (~6.4 GB on hg38). Byte-identical, perf-neutral. The
-     * escape hatch BWAMEM3_REF_PAC_FETCH=0 reloads the legacy `.0123` (only
-     * succeeds on an index that still carries the file). */
-    int ref_pac_fetch;
-    { const char *e = getenv("BWAMEM3_REF_PAC_FETCH");
-      ref_pac_fetch = !(e != NULL && e[0] == '0'); }
-    /* The legacy reload (BWAMEM3_REF_PAC_FETCH=0) reads `<prefix>.0123`, which is
-     * no longer built by default (bwa_idx_build's emit_unpacked_ref). If the user
-     * asks for it but the file is absent, fall back to pac-fetch rather than
-     * aborting — the two paths are byte-identical, so an old script or muscle-
-     * memory env setting still runs. The escape hatch only does anything on an
-     * index that was built (or rebuilt) with the unpacked `.0123` present. */
-    if (!ref_pac_fetch) {
-        const char *probe_prefix = (opt->meth_mode && meth_orig_ref_prefix != NULL)
-                                       ? meth_orig_ref_prefix : ref_prefix;
-        char probe_0123[PATH_MAX];
-        int pn = snprintf(probe_0123, sizeof(probe_0123), "%s.0123", probe_prefix);
-        if (pn > 0 && (size_t)pn < sizeof(probe_0123) && access(probe_0123, R_OK) != 0) {
-            fprintf(stderr,
-                    "* BWAMEM3_REF_PAC_FETCH=0 requested but '%s' is absent "
-                    "(index built without it); falling back to pac-fetch.\n",
-                    probe_0123);
-            ref_pac_fetch = 1;
-        }
-    }
-    if (opt->meth_mode && meth_orig_ref_prefix != NULL && !ref_pac_fetch) {
-        int64_t orig_rlen = 0;
-        int     orig_is_shm = 0;   /* original .0123 is never in shm; force disk */
-        aux.meth_orig_ref_string =
-            load_ref_string(meth_orig_ref_prefix, /*shm_base=*/NULL,
-                            &orig_rlen, &orig_is_shm);
-        if (aux.meth_orig_ref_string == NULL) {
-            fprintf(stderr,
-                    "ERROR: --meth could not load the original reference '%s.0123' "
-                    "(BWAMEM3_REF_PAC_FETCH=0 requires it).\n", meth_orig_ref_prefix);
-            meth_orig_ref_free_handles(&aux);
-            delete aux.fmi;
-            free(opt);
-            if (out_opened) fclose(aux.fp);
-            return 1;
-        }
+    /* pac-fetch: reconstruct the ORIGINAL reference from its `.pac` on demand
+     * (bns_get_seq_v2's ref_string==NULL path) instead of loading the unpacked
+     * `.0123` (~6.4 GB on hg38). This is the only reference path: `index` no
+     * longer builds `.0123` and `mem` never reads it (byte-identical to the
+     * historical `.0123` load, verified on plain + --meth incl. batched rescue). */
+    if (opt->meth_mode && meth_orig_ref_prefix != NULL) {
         fprintf(stderr,
-                "[bwa-mem3:--meth] original reference .0123 loaded for extension "
-                "(%ld bp).\n", (long)orig_rlen);
-    } else if (opt->meth_mode && meth_orig_ref_prefix != NULL) {
-        fprintf(stderr,
-                "[bwa-mem3:--meth] pac-fetch: original .0123 NOT loaded; unpacking "
-                "original bases from .pac on demand.\n");
+                "[bwa-mem3:--meth] pac-fetch: original reference unpacked from "
+                ".pac on demand (.0123 not loaded).\n");
     }
 
-    // reading ref string (from shm if FMI attached, else from .0123 file)
+    // reference bases are pac-fetched from .pac on demand; no .0123 is loaded
     tim = __rdtsc();
     uint64_t timer;
     if (opt->meth_mode) {
@@ -1682,11 +1577,11 @@ int main_mem(int argc, char *argv[])
         timer = __rdtsc();
         fprintf(stderr, "* [--meth] seed reference `.0123` not loaded "
                 "(extension uses the original reference)\n");
-    } else if (ref_pac_fetch) {
-        /* plain pac-fetch (default): unpack the original reference from `.pac` on
-         * demand (bns_get_seq_v2's ref_string==NULL path). idx->pac is resident
-         * on both the disk path (load_pac=true) and the shm-attach path (aliases
-         * the staged PAC section). aux.ref_string==NULL routes every consumer —
+    } else {
+        /* plain pac-fetch: unpack the original reference from `.pac` on demand
+         * (bns_get_seq_v2's ref_string==NULL path). idx->pac is resident on both
+         * the disk path (load_pac=true) and the shm-attach path (aliases the
+         * staged PAC section). aux.ref_string==NULL routes every consumer —
          * extension + batched mate rescue — to pac-fetch (the rescue copies each
          * window into seqBufRef in-iteration, so the single-live-window contract
          * holds). −6.4 GB on hg38, byte-identical. */
@@ -1696,19 +1591,6 @@ int main_mem(int argc, char *argv[])
         timer = __rdtsc();
         fprintf(stderr, "* pac-fetch: reference `.0123` not loaded; "
                 "unpacking original bases from .pac on demand\n");
-    } else {
-        fprintf(stderr, "* Reading reference genome..\n");
-        int64_t rlen = 0;
-        int     ref_is_shm = 0;
-        ref_string = load_ref_string(ref_prefix, aux.shm_base, &rlen, &ref_is_shm);
-        if (ref_string == NULL) {
-            exit(EXIT_FAILURE);
-        }
-        aux.ref_string         = ref_string;
-        aux.ref_string_is_shm  = ref_is_shm;
-        timer = __rdtsc();
-        fprintf(stderr, "* Reference genome size: %ld bp\n", (long)rlen);
-        fprintf(stderr, "* Done reading reference genome !!\n\n");
     }
     tprof[REF_IO][0] += timer - tim;
 

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1663,6 +1663,20 @@ int main_mem(int argc, char *argv[])
         timer = __rdtsc();
         fprintf(stderr, "* [--meth] seed reference `.0123` not loaded "
                 "(extension uses the original reference)\n");
+    } else if (ref_pac_fetch) {
+        /* plain pac-fetch (default): unpack the original reference from `.pac` on
+         * demand (bns_get_seq_v2's ref_string==NULL path). idx->pac is resident
+         * on both the disk path (load_pac=true) and the shm-attach path (aliases
+         * the staged PAC section). aux.ref_string==NULL routes every consumer —
+         * extension + batched mate rescue — to pac-fetch (the rescue copies each
+         * window into seqBufRef in-iteration, so the single-live-window contract
+         * holds). −6.4 GB on hg38, byte-identical. */
+        ref_string             = NULL;
+        aux.ref_string         = NULL;
+        aux.ref_string_is_shm  = 0;
+        timer = __rdtsc();
+        fprintf(stderr, "* pac-fetch: reference `.0123` not loaded; "
+                "unpacking original bases from .pac on demand\n");
     } else {
         fprintf(stderr, "* Reading reference genome..\n");
         int64_t rlen = 0;

--- a/src/index_prelude.cpp
+++ b/src/index_prelude.cpp
@@ -68,7 +68,9 @@ int emit_0123(const PackedText& pac, const char* prefix, int num_threads)
         }
     }
     // Surface deferred I/O errors (delayed-writeback EIO, full filesystem,
-    // etc.). The .0123 file is a non-negotiable index artefact.
+    // etc.) so a truncated .0123 never masquerades as complete. This runs only
+    // when the caller opted into emitting .0123 (off by default; `mem`
+    // pac-fetches from .pac instead).
     if (close(fd) != 0) {
         err_fatal(__func__, "close('%s') failed: %s", out.c_str(), strerror(errno));
     }

--- a/src/libsais_build.h
+++ b/src/libsais_build.h
@@ -8,11 +8,12 @@ struct LibsaisBuildOpts {
     int64_t     max_memory_bytes = 0;
     int         num_threads      = 0;
     std::string tmpdir;
-    /* Emit the unpacked `<prefix>.0123` reference. The D3 --meth SEED index sets
-     * this false: `mem --meth` extends against the ORIGINAL `.0123`, never the
-     * seed's, so emitting the seed `.0123` (~13 GB on hg38) would only write a
-     * file nothing reads. The FM build itself never consumes the `.0123`. */
-    bool        emit_unpacked_ref = true;
+    /* Emit the unpacked `<prefix>.0123` reference. Defaults false: `mem`
+     * pac-fetches the original reference from `<prefix>.pac` on demand and
+     * never reads `.0123` (~8x the `.pac`; ~6.4 GB on hg38, ~13 GB for a
+     * doubled --meth seed). The FM build itself never consumes the `.0123`.
+     * Set true only to emit it for an external consumer (e.g. bwa-mem2). */
+    bool        emit_unpacked_ref = false;
 };
 
 // Build the bwa-mem3 FM index via libsais's generalized-suffix-array
@@ -21,8 +22,8 @@ struct LibsaisBuildOpts {
 // bns_fasta2bntseq (l_pac bases, 2-bit, alphabet A=0 C=1 G=2 T=3; N was
 // replaced by a pseudo-random base).
 //
-// Emits `<prefix>.bwt.2bit.64` (and `<prefix>.0123` unless opts.emit_unpacked_ref
-// is false), byte-identical to the historical sais-lite-based build.
+// Emits `<prefix>.bwt.2bit.64` (and, only when opts.emit_unpacked_ref is set,
+// `<prefix>.0123`), byte-identical to the historical sais-lite-based build.
 int libsais_build_fm_index(const char* prefix, int64_t pac_len,
                            const LibsaisBuildOpts& opts);
 

--- a/test/help_prescan_test.sh
+++ b/test/help_prescan_test.sh
@@ -31,7 +31,7 @@ reads="$fixtures/reads.fa"
 [[ -s "$reads" ]] || { echo "FAIL: reads.fa missing at $reads" >&2; exit 1; }
 
 # Build the phiX FMI index if not already present.
-if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.0123" || ! -s "$ref.amb" \
+if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.amb" \
       || ! -s "$ref.ann"       || ! -s "$ref.pac" ]]; then
     "$bin" index "$ref" >/dev/null 2>&1 \
         || { echo "FAIL: bwa-mem3 index on phix.fa failed" >&2; exit 1; }

--- a/test/libsais_chr22_diff_test.sh
+++ b/test/libsais_chr22_diff_test.sh
@@ -58,14 +58,15 @@ if [[ $baseline_complete -eq 0 ]]; then
     echo "INFO: BWA_TEST_CHR22_BASELINE_BOOTSTRAP=1 -- bootstrapping baseline at $BASELINE_DIR"
     mkdir -p "$BASELINE_DIR"
     cp "$FIXTURE" "$BASELINE_DIR/chr22.fa"
-    "$BWAMEM3" index "$BASELINE_DIR/chr22.fa" >/dev/null
+    "$BWAMEM3" index --emit-unpacked-ref "$BASELINE_DIR/chr22.fa" >/dev/null
 fi
 
 TD="$(mktemp -d)"
 trap 'rm -rf "$TD"' EXIT
 
 cp "$FIXTURE" "$TD/chr22.fa"
-"$BWAMEM3" index "$TD/chr22.fa" >/dev/null
+# --emit-unpacked-ref: EXTS byte-diffs .0123, which is no longer built by default.
+"$BWAMEM3" index --emit-unpacked-ref "$TD/chr22.fa" >/dev/null
 
 FAIL=0
 for ext in "${EXTS[@]}"; do

--- a/test/libsais_determinism_test.sh
+++ b/test/libsais_determinism_test.sh
@@ -16,7 +16,9 @@ for t in 1 4 8; do
     d="$RUN_DIR/t$t"
     mkdir -p "$d"
     cp "$FA_SRC" "$d/t.fa"
-    "$BWAMEM3" index -t "$t" "$d/t.fa" >/dev/null
+    # --emit-unpacked-ref: this test validates .0123 determinism too; .0123 is no
+    # longer built by default (mem pac-fetches from .pac).
+    "$BWAMEM3" index --emit-unpacked-ref -t "$t" "$d/t.fa" >/dev/null
 done
 
 for ext in bwt.2bit.64 0123; do

--- a/test/libsais_hg38_slice_diff_test.sh
+++ b/test/libsais_hg38_slice_diff_test.sh
@@ -61,14 +61,15 @@ if [[ ! -s "$SLICE_DIR/baseline/slice.fa.bwt.2bit.64" ]]; then
     echo "INFO: BWA_TEST_HG38_SLICE_BASELINE_BOOTSTRAP=1 -- bootstrapping baseline at $SLICE_DIR/baseline"
     mkdir -p "$SLICE_DIR/baseline"
     cp "$SLICE_DIR/slice.fa" "$SLICE_DIR/baseline/slice.fa"
-    "$BWAMEM3" index "$SLICE_DIR/baseline/slice.fa" >/dev/null
+    "$BWAMEM3" index --emit-unpacked-ref "$SLICE_DIR/baseline/slice.fa" >/dev/null
 fi
 
 TD="$(mktemp -d)"
 trap 'rm -rf "$TD"' EXIT
 
 cp "$SLICE_DIR/slice.fa" "$TD/slice.fa"
-"$BWAMEM3" index "$TD/slice.fa" >/dev/null
+# --emit-unpacked-ref: this test byte-diffs .0123, which is no longer built by default.
+"$BWAMEM3" index --emit-unpacked-ref "$TD/slice.fa" >/dev/null
 
 FAIL=0
 for ext in pac ann amb 0123 bwt.2bit.64; do

--- a/test/libsais_index_diff_test.sh
+++ b/test/libsais_index_diff_test.sh
@@ -21,7 +21,9 @@ trap 'rm -rf "$TD"' EXIT
 for fa in phix.fa synthetic_1mb.fa; do
     [[ -s "$HERE/fixtures/$fa" ]] || { echo "FAIL: source fixture $HERE/fixtures/$fa missing"; exit 1; }
     cp "$HERE/fixtures/$fa" "$TD/$fa"
-    "$BWAMEM3" index "$TD/$fa" >/dev/null 2>&1
+    # --emit-unpacked-ref: byte-diff the .0123 baseline too; .0123 is no longer
+    # built by default (mem pac-fetches from .pac).
+    "$BWAMEM3" index --emit-unpacked-ref "$TD/$fa" >/dev/null 2>&1
     for ext in 0123 bwt.2bit.64; do
         if ! cmp -s "$BASELINES/$fa.$ext" "$TD/$fa.$ext"; then
             echo "FAIL: $fa.$ext diverges from baseline"

--- a/test/meth_rg_header_test.sh
+++ b/test/meth_rg_header_test.sh
@@ -83,7 +83,7 @@ assert_rg_consistent() {
 # --- default (non-meth) path: SAM output -----------------------------------
 # This path was always correct; it is the control that proves --meth must
 # match it.
-if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.0123" || ! -s "$ref.amb" \
+if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.amb" \
       || ! -s "$ref.ann"       || ! -s "$ref.pac" ]]; then
     "$bin" index "$ref" >/dev/null 2>&1 || { echo "FAIL: bwa-mem3 index on phix.fa failed" >&2; exit 1; }
 fi
@@ -102,13 +102,14 @@ if ! command -v samtools >/dev/null 2>&1; then
     exit 0
 fi
 
-# --meth requires a c2t-converted index built with `index --meth`. Check the
-# full artifact set (converted FASTA + the five FMI files), not just one, so a
-# partial index left by an interrupted run is rebuilt rather than skipped —
-# matching the non-meth block above.
-if [[ ! -s "$ref.bwameth.c2t"            || ! -s "$ref.bwameth.c2t.bwt.2bit.64" \
-      || ! -s "$ref.bwameth.c2t.0123"    || ! -s "$ref.bwameth.c2t.amb"        \
-      || ! -s "$ref.bwameth.c2t.ann"     || ! -s "$ref.bwameth.c2t.pac" ]]; then
+# --meth requires the D3 seed index built with `index --meth`. Check the full
+# artifact set (converted seed FASTA + the four seed FMI files), not just one,
+# so a partial index left by an interrupted run is rebuilt rather than skipped —
+# matching the non-meth block above. The seed has no `.0123` (never read in
+# --meth; extension uses the original reference, which itself pac-fetches).
+if [[ ! -s "$ref.meth.fa"            || ! -s "$ref.meth.bwt.2bit.64" \
+      || ! -s "$ref.meth.amb"        || ! -s "$ref.meth.ann"         \
+      || ! -s "$ref.meth.pac" ]]; then
     "$bin" index --meth "$ref" >/dev/null 2>&1 \
         || { echo "FAIL: bwa-mem3 index --meth on phix.fa failed" >&2; exit 1; }
 fi

--- a/test/pg_cl_escape_test.sh
+++ b/test/pg_cl_escape_test.sh
@@ -35,7 +35,7 @@ reads="$fixtures/reads.fa"
 [[ -s "$reads" ]] || { echo "FAIL: reads.fa missing at $reads" >&2; exit 1; }
 
 # Build the phiX FMI index if not already present.
-if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.0123" || ! -s "$ref.amb" \
+if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.amb" \
       || ! -s "$ref.ann"       || ! -s "$ref.pac" ]]; then
     "$bin" index "$ref" >/dev/null 2>&1 || { echo "FAIL: bwa-mem3 index on phix.fa failed" >&2; exit 1; }
 fi

--- a/test/regression/meth_seed_index.sh
+++ b/test/regression/meth_seed_index.sh
@@ -48,16 +48,17 @@ ann_names=$(mawk 'NR>1 && (NR%2)==0 {print $2}' ref.fa.meth.ann | tr '\n' ' ')
 # --- A2: original index is byte-identical to a plain index ------------------
 cp ref.fa refp.fa
 "$BWA_MEM3" index refp.fa >/dev/null 2>&1 || fail "plain index nonzero exit"
-for ext in pac ann amb 0123 bwt.2bit.64; do
+for ext in pac ann amb bwt.2bit.64; do
     cmp -s "ref.fa.$ext" "refp.fa.$ext" || fail "original --meth index differs from plain index (.$ext)"
 done
 
 # --- remap validation: projected read -> correct f/r contig + pos ----------
-# The `.meth` seed index no longer ships a `.0123` (dropped to save ~13 GB; it is
-# never read by `mem --meth`), so plain `mem` cannot extend against it. Probe the
-# seed FM content via a plain index of the converted seed FASTA `ref.fa.meth.fa`
-# (byte-identical doubled f/r text, plus the `.0123` plain `mem` extension needs),
-# which `index --meth` left on disk. Same contigs/positions as `ref.fa.meth.*`.
+# The `.meth` seed index has no `.0123` (never read by `mem --meth`), so plain
+# `mem` cannot be pointed straight at the seed prefix. Probe the seed FM content
+# via a plain index of the converted seed FASTA `ref.fa.meth.fa` (byte-identical
+# doubled f/r text), which `index --meth` left on disk. Plain `mem` pac-fetches
+# its bases from `.pac`, so no `.0123` is needed. Same contigs/positions as the
+# seed `ref.fa.meth.*`.
 "$BWA_MEM3" index ref.fa.meth.fa >/dev/null 2>&1 || fail "probe index of ref.fa.meth.fa nonzero exit"
 # helper: align one read (seq) against the seed FM content, assert RNAME/POS.
 check() {  # $1=label  $2=seq  $3=want_rname  $4=want_pos

--- a/test/regression/meth_seed_unpacked_ref_not_loaded.sh
+++ b/test/regression/meth_seed_unpacked_ref_not_loaded.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
 # test/regression/meth_seed_unpacked_ref_not_loaded.sh
 #
-# Regression (D3 memory): the SEED index's unpacked reference `<ref>.meth.0123`
-# is neither BUILT nor LOADED. D3 seeds in the doubled `.meth` FM-index but
-# extends/scores against the ORIGINAL reference (meth_orig_*), so the seed
-# `.0123` is dead weight (~13 GB on hg38, never read). `index --meth` therefore
-# does not emit it, and `mem --meth` does not load it.
+# Regression (D3 memory): NEITHER unpacked reference `.0123` is built or loaded.
+# D3 seeds in the doubled `.meth` FM-index but extends/scores against the
+# ORIGINAL reference (meth_orig_*), which it now pac-fetches from `<ref>.pac` on
+# demand. The seed `.meth.0123` (~13 GB on hg38) is never read, and the original
+# `<ref>.0123` (~6.4 GB) is redundant with `.pac`. `index --meth` therefore emits
+# neither, and `mem --meth` loads neither.
 #
 # Asserts:
 #   1. `index --meth` builds the seed FM-index/bns/pac but NOT `<ref>.meth.0123`.
-#   2. The ORIGINAL `<ref>.0123` (the real extension target) IS built.
-#   3. `mem --meth` runs to a valid, non-empty BAM without the seed `.0123`, and
-#      the output is deterministic.
+#   2. The ORIGINAL `<ref>.0123` is also NOT built (mem pac-fetches from `.pac`).
+#   3. `mem --meth` runs to a valid, non-empty BAM without any `.0123`, and the
+#      output is deterministic.
 #
-# RED on a binary that builds + loads the seed `.0123`: assertion 1 fails (the
-# file is present). GREEN once the seed `.0123` is dropped from build + load.
+# RED on a binary that builds the seed `.0123`: assertion 1 fails. RED on one
+# that still builds the original `.0123` by default: assertion 2 fails.
 #
 # Inputs:
 #   BWA_MEM3 — path to the bwa-mem3 binary under test
@@ -38,8 +39,9 @@ Q=$(printf 'I%.0s' $(seq 1 60))
 for f in ref.fa.meth.bwt.2bit.64 ref.fa.meth.ann ref.fa.meth.amb ref.fa.meth.pac; do
   [ -s "$f" ] || fail "expected seed index file $f to be built"
 done
-# 2. The ORIGINAL unpacked reference (the real extension target) must be built.
-[ -s ref.fa.0123 ] || fail "expected original ref.fa.0123 (the --meth extension target) to be built"
+# 2. The ORIGINAL unpacked reference must NOT be built either (mem pac-fetches
+#    the extension target from ref.fa.pac on demand).
+[ ! -e ref.fa.0123 ] || fail "original ref.fa.0123 was built; it must not be by default (mem pac-fetches from .pac)"
 
 # Proper FR pairs derived from the reference (exact windows so they place cleanly).
 : > r1.fq; : > r2.fq
@@ -50,9 +52,9 @@ mk_pair p1 100 300; mk_pair p2 500 720; mk_pair p3 900 1140
 
 run_meth() { "$BWA_MEM3" mem --meth --meth-scoring genomic -t 1 ref.fa r1.fq r2.fq > "$1" 2>/dev/null; }
 
-# 3. mem --meth runs without the seed `.0123`, emits a valid non-empty BAM,
+# 3. mem --meth runs without any `.0123`, emits a valid non-empty BAM,
 #    and is deterministic.
-run_meth a.bam || fail "mem --meth nonzero exit (must not need the seed .0123)"
+run_meth a.bam || fail "mem --meth nonzero exit (must not need any .0123)"
 samtools quickcheck a.bam || fail "a.bam invalid"
 samtools view a.bam > a.records || fail "samtools view a.bam failed"
 [ -s a.records ] || fail "mem --meth produced no alignment records"
@@ -61,4 +63,4 @@ samtools quickcheck b.bam || fail "b.bam invalid"
 samtools view b.bam > b.records || fail "samtools view b.bam failed"
 diff -q a.records b.records >/dev/null 2>&1 || fail "mem --meth output is non-deterministic"
 
-echo "PASS: meth_seed_unpacked_ref_not_loaded (seed .meth.0123 is neither built nor loaded; mem --meth works without it)"
+echo "PASS: meth_seed_unpacked_ref_not_loaded (neither .meth.0123 nor original .0123 is built or loaded; mem --meth works without them)"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -28,10 +28,10 @@ ok()   { echo "OK:   $*"; }
 # against a mismatched source and flaked.
 [[ -s "$FIXTURES/synthetic_1mb.fa" ]] || fail "synthetic_1mb.fa fixture missing at $FIXTURES/synthetic_1mb.fa"
 
-# Build the phiX FMI index if not already present. Check all five artifacts
-# that `bwa-mem3 index` produces so a corrupt/partial prior run is re-indexed.
+# Build the phiX FMI index if not already present. Check all four artifacts
+# that `bwa-mem3 index` produces by default (no `.0123`: mem pac-fetches from
+# `.pac`) so a corrupt/partial prior run is re-indexed.
 if [[ ! -s "$FIXTURES/phix.fa.bwt.2bit.64" || \
-      ! -s "$FIXTURES/phix.fa.0123"        || \
       ! -s "$FIXTURES/phix.fa.amb"         || \
       ! -s "$FIXTURES/phix.fa.ann"         || \
       ! -s "$FIXTURES/phix.fa.pac" ]]; then
@@ -155,7 +155,7 @@ done
 # (~5 kb) is too small to host the alignment, so use the checked-in 1 Mb
 # synthetic reference and a 40 kb read sliced from it.
 SYN="$FIXTURES/synthetic_1mb.fa"
-if [[ ! -s "$SYN.bwt.2bit.64" || ! -s "$SYN.0123" || ! -s "$SYN.amb" || \
+if [[ ! -s "$SYN.bwt.2bit.64" || ! -s "$SYN.amb" || \
       ! -s "$SYN.ann"         || ! -s "$SYN.pac" ]]; then
     "$BWAMEM3" index "$SYN" >/dev/null 2>&1 || fail "bwa-mem3 index on synthetic_1mb.fa failed"
 fi

--- a/test/shm_meth_test.sh
+++ b/test/shm_meth_test.sh
@@ -5,7 +5,7 @@
 # without juggling the `.meth` suffix by hand.
 #
 # D3 (dual index): `index --meth` builds BOTH the original-alphabet index at the
-# bare prefix (`ref.fa.{0123,ann,...}`) AND the converted seed FM-index at
+# bare prefix (`ref.fa.{ann,amb,pac,bwt.2bit.64}`) AND the converted seed FM-index at
 # `ref.fa.meth.*`. `shm --meth <plain>` stages the seed segment under the
 # `ref.fa.meth` basename; `mem --meth <plain>` attaches it from shm. Because the
 # bare index now exists too, plain `shm <plain>` also succeeds (stages the
@@ -36,10 +36,10 @@ echo "[setup] bwa-mem3 index --meth $PLAIN_PREFIX"
 "$BIN" index --meth "$PLAIN_PREFIX" >/dev/null 2>&1
 
 # D3 dual-index invariant: `index --meth` writes the bare original index AND the
-# .meth seed index. The bare original carries the unpacked `.0123` (the --meth
-# extension target); the seed index does NOT — `mem --meth` never extends against
-# the seed, so its `.0123` is not built (saves ~13 GB on hg38).
-for ext in .0123 .ann .amb .pac .bwt.2bit.64; do
+# .meth seed index. Neither carries the unpacked `.0123` by default — `mem`
+# pac-fetches the original reference from `.pac`, and `mem --meth` never extends
+# against the seed at all (saves ~6.4 GB original + ~13 GB seed on hg38).
+for ext in .ann .amb .pac .bwt.2bit.64; do
     if [[ ! -e "${PLAIN_PREFIX}${ext}" ]]; then
         echo "FAIL: dual index missing bare original index ${PLAIN_PREFIX}${ext}" >&2
         exit 1
@@ -51,6 +51,10 @@ for ext in .ann .amb .pac .bwt.2bit.64; do
         exit 1
     fi
 done
+if [[ -e "${PLAIN_PREFIX}.0123" ]]; then
+    echo "FAIL: original index ${PLAIN_PREFIX}.0123 was built; it must not be by default (mem pac-fetches from .pac)" >&2
+    exit 1
+fi
 if [[ -e "${METH_PREFIX}.0123" ]]; then
     echo "FAIL: seed index ${METH_PREFIX}.0123 was built; it must not be (never read in --meth)" >&2
     exit 1

--- a/test/shm_pack_round_trip_test.cpp
+++ b/test/shm_pack_round_trip_test.cpp
@@ -35,20 +35,6 @@
     } \
 } while (0)
 
-static uint8_t *slurp(const char *path, int64_t *len_out) {
-    FILE *fp = std::fopen(path, "rb");
-    CHECK(fp != NULL);
-    std::fseek(fp, 0, SEEK_END);
-    int64_t n = std::ftell(fp);
-    std::rewind(fp);
-    uint8_t *buf = (uint8_t *)std::malloc((size_t)n);
-    CHECK(buf != NULL);
-    err_fread_noeof(buf, 1, (size_t)n, fp);
-    std::fclose(fp);
-    *len_out = n;
-    return buf;
-}
-
 int main(int argc, char *argv[]) {
     if (argc < 2) {
         std::fprintf(stderr, "Usage: %s <prefix>\n", argv[0]);
@@ -74,11 +60,6 @@ int main(int argc, char *argv[]) {
     /* 3. Independently load the same index from disk for comparison. */
     FMI_search ref(prefix);
     ref.load_index();
-
-    char zer_path[4096];
-    std::snprintf(zer_path, sizeof(zer_path), "%s.0123", prefix);
-    int64_t ref_string_len = 0;
-    uint8_t *ref_string = slurp(zer_path, &ref_string_len);
 
     /* 4. Walk sections and compare. */
     auto section = [&](uint32_t kind, uint64_t *off, uint64_t *sz) {
@@ -170,13 +151,14 @@ int main(int argc, char *argv[]) {
     CHECK_EQ((int64_t)sz, (int64_t)(ref.idx->bns->l_pac / 4 + 1));
     CHECK_EQ(std::memcmp(buf + off, ref.idx->pac, (size_t)sz), 0);
 
-    /* REF_STRING (.0123). */
+    /* REF_STRING (.0123) is NEVER staged: the section slot is present (so
+     * n_sections stays 10) but always zero length. `mem` pac-fetches the
+     * original reference from `.pac` on demand, so the unpacked `.0123` is
+     * neither staged nor required on disk. */
     section(BWA_SHM_SEC_REF_STRING, &off, &sz);
-    CHECK_EQ((int64_t)sz, ref_string_len);
-    CHECK_EQ(std::memcmp(buf + off, ref_string, (size_t)sz), 0);
+    CHECK_EQ(sz, 0ull);
 
     /* Cleanup. */
-    std::free(ref_string);
     std::free(buf);
 
     std::printf("shm_pack_round_trip_test: OK\n");

--- a/test/shm_pack_round_trip_test.sh
+++ b/test/shm_pack_round_trip_test.sh
@@ -15,9 +15,10 @@ if [[ ! -x "$INNER" ]]; then
     exit 2
 fi
 
-# Build the phix index if any of the index files are missing.
+# Build the phix index if any of the index files are missing. No `.0123`: it is
+# not built by default (mem pac-fetches from `.pac`) and never staged in shm.
 need_index=0
-for ext in .0123 .amb .ann .bwt.2bit.64 .pac; do
+for ext in .amb .ann .bwt.2bit.64 .pac; do
     if [[ ! -s "${PREFIX}${ext}" ]]; then
         need_index=1; break
     fi

--- a/test/shm_round_trip_test.sh
+++ b/test/shm_round_trip_test.sh
@@ -20,9 +20,10 @@ fi
 "$BIN" shm -d >/dev/null 2>&1 || true
 trap '"$BIN" shm -d >/dev/null 2>&1 || true' EXIT
 
-# Build the phix index if any of the index files are missing.
+# Build the phix index if any of the index files are missing. No `.0123`: it is
+# not built by default (mem pac-fetches from `.pac`) and never staged in shm.
 need_index=0
-for ext in .0123 .amb .ann .bwt.2bit.64 .pac; do
+for ext in .amb .ann .bwt.2bit.64 .pac; do
     if [[ ! -s "${PREFIX}${ext}" ]]; then
         need_index=1; break
     fi

--- a/test/unit/test_bns_get_seq_parity.cpp
+++ b/test/unit/test_bns_get_seq_parity.cpp
@@ -155,19 +155,72 @@ TEST_CASE("bns_get_seq_into vs v2: swapped beg/end (XOR-swap path)") {
     check_range(L, pac.data(), ref_string.data(), /*beg=*/L, /*end=*/0);  // bridging
 }
 
-TEST_CASE("bns_get_seq_v2: NULL ref_string returns NULL with *len = 0") {
-    // Defensive guard: bns_get_seq_v2 must not perform pointer arithmetic on a
-    // NULL ref_string. Without the guard, `ref_string + beg` for beg > 0 yields
-    // a non-null but invalid pointer that evades downstream `seq == 0` checks.
+TEST_CASE("bns_get_seq_v2: NULL ref_string pac-fetches bases identical to .0123") {
+    // pac-fetch contract: a NULL ref_string is no longer a "return NULL" guard —
+    // it means "reconstruct this window from `pac` on demand" (the .0123 view was
+    // not loaded). The bases returned MUST be byte-identical to what a non-NULL
+    // ref_string (the unpacked .0123) view would yield for the same [beg, end),
+    // including the reverse-complement half [l_pac, 2*l_pac). This is the
+    // identity gate for dropping .0123 in favor of unpacking from .pac.
+    std::mt19937 rng(0x5EEDu);
     constexpr int64_t L = 64;
-    std::vector<uint8_t> pac((L + 3) / 4, 0);
-    std::vector<uint8_t> scratch(2 * L, 0xff);
+    std::vector<uint8_t> pac, ref_string;
+    build_synthetic_ref(rng, L, pac, ref_string);
 
-    int64_t len = -1;
-    uint8_t *seq = bns_get_seq_v2(L, pac.data(), /*beg=*/10, /*end=*/20, &len,
-                                  /*ref_string=*/nullptr, scratch.data());
-    CHECK(seq == nullptr);
-    CHECK(len == 0);
+    // Forward windows (beg,end < L) and reverse-complement windows (beg >= L);
+    // bridging windows return len 0 and are covered by the boundary test above.
+    for (int64_t beg : {int64_t{0}, int64_t{10}, int64_t{L - 20}, int64_t{L}, int64_t{L + 5}}) {
+        for (int64_t span : {int64_t{1}, int64_t{17}, int64_t{40}}) {
+            int64_t end = beg + span;
+            if (end > 2 * L || (beg < L && end > L)) continue;  // skip bridging
+            int64_t len_ref = 0, len_pf = 0;
+            std::vector<uint8_t> scratch_ref(2 * L, 0xff);
+            uint8_t *seq_ref = bns_get_seq_v2(L, pac.data(), beg, end, &len_ref,
+                                              ref_string.data(), scratch_ref.data());
+            // ref_string == NULL → pac-fetch path. Result points into a thread-local
+            // buffer valid until the next pac-fetch call; compare immediately.
+            std::vector<uint8_t> scratch_pf(2 * L, 0xff);
+            uint8_t *seq_pf = bns_get_seq_v2(L, pac.data(), beg, end, &len_pf,
+                                             /*ref_string=*/nullptr, scratch_pf.data());
+            REQUIRE(len_pf == len_ref);
+            REQUIRE(len_pf == end - beg);
+            REQUIRE(seq_ref != nullptr);
+            REQUIRE(seq_pf != nullptr);
+            CHECK(std::memcmp(seq_pf, seq_ref, (size_t)len_pf) == 0);
+        }
+    }
+}
+
+TEST_CASE("bns_get_seq_v2: NULL ref_string bridging window returns empty without bases") {
+    // pac-fetch bridging contract: a window crossing the forward/reverse boundary
+    // (beg < l_pac < end) yields nothing, exactly like the .0123 path. The
+    // implementation short-circuits this BEFORE growing its scratch buffer so a
+    // bad bridge query can't balloon RSS toward the doubled reference. Observable
+    // surface here is the empty result; the no-alloc guarantee is internal.
+    std::mt19937 rng(0xB1D6Eu);
+    constexpr int64_t L = 64;
+    std::vector<uint8_t> pac, ref_string;
+    build_synthetic_ref(rng, L, pac, ref_string);
+
+    for (int64_t beg : {int64_t{0}, int64_t{1}, int64_t{L / 2}, int64_t{L - 1}}) {
+        for (int64_t end : {int64_t{L + 1}, int64_t{L + L / 2}, int64_t{2 * L}}) {
+            CAPTURE(beg);
+            CAPTURE(end);
+            int64_t len_pf = -1;
+            std::vector<uint8_t> scratch(2 * L, 0xff);
+            uint8_t *seq_pf = bns_get_seq_v2(L, pac.data(), beg, end, &len_pf,
+                                             /*ref_string=*/nullptr, scratch.data());
+            CHECK(len_pf == 0);
+            CHECK(seq_pf == nullptr);
+        }
+    }
+    // Swapped bridging (end < beg) canonicalizes to the same empty result.
+    int64_t len_pf = -1;
+    std::vector<uint8_t> scratch(2 * L, 0xff);
+    uint8_t *seq_pf = bns_get_seq_v2(L, pac.data(), /*beg=*/L + 10, /*end=*/L - 10,
+                                     &len_pf, /*ref_string=*/nullptr, scratch.data());
+    CHECK(len_pf == 0);
+    CHECK(seq_pf == nullptr);
 }
 
 TEST_CASE("bns_get_seq_into vs v2: large random ref, randomized ranges") {


### PR DESCRIPTION
Makes `bwa-mem3 mem` reconstruct reference bases from the packed `.pac` on demand ("pac-fetch") instead of loading the unpacked `.0123`, and stops building `.0123` by default. Output is byte-for-byte identical; peak RSS on hg38 drops ~6.2 GB (plain) / ~6.3 GB (`--meth`) at neutral-to-slightly-faster wall time. Directly addresses the `--meth`-on-64 GB headroom ask, and the same win applies to plain alignment.

Measured on an r7i.4xlarge (hg38, 5M read pairs, `-t 16`):

| Mode | pac-fetch RSS | legacy `.0123` RSS | Δ | wall | output |
|---|---|---|---|---|---|
| Plain WGS | 17.91 GB | 24.16 GB | −6.24 GB (−26%) | 2:24 vs 2:25 | byte-identical SAM |
| Meth EM-seq | 37.19 GB | 43.51 GB | −6.33 GB (−15%) | 2:48 vs 2:56 (~4% faster) | byte-identical BAM |

## What changed

- `mem` pac-fetches the original reference: `bns_get_seq_v2`'s `ref_string==NULL` path unpacks the requested window from `.pac` into a thread-local scratch buffer (single-live-window contract; the buffer is freed at thread exit so LeakSanitizer is clean). This is the **only** reference path — there is no longer a `.0123` load path or runtime toggle.
- `shm` never stages the `.0123` REF_STRING section (zero-length for every segment).
- `index` no longer writes `.0123` by default (breaking on-disk change, kept as its own commit). New opt-in `index --emit-unpacked-ref` re-emits it for an external consumer that still requires the file (e.g. bwa-mem2); `mem` ignores any `.0123` present.

## Validation

- Byte-identical output, plain and `--meth`, confirmed on hg38 (`cmp` on SAM/BAM).
- Verified the single-live-window contract holds under #175's batched mate-rescue: on a combined local branch, batched-rescue output is byte-identical with vs without pac-fetch, and #175's fixture-guaranteed `meth_rescue_batched_identical.sh` passes under pac-fetch (see PR comment).
- Added a pac-fetch-vs-`.0123` byte-identity unit test. Full `make test` green (59/59 doctests); `run_unit_tests.sh`, all `shm_*` / `libsais_*` / meth regression tests pass; ASAN/LeakSanitizer CI clean.
- Byte-identity/determinism index tests pass `--emit-unpacked-ref` to keep `.0123` coverage (baselines unchanged).
- Fixed issues exposed along the way: a stale `shm_pack_round_trip` doctest, the `shm <plain>`-on-dual-index `.0123` sentinel (now probes `.bwt.2bit.64`), and a thread-local pac-fetch buffer leak (now freed at thread exit).

## Relationship to other PRs

Independent of #175 (batched meth mate-rescue) — disjoint files, both based on `main`, verified compatible. Builds on the merged #174.

## Reading order

`bns_get_seq_v2` pac-fetch + identity test → wire as default (`--meth`, then plain) → shm → docs → stop building `.0123` (breaking) → make pac-fetch unconditional (remove the verification escape hatch + legacy load path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `index --emit-unpacked-ref` to optionally generate the unpacked reference for external compatibility (off by default).

* **Bug Fixes**
  * Updated indexing/alignment to fetch required reference bases from packed data on demand, avoiding default unpacked reference generation; extended to methylation (`--meth`) behavior.

* **Documentation**
  * Refreshed CLI and user-guide docs (including memory/disk expectations) to reflect the new default outputs and on-demand unpacking.

* **Tests**
  * Updated test expectations to match the new default artifact set and pac-fetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->