### PR TITLE
docs(meth): disclose collapsed-mode placement drift vs bwameth.py

### DIFF
--- a/docs/src/best-practices/methylation.md
+++ b/docs/src/best-practices/methylation.md
@@ -10,11 +10,26 @@ when to keep them, and when to override them.
 `--meth` scores against the original 4-letter reference, so it offers two models:
 
 - **`collapsed` (default)** — C/T and G/A interchangeable; bwameth-compatible
-  **placement**; mismatch penalty `-B 2`. Use for methylation-only workflows that
-  must match a bwameth release.
+  **placement**; mismatch penalty `-B 2`. Use for methylation-only workflows.
+  It closely tracks bwameth placement but is **not** identical — re-validate if
+  you are pinned to a specific bwameth release (see the caveat below).
 - **`genomic` (opt-in)** — only the conversion direction is freed, so real
   variants are penalized; truthful `NM`/`MD`; mismatch penalty `-B 4`. Use when
   one BAM must serve both methylation and variant calling.
+
+> **Important — `collapsed` is a placement drop-in, not a drift-free clone**
+>
+> Because `--meth` scores against the original 4-letter reference (not in
+> collapsed 3-letter space like bwameth.py), `collapsed` **approximates**
+> bwameth's placement rather than reproducing it exactly. Expect a small but
+> nonzero fraction of records to differ in `POS`, `CIGAR`, or `MAPQ` — on the
+> order of ~1% on typical WGBS/EM-seq, with true mapped-position changes on a
+> smaller subset. The 4-letter scoring path makes this **larger** than the older
+> 3-letter `--meth` releases. **If your pipeline is validated against a specific
+> bwameth release, treat `collapsed` as a new aligner version and re-validate
+> against your own bwameth output — do not assume placement equivalence.** For
+> strict byte-for-byte reproduction of a bwameth release, keep using bwameth.py
+> (see [bwameth.py drop-in mapping](../methylation/bwameth-mapping.md)).
 
 See [Methylation Reference → Flags](../methylation/flags.md#--meth-scoring-collapsedgenomic).
 
@@ -42,8 +57,10 @@ sets them first; any explicit flag that follows overrides the `--meth`-set value
 
 For standard whole-genome bisulfite sequencing (WGBS) workflows, the defaults
 are appropriate as-is. They were derived from the bwameth.py codebase and are
-expected by most downstream methylation calling tools. Unless you have a
-specific reason to deviate, use:
+expected by most downstream methylation calling tools. Keeping the defaults
+gives bwameth-compatible *placement* — close, but not identical (re-validate
+against your own bwameth output if you are pinned to a release; see the caveat
+above). Unless you have a specific reason to deviate, use:
 
 ```bash
 bwa-mem3 mem --meth -t 16 ref.fa R1.fq.gz R2.fq.gz \
@@ -97,10 +114,12 @@ bwa-mem3 mem --meth --chimera-qc -t 16 ref.fa R1.fq.gz R2.fq.gz \
 
 The `--meth` output BAM carries the Bismark tag set that downstream methylation
 tools expect, so it serves as a placement drop-in for the `bwameth.py` pipeline
-(in `collapsed` mode) — though scoring is computed against the original reference
-rather than in collapsed space, so it is not byte-for-byte identical to bwameth
-output. The following downstream tools have been used
-successfully with `bwa-mem3 --meth` output:
+(in `collapsed` mode). Because scoring is computed against the original reference
+rather than in collapsed space, the placement is a close approximation, **not**
+byte-for-byte identical to bwameth output, and ~1% of records differ in
+`POS`/`CIGAR`/`MAPQ` (see the [scoring-mode caveat](#choosing-a-scoring-mode---meth-scoring)
+above). The following downstream tools have been used successfully with
+`bwa-mem3 --meth` output:
 
 - **`bismark_methylation_extractor`**, **methylKit `processBismarkAln`**,
   **methtuple**, **DMRfinder**, **epialleleR** — read the Bismark `XR:Z`,

--- a/docs/src/getting-started/quick-meth.md
+++ b/docs/src/getting-started/quick-meth.md
@@ -6,9 +6,12 @@ postprocessing step are required.
 
 > **Note — bwameth-compatible by default, variant-aware on request**
 >
-> By default (`--meth-scoring collapsed`) bwa-mem3 reproduces bwameth.py's read **placement** and
+> By default (`--meth-scoring collapsed`) bwa-mem3 closely tracks bwameth.py's read **placement** and
 > emits the standard Bismark tags methylation callers expect (MethylDackel, Bismark, PileOMeth,
-> etc.). It is a placement drop-in — not a byte-for-byte reproduction of bwameth. Add
+> etc.). It is a placement drop-in — *not* a byte-for-byte reproduction of bwameth: a small fraction
+> of records (~1% on typical WGBS/EM-seq) still differ in `POS`/`CIGAR`/`MAPQ`, so re-validate if you
+> are pinned to a specific bwameth release (see
+> [bwameth.py drop-in mapping](../methylation/bwameth-mapping.md)). Add
 > `--meth-scoring genomic` to opt into variant-aware scoring (truthful `NM`/`MD`; one BAM for both
 > methylation and variant calling).
 

--- a/docs/src/methylation/bwameth-mapping.md
+++ b/docs/src/methylation/bwameth-mapping.md
@@ -1,19 +1,31 @@
 # bwameth.py Drop-In Mapping
 
 `bwa-mem3 --meth` is designed so that, in its **default `collapsed` mode**, read
-*placement* matches the bwameth.py pipeline for the standard case, while emitting
-the Bismark tag set methylation callers expect. This page explains what is the
-same, what differs, and where the two approaches diverge by design.
+*placement* closely tracks the bwameth.py pipeline for the standard case (with a
+small, bounded divergence — see the callout below), while emitting the Bismark
+tag set methylation callers expect. This page explains what is the same, what
+differs, and where the two approaches diverge by design.
 
-> **Important — placement drop-in, not byte-identical**
+> **Important — placement drop-in, *not* byte-identical, and *not* drift-free**
 >
-> `collapsed` reproduces bwameth's **placement** (where reads map and their
-> primary/MAPQ behavior) because both treat C/T and G/A as interchangeable. It is
-> **not** a byte-for-byte reproduction: bwa-mem3 scores against the original
-> 4-letter reference rather than in collapsed space, so scores and some CIGARs can
-> differ at the margins, and the tag schema is Bismark (`XR`/`XG`/`XM`), not
-> bwameth (`YS`/`YC`/`YD`). The opt-in `genomic` mode diverges from bwameth on
-> purpose (it penalizes real variants).
+> `collapsed` **approximates** bwameth's placement (where reads map and their
+> primary/MAPQ behavior) because both treat C/T and G/A as interchangeable — but
+> it is **neither** a byte-for-byte reproduction **nor** drift-free. bwa-mem3
+> scores against the original 4-letter reference rather than in collapsed space,
+> so a small but nonzero fraction of records differ from bwameth.py in **`POS`**,
+> **`CIGAR`**, or **`MAPQ`** — on the order of ~1% of records on typical
+> WGBS/EM-seq, with true mapped-position (`POS`) changes affecting a smaller
+> subset (a few tenths of a percent). The 4-letter scoring path **widens** this
+> versus a pure collapsed-space aligner — and versus the older 3-letter `--meth`
+> releases — and the opt-in `genomic` mode diverges further on purpose (it
+> penalizes real variants). The tag schema is also Bismark (`XR`/`XG`/`XM`), not
+> bwameth (`YS`/`YC`/`YD`).
+>
+> **If you are pinned to a specific bwameth release** (e.g. a clinical pipeline
+> validated against a bwameth version), treat `collapsed` as a *new aligner* and
+> **re-validate against your own bwameth output** — do not assume placement
+> equivalence. The divergence is small and bounded, but it is real and it is
+> larger than the older 3-letter `--meth` path.
 
 ## Command comparison
 
@@ -73,12 +85,16 @@ pass. Output is uncompressed BAM (`wb0`) that `samtools sort` reads natively.
 ## What stays the same (collapsed mode)
 
 The output BAM carries the standard methylation tag set, flags, and SEQ
-representation. The `@PG` provenance line and the tag schema intentionally differ:
+representation, and read placement **closely tracks** bwameth at the standard
+case — but "stays the same" here means *functionally equivalent*, not
+*identical*: as the callout above notes, ~1% of records still differ in
+`POS`/`CIGAR`/`MAPQ`. The `@PG` provenance line and the tag schema intentionally
+differ:
 
 | Field | bwameth.py | bwa-mem3 --meth |
 |-------|-----------|-----------------|
 | `@SQ` headers | One per real chromosome | One per real chromosome |
-| Read placement (collapsed) | reference | Matches at the standard case |
+| Read placement (collapsed) | reference | Closely tracks at the standard case; ~1% of records differ in `POS`/`CIGAR`/`MAPQ` (re-validate if pinned to a bwameth release) |
 | Methylation aux tags | `YS:Z`, `YC:Z`, `YD:Z` | `XR:Z`, `XG:Z`, `XM:Z` (Bismark) |
 | `@PG` | `ID:bwameth` | `ID:bwa-mem3-meth` |
 | Chimera QC threshold | Longest M < 44% of read | Same (44%), opt-in via `--chimera-qc` |

--- a/docs/src/methylation/overview.md
+++ b/docs/src/methylation/overview.md
@@ -25,14 +25,21 @@ about bisulfite-converted bases. This is controlled by `--meth-scoring`:
 
 | Mode | Default? | Matrix | `-B` | Behavior |
 |------|----------|--------|------|----------|
-| **`collapsed`** | **yes** | frees C↔T *and* G↔A both ways (two cells) | `2` | bwameth-compatible **placement** — C/T and G/A are interchangeable, so it matches bwameth's collapsed-space mapping. The drop-in default for pipelines pinned to bwameth. |
+| **`collapsed`** | **yes** | frees C↔T *and* G↔A both ways (two cells) | `2` | bwameth-compatible **placement** — C/T and G/A are interchangeable, so it closely tracks bwameth's collapsed-space mapping. A close approximation, **not** exact: ~1% of records differ in `POS`/`CIGAR`/`MAPQ`, so re-validate if pinned to a bwameth release. |
 | **`genomic`** | no (opt-in) | frees only the conversion direction (one cell) | `4` | **variant-aware** — a real C/T or G/A variant scores as a mismatch, so `NM`/`MD` are truthful and the BAM is usable for variant calling. |
 
 The default is `collapsed` so existing methylation pipelines see
 bwameth-compatible read placement unless they explicitly opt into `genomic`.
-`collapsed` reproduces bwameth's *placement* and emits the same Bismark tag set;
-it is a placement drop-in, not a byte-for-byte reproduction of bwameth or of any
-prior 3-letter `--meth` release.
+`collapsed` **closely tracks** bwameth's *placement* and emits the same Bismark
+tag set, but it is a placement drop-in — **not** a byte-for-byte reproduction of
+bwameth, and not drift-free. Because scoring runs against the original 4-letter
+reference rather than in collapsed 3-letter space, a small but nonzero fraction
+of records (on the order of ~1% on typical WGBS/EM-seq) differ from bwameth.py in
+`POS`, `CIGAR`, or `MAPQ`; this 4-letter scoring path is also why `collapsed`
+diverges *more* than the older 3-letter `--meth` releases did. If you are pinned
+to a specific bwameth release, re-validate against your own bwameth output rather
+than assume equivalence — see the
+[bwameth.py drop-in mapping](bwameth-mapping.md) page.
 
 ## Pipeline at a glance
 


### PR DESCRIPTION
## Summary

The `--meth-scoring` docs described `collapsed` mode as "bwameth-compatible placement" — a "drop-in" that "matches" or "reproduces" bwameth.py — while the only non-identity caveat was a single understated "not byte-for-byte identical" line buried in the downstream-tools section of the best-practices page. That overstates equivalence.

Because `--meth` scores against the **original 4-letter reference** (not in collapsed 3-letter space like bwameth.py), `collapsed` only *approximates* bwameth placement: a small but nonzero fraction of records (on the order of ~1% on typical WGBS/EM-seq) differ in `POS`/`CIGAR`/`MAPQ`, with true mapped-position changes on a smaller subset. The D3 4-letter scoring path (#174) widens this versus the older 3-letter `--meth` releases. A reader pinning a validated/clinical pipeline to a bwameth release could read the old wording as a guarantee of placement equivalence — it isn't.

This PR updates the four user-facing methylation pages to say `collapsed` **closely tracks but does not reproduce** bwameth placement, quantifies the drift, and tells anyone pinned to a specific bwameth release to **re-validate against their own bwameth output** rather than assume equivalence. `genomic` is left as "diverges further on purpose" — its larger divergence is by design.

## Changes

- **`methylation/bwameth-mapping.md`** — rewrote the `Important` callout (now "not byte-identical, *and not drift-free*") with the ~1% magnitude and a re-validation directive; fixed the over-reassuring `Read placement → "Matches at the standard case"` table row; softened the "What stays the same" intro.
- **`best-practices/methylation.md`** (was the weakest page) — added a prominent caveat **inside** the "Choosing a scoring mode" section, added re-validation language to the `collapsed` bullet and "When to keep the defaults", and upgraded the buried downstream-tools line.
- **`methylation/overview.md`** — strengthened the `collapsed` table cell and the paragraph after the table (notes the 4-letter scoring is *why* it diverges more than the old 3-letter path).
- **`getting-started/quick-meth.md`** — the entry-point note now flags the ~1% drift and re-validation.

## Notes

- The magnitude is phrased as approximate / workload-dependent ("~1% on typical WGBS/EM-seq"), consistent with the placement figures in #174. No internal benchmark infrastructure or exact-percentage budgets are cited in the user-facing book.
- Docs-only. `mdbook build` + linkcheck pass clean (the new cross-page/intra-page anchors resolve).

## Test plan

- [x] `mdbook build` succeeds, no new linkcheck errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for methylation scoring modes and quick-start usage.
  * Stated that the default “collapsed” mode closely tracks prior placement behavior, but is not exact.
  * Added clearer expectations for small differences in `POS`, `CIGAR`, and `MAPQ`.
  * Expanded notes on when to re-validate results if using a pinned prior release.
  * Improved the comparison of supported methylation tag formats and mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->