### PR TITLE
docs: collapse the mdbook sidebar into nested, foldable sections

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -23,7 +23,10 @@ enable = true
 
 [output.html.fold]
 enable = true
-level = 1
+# level = 0 -> every nested section starts collapsed; mdBook's runtime JS expands
+# only the section containing the current page. This keeps the sidebar to ~10
+# top-level entries instead of rendering all ~60 child pages at once.
+level = 0
 
 [output.html.playground]
 editable = false

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,95 +1,81 @@
 # Summary
 
+<!-- The `- [Title]()` entries below are intentional mdBook draft chapters
+     (non-clickable, collapsible section headers); markdownlint flags them as
+     empty links (MD042), so disable that rule for this file. -->
+<!-- markdownlint-disable MD042 -->
+
 [Home](index.md)
 
-# Getting Started
-
-- [Installation](getting-started/installation.md)
-- [Coming from bwa or bwa-mem2](getting-started/migrating.md)
-- [Host requirements](getting-started/host-requirements.md)
-- [Quick start: align paired-end FASTQs](getting-started/quick-align.md)
-- [Quick start: methylation alignment](getting-started/quick-meth.md)
-- [Quick start: shared-memory index](getting-started/quick-shm.md)
-
-# User Guide
-
-- [Indexing the reference](user-guide/indexing.md)
-- [Aligning short reads (mem)](user-guide/aligning.md)
-- [Output: SAM/BAM, headers, tags](user-guide/output.md)
-- [Threading and resource use](user-guide/threading.md)
-- [Memory allocator (mimalloc)](user-guide/allocator.md)
-- [Memory budgeting and data-type tuning](user-guide/memory-and-data-types.md)
-- [Tips and best practices](user-guide/tips.md)
-
-# Performance
-
-- [Overview](performance/overview.md)
-- [SIMD dispatch matrix](performance/simd-dispatch.md)
-- [PGO build](performance/pgo.md)
-
-# Best Practices
-
-- [Optimization checklist](best-practices/optimization-checklist.md)
-- [Settings profiles: bwa drop-in vs recommended](best-practices/settings-profiles.md)
-- [Build](best-practices/build.md)
-- [Output format](best-practices/output-format.md)
-- [Multi-sample workflows](best-practices/multi-sample.md)
-- [Methylation defaults](best-practices/methylation.md)
-- [Multi-architecture deployment](best-practices/multi-arch-deployment.md)
-- [Anti-patterns](best-practices/anti-patterns.md)
-
-# CLI Reference
-
-- [Overview](cli/overview.md)
-- [index](cli/index-cmd.md)
-- [mem](cli/mem.md)
-- [shm](cli/shm.md)
-- [version](cli/version.md)
-
-# Methylation Reference
-
-- [Overview](methylation/overview.md)
-- [bwameth.py drop-in mapping](methylation/bwameth-mapping.md)
-- [Conversion details (C->T, G->A)](methylation/conversion.md)
-- [SAM tags: XR, XG, XM](methylation/tags.md)
-- [Chimera QC and header rewriting](methylation/post-processing.md)
-- [Flags: --set-as-failed, --chimera-qc](methylation/flags.md)
-- [Migrating from bwameth.py c2t](methylation/external-c2t.md)
-
-# What's Different from bwa-mem2
-
-- [Overview](whats-different/overview.md)
-- [Equivalence with bwa-mem2](whats-different/equivalence.md)
-- [Correctness fixes](whats-different/correctness.md)
-- [Performance improvements](whats-different/performance.md)
-- [Features](whats-different/features.md)
-- [Architecture support](whats-different/arch-support.md)
-- [Build & infrastructure](whats-different/build-infra.md)
-- [`BASELINE_ARCH=avx512bw` build flag](whats-different/avx512-baseline.md)
-
-# Developer Guide
-
-- [Building from source](developer-guide/building.md)
-- [SIMD dispatch architecture](developer-guide/simd-dispatch.md)
-- [Single-binary SIMD dispatch (x86)](developer-guide/launcher.md)
-- [Apple Silicon / NEON port](developer-guide/neon-port.md)
-- [Regression test framework](developer-guide/regression-tests.md)
-- [Release process](developer-guide/release.md)
-- [Branch and worktree conventions](developer-guide/branches.md)
-- [Contributing](developer-guide/contributing.md)
-
-# Related Projects
-
-- [bwa-mem3-bench](related-projects/bwa-mem3-bench.md)
-- [bwa-mem3-rs](related-projects/bwa-mem3-rs.md)
-- [bwa-mem2 (upstream)](related-projects/bwa-mem2.md)
-- [fgumi](related-projects/fgumi.md)
-- [bwameth.py](related-projects/bwameth.md)
-
-# Reference
-
-- [PR catalog](reference/pr-catalog.md)
-- [Glossary](reference/glossary.md)
-- [Citation](reference/citation.md)
-- [License](reference/license.md)
-- [Changelog](reference/changelog.md)
+- [Getting Started]()
+  - [Installation](getting-started/installation.md)
+  - [Coming from bwa or bwa-mem2](getting-started/migrating.md)
+  - [Host requirements](getting-started/host-requirements.md)
+  - [Quick start: align paired-end FASTQs](getting-started/quick-align.md)
+  - [Quick start: methylation alignment](getting-started/quick-meth.md)
+  - [Quick start: shared-memory index](getting-started/quick-shm.md)
+- [User Guide]()
+  - [Indexing the reference](user-guide/indexing.md)
+  - [Aligning short reads (mem)](user-guide/aligning.md)
+  - [Output: SAM/BAM, headers, tags](user-guide/output.md)
+  - [Threading and resource use](user-guide/threading.md)
+  - [Memory allocator (mimalloc)](user-guide/allocator.md)
+  - [Memory budgeting and data-type tuning](user-guide/memory-and-data-types.md)
+  - [Tips and best practices](user-guide/tips.md)
+- [Performance]()
+  - [Overview](performance/overview.md)
+  - [SIMD dispatch matrix](performance/simd-dispatch.md)
+  - [PGO build](performance/pgo.md)
+- [Best Practices]()
+  - [Optimization checklist](best-practices/optimization-checklist.md)
+  - [Settings profiles: bwa drop-in vs recommended](best-practices/settings-profiles.md)
+  - [Build](best-practices/build.md)
+  - [Output format](best-practices/output-format.md)
+  - [Multi-sample workflows](best-practices/multi-sample.md)
+  - [Methylation defaults](best-practices/methylation.md)
+  - [Multi-architecture deployment](best-practices/multi-arch-deployment.md)
+  - [Anti-patterns](best-practices/anti-patterns.md)
+- [CLI Reference]()
+  - [Overview](cli/overview.md)
+  - [index](cli/index-cmd.md)
+  - [mem](cli/mem.md)
+  - [shm](cli/shm.md)
+  - [version](cli/version.md)
+- [Methylation Reference]()
+  - [Overview](methylation/overview.md)
+  - [bwameth.py drop-in mapping](methylation/bwameth-mapping.md)
+  - [Conversion details (C->T, G->A)](methylation/conversion.md)
+  - [SAM tags: XR, XG, XM](methylation/tags.md)
+  - [Chimera QC and header rewriting](methylation/post-processing.md)
+  - [Flags: --set-as-failed, --chimera-qc](methylation/flags.md)
+  - [Migrating from bwameth.py c2t](methylation/external-c2t.md)
+- [What's Different from bwa-mem2]()
+  - [Overview](whats-different/overview.md)
+  - [Equivalence with bwa-mem2](whats-different/equivalence.md)
+  - [Correctness fixes](whats-different/correctness.md)
+  - [Performance improvements](whats-different/performance.md)
+  - [Features](whats-different/features.md)
+  - [Architecture support](whats-different/arch-support.md)
+  - [Build & infrastructure](whats-different/build-infra.md)
+  - [`BASELINE_ARCH=avx512bw` build flag](whats-different/avx512-baseline.md)
+- [Developer Guide]()
+  - [Building from source](developer-guide/building.md)
+  - [SIMD dispatch architecture](developer-guide/simd-dispatch.md)
+  - [Single-binary SIMD dispatch (x86)](developer-guide/launcher.md)
+  - [Apple Silicon / NEON port](developer-guide/neon-port.md)
+  - [Regression test framework](developer-guide/regression-tests.md)
+  - [Release process](developer-guide/release.md)
+  - [Branch and worktree conventions](developer-guide/branches.md)
+  - [Contributing](developer-guide/contributing.md)
+- [Related Projects]()
+  - [bwa-mem3-bench](related-projects/bwa-mem3-bench.md)
+  - [bwa-mem3-rs](related-projects/bwa-mem3-rs.md)
+  - [bwa-mem2 (upstream)](related-projects/bwa-mem2.md)
+  - [fgumi](related-projects/fgumi.md)
+  - [bwameth.py](related-projects/bwameth.md)
+- [Reference]()
+  - [PR catalog](reference/pr-catalog.md)
+  - [Glossary](reference/glossary.md)
+  - [Citation](reference/citation.md)
+  - [License](reference/license.md)
+  - [Changelog](reference/changelog.md)

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -188,11 +188,34 @@ h1, h2, h3, h4, h5, h6 {
     text-decoration: none;
 }
 
-/* Section header spans (no-link items like "Core Concepts") */
+/* Section header spans (no-link draft chapters like "Getting Started").
+   sidebar-brand.js makes the whole row fold its section on click, so render
+   the header as interactive. */
 .sidebar .chapter-link-wrapper > span {
     color: var(--fg-blue) !important;
     font-size: 0.8rem;
     font-weight: 500;
+    cursor: pointer;
+}
+
+/* "Home" is the only top-level *link* (every section is a draft-chapter span),
+   so by default it picks up the light-grey link color and looks out of place
+   next to the blue section headers. Color it blue to match when it is not the
+   current page; the active rule below keeps it white + green bar when it is. */
+.sidebar .chapter > li.chapter-item > .chapter-link-wrapper > a:not(.active) {
+    color: var(--fg-blue) !important;
+}
+.sidebar .chapter > li.chapter-item > .chapter-link-wrapper > a:not(.active):hover {
+    color: var(--fg-sky) !important;
+}
+
+/* mdBook 0.5 injects the *current* page's in-page headings into the left
+   sidebar as an always-expanded ".on-this-page" outline under the active entry.
+   That makes the active item (e.g. Home) the one thing in the sidebar that
+   cannot be collapsed, clashing with the uniform collapsible sections. Hide it;
+   the page's headings remain visible in the page body itself. */
+.sidebar .on-this-page {
+    display: none !important;
 }
 
 /* Active page — green left-bar accent */
@@ -205,9 +228,11 @@ h1, h2, h3, h4, h5, h6 {
 .sidebar a.active::before {
     content: '';
     position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
+    /* Sit in the left gutter rather than flush against the text, so there is a
+       clear gap between the accent bar and the active label. */
+    left: -0.6rem;
+    top: 0.1rem;
+    bottom: 0.1rem;
     width: 3px;
     background: var(--fg-green);
     border-radius: 0 2px 2px 0;

--- a/docs/theme/sidebar-brand.js
+++ b/docs/theme/sidebar-brand.js
@@ -199,12 +199,34 @@
         }
     }
 
+    // ── Whole-row fold for draft-chapter section headers ──────────────────────
+    // Section headers (Getting Started, User Guide, ...) are mdBook "draft
+    // chapters": non-link <span>s that fold their children. mdBook only wires
+    // its fold handler to the small ❱ arrow (a.chapter-fold-toggle), so by
+    // default clicking the header *text* does nothing. Delegate clicks at the
+    // document level (the TOC is injected asynchronously by mdBook's toc.js, so
+    // a stable ancestor is the reliable place to listen) and forward a click on
+    // anywhere in a draft header row to that existing toggle -- reusing mdBook's
+    // own fold logic and persistence rather than reimplementing it.
+    function enableDraftHeaderFold() {
+        document.addEventListener('click', function (e) {
+            // Real anchors (child page links, the ❱ arrow itself, brand links)
+            // handle their own clicks -- don't hijack or double-toggle them.
+            if (e.target.closest('a')) return;
+            var wrapper = e.target.closest('.chapter-link-wrapper');
+            if (!wrapper) return;
+            var toggle = wrapper.querySelector('a.chapter-fold-toggle');
+            if (toggle) toggle.click();
+        });
+    }
+
     // ── Init ──────────────────────────────────────────────────────────────────
     function init() {
         injectBrand();
         injectFooter();
         injectBreadcrumb();
         colorMenuTitle();
+        enableDraftHeaderFold();
     }
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
## Problem

The published docs sidebar (https://bwa-mem3.readthedocs.io/en/latest/) renders **all ~60 pages at once** — a wall of ~73 entries down the left column.

Root cause: `docs/src/SUMMARY.md` used 10 mdBook **part-title headers** (`# Getting Started`, `# User Guide`, …) with a flat page list under each. In mdBook, part titles are permanent, non-collapsible dividers, and `[output.html.fold]` only collapses *nested children* — of which there were none. So folding was enabled but did nothing.

## Change

Restructure the nav into **nested chapters** so each section is one collapsible top-level entry, and set `fold.level = 0` so everything starts collapsed (mdBook expands only the section containing the current page at runtime).

Every section becomes a **draft chapter** — a non-clickable section header that folds its children. This keeps all 10 headers visually and behaviourally uniform: the theme (`theme/custom.css`) styles draft-chapter spans as blue section headers and child links as white pages, so making *some* parents clickable `<a>` elements would render those headers white and navigate-on-click while the rest stayed blue and expand-only (an inconsistent blue/white sidebar where you can't tell which headers do what). Sections that had a standalone overview page (Performance, CLI Reference, Methylation Reference, What's Different) keep it as an **"Overview" first child**.

Two follow-on tweaks to make the collapsed sidebar behave consistently:

- **Whole-row fold.** mdBook wires its fold handler only to the small arrow on a draft chapter, so clicking the header *text* would otherwise do nothing. `theme/sidebar-brand.js` now delegates clicks (at the document level, since the TOC is injected asynchronously) so clicking **anywhere on a header row folds its section**, reusing mdBook's own toggle; `theme/custom.css` gives the header a pointer cursor.
- **Hide the "on this page" outline.** mdBook 0.5 injects the *current* page's in-page headings into the left sidebar as an always-expanded `.on-this-page` block under the active entry — which made the active item (e.g. Home) the one thing in the sidebar that couldn't be collapsed. `theme/custom.css` hides it so every page renders as a single uniform entry; page headings remain visible in the page body.

The sidebar now shows **10 collapsed top-level entries** instead of ~60, all styled identically, each folding on a full-row click, with no special always-expanded active entry.

No pages moved and no directories changed, so the breadcrumb/section maps in `theme/sidebar-brand.js` still resolve unchanged.

## Verification

Local `mdbook` 0.5.2 build (matching the pinned CI/RTD versions):

- `mdbook build` exits 0; `linkcheck2` passes — only the pre-existing bracketed-literal "incomplete link" warnings (e.g. `[_*]`, `[proto]` in captured `--help`/PR-catalog text), no broken internal links, no orphaned/unused pages.
- Generated `toc.html` shows every section rendered **collapsed** (0 `expanded` items at rest), each carrying a fold toggle, and all 10 section headers rendered as **uniform draft spans** (the only top-level link is Home).
- The full-row fold handler, pointer cursor, and `.on-this-page` hide rule are present in the built (fingerprinted) `theme/` assets and referenced from the pages.

## Follow-ups (intentionally out of scope)

Sub-section *count* per section (6–8) is normal and only visible on expand, so it is not part of this fix. If a later content pass wants to trim over-granular pages, the candidates are `whats-different/avx512-baseline` (a whole page for one build flag) and a couple of thin Best Practices pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the documentation sidebar to a cleaner nested, book-style navigation with a Home entry and grouped section links.
  * Improved draft chapter UX so users can expand/collapse by clicking anywhere on the draft chapter header row.
* **Style**
  * Refined sidebar styling for draft rows and the Home link, adjusted the active item indicator, and reduced sidebar clutter by hiding the on-this-page outline.
* **Chores**
  * Tweaked documentation fold behavior to keep the sidebar less expanded by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->