### PR TITLE
docs(contributing): document breaking-change commit footers

### DIFF
--- a/docs/src/developer-guide/contributing.md
+++ b/docs/src/developer-guide/contributing.md
@@ -45,6 +45,37 @@ Updated kswv
 WIP
 ```
 
+### Flagging breaking changes
+
+Releases are generated automatically by [release-please](https://github.com/googleapis/release-please) from the conventional-commit history (see [Release process](release.md)). A change that breaks a downstream consumer — see the [semver policy](release.md#semver-policy) for what qualifies — **must** be marked so the breaking-change notice lands in `CHANGELOG.md` and the GitHub release body. Describing the break only in the commit body is not enough: release-please does not read prose, so an unmarked break is silently filed under its plain type (e.g. a `perf:` commit lands under "Performance" with no warning) and downstream users never see it.
+
+Mark a break either way:
+
+- Append a `!` after the type/scope: `perf(index)!: stop building .0123 by default`, **and/or**
+- Add a `BREAKING CHANGE:` footer (the colon is required) describing the break and the migration path.
+
+```text
+perf(index)!: stop building the unpacked .0123 reference by default
+
+BREAKING CHANGE: `bwa-mem3 index` no longer writes `.0123`; `mem` reconstructs
+reference bases from `.pac` on demand. External tools that read `.0123` directly
+(e.g. sharing an index with bwa-mem2) must re-run with `index --emit-unpacked-ref`.
+```
+
+release-please then emits a `⚠ BREAKING CHANGES` section automatically. While the project is pre-1.0 this still bumps only the minor version (`bump-minor-pre-major` is set), matching the [semver policy](release.md#semver-policy)'s rule that a pre-1.0 break is allowed when it is called out clearly — the footer is how it gets called out.
+
+> **Note — Squash merges**
+>
+> The project [squash-merges single-commit PRs and rebase-merges multi-commit
+> PRs with a clean history](branches.md). For a **squash-merged** PR,
+> release-please reads only the squash-merge commit subject (which defaults to
+> the PR title), **not** the individual commit bodies — so put the `!` /
+> `BREAKING CHANGE:` marker on the PR title or the squash commit message itself,
+> because a marker buried in a sub-commit body is discarded at squash time. A
+> **rebase-merged** PR keeps its individual commits, so a marker in any sub-commit
+> message is preserved and detected; even so, prefer putting it on the PR title
+> as well so the convention is uniform regardless of how the PR is merged.
+
 ## Pull request workflow
 
 1. Push your branch to `fg-labs/bwa-mem3` (or your fork) and open a PR targeting `fg-labs/bwa-mem3 main`.


### PR DESCRIPTION
## Motivation

bwa-mem3 v0.4.0 shipped a breaking on-disk change — `bwa-mem3 index` no longer writes the unpacked `.0123` reference by default (#177) — but the published release notes had no breaking-change notice. The change merged as a `perf:` commit with no `!` and no `BREAKING CHANGE:` footer, so release-please filed it under "Performance" and never emitted a `⚠ BREAKING CHANGES` section. (The v0.4.0 release body has since been amended by hand to call it out.)

Nothing in the contributing guide tells authors how to make release-please surface a break, so the gap will recur. This documents the convention.

## What changed

Adds a **"Flagging breaking changes"** subsection to the Commit message conventions section of `docs/src/developer-guide/contributing.md`:

- A change that breaks a downstream consumer (per the [semver policy](https://github.com/fg-labs/bwa-mem3/blob/main/docs/src/developer-guide/release.md)) must be marked with a `!` type suffix and/or a `BREAKING CHANGE:` footer, or release-please silently files it under its plain type.
- A worked example (the #177 `.0123` change itself).
- The squash-merge gotcha: release-please reads only the squash-merge subject (PR title), **not** sub-commit bodies — so the marker must live on the PR title / squash message. This is the precise reason #177's break vanished: the breaking language was in a squashed sub-commit body.
- Cross-references to the existing semver policy in `release.md`.

## Validation

- `mdbook build` is clean. The 5 `Potential incomplete link` warnings it prints are all pre-existing in `reference/pr-catalog.md` (literal `[=LEVEL]` / `[proto]` text) and unrelated to this change.

Docs-only; no fork-carried commit, so no `FG-MAIN-TABLE` update required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide section on flagging breaking changes in conventional-commit history so they are included in changelogs and GitHub release notes.
  * Clarified the accepted markers (using `!` and/or a `BREAKING CHANGE:` footer) and that commit messages must include migration details.
  * Explained how automated breaking-change sections are generated and how squash merges affect which text is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->