### PR TITLE
docs(changelog): backfill the 0.4.0 breaking-change notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [0.4.0](https://github.com/fg-labs/bwa-mem3/compare/v0.3.0...v0.4.0) (2026-06-27)
 
 
+### ⚠ BREAKING CHANGES
+
+* **index:** `bwa-mem3 index` no longer writes the unpacked `.0123` reference file by default ([#177](https://github.com/fg-labs/bwa-mem3/pull/177)). `bwa-mem3 mem` now reconstructs reference bases from the packed `.pac` on demand ("pac-fetch") and ignores any `.0123` present, so the file is redundant for bwa-mem3 itself. External tools that read `.0123` directly — most notably sharing a single index with **bwa-mem2** — will break, since the expected file is now absent. To restore the old on-disk layout, re-run indexing with the new opt-in flag `index --emit-unpacked-ref`. Alignment output is byte-for-byte identical; the change is purely to the index artifact set.
+
+
 ### Features
 
 * **mem:** --min-ext-len opt-in filter to skip extension of short seeds ([#169](https://github.com/fg-labs/bwa-mem3/issues/169)) ([13db252](https://github.com/fg-labs/bwa-mem3/commit/13db252ad4c7c39eff18bd3674430aac51570346))


### PR DESCRIPTION
## Motivation

The v0.4.0 [GitHub release body](https://github.com/fg-labs/bwa-mem3/releases/tag/v0.4.0) was amended by hand to add a `⚠ BREAKING CHANGES` section for #177 — `bwa-mem3 index` no longer writes the unpacked `.0123` reference by default — but `CHANGELOG.md` was not, so the two records of the same release diverged.

The break never made it into the auto-generated notes because #177 merged as a `perf:` commit with no `!` / `BREAKING CHANGE:` marker, so release-please filed it under "Performance." (The convention to prevent this going forward is documented in #181.)

## What changed

Adds a `⚠ BREAKING CHANGES` section to the existing 0.4.0 entry in `CHANGELOG.md`, matching release-please's own section format and the wording already in the release body, so the two are identical.

## Why this is safe

release-please only prepends a new section for each new version and preserves existing entries verbatim — it does not regenerate past releases — so this manual edit to the 0.4.0 section is stable across future release PRs. The inserted heading (`### ⚠ BREAKING CHANGES`) matches the format release-please would have produced, so there is no formatting drift.

## Note

`docs/src/reference/changelog.md` includes `NEWS.md` (frozen at 0.2.0), not `CHANGELOG.md`, so this file is not part of the mdbook build and no docs rebuild is needed. (That the rendered docs "Changelog" page only shows ≤0.2.0 is a separate staleness issue in the same family as #182; not addressed here.)

Docs-only; no fork-carried commit, so no `FG-MAIN-TABLE` update required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `bwa-mem3 index` no longer creates the unpacked `.0123` reference file by default.
  * `bwa-mem3 mem` now reconstructs reference bases from the packed `.pac` file as needed.
  * If you use tools that rely on `.0123`, re-run indexing with `index --emit-unpacked-ref`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->