### PR TITLE
docs(changelog): render the live changelog, not the frozen NEWS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,5 +109,3 @@
 ### Documentation
 
 * **readme:** add bioconda badges and install instructions ([#106](https://github.com/fg-labs/bwa-mem3/issues/106)) ([830276c](https://github.com/fg-labs/bwa-mem3/commit/830276ce01774805c20bfff69c63cfebab239166))
-
-## Changelog

--- a/docs/src/reference/changelog.md
+++ b/docs/src/reference/changelog.md
@@ -1,6 +1,19 @@
 # Changelog
 
-{{#include ../../../NEWS.md}}
+Release notes from 0.2.1 onward are generated automatically by [release-please](https://github.com/googleapis/release-please) from the commit history (see [Release process](../developer-guide/release.md)) and mirror the [GitHub Releases](https://github.com/fg-labs/bwa-mem3/releases) page.
+
+<!-- Line-range includes skip each file's top matter: CHANGELOG.md line 1 is
+     its own `# Changelog` h1 (would duplicate this page's title); NEWS.md
+     lines 1-2 are a preamble pointing here, redundant once the two are on the
+     same page. release-please's header is a stable single h1 line, and NEWS.md
+     is frozen, so the start offsets do not drift. -->
+{{#include ../../../CHANGELOG.md:2:}}
+
+## Earlier releases and upstream history
+
+The 0.2.0 and 0.1.0-pre fg-labs notes, plus the upstream bwa-mem2 release history, are preserved below as a frozen archive.
+
+{{#include ../../../NEWS.md:3:}}
 
 ---
 


### PR DESCRIPTION
## Motivation

The rendered docs "Changelog" page (`docs/src/reference/changelog.md`) `{{#include}}`s only `NEWS.md`, which is frozen at 0.2.0 — so the published docs site shows **nothing** from the release-please era (0.2.1, 0.2.2, 0.3.0, 0.4.0). Meanwhile `CHANGELOG.md` (the release-please-owned, always-current file) was never surfaced in the docs at all.

This is the same staleness family as #182; surfaced while investigating the missing #177 breaking-change notice.

## What changed

- **`docs/src/reference/changelog.md`** now includes `CHANGELOG.md` (current releases, 0.2.1+) first, then `NEWS.md` below under an "Earlier releases and upstream history" heading (the 0.2.0 / 0.1.0-pre fg-labs notes and the upstream bwa-mem2 release history, 2.0pre2 → 2.2.1).
- **`CHANGELOG.md`** — strips a stray empty `## Changelog` heading release-please left at the tail of the file, which would otherwise render as a phantom section once the file is surfaced on the docs page.

The result: the docs Changelog page tracks **every future release automatically** — release-please updates `CHANGELOG.md`, the include picks it up on the next docs build, no manual step. `NEWS.md` is kept (it is the only home for the upstream bwa-mem2 lineage and the pre-0.2.1 notes) but is now purely a frozen archive.

### Why line-range includes

`{{#include}}` is a raw text splice and does not adjust heading levels, so each source file's top matter is skipped:

- `CHANGELOG.md:2:` — skips line 1, its own `# Changelog` h1, which would otherwise duplicate the page title.
- `NEWS.md:3:` — skips the two-line preamble that points readers to `CHANGELOG.md`, redundant once both are on the same page.

release-please always emits a single `# Changelog` h1 as line 1, and `NEWS.md` is frozen, so the start offsets do not drift. A comment in the file records this.

## Validation

- `mdbook build` exits 0. The rendered page shows a single "Changelog" h1, then 0.4.0 → 0.2.1 from `CHANGELOG.md`, then "Earlier releases and upstream history" with 0.2.0 → bwa-mem2 2.0pre2 from `NEWS.md`. No duplicate headings.
- linkcheck emits one **new** `Potential incomplete link` warning — `[0,255]` in the historical 0.3.0 `bsw` entry, a literal-brackets-in-prose false positive identical in kind to the 5 pre-existing ones in `reference/pr-catalog.md`. Left as-is to keep the changelog text byte-identical to the GitHub release notes; trivially escapable in a follow-up if desired.

## Note for reviewers

This PR also edits `CHANGELOG.md` (strips the trailing phantom heading), as does #183 (adds the 0.4.0 `⚠ BREAKING CHANGES` section). The two edits are in disjoint regions — top vs. tail of the file — so they merge cleanly in either order. Docs-only; no fork-carried commit, so no `FG-MAIN-TABLE` update required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the changelog reference page to display upstream release history more cleanly.
  * Adjusted how release notes are included so headings and preamble content no longer appear duplicated.
* **Bug Fixes**
  * Removed an extra trailing header from the changelog file, so the document now ends cleanly after the latest listed item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->