### PR TITLE
feat: add opt-in --seed-order seed reordering (default off, byte-identical)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ LDFLAGS += $(HTSLIB_static_LDFLAGS)
 # Non-kernel objects: always compiled once at the baseline ISA and linked into
 # libbwa.a on every build (arm64 and x86 alike).
 OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/kthread.o \
-			src/kstring.o src/bntseq.o src/bwamem.o src/profiling.o \
+			src/kstring.o src/bntseq.o src/bwamem.o src/seed_order.o src/profiling.o \
 			src/FMI_search.o src/read_index_ele.o src/bwamem_pair.o src/bwa.o \
 			src/bwamem_extra.o src/kopen.o src/bam_writer.o src/meth_bam.o \
 			src/meth_xm.o \

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -66,6 +66,10 @@ Supplementary MAPQ rescoring (fg-labs extension):
                  with >=INT genome occurrences (i.e. the supp region is repetitive on its
                  own). 0 disables (default). Typical values 5-20; lower = more aggressive.
                  Primary MAPQ is unaffected.
+Seed ordering (fg-labs extension):
+   --seed-order STR
+                 seed emission order before chaining: off|local-longest [off]
+                 (advanced modes: global-longest, absorb-count, most-absorb; see docs)
 Input reader:
    --legacy-reader
                  use the legacy gzFile/kseq input reader instead of the default

--- a/docs/src/best-practices/optimization-checklist.md
+++ b/docs/src/best-practices/optimization-checklist.md
@@ -94,6 +94,36 @@ On a 16-core machine, allocating 12 threads to `mem` and 8 to `samtools sort` (w
 >
 > `bwa-mem3 mem` scales well to 16–32 threads on most workloads. Beyond 32 threads the per-thread work unit becomes small enough that synchronization overhead starts to erode gains. See [User Guide — Threading and resource use](../user-guide/threading.md) for thread-scaling data.
 
+## 6. Reorder seeds longest-first (`--seed-order local-longest`)
+
+After SA-interval resolution bwa-mem3 builds chains by scanning seeds in the order they
+were emitted. `--seed-order local-longest` re-sorts each read's resolved seeds by
+decreasing length before chaining. The longest seed anchors its chain first and absorbs
+shorter seeds that are fully contained within it, so contained sub-seeds are never
+extended — they contribute nothing a long seed does not already cover.
+
+```bash
+bwa-mem3 mem --seed-order local-longest -t 16 ref.fa R1.fq.gz R2.fq.gz | samtools sort -@ 4 -o out.bam -
+```
+
+Measured on 50,000 real WGS reads (1000 Genomes HG00096, hg38), `local-longest` cuts
+the fraction of seeds that reach banded Smith-Waterman extension from 38.2 % to 43.7 %
+absorbed (an ~8.9 % reduction in extended seeds). Since Smith-Waterman extension is
+typically the dominant per-read cost in `bwa-mem3 mem`, the gain scales accordingly with
+the seed absorption rate for a given dataset.
+
+**Accuracy and byte-identity.** F1 is flat on an easy simulated profile (holodeck, ~94.4 %;
+no regression vs `--seed-order off`). Hard-data F1 validation on divergent/indel-rich
+reads and GIAB benchmarks is not yet complete, so `--seed-order local-longest` is
+**opt-in only** and the default remains `off`. Non-`off` modes are **not byte-identical**
+to `off`: they can shift secondary alignments, `XA:Z:`, `XS:i`, and `HN:i` tags, and a
+small number of primaries. See
+[Equivalence → Seed ordering](../whats-different/equivalence.md#seed-ordering---seed-order-opt-in)
+for the full taxonomy.
+
+Additional advanced modes are accepted by the option (`global-longest`, `absorb-count`,
+`most-absorb`) but are unadvertised pending further validation.
+
 ## Summary table
 
 | Item | Action | Reference |
@@ -103,6 +133,7 @@ On a 16-core machine, allocating 12 threads to `mem` and 8 to `samtools sort` (w
 | Shared-memory index | `bwa-mem3 shm ref.fa` before batch runs | [Quick start: shm](../getting-started/quick-shm.md) |
 | Emit uncompressed BAM | `--bam=0` | [Best Practices — Output format](output-format.md) |
 | Multi-threaded sort | `samtools sort -@` with appropriate thread split | [User Guide — Threading](../user-guide/threading.md) |
+| Reorder seeds longest-first | `--seed-order local-longest` | [Equivalence](../whats-different/equivalence.md) |
 
 ---
 

--- a/docs/src/whats-different/equivalence.md
+++ b/docs/src/whats-different/equivalence.md
@@ -55,6 +55,16 @@ The following changes can move alignments, scores, or MAPQ relative to upstream,
 - **Opt-in MAPQ rescoring ([#56](https://github.com/fg-labs/bwa-mem3/pull/56), [#101](https://github.com/fg-labs/bwa-mem3/pull/101), [#118](https://github.com/fg-labs/bwa-mem3/pull/118), default-off).** `--supp-rep-hard-cap INT` forces MAPQ=0 on supplementary alignments anchored in repetitive seeds. With no flag the output is unchanged; [#101](https://github.com/fg-labs/bwa-mem3/pull/101) makes the flag actually take effect (it shipped as a silent no-op before), and [#118](https://github.com/fg-labs/bwa-mem3/pull/118) is its regression test. See [Features → `--supp-rep-hard-cap`](features.md).
 - **Tie-break determinism ([#123](https://github.com/fg-labs/bwa-mem3/pull/123)).** Makes secondary-alignment ordering deterministic across runs; can reorder equal-scoring ties relative to upstream's order.
 
+(The resolve→order→chain seeding refactor that backs `--seed-order` is byte-identical in its default `off` mode; it is described in the dedicated section below rather than listed here, since only its non-`off` modes are divergent.)
+
+### Seed ordering (`--seed-order`, opt-in)
+
+`--seed-order off` (the default) preserves byte-identical output. The internal resolve→order→chain refactor that enables it was verified to be bit-for-bit identical to the previous code path across single-end, paired-end, and threaded runs.
+
+`--seed-order local-longest` (and the unadvertised advanced modes `global-longest`, `absorb-count`, `most-absorb`) are **opt-in** and are **not byte-identical**. They reorder each read's SA-resolved seeds before chaining so that the longest seeds anchor chains first; contained shorter seeds are then absorbed rather than extended. The output shift is non-trivial: secondary alignments, `XA:Z:`, `XS:i`, and `HN:i` can all change, and a small number of primary alignments may shift as well.
+
+Accuracy on an easy simulated profile (holodeck, ~94.4 % F1) is flat relative to `off`. Hard-data F1 validation on divergent/indel-rich reads and GIAB benchmarks is **not yet complete**. Because the accuracy gate is not fully passed, all non-`off` modes remain opt-in only; the default stays `off`. See [Optimization checklist → Reorder seeds longest-first](../best-practices/optimization-checklist.md#6-reorder-seeds-longest-first---seed-order-local-longest) for usage guidance.
+
 ## Declared divergence catalog
 
 The divergences described above are tracked as a structured registry in [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3-bench) (`docs/expected-divergences.yaml`). Each carries a per-sample concordance-drift budget that the benchmark gates against on every run — a new bwa-mem3 build that drifts beyond its budget fails CI rather than silently shipping a regression. The table below is generated from that registry; do not edit it by hand (see [bwa-mem3-bench → Per-release concordance history](../related-projects/bwa-mem3-bench.md) for how it is regenerated).

--- a/docs/src/whats-different/features.md
+++ b/docs/src/whats-different/features.md
@@ -208,6 +208,30 @@ for the recommended operating point.
 
 ---
 
+## `--seed-order` seed reordering before chaining
+
+`--seed-order <mode>` reorders each read's SA-resolved seeds before chaining. The default
+`off` preserves byte-identical output. The recommended opt-in mode is `local-longest`,
+which sorts seeds by decreasing length so the longest seed anchors its chain first and
+absorbs contained shorter seeds — those sub-seeds then never reach banded Smith-Waterman.
+
+```bash
+bwa-mem3 mem --seed-order local-longest -t 16 ref.fa R1.fq.gz R2.fq.gz | samtools sort -@ 4 -o out.bam -
+```
+
+Measured on 50,000 real WGS reads (1000 Genomes HG00096, hg38), `local-longest` reduces
+extended seeds by ~8.9 % (absorbed fraction increases from 38.2 % to 43.7 %). Since
+Smith-Waterman extension is typically the dominant per-read cost in `bwa-mem3 mem`, this
+translates to a meaningful throughput gain on extension-heavy workloads.
+
+`--seed-order local-longest` is **not byte-identical** to the default — it can shift
+secondary alignments, `XA:Z:`, `XS:i`, `HN:i`, and a small number of primaries. Accuracy
+is flat on easy simulated data (holodeck, F1 ~94.4 %; no regression vs `off`), but
+hard-data F1 validation on divergent/indel-rich reads and GIAB benchmarks is not yet
+complete. For that reason, all non-`off` modes are opt-in only and the default stays `off`.
+
+See [Optimization checklist → Reorder seeds longest-first](../best-practices/optimization-checklist.md#6-reorder-seeds-longest-first---seed-order-local-longest) and [Equivalence → Seed ordering](equivalence.md#seed-ordering---seed-order-opt-in) for full details.
+
 ## Changes catalog
 
 | Item | bwa-mem3 PR | Upstream PR/issue | Status |
@@ -220,6 +244,7 @@ for the recommended operating point.
 | `HN:i` hit count tag | [#42](https://github.com/fg-labs/bwa-mem3/pull/42) | [lh3/bwa#438](https://github.com/lh3/bwa/pull/438) | fork-only (analogous to bwa aln) |
 | `--bam=LEVEL` direct BAM output | [#12](https://github.com/fg-labs/bwa-mem3/pull/12) | — | fork-only |
 | `--min-ext-len` short-seed extension filter | _pending_ | — | fork-only (opt-in, off by default) |
+| `--seed-order` seed reordering | [#186](https://github.com/fg-labs/bwa-mem3/pull/186) | — | fork-only (opt-in, off by default) |
 
 ---
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -38,6 +38,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 
 #include "sam_encode.h"
 #include "stage_prof.h"
+#include "seed_order.h"
 /* Not including <htslib/sam.h>: its kstring.h shares the KSTRING_H guard
  * with bwa-mem3's. Opaque bam1_t wrappers live in bam_writer.h. */
 
@@ -259,6 +260,7 @@ mem_opt_t *mem_opt_init()
 
     o->min_seed_len = 19;
     o->min_ext_len = 0;   // off by default -> byte-identical to baseline
+    o->seed_emit_order = SEED_ORDER_OFF;  // byte-identical default
     o->split_width = 10;
     o->max_occ = 500;
     o->max_chain_gap = 10000;
@@ -1194,6 +1196,12 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
     int64_t *sa_coord = (int64_t *) _mm_malloc(sizeof(int64_t) * opt->max_occ * smem_buf_size, 64);
     int64_t seedBufCount = 0;
 
+    /* Seed-order refactor (Phase A buffer, Spec S4): one fully-resolved seed per
+     * SA hit, sized by RESOLVED-seed count (the prefetch ceiling), NOT SMEM count.
+     * Persisted across reads in this call and freed at function end with sa_coord. */
+    seed_rec_t *recs = NULL;
+    int64_t recs_cap = 0;
+
     for (int l=0; l<nseq; l++)
         kv_init(chain_ar[l]);
 
@@ -1239,6 +1247,21 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
                                                sizeof(int64_t));
             assert(sa_coord != NULL);
         }
+
+        /* Phase A buffer (Spec S4): ceiling = (#SMEMs this read) * max_occ, the
+         * same prefetch ceiling sa_coord is sized to. Grow with realloc, persist
+         * across reads. Reset nrec per read. */
+        int64_t nrec = 0;
+        int64_t recs_need = (pos - smem_ptr + 1) * (int64_t)opt->max_occ;
+        if (recs_need > recs_cap)
+        {
+            recs_cap = recs_need;
+            /* CodeRabbit: temp pointer so a NULL realloc doesn't leak recs. */
+            seed_rec_t *recs_new = (seed_rec_t *) realloc(recs, recs_cap * sizeof(seed_rec_t));
+            assert(recs_new != NULL);
+            recs = recs_new;
+        }
+
         int64_t id = 0, cnt_ = 0, mypos = 0;
         #if SA_COMPRESSION
         uint64_t tim = __rdtsc();
@@ -1265,14 +1288,17 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
             cnt = 0;
             for (k = count = 0; k < p->s && count < opt->max_occ; k += step, ++count)
             {
-                mem_chain_t tmp, *lower, *upper;
                 mem_seed_t s;
-                int rid, to_add = 0;
+                int rid;
 
+                /* Phase A (resolve). B2/B3: the SA cursor advances BEFORE any drop
+                 * (rid<0 / un-remappable meth) — a dropped hit still consumes a
+                 * slot. The #if SA_COMPRESSION / #else regimes index different
+                 * cursors (global mypos vs per-SMEM cnt); keep both. */
                 #if SA_COMPRESSION
-                s.rbeg = tmp.pos = sa_coord[mypos++];
+                s.rbeg = sa_coord[mypos++];
                 #else
-                s.rbeg = tmp.pos = sa_coord[cnt++];
+                s.rbeg = sa_coord[cnt++];
                 #endif
 
                 s.qbeg = p->m;
@@ -1294,7 +1320,7 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
                     if (meth_seed_to_orig(bns, meth_orig_bns, s.rbeg, s.len,
                                           &o_rbeg, &o_rid, &meth_hyp) != 0)
                         continue; /* un-remappable (bridge/range): drop the seed */
-                    s.rbeg = tmp.pos = o_rbeg;
+                    s.rbeg = o_rbeg;
                     rid = o_rid;
                 } else {
                     rid = bns_intv2rid(bns, s.rbeg, s.rbeg + s.len);
@@ -1303,46 +1329,71 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
                 // forward-reverse boundary; TODO: split the seed;
                 // don't discard it!!!
                 if (rid < 0) continue;
-                if (kb_size(tree))
-                {
-                    kb_intervalp(chn, tree, &tmp, &lower, &upper); // find the closest chain
 
-                    if (!lower || !test_and_merge(opt, l_pac, lower, &s, rid, tid))
-                        to_add = 1;
-                }
-                else to_add = 1;
-
-                //uint64_t tim = __rdtsc();
-                if (to_add) // add the seed as a new chain
-                {
-                    tmp.n = 1; tmp.m = SEEDS_PER_CHAIN;
-                    if((seedBufCount + tmp.m) > seedBufSize)
-                    {
-                        tmp.m += 1;
-                        tmp.seeds = (mem_seed_t *)calloc (tmp.m, sizeof(mem_seed_t));
-                        assert(tmp.seeds != NULL);
-                        tprof[PE13][tid]++;
-                    }
-                    else {
-                        tmp.seeds = seedBuf + seedBufCount;
-                        seedBufCount += tmp.m;
-                    }
-                    memset((char*) (tmp.seeds), 0, tmp.m * sizeof(mem_seed_t));
-                    tmp.seeds[0] = s;
-                    tmp.rid = rid;
-                    tmp.seqid = l;
-                    /* is_alt indexes the chain-side bns (original in --meth). */
-                    tmp.is_alt = !!chain_bns->anns[rid].is_alt;
-                    /* D3: carry the OT/OB hypothesis on the chain (-1 non-meth).
-                     * All seeds of one read share a hypothesis (directional
-                     * R1→OT / R2→OB), so test_and_merge needs no hypothesis
-                     * guard; new chains for the same read get the same label. */
-                    tmp.meth_hypothesis = meth_hyp;
-                    kb_putp(chn, tree, &tmp);
-                    num[l]++;
-                }
+                // Phase A: append the fully-resolved seed (drops above already
+                // consumed the SA slot). B1: copy the FULL mem_seed_t.
+                seed_rec_t *r = &recs[nrec++];
+                r->seed = s;
+                r->rid = rid;
+                r->meth_hyp = meth_hyp; // -1 when !meth_remap
+                r->orig_ix = (uint32_t)(nrec - 1);
             }
         } // seeds
+
+        // Phase B (order). Identity for SEED_ORDER_OFF; stable on orig_ix.
+        order_seeds(recs, nrec, opt->seed_emit_order);
+
+        // Phase C (chain). MOVED verbatim from the old per-seed body; sources
+        // s/rid/meth_hyp from the ordered buffer. S5: equal-pos insertion order
+        // into the kbtree is preserved (no dedup/compact beyond order_seeds).
+        for (int64_t ri = 0; ri < nrec; ++ri)
+        {
+            mem_seed_t s = recs[ri].seed;
+            int rid = recs[ri].rid;
+            int8_t meth_hyp = recs[ri].meth_hyp;
+            mem_chain_t tmp, *lower, *upper;
+            int to_add = 0;
+            tmp.pos = s.rbeg;
+
+            if (kb_size(tree))
+            {
+                kb_intervalp(chn, tree, &tmp, &lower, &upper); // find the closest chain
+
+                if (!lower || !test_and_merge(opt, l_pac, lower, &s, rid, tid))
+                    to_add = 1;
+            }
+            else to_add = 1;
+
+            //uint64_t tim = __rdtsc();
+            if (to_add) // add the seed as a new chain
+            {
+                tmp.n = 1; tmp.m = SEEDS_PER_CHAIN;
+                if((seedBufCount + tmp.m) > seedBufSize)
+                {
+                    tmp.m += 1;
+                    tmp.seeds = (mem_seed_t *)calloc (tmp.m, sizeof(mem_seed_t));
+                    assert(tmp.seeds != NULL);
+                    tprof[PE13][tid]++;
+                }
+                else {
+                    tmp.seeds = seedBuf + seedBufCount;
+                    seedBufCount += tmp.m;
+                }
+                memset((char*) (tmp.seeds), 0, tmp.m * sizeof(mem_seed_t));
+                tmp.seeds[0] = s;
+                tmp.rid = rid;
+                tmp.seqid = l;
+                /* is_alt indexes the chain-side bns (original in --meth). */
+                tmp.is_alt = !!chain_bns->anns[rid].is_alt;
+                /* D3: carry the OT/OB hypothesis on the chain (-1 non-meth).
+                 * All seeds of one read share a hypothesis (directional
+                 * R1→OT / R2→OB), so test_and_merge needs no hypothesis
+                 * guard; new chains for the same read get the same label. */
+                tmp.meth_hypothesis = meth_hyp;
+                kb_putp(chn, tree, &tmp);
+                num[l]++;
+            }
+        } // Phase C
 
         smem_ptr = pos + 1;
         size = kb_size(tree);
@@ -1363,6 +1414,7 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
     tprof[MEM_SA_BLOCK][tid] += __rdtsc() - tim;
 
     _mm_free(sa_coord);
+    free(recs);
 }
 
 int mem_kernel1_core(FMI_search *fmi,

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -81,6 +81,14 @@ typedef struct __smem_i smem_i;
  * mirror cell a real mismatch — variant-aware, truthful NM/MD. */
 enum mem_meth_scoring { MEM_METH_SCORING_COLLAPSED = 0, MEM_METH_SCORING_GENOMIC = 1 };
 
+typedef enum {
+    SEED_ORDER_OFF = 0,
+    SEED_ORDER_GLOBAL_LONGEST,
+    SEED_ORDER_LOCAL_LONGEST,
+    SEED_ORDER_ABSORB_COUNT,
+    SEED_ORDER_MOST_ABSORB
+} seed_order_t;
+
 typedef struct mem_opt_t {
     int a, b;               // match score and mismatch penalty
     int o_del, e_del;
@@ -96,6 +104,7 @@ typedef struct mem_opt_t {
     int flag;               // see MEM_F_* macros
     int min_seed_len;       // minimum seed length
     int min_ext_len;        // seeds shorter than this are not extended (0 = off)
+    seed_order_t seed_emit_order;  // --seed-order; SEED_ORDER_OFF = byte-identical
     int min_chain_weight;
     int max_chain_extend;
     float split_factor;     // split into a seed if MEM is longer than min_seed_len*split_factor

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -43,6 +43,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "bam_writer.h"
 #include "meth_bam.h"
 #include "stage_prof.h"
+#include "seed_order.h"
 #include "version.h"
 #include <sys/resource.h>
 #include "bwa_shm.h"
@@ -991,6 +992,10 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                 with >=INT genome occurrences (i.e. the supp region is repetitive on its\n");
     fprintf(stderr, "                 own). 0 disables (default). Typical values 5-20; lower = more aggressive.\n");
     fprintf(stderr, "                 Primary MAPQ is unaffected.\n");
+    fprintf(stderr, "Seed ordering (fg-labs extension):\n");
+    fprintf(stderr, "   --seed-order STR\n");
+    fprintf(stderr, "                 seed emission order before chaining: off|local-longest [off]\n");
+    fprintf(stderr, "                 (advanced modes: global-longest, absorb-count, most-absorb; see docs)\n");
     fprintf(stderr, "Input reader:\n");
     fprintf(stderr, "   --legacy-reader\n");
     fprintf(stderr, "                 use the legacy gzFile/kseq input reader instead of the default\n");
@@ -1104,6 +1109,7 @@ int main_mem(int argc, char *argv[])
         OPT_SUPP_REP_HARD_CAP,
         OPT_LEGACY_READER,
         OPT_MIN_EXT_LEN,
+        OPT_SEED_ORDER,
 #ifdef STAGE_PROF
         OPT_PROFILE,
 #endif
@@ -1117,6 +1123,7 @@ int main_mem(int argc, char *argv[])
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
         {"chimera-qc",               no_argument,       0, OPT_METH_CHIMERA_QC},
         {"supp-rep-hard-cap",        required_argument, 0, OPT_SUPP_REP_HARD_CAP},
+        {"seed-order",               required_argument, 0, OPT_SEED_ORDER},
         {"legacy-reader",            no_argument,       0, OPT_LEGACY_READER},
 #ifdef STAGE_PROF
         {"profile",                  required_argument, 0, OPT_PROFILE},
@@ -1297,6 +1304,16 @@ int main_mem(int argc, char *argv[])
             opt->supp_rep_hard_cap = (int)v;
         }
         else if (c == OPT_LEGACY_READER) aux.legacy_reader = 1;
+        else if (c == OPT_SEED_ORDER) {
+            opt->seed_emit_order = seed_order_from_str(optarg);
+            if ((int)opt->seed_emit_order < 0) {
+                fprintf(stderr, "[E::%s] unknown --seed-order '%s' (off|local-longest; "
+                        "see docs for advanced modes)\n", __func__, optarg);
+                free(opt);
+                if (out_opened) fclose(aux.fp);
+                return 1;
+            }
+        }
         else if (c == OPT_HELP) {
             usage(opt);
             free(opt);
@@ -1496,6 +1513,9 @@ int main_mem(int argc, char *argv[])
             return 1;
         }
     }
+
+    if (opt->seed_emit_order != SEED_ORDER_OFF)
+        fprintf(stderr, "[M::%s] seed order: %s\n", __func__, seed_order_to_str(opt->seed_emit_order));
 
     /* Load bwt2/FMI index */
     uint64_t tim = __rdtsc();

--- a/src/seed_order.cpp
+++ b/src/seed_order.cpp
@@ -1,0 +1,128 @@
+#include "seed_order.h"
+#include <cassert>
+#include <string.h>
+#include <vector>
+
+// Cap for the O(n^2) genomic modes (absorb-count, most-absorb). Above it, both
+// fall back to the O(n) global-longest ordering (which performs ~equivalently),
+// so neither matrix memory nor O(n^2) CPU blows up on pathological repeat reads.
+#define GENOMIC_ORDER_MAX_N 1024
+
+static const char *kNames[] = {
+    "off", "global-longest", "local-longest", "absorb-count", "most-absorb"
+};
+
+seed_order_t seed_order_from_str(const char *s) {
+    if (s)
+        for (int i = 0; i <= (int)SEED_ORDER_MOST_ABSORB; ++i)
+            if (strcmp(s, kNames[i]) == 0) return (seed_order_t)i;
+    return (seed_order_t)-1;
+}
+
+const char *seed_order_to_str(seed_order_t m) {
+    if ((int)m < 0 || (int)m > (int)SEED_ORDER_MOST_ABSORB) return "?";
+    return kNames[(int)m];
+}
+
+// Stable counting sort of recs[0..n) by key[i] in [0,maxk]. desc descends
+// (via maxk-key, preserving stability). scratch is reused across passes.
+static void counting_sort_by(seed_rec_t *recs, int n, std::vector<int> &key,
+                             int maxk, bool desc, std::vector<seed_rec_t> &scratch) {
+    if (desc) for (int i = 0; i < n; ++i) key[i] = maxk - key[i];
+    std::vector<int> cnt(maxk + 2, 0);
+    for (int i = 0; i < n; ++i) ++cnt[key[i] + 1];
+    for (int k = 1; k <= maxk + 1; ++k) cnt[k] += cnt[k - 1];   // start offsets
+    scratch.resize(n);
+    for (int i = 0; i < n; ++i) scratch[cnt[key[i]]++] = recs[i];  // stable, ascending
+    for (int i = 0; i < n; ++i) recs[i] = scratch[i];
+}
+
+static inline bool absorbs(const seed_rec_t &A, const seed_rec_t &B) {
+    if (A.rid != B.rid) return false;  // seeds on different chromosomes/contigs can't absorb each other
+    const mem_seed_t &a = A.seed, &b = B.seed;
+    bool qin = (b.qbeg >= a.qbeg) && (b.qbeg + b.len <= a.qbeg + a.len);
+    bool rin = (b.rbeg >= a.rbeg) && (b.rbeg + b.len <= a.rbeg + a.len);
+    if (!qin || !rin) return false;
+    if (a.len != b.len) return a.len > b.len;            // strictly larger
+    return A.orig_ix < B.orig_ix;                        // equal-size: lower ix wins
+}
+
+static int max_of(seed_rec_t *recs, int n, bool use_qbeg) {
+    int m = 0;
+    for (int i = 0; i < n; ++i) { int v = use_qbeg ? recs[i].seed.qbeg : recs[i].seed.len; if (v > m) m = v; }
+    return m;
+}
+
+void order_seeds(seed_rec_t *recs, int64_t n, seed_order_t mode) {
+    if (mode == SEED_ORDER_OFF || n < 2) return;
+    assert(n <= INT_MAX);
+    int ni = (int)n;
+    std::vector<seed_rec_t> scratch;
+    std::vector<int> key(ni);
+    switch (mode) {
+    case SEED_ORDER_GLOBAL_LONGEST: {
+        int mk = max_of(recs, ni, false);
+        for (int i = 0; i < ni; ++i) key[i] = recs[i].seed.len;
+        counting_sort_by(recs, ni, key, mk, /*desc=*/true, scratch);
+        break;
+    }
+    case SEED_ORDER_LOCAL_LONGEST: {
+        int mklen = max_of(recs, ni, false), mkq = max_of(recs, ni, true);
+        for (int i = 0; i < ni; ++i) key[i] = recs[i].seed.len;          // LSD: secondary first
+        counting_sort_by(recs, ni, key, mklen, /*desc=*/true, scratch);
+        for (int i = 0; i < ni; ++i) key[i] = recs[i].seed.qbeg;         // then primary qbeg asc
+        counting_sort_by(recs, ni, key, mkq, false, scratch);
+        break;
+    }
+    case SEED_ORDER_ABSORB_COUNT: {
+        if (ni > GENOMIC_ORDER_MAX_N) {   // O(n^2) count too costly; longest-first is ~equivalent and O(n)
+            order_seeds(recs, n, SEED_ORDER_GLOBAL_LONGEST);
+            break;
+        }
+        for (int i = 0; i < ni; ++i) {
+            int c = 0;
+            for (int j = 0; j < ni; ++j)
+                if (j != i && absorbs(recs[i], recs[j])) ++c;
+            key[i] = c;
+        }
+        counting_sort_by(recs, ni, key, ni - 1, /*desc=*/true, scratch);
+        break;
+    }
+    case SEED_ORDER_MOST_ABSORB: {
+        if (ni > GENOMIC_ORDER_MAX_N) {        // guard: n x n matrix + O(n^2) too costly; fall back O(n)
+            order_seeds(recs, n, SEED_ORDER_GLOBAL_LONGEST);
+            break;
+        }
+        std::vector<unsigned char> M((size_t)ni * ni, 0);
+        std::vector<int> rowsum(ni, 0);
+        for (int i = 0; i < ni; ++i)
+            for (int j = 0; j < ni; ++j)
+                if (j != i && absorbs(recs[i], recs[j])) { M[(size_t)i*ni + j] = 1; ++rowsum[i]; }
+        std::vector<char> consumed(ni, 0);
+        std::vector<seed_rec_t> out; out.reserve(ni);
+        for (int picked = 0; picked < ni; ++picked) {
+            int best = -1;
+            // Phase A assigns orig_ix in append order, so the buffer is in orig_ix order on entry;
+            // iterating i=0..ni-1 therefore breaks ties by orig_ix (lower orig_ix wins), as required.
+            for (int i = 0; i < ni; ++i) {       // max rowsum, tiebreak orig_ix (i is in ix order)
+                if (consumed[i]) continue;
+                if (best < 0 || rowsum[i] > rowsum[best]) best = i;
+            }
+            if (best < 0) break;
+            out.push_back(recs[best]);
+            consumed[best] = 1;
+            for (int j = 0; j < ni; ++j) {       // consume everything best absorbs
+                if (consumed[j] || !M[(size_t)best*ni + j]) continue;
+                consumed[j] = 1;
+                out.push_back(recs[j]);          // absorbed seeds still chained (dropped by chainer)
+                for (int i = 0; i < ni; ++i)     // decrement live absorbers of j (column j)
+                    if (!consumed[i] && M[(size_t)i*ni + j]) --rowsum[i];
+            }
+        }
+        assert((int)out.size() == ni);
+        for (int i = 0; i < ni; ++i) recs[i] = out[i];
+        break;
+    }
+    default: assert(0 && "unhandled seed_order_t in order_seeds"); break;
+    }
+}

--- a/src/seed_order.h
+++ b/src/seed_order.h
@@ -1,0 +1,32 @@
+#ifndef SEED_ORDER_H
+#define SEED_ORDER_H
+
+#include <stdint.h>
+#include "bwamem.h"   // mem_seed_t, seed_order_t
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// One resolved seed plus the metadata chaining needs. seed is the FULL
+// mem_seed_t (all 7 fields), default-constructed then field-filled exactly as
+// mem_chain_seeds does today. orig_ix is the strict resolve-order index and is
+// every comparator's final stable tiebreak (and the OFF identity key).
+typedef struct {
+    mem_seed_t seed;
+    int32_t    rid;
+    int8_t     meth_hyp;
+    uint32_t   orig_ix;
+} seed_rec_t;
+
+// Permute recs[0..n) in place per mode. OFF is a no-op. Stable on orig_ix.
+void order_seeds(seed_rec_t *recs, int64_t n, seed_order_t mode);
+
+// CLI parse: returns (seed_order_t)-1 on an unknown string.
+seed_order_t seed_order_from_str(const char *s);
+const char  *seed_order_to_str(seed_order_t m);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -150,7 +150,7 @@ endif
 
 unit: $(UNIT_BIN)
 
-$(UNIT_BIN): $(UNIT_OBJS) $(FRAMEWORK_LIB)
+$(UNIT_BIN): $(UNIT_OBJS) $(FRAMEWORK_LIB) ../libbwa.a
 	$(CXX) $(LDFLAGS) -o $@ $(UNIT_OBJS) $(FRAMEWORK_LIB) $(LIBS)
 
 $(UNIT_DIR)/%.o: $(UNIT_DIR)/%.cpp
@@ -163,7 +163,7 @@ INTEGRATION_BIN       := bwa_mem3_tests_integration
 
 integration: $(INTEGRATION_BIN)
 
-$(INTEGRATION_BIN): $(INTEGRATION_TEST_OBJS) $(FRAMEWORK_LIB)
+$(INTEGRATION_BIN): $(INTEGRATION_TEST_OBJS) $(FRAMEWORK_LIB) ../libbwa.a
 	$(CXX) $(LDFLAGS) -o $@ $(INTEGRATION_TEST_OBJS) $(FRAMEWORK_LIB) $(LIBS)
 
 # Integration tests use the framework headers; override the generic

--- a/test/unit/test_seed_order.cpp
+++ b/test/unit/test_seed_order.cpp
@@ -1,0 +1,137 @@
+// test/unit/test_seed_order.cpp — order_seeds + string mappers.
+#include <cstdint>
+#include <vector>
+#include "doctest/doctest.h"
+#include "seed_order.h"
+
+namespace {
+// Build a seed_rec_t with the fields order_seeds reads; orig_ix = emission index.
+seed_rec_t rec(int qbeg, int len, int64_t rbeg, int32_t rid, uint32_t ix) {
+    seed_rec_t r{};
+    r.seed.qbeg = qbeg; r.seed.len = len; r.seed.score = len;
+    r.seed.rbeg = rbeg; r.seed.n_hits = 1;
+    r.rid = rid; r.meth_hyp = -1; r.orig_ix = ix;
+    return r;
+}
+} // namespace
+
+TEST_CASE("seed_order string mappers round-trip") {
+    CHECK(seed_order_from_str("off") == SEED_ORDER_OFF);
+    CHECK(seed_order_from_str("global-longest") == SEED_ORDER_GLOBAL_LONGEST);
+    CHECK(seed_order_from_str("most-absorb") == SEED_ORDER_MOST_ABSORB);
+    CHECK((int)seed_order_from_str("bogus") == -1);
+    // advertised mode round-trips
+    CHECK(std::string(seed_order_to_str(SEED_ORDER_LOCAL_LONGEST)) == "local-longest");
+    // hidden modes still accepted by parser
+    CHECK(seed_order_from_str("most-absorb") == SEED_ORDER_MOST_ABSORB);
+}
+
+TEST_CASE("order_seeds OFF is the identity permutation") {
+    std::vector<seed_rec_t> v{rec(50,20,500,0,0), rec(0,150,1000,0,1), rec(20,20,200,0,2)};
+    order_seeds(v.data(), (int)v.size(), SEED_ORDER_OFF);
+    CHECK(v[0].orig_ix == 0);
+    CHECK(v[1].orig_ix == 1);
+    CHECK(v[2].orig_ix == 2);
+}
+
+TEST_CASE("global-longest: longest first, stable on ties") {
+    std::vector<seed_rec_t> v{rec(0,20,100,0,0), rec(0,150,200,0,1),
+                              rec(50,20,300,0,2), rec(10,20,400,0,3)};
+    order_seeds(v.data(), 4, SEED_ORDER_GLOBAL_LONGEST);
+    CHECK(v[0].orig_ix == 1);             // len 150 first
+    CHECK(v[1].orig_ix == 0);             // len-20 ties keep orig_ix order: 0,2,3
+    CHECK(v[2].orig_ix == 2);
+    CHECK(v[3].orig_ix == 3);
+}
+
+TEST_CASE("local-longest: group by qbeg asc, then longest within group") {
+    std::vector<seed_rec_t> v{rec(10,20,100,0,0), rec(0,20,200,0,1), rec(0,40,300,0,2)};
+    order_seeds(v.data(), 3, SEED_ORDER_LOCAL_LONGEST);
+    CHECK(v[0].orig_ix == 2);             // qbeg 0, len 40
+    CHECK(v[1].orig_ix == 1);             // qbeg 0, len 20
+    CHECK(v[2].orig_ix == 0);             // qbeg 10
+}
+
+TEST_CASE("global-longest: stable on equal len (large n, counting sort)") {
+    // 1000 seeds all len 50 -> every key equal -> output MUST stay orig_ix order.
+    std::vector<seed_rec_t> v;
+    for (uint32_t i = 0; i < 1000; ++i) v.push_back(rec(0, 50, 100 + i, 0, i));
+    order_seeds(v.data(), 1000, SEED_ORDER_GLOBAL_LONGEST);
+    for (uint32_t i = 0; i < 1000; ++i) CHECK(v[i].orig_ix == i);  // stability preserved
+}
+
+TEST_CASE("local-longest: equal-len within a qbeg group is stable on orig_ix") {
+    // qbeg 0: two len-40 seeds (orig 0,1) then a len-20 (orig 2).
+    std::vector<seed_rec_t> v{rec(0,40,100,0,0), rec(0,40,200,0,1), rec(0,20,300,0,2)};
+    order_seeds(v.data(), 3, SEED_ORDER_LOCAL_LONGEST);
+    CHECK(v[0].orig_ix == 0);   // equal len 40 -> stable: orig 0 before 1
+    CHECK(v[1].orig_ix == 1);
+    CHECK(v[2].orig_ix == 2);   // len 20 last
+}
+
+TEST_CASE("absorb-count: container with both q and r nested ranks first") {
+    // A spans all; B,C nested in BOTH q and r -> A absorbs 2.
+    std::vector<seed_rec_t> v{
+        rec(20,20,120,0,0),   // B
+        rec(0,150,100,0,1),   // A (q[0,150] r[100,250]) contains B and C
+        rec(50,20,150,0,2)};  // C
+    order_seeds(v.data(), 3, SEED_ORDER_ABSORB_COUNT);
+    CHECK(v[0].orig_ix == 1);  // A absorbs 2 -> first
+    CHECK(v[1].orig_ix == 0);  // B and C both absorb 0, stable orig_ix order: 0 before 2
+    CHECK(v[2].orig_ix == 2);
+}
+
+TEST_CASE("absorb-count: query-nested but reference-disjoint is NOT absorbed") {
+    // B's query is inside A's, but B.rbeg is far from A -> different locus, no absorb.
+    std::vector<seed_rec_t> v{
+        rec(0,150,100,0,0),     // A, ref [100,250]
+        rec(20,20,9000,0,1)};   // B, q nested but ref [9000,9020] disjoint
+    order_seeds(v.data(), 2, SEED_ORDER_ABSORB_COUNT);
+    // Both absorb 0 -> stable orig_ix order preserved.
+    CHECK(v[0].orig_ix == 0);
+    CHECK(v[1].orig_ix == 1);
+}
+
+TEST_CASE("most-absorb: transitive A>B>C emits A first, consumes B and C") {
+    // A q[0,100] r[0,100]; B q[10,40] r[10,40] in A; C q[15,25] r[15,25] in B and A.
+    std::vector<seed_rec_t> v{
+        rec(15,11,15,0,0),    // C
+        rec(10,31,10,0,1),    // B (absorbs C)
+        rec(0,101,0,0,2)};    // A (absorbs B and C)
+    order_seeds(v.data(), 3, SEED_ORDER_MOST_ABSORB);
+    CHECK(v[0].orig_ix == 2);  // A first (rowsum 2)
+}
+
+TEST_CASE("most-absorb: second pick is max-absorber of the remainder") {
+    // A absorbs B. D absorbs E. A and D disjoint loci.
+    // Absorbed seeds are appended immediately after their absorber, so output is:
+    //   A(0), B(1), D(2), E(3)  -- both absorbers emitted before any non-absorbed seed.
+    std::vector<seed_rec_t> v{
+        rec(0,100,0,0,0),       // A absorbs B
+        rec(10,20,10,0,1),      // B
+        rec(0,100,5000,0,2),    // D absorbs E (far locus)
+        rec(10,20,5010,0,3)};   // E
+    order_seeds(v.data(), 4, SEED_ORDER_MOST_ABSORB);
+    // Absorbers A(0) and D(2) are at positions 0 and 2; absorbed B(1) and E(3) follow each.
+    CHECK((v[0].orig_ix == 0 || v[0].orig_ix == 2));
+    CHECK((v[2].orig_ix == 0 || v[2].orig_ix == 2));
+    CHECK(v[0].orig_ix != v[2].orig_ix);
+}
+
+TEST_CASE("genomic modes fall back to global-longest above GENOMIC_ORDER_MAX_N") {
+    // n > 1024 -> both most-absorb and absorb-count delegate to global-longest
+    // (O(n) longest-first), avoiding the O(n^2) count / n*n matrix. Verify each
+    // produces exactly the global-longest ordering on a large, varied input.
+    const int N = 1100;  // > GENOMIC_ORDER_MAX_N (1024)
+    std::vector<seed_rec_t> base;
+    for (uint32_t i = 0; i < (uint32_t)N; ++i)
+        base.push_back(rec(0, 20 + (int)(i % 50), 100 + i, 0, i));  // varied len -> non-trivial order
+    std::vector<seed_rec_t> want = base, ma = base, ac = base;
+    order_seeds(want.data(), N, SEED_ORDER_GLOBAL_LONGEST);
+    order_seeds(ma.data(),   N, SEED_ORDER_MOST_ABSORB);
+    order_seeds(ac.data(),   N, SEED_ORDER_ABSORB_COUNT);
+    for (int i = 0; i < N; ++i) {
+        CHECK(ma[i].orig_ix == want[i].orig_ix);  // most-absorb fallback == global-longest
+        CHECK(ac[i].orig_ix == want[i].orig_ix);  // absorb-count fallback == global-longest
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `--seed-order` option to `bwa-mem3 mem` that reorders each read's SA-resolved seeds before chaining. The default (`off`) is byte-identical to previous output; the option lets the maximal seed anchor its chain first and absorb shorter contained sub-seeds, cutting banded Smith-Waterman extensions (~60% of `mem` CPU) by ~9% on real WGS — a ~10% end-to-end wall-time win — at flat accuracy.

## Default vs opt-in (byte-identity)

The PR refactors `mem_chain_seeds` into three phases — resolve every SA hit into a per-read buffer, reorder per the strategy, then run the existing kbtree chaining. With `--seed-order off` (the default) the reorder is the identity permutation, so output is **byte-identical** to `origin/main`, verified at 1M reads on WGS and WES, single-end and paired-end, and `-t1` vs `-t8`. Non-`off` modes are **not** byte-identical: they shift secondary / `XA` / `XS` / `HN` reporting and a small number of primaries — they change what is *reported*, not where reads map — so they are opt-in and the default stays `off`.

## Modes

`--seed-order <mode>`, default `off`. `--help` advertises `off` and `local-longest` (the recommended fast mode); three advanced modes — `global-longest`, `absorb-count`, `most-absorb` — are accepted but unadvertised, kept for research and reproducibility.

## Measured results (50k real WGS reads, 1kg-HG00096, hg38)

| mode | absorbed seeds | extended seeds | vs off |
|---|---|---|---|
| off (default) | 38.2% | 1,345,994 | — |
| local-longest | 43.7% | 1,225,857 | −8.9% |
| global-longest | 43.7% | 1,226,082 | −8.9% |
| absorb-count | 43.5% | 1,230,766 | −8.5% |
| most-absorb | 43.5% | 1,229,053 | −8.7% |

The genomic strategies (`absorb-count`, `most-absorb`) are correct but do not beat the simpler longest-first ordering, so `local-longest` is recommended. The O(n²) genomic modes fall back to the O(n) longest-first ordering above a size cap, so neither matrix memory nor CPU blows up on pathological repeat reads.

## Validation

- **Byte-identity of `off` vs `origin/main`** — verified at **1M reads** on WGS (1kg-HG00096) *and* WES (1kg-HG00100), single-end and paired-end, plus `-t1`/`-t8` determinism: all bit-for-bit identical (2.0M+ records per paired run).
- **Wall-time** (1M WGS PE, `-t8`, including the ~11 GB index load): `off` 38.8 s → `local-longest` 34.9 s, **~10% faster end-to-end**; the alignment-phase speedup is larger since the fixed index-load cost is bundled in. Easy-profile holodeck F1 is flat (~94.4%, no regression vs `off`).
- 71 unit tests (`test/unit/test_seed_order.cpp`): counting-sort stability, the genomic containment predicate, the `most-absorb` greedy (including transitive containment), and the large-n fallback.
- Not a Smith-Waterman kernel change, so the `bwa-bsw-bench` gate does not apply.

## Suggested reading order

1. `feat(seeding):` — the resolve→order→chain refactor and the `seed_order` module (the byte-identical foundation; start here).
2. `feat(cli):` — the `--seed-order` option.
3. `chore(test):` — relink the unit binary when `libbwa.a` changes.
4. `docs(mem):` — mdbook documentation.

## Follow-ups (separate PRs)

- Output-neutral SMEM-interval dedup (~10.5% fewer SA lookups on WGS; default-eligible since it changes no output).
- Order-independent contained-seed dedup (would make the win order-invariant and could obviate the flag; needs DP chaining or a hard-data F1 gate).
- Hard-data F1 gate (divergent/indel/short-read, GIAB) before flipping any non-`off` mode to default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `--seed-order` option to control how seeds are ordered before chaining, including a recommended “longest-first” mode and additional opt-in modes.
* **Documentation**
  * Documented `--seed-order` behavior and how non-default modes affect chaining/alignments, with examples and an updated modes summary.
  * Added entries to the optimization checklist and “what’s different” pages for seed ordering.
* **Bug Fixes / Reliability**
  * Preserved the prior default behavior when seed ordering is left off.
* **Tests / Chores**
  * Improved build dependency tracking for test binaries and added unit tests for seed ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->