### PR TITLE
feat(mem): add --fast speed preset

### DIFF
--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -17,7 +17,7 @@ Options:
     -m INT        perform at most INT rounds of mate rescues for each read [50]
     -S            skip mate rescue
     -P            skip pairing; mate rescue performed unless -S also in use
-    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup (and -s 0
+    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup (and -s 2
                   under --meth). Opt-in; explicit flags override where applicable;
                   --smem-dedup is always enabled. NOT byte-identical to the default
                   (divergence confined to the low-confidence tail).

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -17,6 +17,10 @@ Options:
     -m INT        perform at most INT rounds of mate rescues for each read [50]
     -S            skip mate rescue
     -P            skip pairing; mate rescue performed unless -S also in use
+    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup (and -s 0
+                  under --meth). Opt-in; explicit flags override where applicable;
+                  --smem-dedup is always enabled. NOT byte-identical to the default
+                  (divergence confined to the low-confidence tail).
 Scoring options:
    -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [1]
    -B INT        penalty for a mismatch [4]

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -43,6 +43,11 @@ No extra flags. Use this when you are:
 bwa-mem3 mem -t <N> -m 10 -y 0 ref.fa R1.fq R2.fq > out.sam
 ```
 
+> **Shorthand:** `bwa-mem3 mem --fast` applies `-m 10 -y 0 --min-ext-len 30
+> --smem-dedup` (and `-s 0` under `--meth`) in one flag. Explicit flags still
+> override individual levers where applicable; `--smem-dedup` is always enabled.
+> See [`mem` → `--fast`](../cli/mem.md#--fast--speed-preset-opt-in-not-byte-identical).
+
 Use this for new pipelines, or once a drop-in migration is validated and you want bwa-mem3's best
 speed/accuracy trade-off. Current recommended deviations:
 

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -188,40 +188,50 @@ many placements as it sacrifices (net within noise), so there is no cheap middle
 
 ## Short-seed extension: `--min-ext-len 30`
 
-`--min-ext-len INT` drops seeds shorter than `INT` bp before banded Smith–Waterman, so their
-extension never runs (off by default, `0` → byte-identical to baseline). Extension is ~60% of `mem`
-CPU and almost all of it is spent on short seeds — seeds ≤40 bp hold ~90% of all banded-SW *cells*
-yet are ~99% wasted, because long seeds already resolve via the ungapped fast-path. Skipping them
+`--min-ext-len INT` skips banded Smith–Waterman extension of seeds shorter than `INT` bp **in chains
+that still hold a longer anchor seed** — those short seeds are collinear with the anchor, whose
+extension already covers them, so dropping them is near output-neutral and pure speed. A chain whose
+seeds are *all* short is left untouched, so the filter never empties a chain and never drops a read;
+such all-short chains (common on low-mappability / repetitive loci) extend exactly as the default
+does. Off by default (`0` → byte-identical to baseline). Extension is ~60% of `mem` CPU and almost
+all of it is spent on short seeds — seeds ≤40 bp hold ~90% of all banded-SW *cells* yet are ~99%
+wasted, because long seeds already resolve via the ungapped fast-path. Skipping the *redundant* ones
 thins the extension stage without touching seeding or chaining.
 
-**The accuracy change is confined to reads that were already low-confidence.** On real HG002 1M PE
-WGS at `--min-ext-len 30`, 0.40% of reads change, and profiling every one of them against the
-population shows the cost lands entirely on reads that were *already* marginal — heavily soft-clipped
-partial alignments (median 95 of 150 bp clipped), high edit distance, or multi-mappers. **Zero**
-confidently, uniquely mapped reads (MAPQ ≥ 60, NM ≤ 1, no soft-clip) regress. Like `-m 10`, the
-mapped count only ever *decreases* (≈0.11% newly unmapped; it essentially never newly maps a
-previously-unmapped read), and the reads whose locus changes are repeat/paralog churn with
-sub-2-mismatch score deltas — about 1 in 4 of which the filter actually *improves*. On simulated
-clean Illumina and indel-rich data the change is nil-to-positive even at larger thresholds.
+> **Recall-safe (non-emptying filter).** Earlier releases dropped *every* short seed unconditionally,
+> which emptied all-short chains and silently unmapped reads whose only evidence was short —
+> negligible on clean WGS but catastrophic on low-mappability short-read data (a 151 bp
+> low-mappability sample lost 63% of its mappings). The current filter only drops a short seed when a
+> longer anchor survives in the same chain, making it a *strict recall improvement*: it can reduce
+> extension work but can never lose a read.
 
-**In exchange, alignment CPU drops ~10–20% single-thread**, largest on data carrying many short
-seeds (real WGS sees more than idealized simulated reads). Because the speedup thins extension rather
-than speeding seeding — and seeding dominates the wall — the wall-clock gain is smaller than the
-~90% banded-SW *cell* reduction would suggest.
+**The accuracy change is small, confined to low-confidence reads, and costs no recall.** On real
+HG002 1M PE WGS at `--min-ext-len 30` (non-emptying filter), the mapped count is unchanged from
+default (99.75% both), and only ~0.10% of reads change locus — down from ~0.40% under the old
+emptying filter, because the reads that used to vanish now map identically to default. The locus
+changes concentrate in the low-confidence tail (repeat/paralog churn); ~0.005% of reads (≈100 of
+2 M) change at MAPQ ≥ 60.
 
-**Contraindication — very high per-base error.** On degraded-chemistry or cross-species libraries
-(per-base error well above modern Illumina), every seed is short, so some correct alignments depend
-*solely* on short seeds and the cost rises sharply (e.g. at 2–15% simulated substitution error, F1
-−0.2% at `30`, growing to −1.4% at `40` and a cliff at `50`). Keep `--min-ext-len` low or off for
-such data. **Indels and structural variants are *not* a contraindication** — an indel splits a read
-into two still-long exact segments that the fast-path handles, so indel-rich data is free.
+**In exchange, alignment CPU drops ~10% single-thread at `--min-ext-len 30`** (measured −9.5%
+`main_mem` on HG002 WGS-1M), largest on data carrying many short seeds. Because the speedup thins
+extension rather than speeding seeding — and seeding dominates the wall — the wall-clock gain is
+smaller than the ~90% banded-SW *cell* reduction would suggest.
 
-`30` is the accuracy-safe knee; `40`–`50` give a little more speed on known-clean data but trade
-accuracy as divergence rises. The CPU win is confirmed cross-architecture: on Graviton4/Linux
-(c8g) the same single-thread sweep gives realistic **+15.8%** and HG002 **+20.5%** (T=0→T=30),
-matching macOS — the filter is algorithmic, so it ports. Remaining before this graduates from
-"recommended for standard-error reads" to an unqualified default: a multi-thread + broader
-[bwa-mem3-bench](../related-projects/bwa-mem3-bench.md) run (all current figures are single-thread).
+**Higher thresholds no longer cliff.** Because all-short chains are now protected, raising
+`--min-ext-len` to `40`–`50` no longer drops reads: on HG002 WGS-1M the mapped count holds at 99.75%
+and divergence stays ~0.10% across `30`–`50`. The previously-documented high-error F1 cliff (F1
+−1.4% at `40`, a cliff at `50` on 2–15% simulated substitution error) was a property of the
+*emptying* behavior — its mechanism, correct alignments carried *solely* on short seeds being
+dropped, is exactly what the non-emptying filter now protects — so it is expected to be largely
+removed, **pending re-validation** of the simulated-error sweep under the new filter. **Indels and
+structural variants were never a contraindication** — an indel splits a read into two still-long
+exact segments the fast-path handles, so indel-rich data is free.
+
+`30` remains the recommended value. **Validation status:** the non-emptying filter changes the
+observable output of `--min-ext-len` (and therefore `--fast`), so the cross-architecture speed
+figures and the golden-truth F1 sweep need a fresh
+[bwa-mem3-bench](../related-projects/bwa-mem3-bench.md) run (multi-thread, all regimes) before
+`--min-ext-len` / `--fast` graduate from "recommended" to an unqualified default.
 
 ## Speed: drop-in and recommended
 

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -16,7 +16,7 @@ with explicit flags — so upgrading bwa-mem3 never silently changes your alignm
 | Your situation | Profile | Invocation |
 |---|---|---|
 | Migrating a bwa-mem2 pipeline, or validating against bwa/bwa-mem2 | **Drop-in** | `bwa-mem3 mem` (no extra flags) |
-| New pipeline, or migration already validated | **Recommended** | `bwa-mem3 mem -m 10 -y 0` (add `-s 0` under `--meth`) |
+| New pipeline, or migration already validated | **Recommended** | `bwa-mem3 mem -m 10 -y 0` (add `-s 2` under `--meth`) |
 
 > bwa-mem3 is already, by design, *not* byte-identical to bwa-mem2 even at default settings
 > (additive SAM tags, per-architecture SIMD `score2`/MAPQ convergence, deterministic tie-breaks, a
@@ -44,7 +44,7 @@ bwa-mem3 mem -t <N> -m 10 -y 0 ref.fa R1.fq R2.fq > out.sam
 ```
 
 > **Shorthand:** `bwa-mem3 mem --fast` applies `-m 10 -y 0 --min-ext-len 30
-> --smem-dedup` (and `-s 0` under `--meth`) in one flag. Explicit flags still
+> --smem-dedup` (and `-s 2` under `--meth`) in one flag. Explicit flags still
 > override individual levers where applicable; `--smem-dedup` is always enabled.
 > See [`mem` → `--fast`](../cli/mem.md#--fast--speed-preset-opt-in-not-byte-identical).
 
@@ -55,7 +55,7 @@ speed/accuracy trade-off. Current recommended deviations:
 |---|---|---|---|
 | `-m` (mate-rescue depth) | 50 | **10** | ~11–22% less alignment CPU; near-neutral accuracy (see below) |
 | `-y` (3rd-round seeding occurrence) | 20 | **0** | ~11–30% less alignment CPU; F1 near-neutral across regimes (within ±0.02; better on divergent/repeat — see below) |
-| `-s` (Pass-2 re-seed width), **`--meth` only** | 10 | **0** | ~20% less alignment CPU; near-neutral accuracy (see below) |
+| `-s` (Pass-2 re-seed width), **`--meth` only** | 10 | **2** | light re-seed: ~same speed as `-s 0` but recovers the MAPQ/placement `-s 0` lost (see below) |
 | `--min-ext-len` (skip short-seed extension), **standard-error reads** | 0 | **30** | ~10–20% less alignment CPU; accuracy change confined to the already-low-confidence tail (see below) |
 
 This table will grow as we benchmark additional tunings; each entry is gated on the same
@@ -64,7 +64,7 @@ This table will grow as we benchmark additional tunings; each entry is gated on 
 For a bisulfite (`--meth`) pipeline the recommended invocation is therefore:
 
 ```bash
-bwa-mem3 mem -t <N> --meth -m 10 -s 0 -y 0 ref.fa R1.fq R2.fq > out.sam
+bwa-mem3 mem -t <N> --meth -m 10 -s 2 -y 0 ref.fa R1.fq R2.fq > out.sam
 ```
 
 ## Mate-rescue depth: `-m 10`
@@ -146,7 +146,19 @@ alignment CPU (~50–63 %), but round 2 *is* genuine split-read/divergence sensi
 bin). Use `-y 0 -r 10` only on known-clean, low-divergence libraries; `-y 0` alone is the
 broadly-safe recommendation.
 
-## Pass-2 re-seeding under `--meth`: `-s 0`
+## Pass-2 re-seeding under `--meth`: `-s 2`
+
+> **`--fast --meth` uses `-s 2` (light Pass-2 re-seed), not `-s 0`.** Earlier releases set `-s 0`
+> (no re-seed). Read-level analysis on holodeck sim reads showed `-s 0` **inflates MAPQ**: the affected
+> reads map on occurrence-1 SMEMs that hide an *interior* repeat only Pass-2 would surface, so without
+> it they look uniquely placed and MAPQ is pushed toward 60 — the calibration caveat noted below, now
+> quantified. `-s 2` re-seeds exactly those occurrence-1 SMEMs (the cheap subset), recovering MAPQ
+> **and** placement at ≈ the speed of `-s 0` (3.6× vs 3.25× on twist-em-seq 5M; MAPQ matches the `-s 10`
+> default on 85/86 changed reads; placement 97.6% = default). This is the "cheap middle ground" the
+> read-confidence fallback at the end of this section did not find (it re-seeds by SMEM *occurrence*,
+> not by read confidence). **Validation status:** the `-s 0` recall/speed figures below are the
+> genome-wide em-seq bench; the `-s 2` MAPQ/placement recovery is read-level + chr1 sim, with a
+> genome-wide em-seq re-run pending.
 
 `-s` controls bwa-mem's Pass-2 "re-seeding" — after the first seeding pass, long super-maximal exact
 matches whose occurrence count is `≤ -s` are re-seeded from their midpoint to recover shorter, more

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -241,9 +241,10 @@ exact segments the fast-path handles, so indel-rich data is free.
 
 `30` remains the recommended value. **Validation status:** the non-emptying filter changes the
 observable output of `--min-ext-len` (and therefore `--fast`), so the cross-architecture speed
-figures and the golden-truth F1 sweep need a fresh
-[bwa-mem3-bench](../related-projects/bwa-mem3-bench.md) run (multi-thread, all regimes) before
-`--min-ext-len` / `--fast` graduate from "recommended" to an unqualified default.
+figures and the golden-truth F1 sweep warrant a fresh
+[bwa-mem3-bench](../related-projects/bwa-mem3-bench.md) run (multi-thread, all regimes) to confirm
+these `--fast` accuracy figures genome-wide. `--min-ext-len` and `--fast` stay opt-in; the drop-in
+defaults are unchanged.
 
 ## Speed: drop-in and recommended
 

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -217,12 +217,14 @@ very short, low-confidence chains.
 
 #### `--min-ext-len INT` — skip Smith-Waterman extension of short seeds
 
-Off by default (`0`) → output byte-identical to baseline. When `INT > 0`, seeds
-shorter than `INT` bp are dropped before banded Smith-Waterman, so their
-extension never runs (~10–20 % less alignment CPU). `30` is the recommended,
-accuracy-safe value for standard-error reads; keep it low or off for very
-high-error libraries. For the benchmarks, recommended value, and the high-error
-contraindication, see
+Off by default (`0`) → output byte-identical to baseline. When `INT > 0`, a short
+seed (< `INT` bp) is dropped before banded Smith-Waterman **only if its chain
+still has a longer anchor seed** — its extension is then redundant (the anchor
+already covers it), so skipping it is near output-neutral (~10 % less alignment
+CPU at `30`). A chain whose seeds are *all* short is left untouched, so the filter
+never empties a chain or drops a read: it is recall-safe by construction. `30` is
+the recommended value. For the benchmarks, behavior details, and validation
+status, see
 [Settings profiles → `--min-ext-len 30`](../best-practices/settings-profiles.md#short-seed-extension---min-ext-len-30).
 
 #### `-h INT[,INT]` — secondary alignment reporting

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -253,7 +253,10 @@ the alignment score and mapping quality for each secondary hit.
 bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup
 ```
 
-Under `--meth` it additionally sets `-s 0` (drop Pass-2 re-seeding).
+Under `--meth` it additionally sets `-s 2` (light Pass-2 re-seeding). Earlier releases
+used `-s 0` (no re-seed), which inflated MAPQ on bisulfite reads; `-s 2` recovers the
+MAPQ/placement at nearly the same speed. See
+[Settings profiles → Pass-2 re-seeding](../best-practices/settings-profiles.md#pass-2-re-seeding-under---meth--s-2).
 
 Each lever is applied only if you did not set it explicitly, so explicit flags
 win where applicable (`--fast -m 30` keeps `-m 30`); `--smem-dedup` is always

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -241,6 +241,26 @@ hit reporting with `-h`. Default: 0.80.
 Outputs `XB` in place of `XA`. `XB` is an extension of `XA` that also carries
 the alignment score and mapping quality for each secondary hit.
 
+### Speed preset
+
+#### `--fast` — speed preset (opt-in, not byte-identical)
+
+`--fast` is a one-flag shorthand for the characterized speed levers:
+
+```text
+bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup
+```
+
+Under `--meth` it additionally sets `-s 0` (drop Pass-2 re-seeding).
+
+Each lever is applied only if you did not set it explicitly, so explicit flags
+win where applicable (`--fast -m 30` keeps `-m 30`); `--smem-dedup` is always
+enabled and cannot be opted back out of once `--fast` is set. Output is **not**
+byte-identical to the default; the accuracy cost of each lever is characterized in
+[Settings profiles](../best-practices/settings-profiles.md) and is confined to
+the already-low-confidence tail. `bwa-mem3 mem` prints the resolved preset to
+stderr (`[M::main_mem] --fast: ...`) so runs are self-documenting.
+
 ### Methylation (`--meth`)
 
 #### `--meth` — enable bisulfite alignment mode

--- a/docs/src/whats-different/features.md
+++ b/docs/src/whats-different/features.md
@@ -193,44 +193,48 @@ analysis](https://github.com/fg-labs/bwa-mem3/pull/187) for the full characteriz
 
 ## `--min-ext-len` short-seed extension filter
 
-`--min-ext-len INT` opts into skipping banded Smith-Waterman extension of seeds
-shorter than `INT` bp. Off by default (`0`) → output byte-identical to baseline.
+`--min-ext-len INT` opts into skipping banded Smith-Waterman extension of short
+seeds (< `INT` bp) **that sit in a chain with a longer anchor seed** — the
+anchor's extension already covers them, so their own extension is redundant. Off
+by default (`0`) → output byte-identical to baseline.
 
 Smith-Waterman extension is ~60 % of `bwa-mem3 mem` CPU, and almost all of it is
 spent on short seeds: seeds ≤40 bp hold roughly **90 % of all banded-SW cells**
 yet are ~99 % wasted, because long seeds already resolve via the ungapped
-fast-path at near-zero cost. `--min-ext-len` drops the short seeds before
+fast-path at near-zero cost. The filter drops those redundant short seeds before
 extension (`mem_chain_drop_short_seeds`, a stable in-place compaction of each
 chain's seeds, called from `mem_flt_chained_seeds` in `src/bwamem.cpp`), so their
 extension never runs while seeding and chaining are untouched.
 
-Measured single-thread on hg38:
+**Recall-safe by construction.** A chain whose seeds are *all* short is left
+intact — dropping its only evidence would unmap the read — so the filter never
+empties a chain. (An earlier version dropped every short seed unconditionally,
+which silently unmapped low-mappability reads: a 151 bp low-mappability sample
+lost 63 % of its mappings. The anchor guard fixes this; it is a strict recall
+improvement that can reduce work but never lose a read.)
 
-- **Real HG002 1M PE WGS: ~20 % lower alignment CPU at `--min-ext-len 30`.** The
-  accuracy effect is confined to reads that were already low-confidence — 0.40 %
-  of reads change (mostly partial, heavily soft-clipped, or repeat/multi-mapping
-  reads); **zero** confidently and uniquely mapped reads (MAPQ ≥ 60, NM ≤ 1,
-  no soft-clip) regress.
-- Simulated clean Illumina and indel-rich data: free (F1 unchanged or slightly
-  better, even at larger thresholds).
-- The only workload with a real accuracy cost is very high per-base error
-  (degraded chemistry, cross-species) — there, every seed is short, so some
-  correct alignments depend solely on short seeds. Indels and structural variants
-  are *not* a contraindication: an indel leaves two still-long exact segments
-  that the fast-path handles.
-- Confirmed cross-architecture: Graviton4/Linux reproduces the win (realistic
-  +15.8 %, HG002 +20.5 %), matching macOS — the speedup is algorithmic, not
-  microarch tuning.
+Measured single-thread on hg38 (HG002 1M PE WGS, non-emptying filter):
 
-`30` is the recommended opt-in value (accuracy-safe across clean, indel-rich, and
-moderately-divergent data); `40`–`50` are also safe on known-clean data but cost
-accuracy as divergence rises. Because the speedup is thinning the extension stage
-— not faster seeding — the wall-clock gain is smaller than the cell-count
-reduction would suggest (seeding, which the filter does not touch, dominates
-runtime). See
+- **~10 % lower `main_mem` CPU at `--min-ext-len 30` (−9.5 % measured), with no
+  recall loss** — mapped count is identical to default (99.75 %). ~0.10 % of
+  reads change locus (down from ~0.40 % under the old emptying filter), confined
+  to the low-confidence tail; ~0.005 % of reads change at MAPQ ≥ 60.
+- **Higher thresholds no longer cliff:** mapped count and ~0.10 % divergence hold
+  flat across `30`–`50`, because all-short chains are now protected.
+- The previously-documented high-error F1 cliff and the cross-architecture speed
+  figures were measured under the *emptying* behavior; both need a fresh
+  [bwa-mem3-bench](../related-projects/bwa-mem3-bench.md) run under the
+  non-emptying filter. Indels and structural variants were never a
+  contraindication (an indel leaves two still-long exact segments the fast-path
+  handles).
+
+`30` is the recommended opt-in value. Because the speedup thins the extension
+stage — not seeding — the wall-clock gain is smaller than the cell-count
+reduction suggests (seeding, which the filter does not touch, dominates runtime).
+See
 [CLI → mem `--min-ext-len`](../cli/mem.md#--min-ext-len-int--skip-smith-waterman-extension-of-short-seeds)
 and
-[Settings profiles](../best-practices/settings-profiles.md#why-we-recommend---min-ext-len-30-standard-error-reads)
+[Settings profiles](../best-practices/settings-profiles.md#short-seed-extension---min-ext-len-30)
 for the recommended operating point.
 
 ---

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -681,15 +681,27 @@ void mem_print_chain(const bntseq_t *bns, mem_chain_v *chn)
     }
 }
 
-// Skip-short-seed extension filter: drop seeds shorter than min_ext_len from a
-// chain in place, so they are never extended (their banded Smith-Waterman is
-// skipped downstream). Stable compaction -- surviving seeds keep their order.
-// Returns the new seed count. min_ext_len <= 0 is a no-op, which keeps default
-// output byte-identical to baseline.
+// Skip-short-seed extension filter: in a chain that still has a long-enough
+// anchor, drop seeds shorter than min_ext_len so they are never extended (their
+// banded Smith-Waterman is skipped downstream) -- those short seeds are collinear
+// with the anchor and its extension already covers them, so dropping them is
+// near output-neutral and pure speed.
+//
+// A chain with NO seed >= min_ext_len is left untouched: its only evidence is
+// short, so dropping it would empty the chain and the read would go unmapped.
+// Such all-short chains (common on low-mappability / repetitive reads) therefore
+// extend exactly as the default does. This guarantees the filter never empties a
+// non-empty chain, so it can only reduce extension work, never lose a read.
+//
+// Stable compaction -- surviving seeds keep their order. Returns the new seed
+// count. min_ext_len <= 0 is a no-op (default), byte-identical to baseline.
 int mem_chain_drop_short_seeds(mem_chain_t *c, int min_ext_len)
 {
     if (min_ext_len <= 0) return c->n;
     int j, k;
+    for (j = 0; j < c->n; ++j)
+        if (c->seeds[j].len >= min_ext_len) break;
+    if (j == c->n) return c->n;            /* no anchor: all-short chain, leave intact */
     for (j = k = 0; j < c->n; ++j)
         if (c->seeds[j].len >= min_ext_len)
             c->seeds[k++] = c->seeds[j];
@@ -725,8 +737,10 @@ void mem_flt_chained_seeds(const mem_opt_t *opt, const bntseq_t *bns, const uint
         // read lengths -- dropping seeds inside that loop would no-op on the main
         // workload. Off (min_ext_len==0): no-op, output byte-identical.
         mem_chain_drop_short_seeds(c, opt->min_ext_len);
-        if (c->n == 0) continue;  /* CodeRabbit: drop_short_seeds can empty the
-                                   * chain; the meth block below reads seeds[0]. */
+        if (c->n == 0) continue;  /* Defensive: drop_short_seeds never empties a
+                                   * non-empty chain (it leaves all-short chains
+                                   * intact), but the meth block below reads
+                                   * seeds[0], so guard regardless. */
 
         /* D3 (--meth, PR-4): swap to the original read + per-hypothesis matrix. */
         const int8_t *mat = opt->mat;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -938,7 +938,7 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
     fprintf(stderr, "    -S            skip mate rescue\n");
     fprintf(stderr, "    -P            skip pairing; mate rescue performed unless -S also in use\n");
-    fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup (and -s 0\n");
+    fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup (and -s 2\n");
     fprintf(stderr, "                  under --meth). Opt-in; explicit flags override where applicable;\n");
     fprintf(stderr, "                  --smem-dedup is always enabled. NOT byte-identical to the default\n");
     fprintf(stderr, "                  (divergence confined to the low-confidence tail).\n");
@@ -1433,7 +1433,11 @@ int main_mem(int argc, char *argv[])
         if (!opt0.min_ext_len)  opt->min_ext_len  = 30;  /* --min-ext-len 30 */
         opt->smem_dedup = 1;                             /* --smem-dedup (plain on/off) */
         if (opt->meth_mode && !opt0.split_width)
-            opt->split_width = 0;                        /* -s 0 (meth only) */
+            opt->split_width = 2;                        /* -s 2 (meth only): light Pass-2 reseed.
+                                                          * -s 0 (no reseed) inflates MAPQ on bisulfite
+                                                          * reads (interior-repeat competitors go unfound);
+                                                          * -s 2 reseeds the occurrence-1 SMEMs that inflate,
+                                                          * recovering MAPQ+placement at ~the same speed. */
     }
 
     /* Meth-mode default tuning. bwameth.py runs bwa as

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -938,6 +938,10 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
     fprintf(stderr, "    -S            skip mate rescue\n");
     fprintf(stderr, "    -P            skip pairing; mate rescue performed unless -S also in use\n");
+    fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup (and -s 0\n");
+    fprintf(stderr, "                  under --meth). Opt-in; explicit flags override where applicable;\n");
+    fprintf(stderr, "                  --smem-dedup is always enabled. NOT byte-identical to the default\n");
+    fprintf(stderr, "                  (divergence confined to the low-confidence tail).\n");
     fprintf(stderr, "Scoring options:\n");
     fprintf(stderr, "   -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [%d]\n", opt->a);
     fprintf(stderr, "   -B INT        penalty for a mismatch [%d]\n", opt->b);
@@ -1071,6 +1075,7 @@ int main_mem(int argc, char *argv[])
     int          fixed_chunk_size          = -1;
     char        *p, *rg_line               = 0, *hdr_line = 0;
     const char  *mode                      = 0;
+    int          fast                      = 0;
 
     mem_opt_t    *opt, opt0;
     gzFile        fp = 0, fp2 = 0;
@@ -1112,6 +1117,7 @@ int main_mem(int argc, char *argv[])
         OPT_MIN_EXT_LEN,
         OPT_SEED_ORDER,
         OPT_SMEM_DEDUP,
+        OPT_FAST,
 #ifdef STAGE_PROF
         OPT_PROFILE,
 #endif
@@ -1121,6 +1127,7 @@ int main_mem(int argc, char *argv[])
         {"bam",                      optional_argument, 0, OPT_BAM},
         {"min-ext-len",              required_argument, 0, OPT_MIN_EXT_LEN},
         {"smem-dedup",               no_argument,       0, OPT_SMEM_DEDUP},
+        {"fast",                     no_argument,       0, OPT_FAST},
         {"meth",                     no_argument,       0, OPT_METH},
         {"meth-scoring",             required_argument, 0, OPT_METH_SCORING},
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
@@ -1318,6 +1325,7 @@ int main_mem(int argc, char *argv[])
             }
         }
         else if (c == OPT_SMEM_DEDUP) opt->smem_dedup = 1;
+        else if (c == OPT_FAST) fast = 1;
         else if (c == OPT_HELP) {
             usage(opt);
             free(opt);
@@ -1410,6 +1418,23 @@ int main_mem(int argc, char *argv[])
             return 1;
         }
     } else update_a(opt, &opt0);
+
+    /* --fast: one-flag shorthand for the characterized speed levers
+     *   -m 10  -y 0  --min-ext-len 30  --smem-dedup   (+ -s 0 under --meth).
+     * Mirrors the -x preset: each lever is applied only when the user did not
+     * set it explicitly (opt0), so explicit flags win where applicable. The one
+     * exception is --smem-dedup, which is forced on unconditionally (no opt-out).
+     * Output is NOT byte-identical to the default; divergence is confined to the
+     * low-confidence tail (see docs/best-practices/settings-profiles.md).
+     * meth_mode is already resolved here (parsed in the getopt loop above). */
+    if (fast) {
+        if (!opt0.max_matesw)   opt->max_matesw   = 10;  /* -m 10 */
+        if (!opt0.max_mem_intv) opt->max_mem_intv = 0;   /* -y 0  */
+        if (!opt0.min_ext_len)  opt->min_ext_len  = 30;  /* --min-ext-len 30 */
+        opt->smem_dedup = 1;                             /* --smem-dedup (plain on/off) */
+        if (opt->meth_mode && !opt0.split_width)
+            opt->split_width = 0;                        /* -s 0 (meth only) */
+    }
 
     /* Meth-mode default tuning. bwameth.py runs bwa as
      * `bwa mem -T 40 -B 2 -L 10 -CM`, adding `-U 100 -p` for paired-end. We adopt
@@ -1520,6 +1545,14 @@ int main_mem(int argc, char *argv[])
 
     if (opt->seed_emit_order != SEED_ORDER_OFF)
         fprintf(stderr, "[M::%s] seed order: %s\n", __func__, seed_order_to_str(opt->seed_emit_order));
+    if (fast) {
+        if (opt->meth_mode)
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup -s %d\n",
+                    __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->split_width);
+        else
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup\n",
+                    __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len);
+    }
 
     /* Load bwt2/FMI index */
     uint64_t tim = __rdtsc();

--- a/test/fast_preset_test.sh
+++ b/test/fast_preset_test.sh
@@ -2,7 +2,7 @@
 # test/fast_preset_test.sh
 #
 # Asserts that `bwa-mem3 mem --fast` resolves the four characterized speed
-# levers (-m 10 -y 0 --min-ext-len 30 --smem-dedup, plus -s 0 under --meth),
+# levers (-m 10 -y 0 --min-ext-len 30 --smem-dedup, plus -s 2 under --meth),
 # that explicit user flags override the preset, and that the default path is
 # untouched when --fast is absent.
 #
@@ -70,25 +70,25 @@ echo "OK:   explicit -m/-y/--min-ext-len override only their field; rest of pres
     || { echo "FAIL: audit line present without --fast" >&2; exit 1; }
 echo "OK:   no --fast => no audit line (default path untouched)"
 
-# 4. Meth path: --fast --meth additionally sets -s 0. Build a meth index on a
+# 4. Meth path: --fast --meth additionally sets -s 2. Build a meth index on a
 #    copy of phiX; if meth indexing is unavailable in this build, SKIP.
 cp "$ref" "$mdir/ref.fa"
 if "$bin" index --meth "$mdir/ref.fa" >/dev/null 2>&1; then
     "$bin" mem --meth --fast -t 1 "$mdir/ref.fa" "$reads" >/dev/null 2>"$err" \
         || { echo "FAIL: mem --meth --fast nonzero" >&2; cat "$err" >&2; exit 1; }
     line="$(grep -E '^\[M::main_mem\] --fast:' "$err" || true)"
-    [[ "$line" == *"-s 0"* ]] \
-        || { echo "FAIL: --fast --meth should resolve -s 0: '$line'" >&2; exit 1; }
-    echo "OK:   --fast --meth additionally sets -s 0"
-    # Explicit -s wins even under --meth (src/fastmap.cpp: -s 0 is gated on !opt0.split_width).
+    [[ "$line" == *"-s 2"* ]] \
+        || { echo "FAIL: --fast --meth should resolve -s 2: '$line'" >&2; exit 1; }
+    echo "OK:   --fast --meth additionally sets -s 2"
+    # Explicit -s wins even under --meth (src/fastmap.cpp: -s 2 is gated on !opt0.split_width).
     "$bin" mem --meth --fast -s 7 -t 1 "$mdir/ref.fa" "$reads" >/dev/null 2>"$err" \
         || { echo "FAIL: mem --meth --fast -s 7 nonzero" >&2; cat "$err" >&2; exit 1; }
     line="$(grep -E '^\[M::main_mem\] --fast:' "$err" || true)"
     [[ "$line" == *"-s 7"* ]] \
         || { echo "FAIL: explicit -s 7 should win under --meth: '$line'" >&2; exit 1; }
-    echo "OK:   explicit -s 7 overrides --fast --meth's -s 0"
+    echo "OK:   explicit -s 7 overrides --fast --meth's -s 2"
 else
-    echo "SKIP: index --meth unavailable; meth -s 0 case not checked" >&2
+    echo "SKIP: index --meth unavailable; meth -s 2 case not checked" >&2
 fi
 
 echo "PASS: fast_preset_test"

--- a/test/fast_preset_test.sh
+++ b/test/fast_preset_test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# test/fast_preset_test.sh
+#
+# Asserts that `bwa-mem3 mem --fast` resolves the four characterized speed
+# levers (-m 10 -y 0 --min-ext-len 30 --smem-dedup, plus -s 0 under --meth),
+# that explicit user flags override the preset, and that the default path is
+# untouched when --fast is absent.
+#
+# The assertion surface is the audit line main_mem prints to stderr when
+# --fast is active: it reports the *resolved* mem_opt_t values, so an explicit
+# override is visible in the line itself.
+#
+# Usage: test/fast_preset_test.sh <bwa-mem3-binary> <fixtures-dir>
+set -euo pipefail
+
+[[ $# -eq 2 ]] || { echo "usage: $0 <bwa-mem3-binary> <fixtures-dir>" >&2; exit 2; }
+bin="$1"; fixtures="$2"
+src_ref="$fixtures/phix.fa"; reads="$fixtures/reads.fa"
+
+[[ -x "$bin" ]]     || { echo "FAIL: binary not executable: $bin" >&2; exit 1; }
+[[ -s "$src_ref" ]] || { echo "FAIL: phix.fa missing: $src_ref" >&2; exit 1; }
+[[ -s "$reads" ]]   || { echo "FAIL: reads.fa missing: $reads" >&2; exit 1; }
+
+err="$(mktemp)"; mdir="$(mktemp -d)"
+trap 'rm -f "$err"; rm -rf "$mdir"' EXIT
+
+# Index a private copy of phiX in temp space so the test never writes derived
+# index files into the (possibly read-only or shared) fixtures tree. The meth
+# path below does the same; keep both hermetic. The copy is always fresh, so
+# index unconditionally.
+ref="$mdir/phix.fa"
+cp "$src_ref" "$ref"
+"$bin" index "$ref" >/dev/null 2>&1 || { echo "FAIL: index phix.fa" >&2; exit 1; }
+
+# Run mem with extra args; echo the resolved --fast audit line (empty if none).
+fast_line() {
+    "$bin" mem "$@" "$ref" "$reads" >/dev/null 2>"$err" \
+        || { echo "FAIL: mem exited nonzero (args: $*)" >&2; cat "$err" >&2; exit 1; }
+    grep -E '^\[M::main_mem\] --fast:' "$err" || true
+}
+
+# 1. Bundle correctness (non-meth).
+line="$(fast_line --fast)"
+[[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
+   && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* ]] \
+    || { echo "FAIL: --fast bundle wrong: '$line'" >&2; exit 1; }
+[[ "$line" != *"-s "* ]] \
+    || { echo "FAIL: non-meth --fast must not set -s: '$line'" >&2; exit 1; }
+echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup"
+
+# 2. Override precedence: an explicit flag wins *only* for its own field; the
+#    rest of the preset (including the unconditional --smem-dedup) must survive.
+line="$(fast_line --fast -m 30)"
+[[ "$line" == *"-m 30"* && "$line" == *"-y 0"* \
+   && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* ]] \
+    || { echo "FAIL: explicit -m 30 should only override -m: '$line'" >&2; exit 1; }
+line="$(fast_line --fast -y 5)"
+[[ "$line" == *"-m 10"* && "$line" == *"-y 5"* \
+   && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* ]] \
+    || { echo "FAIL: explicit -y 5 should only override -y: '$line'" >&2; exit 1; }
+line="$(fast_line --fast --min-ext-len 45)"
+[[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
+   && "$line" == *"--min-ext-len 45"* && "$line" == *"--smem-dedup"* ]] \
+    || { echo "FAIL: explicit --min-ext-len 45 should only override min-ext-len: '$line'" >&2; exit 1; }
+echo "OK:   explicit -m/-y/--min-ext-len override only their field; rest of preset survives"
+
+# 3. Default contract: no --fast => no audit line at all.
+"$bin" mem "$ref" "$reads" >/dev/null 2>"$err" || { echo "FAIL: plain mem nonzero" >&2; exit 1; }
+! grep -qE '^\[M::main_mem\] --fast:' "$err" \
+    || { echo "FAIL: audit line present without --fast" >&2; exit 1; }
+echo "OK:   no --fast => no audit line (default path untouched)"
+
+# 4. Meth path: --fast --meth additionally sets -s 0. Build a meth index on a
+#    copy of phiX; if meth indexing is unavailable in this build, SKIP.
+cp "$ref" "$mdir/ref.fa"
+if "$bin" index --meth "$mdir/ref.fa" >/dev/null 2>&1; then
+    "$bin" mem --meth --fast -t 1 "$mdir/ref.fa" "$reads" >/dev/null 2>"$err" \
+        || { echo "FAIL: mem --meth --fast nonzero" >&2; cat "$err" >&2; exit 1; }
+    line="$(grep -E '^\[M::main_mem\] --fast:' "$err" || true)"
+    [[ "$line" == *"-s 0"* ]] \
+        || { echo "FAIL: --fast --meth should resolve -s 0: '$line'" >&2; exit 1; }
+    echo "OK:   --fast --meth additionally sets -s 0"
+    # Explicit -s wins even under --meth (src/fastmap.cpp: -s 0 is gated on !opt0.split_width).
+    "$bin" mem --meth --fast -s 7 -t 1 "$mdir/ref.fa" "$reads" >/dev/null 2>"$err" \
+        || { echo "FAIL: mem --meth --fast -s 7 nonzero" >&2; cat "$err" >&2; exit 1; }
+    line="$(grep -E '^\[M::main_mem\] --fast:' "$err" || true)"
+    [[ "$line" == *"-s 7"* ]] \
+        || { echo "FAIL: explicit -s 7 should win under --meth: '$line'" >&2; exit 1; }
+    echo "OK:   explicit -s 7 overrides --fast --meth's -s 0"
+else
+    echo "SKIP: index --meth unavailable; meth -s 0 case not checked" >&2
+fi
+
+echo "PASS: fast_preset_test"

--- a/test/min_ext_len_safety_test.sh
+++ b/test/min_ext_len_safety_test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# test/min_ext_len_safety_test.sh
+#
+# Guards the --min-ext-len recall-safety invariant (the "non-emptying" filter,
+# mem_chain_drop_short_seeds): a chain with no seed >= min_ext_len is left
+# untouched, so the filter can never empty a chain and never lose a read. A
+# min_ext_len larger than any possible seed therefore makes EVERY chain all-short
+# -> every chain untouched -> output identical to default.
+#
+# Regression for the smoke-1M collapse: the previous (emptying) filter dropped
+# every seed < min_ext_len unconditionally, so reads whose only seeds were short
+# (low-mappability / repetitive) went unmapped -- 63% of a real 151bp WGS sample.
+# Under that behavior a huge --min-ext-len would unmap (nearly) everything; under
+# the fixed filter it is a no-op.
+#
+# Usage: test/min_ext_len_safety_test.sh <bwa-mem3-binary> <fixtures-dir>
+set -euo pipefail
+
+[[ $# -eq 2 ]] || { echo "usage: $0 <bwa-mem3-binary> <fixtures-dir>" >&2; exit 2; }
+bin="$1"; fixtures="$2"
+ref="$fixtures/phix.fa"; reads="$fixtures/reads.fa"
+
+[[ -x "$bin" ]]   || { echo "FAIL: binary not executable: $bin" >&2; exit 1; }
+[[ -s "$ref" ]]   || { echo "FAIL: phix.fa missing: $ref" >&2; exit 1; }
+[[ -s "$reads" ]] || { echo "FAIL: reads.fa missing: $reads" >&2; exit 1; }
+
+if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.amb" || ! -s "$ref.ann" || ! -s "$ref.pac" ]]; then
+    "$bin" index "$ref" >/dev/null 2>&1 || { echo "FAIL: index phix.fa" >&2; exit 1; }
+fi
+
+d="$(mktemp -d)"; trap 'rm -rf "$d"' EXIT
+
+# Alignment records only (strip @ header lines, whose @PG CL: differs by flags).
+# -t 1 for deterministic output. A min-ext-len far above any seed length makes
+# every chain all-short, which the fixed filter must leave untouched.
+"$bin" mem -t 1                     "$ref" "$reads" 2>/dev/null | grep -v '^@' > "$d/default.sam"
+"$bin" mem -t 1 --min-ext-len 1000000 "$ref" "$reads" 2>/dev/null | grep -v '^@' > "$d/huge.sam"
+
+[[ -s "$d/default.sam" ]] || { echo "FAIL: default run produced no alignment records" >&2; exit 1; }
+
+# 1. Core invariant: no read is lost. Count mapped records (FLAG bit 0x4 clear);
+#    int($2/4)%2==0 is pure arithmetic so it works in any awk (no and()).
+dmap=$(awk 'int($2/4)%2==0' "$d/default.sam" | wc -l | tr -d ' ')
+hmap=$(awk 'int($2/4)%2==0' "$d/huge.sam"    | wc -l | tr -d ' ')
+[[ "$dmap" -gt 0 ]] || { echo "FAIL: default mapped 0 records -- fixture cannot exercise the test" >&2; exit 1; }
+[[ "$dmap" == "$hmap" ]] \
+    || { echo "FAIL: huge --min-ext-len dropped reads ($dmap mapped at default vs $hmap)" >&2; exit 1; }
+echo "OK:   huge --min-ext-len keeps all $dmap mapped records (filter never empties a chain)"
+
+# 2. Stronger: the whole alignment block is byte-identical to default, since every
+#    chain is all-short and therefore untouched.
+if diff -q "$d/default.sam" "$d/huge.sam" >/dev/null; then
+    echo "OK:   huge --min-ext-len output byte-identical to default (all-short chains untouched)"
+else
+    echo "FAIL: huge --min-ext-len diverged from default output" >&2
+    diff "$d/default.sam" "$d/huge.sam" | head -10 >&2
+    exit 1
+fi
+
+echo "PASS: min_ext_len_safety_test"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -123,6 +123,13 @@ ok "help_prescan_test"
 "$HERE/fast_preset_test.sh" "$BWAMEM3" "$FIXTURES" || fail "fast_preset_test failed"
 ok "fast_preset_test"
 
+# --- min_ext_len_safety_test ----------------------------------------------
+# The --min-ext-len short-seed filter must never empty a chain: an all-short
+# chain is left intact, so a huge --min-ext-len is a no-op (== default), not a
+# read-dropping cliff. Regression for the smoke-1M low-mappability collapse.
+"$HERE/min_ext_len_safety_test.sh" "$BWAMEM3" "$FIXTURES" || fail "min_ext_len_safety_test failed"
+ok "min_ext_len_safety_test"
+
 # --- smem_lockstep_parity_test --------------------------------------------
 OUT="$(cd "$HERE" && ./smem_lockstep_parity_test "$FIXTURES/phix.fa" 2>&1)"
 CASES_PASSED="$(echo "$OUT" | sed -nE 's/^([0-9]+) \/ ([0-9]+) cases passed$/\1/p')"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -117,6 +117,12 @@ ok "meth_sidecar_enrich_test"
 "$HERE/help_prescan_test.sh" "$BWAMEM3" "$FIXTURES" || fail "help_prescan_test failed"
 ok "help_prescan_test"
 
+# --- fast_preset_test -----------------------------------------------------
+# --fast bundles the four characterized speed levers; explicit flags override;
+# default path stays clean. Asserts on the resolved-opts audit line.
+"$HERE/fast_preset_test.sh" "$BWAMEM3" "$FIXTURES" || fail "fast_preset_test failed"
+ok "fast_preset_test"
+
 # --- smem_lockstep_parity_test --------------------------------------------
 OUT="$(cd "$HERE" && ./smem_lockstep_parity_test "$FIXTURES/phix.fa" 2>&1)"
 CASES_PASSED="$(echo "$OUT" | sed -nE 's/^([0-9]+) \/ ([0-9]+) cases passed$/\1/p')"

--- a/test/unit/test_min_ext_len.cpp
+++ b/test/unit/test_min_ext_len.cpp
@@ -1,7 +1,10 @@
 // Unit tests for the --min-ext-len short-seed extension filter
-// (mem_chain_drop_short_seeds). The filter drops seeds shorter than the
-// threshold from a chain so they are never extended; min_ext_len <= 0 is a
-// no-op (default), which keeps output byte-identical to baseline.
+// (mem_chain_drop_short_seeds). In a chain that still holds a seed >=
+// min_ext_len (an anchor), seeds shorter than the threshold are dropped so they
+// are never extended. A chain with NO such anchor -- every seed shorter than the
+// threshold -- is left untouched, so the filter never empties a chain and never
+// loses a read (recall-safety invariant). min_ext_len <= 0 is a no-op (default),
+// which keeps output byte-identical to baseline.
 
 #include "doctest/doctest.h"
 #include "bwamem.h"
@@ -85,11 +88,14 @@ TEST_CASE("boundary: seed length == threshold is kept (>=)"
     CHECK(drop_short(seeds, 30) == std::vector<int>{30, 31});
 }
 
-TEST_CASE("all seeds shorter than threshold -> empty chain"
+TEST_CASE("all seeds shorter than threshold -> chain left intact (non-emptying)"
           * doctest::test_suite("unit/min_ext_len"))
 {
+    // No seed >= 30 means there is no anchor whose extension covers the short
+    // seeds, so the filter must leave the chain untouched rather than empty it
+    // (recall-safety: an all-short chain is a read's only evidence).
     auto seeds = make_seeds({10, 19, 25});
-    CHECK(drop_short(seeds, 30).empty());
+    CHECK(drop_short(seeds, 30) == std::vector<int>{10, 19, 25});
 }
 
 TEST_CASE("all seeds at least threshold -> all kept"


### PR DESCRIPTION
## Summary

Adds an opt-in `--fast` flag to `bwa-mem3 mem` bundling four already-merged, individually-characterized speed levers, plus two correctness fixes to levers the preset relies on (one surfaced by benchmarking `--fast`, one by a read-level meth investigation).

```
bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup
```

Under `--meth` it additionally applies **`-s 2`** (light Pass-2 re-seed). Every lever already exists as a discrete opt-in flag (#168, #169, #171, #187); `--fast` is the one-flag shorthand for the recommended profile in `best-practices/settings-profiles.md`.

## `--fast` semantics

- **Mirrors the `-x` mode preset.** Each lever applies only if the user didn't set it explicitly (`opt0`), so explicit flags win (`--fast -m 30` keeps `-m 30`). `--smem-dedup` is set unconditionally.
- **Default path is byte-identical.** Preset block + audit line are gated on `--fast`.
- **Auditable.** `mem` prints the resolved levers to stderr: `[M::main_mem] --fast: -m 10 -y 0 --min-ext-len 30 --smem-dedup` (`+ -s 2` under `--meth`).

`--fast` output is **not** byte-identical to default; divergence is confined to the low-confidence tail.

## Fix 1 — `--min-ext-len` recall-safety (non-emptying short-seed filter)

Benchmarking surfaced a collapse on a 151 bp low-mappability sample: only **20%** of reads mapped vs **83%** at default. Root cause: `--min-ext-len` dropped *every* short seed, emptying chains whose seeds were all short → those reads went unmapped. Fix: drop a short seed only when its chain retains a longer anchor; a no-anchor chain is left intact, so the filter never empties a chain and never loses a read. Re-validated on HG002 WGS-1M: no recall loss at `--min-ext-len 30/40/50` (99.75% = default), divergence ~0.10% (down from ~0.40%), speedup retained.

## Fix 2 — `--fast --meth` uses `-s 2`, not `-s 0`

A read-level investigation (holodeck sim + em-seq) found `-s 0` (Pass-2 reseed off) **inflates MAPQ** on bisulfite reads: the affected reads map on occurrence-1 SMEMs hiding an *interior* repeat that only Pass-2 surfaces, so without reseed they look uniquely placed and MAPQ is pushed toward 60 (`chain_n_hits` is 1 for these, so no repeat signal catches it). At N=1000 sim, `-s 0` mis-set MAPQ on 86 reads (all upward) and moved ~1.2% of reads (mostly already-ambiguous, plus a few gross mismaps).

`-s 2` reseeds exactly those occurrence-1 SMEMs — the cheap subset — recovering MAPQ **and** placement at ~the same speed:

| meth arm (twist-em-seq 5M, main_mem) | speedup | MAPQ match/86 (target=`-s 10`) | placement (chr1 sim) |
|---|---|---|---|
| `-s 0` (old) | 3.25× | 34 (inflated) | 97.35% |
| **`-s 2` (new)** | **3.60×** | **85** | **97.60%** = default |
| `-s 10` (full reseed) | 1.74× | (target) | 97.75% |

`-s 2` is *faster* than `-s 0` and near-fully recovers accuracy. The `-s` speed knob does **not** transfer to non-meth (4-letter seeds aren't repetitive enough — confirmed on WGS-5M: `-s 2` gives 1.01× / no speedup), so non-meth `--fast` is unchanged.

## Benchmark — `--fast` end-to-end (HG002 WGS 1M PE → GRCh38, Apple M2 Max, NEON, `-t 12`)

| Metric | Default | `--fast` | Δ |
|---|---:|---:|---:|
| Wall-clock (hyperfine mean) | 35.33 s | 18.96 s | **−46.3% (1.86×)** |
| CPU time | 352.3 s | 172.5 s | **−51.0% (2.04×)** |
| Alignment compute (`main_mem`) | 33.78 s | 18.68 s | **−44.7% (1.81×)** |

Concordance vs default: divergence concentrated in the low-confidence tail; only **0.17%** of primaries diverge at MAPQ60+.

## Tests
- `test/fast_preset_test.sh` — resolved bundle, override precedence, default-clean, meth `-s 2` path (+ explicit `-s` override).
- `test/min_ext_len_safety_test.sh` — huge `--min-ext-len` must be byte-identical to default (recall-cliff guard).
- Full unit suite passes; docs build clean. No SW-kernel file touched.

## Validation status
`--min-ext-len` (non-emptying) and `--fast --meth -s 2` change observable output, so a genome-wide [bwa-mem3-bench](https://github.com/fg-labs/bwa-mem3) F1/em-seq run would confirm these `--fast` accuracy figures beyond the read-level + chr1-sim analysis here (`-s 2`'s 5M speed is already genome-wide real data). **This PR changes no defaults** — plain `mem` is byte-identical to before, all lever defaults (`-s 10`, `-c 500`, `--min-ext-len 0`) are unchanged, and `--fast` is entirely opt-in.

## Out of scope (deliberate)
- Uncharacterized generic knobs (`-k`/`-c`/`-w`/`-d`/…) — separate study. `-c` representative-cap explored during the meth dig: real speed but `-c 5` diverges 37% on non-meth WGS, so not bundled.
- Docs-flagged regressions (`-S`/`-m 0`, `-y 0 -r 10`) and `--bam=0`.

## Commits
- `feat(mem): add --fast preset bundling characterized speed levers`
- `docs(mem): document the --fast speed preset`
- `fix(seeding): make --min-ext-len recall-safe (non-emptying short-seed filter)`
- `fix(mem): --fast --meth uses -s 2 (light reseed), not -s 0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `bwa-mem3 mem --fast` speed preset with resolved-option reporting; it auto-enables `--smem-dedup`.
  * Under `--meth`, the preset defaults to `-s 2` when `-s/--split_width` isn’t explicitly set, with clear per-flag precedence behavior.

* **Documentation**
  * Updated `--min-ext-len` guidance to emphasize recall-safe, non-emptying short-seed extension filtering and revised related recommendations/performance notes.

* **Tests**
  * Added integration and safety tests for `--fast` resolution/overrides and for `--min-ext-len` “never lose reads” invariants.
  * Extended the unit test harness to run the new scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
