### PR TITLE
refactor(kswv): drop duplicate F warm-up prefetch in kswv512_16

### DIFF
--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -3290,7 +3290,6 @@ int kswv::kswv512_16_impl(int16_t seq1SoA[],
     _mm_prefetch((const char*) seq2SoA, _MM_HINT_T1);
     _mm_prefetch((const char*) seq1SoA, _MM_HINT_NTA);
     _mm_prefetch((const char*) (H1 + SIMD_WIDTH16), _MM_HINT_T0);
-    _mm_prefetch((const char*) (F + SIMD_WIDTH16), _MM_HINT_T0);
 
     for (int i=ncol; i >= 0; i--) {
         _mm512_store_si512((__m512*) (H0 + i * SIMD_WIDTH16), zero512);


### PR DESCRIPTION
## Summary

Removes a duplicate warm-up prefetch in the AVX-512 16-bit mate-rescue kernel `kswv512_16`. Its per-strip warm-up block issued **five** prefetches where **four** were intended — `F + SIMD_WIDTH16` was prefetched twice (a copy-paste duplicate), while `seq2SoA` / `seq1SoA` / `H1` were each prefetched once:

```c
_mm_prefetch((const char*) (F  + SIMD_WIDTH16), _MM_HINT_T0);   // F
_mm_prefetch((const char*) seq2SoA,             _MM_HINT_T1);
_mm_prefetch((const char*) seq1SoA,             _MM_HINT_NTA);
_mm_prefetch((const char*) (H1 + SIMD_WIDTH16), _MM_HINT_T0);
_mm_prefetch((const char*) (F  + SIMD_WIDTH16), _MM_HINT_T0);   // ← removed (dup of the first)
```

After this change the block matches the four-array warm-up of every other kswv kernel (`kswv_neon_u8/16`, `kswv256_u8`, `kswv512_u8`, and the AVX2 8-bit path).

## Impact

Pure hygiene. Prefetch is an architecturally inert locality hint, so output is **byte-identical**, and there's **no measurable perf effect** — the removed prefetch targeted an address already in flight from the first `F` prefetch on the line above.

## Validation

Byte-identity holds by construction (prefetch cannot change results). `kswv512_16` is AVX-512-only and does not compile on arm64, so it isn't exercised by a local NEON `bwa-bsw-bench` golden run — this relies on x86 CI for the build. Happy to run the x86 rescue-mode golden gate on an AVX-512 box if preferred before merge, though the change is inert by inspection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved low-level processing behavior by removing an unnecessary memory prefetch, which may help keep performance more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->