### PR TITLE
feat(mem): add --skip-contained-ext and enable it under --fast

### DIFF
--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -12,6 +12,7 @@ Options:
     -y INT        seed occurrence for the 3rd round seeding [20]
     -c INT        skip seeds with more than INT occurrences [500]
     --smem-dedup  dedup identical SMEMs before chaining: fewer SA lookups, ~10% fewer; opt-in, NOT byte-identical (changes XS/secondary on a small fraction of reads) [off]
+    --skip-contained-ext  skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed; byte-identical (non-meth), ~10% less alignment CPU; no effect under --meth [off]
     -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [0.50]
     -W INT        discard a chain if seeded bases shorter than INT [0]
     -m INT        perform at most INT rounds of mate rescues for each read [50]

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -18,10 +18,11 @@ Options:
     -m INT        perform at most INT rounds of mate rescues for each read [50]
     -S            skip mate rescue
     -P            skip pairing; mate rescue performed unless -S also in use
-    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup (and -s 2
-                  under --meth). Opt-in; explicit flags override where applicable;
-                  --smem-dedup is always enabled. NOT byte-identical to the default
-                  (divergence confined to the low-confidence tail).
+    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup
+                  --skip-contained-ext (and -s 2 under --meth). Opt-in; explicit
+                  flags override where applicable; --smem-dedup and
+                  --skip-contained-ext are always enabled. NOT byte-identical to
+                  the default (divergence confined to the low-confidence tail).
 Scoring options:
    -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [1]
    -B INT        penalty for a mismatch [4]

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -44,8 +44,11 @@ bwa-mem3 mem -t <N> -m 10 -y 0 ref.fa R1.fq R2.fq > out.sam
 ```
 
 > **Shorthand:** `bwa-mem3 mem --fast` applies `-m 10 -y 0 --min-ext-len 30
-> --smem-dedup` (and `-s 2` under `--meth`) in one flag. Explicit flags still
-> override individual levers where applicable; `--smem-dedup` is always enabled.
+> --smem-dedup --skip-contained-ext` (and `-s 2` under `--meth`) in one flag.
+> Explicit flags still override individual levers where applicable; `--smem-dedup`
+> and `--skip-contained-ext` are forced on with no opt-out. `--skip-contained-ext`
+> no-ops under `--meth` (its own internal gate disables it there), so on a `--meth`
+> run the effective levers are `-m 10 -y 0 --min-ext-len 30 --smem-dedup -s 2`.
 > See [`mem` → `--fast`](../cli/mem.md#--fast--speed-preset-opt-in-not-byte-identical).
 
 Use this for new pipelines, or once a drop-in migration is validated and you want bwa-mem3's best

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -250,8 +250,12 @@ the alignment score and mapping quality for each secondary hit.
 `--fast` is a one-flag shorthand for the characterized speed levers:
 
 ```text
-bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup
+bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext
 ```
+
+`--skip-contained-ext` is byte-identical to the default on non-meth single- and paired-end
+reads and no-ops under `--meth` (via its own internal gate), so it is pure upside where it
+applies (~10% lower alignment CPU on long-read inputs) and safe elsewhere.
 
 Under `--meth` it additionally sets `-s 2` (light Pass-2 re-seeding). Earlier releases
 used `-s 0` (no re-seed), which inflated MAPQ on bisulfite reads; `-s 2` recovers the
@@ -259,8 +263,9 @@ MAPQ/placement at nearly the same speed. See
 [Settings profiles → Pass-2 re-seeding](../best-practices/settings-profiles.md#pass-2-re-seeding-under---meth--s-2).
 
 Each lever is applied only if you did not set it explicitly, so explicit flags
-win where applicable (`--fast -m 30` keeps `-m 30`); `--smem-dedup` is always
-enabled and cannot be opted back out of once `--fast` is set. Output is **not**
+win where applicable (`--fast -m 30` keeps `-m 30`); `--smem-dedup` and
+`--skip-contained-ext` are always enabled and cannot be opted back out of once
+`--fast` is set. Output is **not**
 byte-identical to the default; the accuracy cost of each lever is characterized in
 [Settings profiles](../best-practices/settings-profiles.md) and is confined to
 the already-low-confidence tail. `bwa-mem3 mem` prints the resolved preset to

--- a/docs/src/whats-different/features.md
+++ b/docs/src/whats-different/features.md
@@ -277,6 +277,7 @@ See [Optimization checklist → Reorder seeds longest-first](../best-practices/o
 | `--smem-dedup` SMEM deduplication | [#187](https://github.com/fg-labs/bwa-mem3/pull/187) | — | fork-only (opt-in, not byte-identical) |
 | `--min-ext-len` short-seed extension filter | _pending_ | — | fork-only (opt-in, off by default) |
 | `--seed-order` seed reordering | [#186](https://github.com/fg-labs/bwa-mem3/pull/186) | — | fork-only (opt-in, off by default) |
+| `--skip-contained-ext` contained-seed extension skip | [#192](https://github.com/fg-labs/bwa-mem3/pull/192) | — | fork-only (opt-in, byte-identical non-meth, no-op under --meth) |
 
 ---
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -263,6 +263,7 @@ mem_opt_t *mem_opt_init()
     o->min_ext_len = 0;   // off by default -> byte-identical to baseline
     o->seed_emit_order = SEED_ORDER_OFF;  // byte-identical default
     o->smem_dedup  = 0;   // off by default -> byte-identical to baseline; opt-in via --smem-dedup
+    o->skip_contained_ext = 0;   // off by default; opt-in via --skip-contained-ext (byte-identical)
     o->split_width = 10;
     o->max_occ = 500;
     o->max_chain_gap = 10000;
@@ -3142,6 +3143,52 @@ static inline int ungapped_analyze(const uint8_t *qs, const uint8_t *rs, int N,
     return FP_STATUS_HIT;
 }
 
+/* ------------------------------------------------------------------------
+ * Byte-identical contained-seed extension skip (--skip-contained-ext).
+ *
+ * A seed s strictly contained (same diagonal, query subinterval) in a longer
+ * seed of the same chain is dominated by that longer seed's extension: the
+ * longest seed on a diagonal is always extended, its alnreg covers s's region,
+ * so s's own alnreg is purged post-extension anyway (the PE18 containment purge
+ * later in this function). We detect this before extension and skip building s's
+ * banded-SW pair, marking its alnreg purged (qb=qe=-1) exactly as PE18 would --
+ * but s stays in c->seeds, so seedcov/MAPQ are untouched.
+ *
+ * Byte-identity: the skip set is a proven subset of PE18's purge set. (a) seed
+ * containment implies containment in the longer seed's (extension-grown) alnreg,
+ * so PE18 would purge it; (b) we replicate PE18's interference guard (a
+ * comparably-long seed overlapping s on a *different* diagonal forces
+ * extension) using seed coordinates; (c) dropping s as a container for other
+ * seeds is safe because the longest same-diagonal seed (always extended) is a
+ * superset container.
+ * ---------------------------------------------------------------------- */
+static inline int mem_seed_ext_redundant(const mem_chain_t *c, int si)
+{
+    const mem_seed_t *s = &c->seeds[si];
+    long sd = (long)s->rbeg - s->qbeg;
+    int has_container = 0, j;
+    for (j = 0; j < c->n; ++j) {
+        if (j == si) continue;
+        const mem_seed_t *t = &c->seeds[j];
+        if (t->len <= s->len) continue;                    /* strictly longer */
+        if ((long)t->rbeg - t->qbeg != sd) continue;       /* same diagonal */
+        if (s->qbeg >= t->qbeg && s->qbeg + s->len <= t->qbeg + t->len) { has_container = 1; break; }
+    }
+    if (!has_container) return 0;
+    /* interference guard: mirror PE18 (a seed >= .95*len overlapping s on a
+     * different diagonal by >= s->len/4 means s could lead to a distinct aln). */
+    for (j = 0; j < c->n; ++j) {
+        if (j == si) continue;
+        const mem_seed_t *u = &c->seeds[j];
+        if (u->len < s->len * .95) continue;
+        if (s->qbeg <= u->qbeg && s->qbeg + s->len - u->qbeg >= s->len >> 2 &&
+            u->qbeg - s->qbeg != u->rbeg - s->rbeg) return 0;
+        if (u->qbeg <= s->qbeg && u->qbeg + u->len - s->qbeg >= s->len >> 2 &&
+            s->qbeg - u->qbeg != s->rbeg - u->rbeg) return 0;
+    }
+    return 1;
+}
+
 
 void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                                    const uint8_t *pac, bseq1_t *seq_, int nseq,
@@ -3376,6 +3423,17 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                 a->rb = a->qb = a->re = a->qe = H0_;
 
                 tprof[PE19][tid] ++;
+
+                /* NB: gated off under --meth. The dominance argument assumes a
+                 * longer same-diagonal seed's extension covers the shorter one;
+                 * meth's asymmetric C->T matrix breaks this (a contained seed can
+                 * extend to a differently-scored aln), so the skip is NOT
+                 * byte-identical under --meth (measured ~0.17% of pairs diverge). */
+                if (opt->skip_contained_ext && !opt->meth_mode &&
+                    mem_seed_ext_redundant(c, (uint32_t)srt[k])) {
+                    a->qb = a->qe = -1;   /* pre-purge exactly as PE18 would */
+                    continue;
+                }
 
                 int flag = 0;
                 std::pair<int, int> pr;

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -145,6 +145,7 @@ typedef struct mem_opt_t {
     int    meth_chimera_qc; // 1 to enable bwameth.py-style longest-M <44% chimera heuristic (default off; not in Bismark)
     int    supp_rep_hard_cap; // supp alnregs whose chain's seeds share >=this many genome hits are forced to MAPQ=0; 0 disables
     int    smem_dedup;        // 1 = dedup fully-identical SMEMs before SA expansion (--smem-dedup); 0 = off (default, byte-identical to baseline)
+    int    skip_contained_ext; // 1 = skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed (--skip-contained-ext); 0 = off. Byte-identical to baseline: the skip set is a subset of the post-extension containment purge (PE18).
 } mem_opt_t;
 
 

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -933,6 +933,7 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -y INT        seed occurrence for the 3rd round seeding [%ld]\n", (long)opt->max_mem_intv);
     fprintf(stderr, "    -c INT        skip seeds with more than INT occurrences [%d]\n", opt->max_occ);
     fprintf(stderr, "    --smem-dedup  dedup identical SMEMs before chaining: fewer SA lookups, ~10%% fewer; opt-in, NOT byte-identical (changes XS/secondary on a small fraction of reads) [off]\n");
+    fprintf(stderr, "    --skip-contained-ext  skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed; byte-identical (non-meth), ~10%% less alignment CPU; no effect under --meth [off]\n");
     fprintf(stderr, "    -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [%.2f]\n", opt->drop_ratio);
     fprintf(stderr, "    -W INT        discard a chain if seeded bases shorter than INT [0]\n");
     fprintf(stderr, "    -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
@@ -1118,6 +1119,7 @@ int main_mem(int argc, char *argv[])
         OPT_SEED_ORDER,
         OPT_SMEM_DEDUP,
         OPT_FAST,
+        OPT_SKIP_CONTAINED_EXT,
 #ifdef STAGE_PROF
         OPT_PROFILE,
 #endif
@@ -1128,6 +1130,7 @@ int main_mem(int argc, char *argv[])
         {"min-ext-len",              required_argument, 0, OPT_MIN_EXT_LEN},
         {"smem-dedup",               no_argument,       0, OPT_SMEM_DEDUP},
         {"fast",                     no_argument,       0, OPT_FAST},
+        {"skip-contained-ext",       no_argument,       0, OPT_SKIP_CONTAINED_EXT},
         {"meth",                     no_argument,       0, OPT_METH},
         {"meth-scoring",             required_argument, 0, OPT_METH_SCORING},
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
@@ -1326,6 +1329,7 @@ int main_mem(int argc, char *argv[])
         }
         else if (c == OPT_SMEM_DEDUP) opt->smem_dedup = 1;
         else if (c == OPT_FAST) fast = 1;
+        else if (c == OPT_SKIP_CONTAINED_EXT) opt->skip_contained_ext = 1;
         else if (c == OPT_HELP) {
             usage(opt);
             free(opt);

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -939,10 +939,11 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
     fprintf(stderr, "    -S            skip mate rescue\n");
     fprintf(stderr, "    -P            skip pairing; mate rescue performed unless -S also in use\n");
-    fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup (and -s 2\n");
-    fprintf(stderr, "                  under --meth). Opt-in; explicit flags override where applicable;\n");
-    fprintf(stderr, "                  --smem-dedup is always enabled. NOT byte-identical to the default\n");
-    fprintf(stderr, "                  (divergence confined to the low-confidence tail).\n");
+    fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup\n");
+    fprintf(stderr, "                  --skip-contained-ext (and -s 2 under --meth). Opt-in; explicit\n");
+    fprintf(stderr, "                  flags override where applicable; --smem-dedup and\n");
+    fprintf(stderr, "                  --skip-contained-ext are always enabled. NOT byte-identical to\n");
+    fprintf(stderr, "                  the default (divergence confined to the low-confidence tail).\n");
     fprintf(stderr, "Scoring options:\n");
     fprintf(stderr, "   -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [%d]\n", opt->a);
     fprintf(stderr, "   -B INT        penalty for a mismatch [%d]\n", opt->b);
@@ -1424,10 +1425,15 @@ int main_mem(int argc, char *argv[])
     } else update_a(opt, &opt0);
 
     /* --fast: one-flag shorthand for the characterized speed levers
-     *   -m 10  -y 0  --min-ext-len 30  --smem-dedup   (+ -s 0 under --meth).
+     *   -m 10  -y 0  --min-ext-len 30  --smem-dedup  --skip-contained-ext
+     *   (+ -s 2 under --meth).
      * Mirrors the -x preset: each lever is applied only when the user did not
-     * set it explicitly (opt0), so explicit flags win where applicable. The one
-     * exception is --smem-dedup, which is forced on unconditionally (no opt-out).
+     * set it explicitly (opt0), so explicit flags win where applicable. The
+     * exceptions are --smem-dedup and --skip-contained-ext, which are plain
+     * on/off booleans forced on unconditionally (no opt-out flag exists).
+     * --skip-contained-ext is byte-identical on non-meth SE/PE and no-ops under
+     * --meth via its own internal gate (see bwamem.cpp), so forcing it on here is
+     * safe for --fast --meth too.
      * Output is NOT byte-identical to the default; divergence is confined to the
      * low-confidence tail (see docs/best-practices/settings-profiles.md).
      * meth_mode is already resolved here (parsed in the getopt loop above). */
@@ -1436,6 +1442,8 @@ int main_mem(int argc, char *argv[])
         if (!opt0.max_mem_intv) opt->max_mem_intv = 0;   /* -y 0  */
         if (!opt0.min_ext_len)  opt->min_ext_len  = 30;  /* --min-ext-len 30 */
         opt->smem_dedup = 1;                             /* --smem-dedup (plain on/off) */
+        opt->skip_contained_ext = 1;                     /* --skip-contained-ext (plain on/off;
+                                                          * meth-gated internally) */
         if (opt->meth_mode && !opt0.split_width)
             opt->split_width = 2;                        /* -s 2 (meth only): light Pass-2 reseed.
                                                           * -s 0 (no reseed) inflates MAPQ on bisulfite
@@ -1555,10 +1563,12 @@ int main_mem(int argc, char *argv[])
         fprintf(stderr, "[M::%s] seed order: %s\n", __func__, seed_order_to_str(opt->seed_emit_order));
     if (fast) {
         if (opt->meth_mode)
+            /* --skip-contained-ext is set but no-ops under --meth (internal gate), so it is
+             * intentionally omitted from the meth audit line to reflect the effective levers. */
             fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup -s %d\n",
                     __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->split_width);
         else
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup\n",
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext\n",
                     __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len);
     }
 

--- a/test/fast_preset_test.sh
+++ b/test/fast_preset_test.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # test/fast_preset_test.sh
 #
-# Asserts that `bwa-mem3 mem --fast` resolves the four characterized speed
-# levers (-m 10 -y 0 --min-ext-len 30 --smem-dedup, plus -s 2 under --meth),
-# that explicit user flags override the preset, and that the default path is
-# untouched when --fast is absent.
+# Asserts that `bwa-mem3 mem --fast` resolves the characterized speed levers
+# (-m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext, plus -s 2
+# under --meth), that explicit user flags override the preset, and that the
+# default path is untouched when --fast is absent. --skip-contained-ext no-ops
+# under --meth (internal gate), so it is omitted from the meth audit line.
 #
 # The assertion surface is the audit line main_mem prints to stderr when
 # --fast is active: it reports the *resolved* mem_opt_t values, so an explicit
@@ -42,25 +43,29 @@ fast_line() {
 # 1. Bundle correctness (non-meth).
 line="$(fast_line --fast)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
-   && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* ]] \
+   && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
+   && "$line" == *"--skip-contained-ext"* ]] \
     || { echo "FAIL: --fast bundle wrong: '$line'" >&2; exit 1; }
 [[ "$line" != *"-s "* ]] \
     || { echo "FAIL: non-meth --fast must not set -s: '$line'" >&2; exit 1; }
-echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup"
+echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext"
 
 # 2. Override precedence: an explicit flag wins *only* for its own field; the
 #    rest of the preset (including the unconditional --smem-dedup) must survive.
 line="$(fast_line --fast -m 30)"
 [[ "$line" == *"-m 30"* && "$line" == *"-y 0"* \
-   && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* ]] \
+   && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
+   && "$line" == *"--skip-contained-ext"* ]] \
     || { echo "FAIL: explicit -m 30 should only override -m: '$line'" >&2; exit 1; }
 line="$(fast_line --fast -y 5)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 5"* \
-   && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* ]] \
+   && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
+   && "$line" == *"--skip-contained-ext"* ]] \
     || { echo "FAIL: explicit -y 5 should only override -y: '$line'" >&2; exit 1; }
 line="$(fast_line --fast --min-ext-len 45)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
-   && "$line" == *"--min-ext-len 45"* && "$line" == *"--smem-dedup"* ]] \
+   && "$line" == *"--min-ext-len 45"* && "$line" == *"--smem-dedup"* \
+   && "$line" == *"--skip-contained-ext"* ]] \
     || { echo "FAIL: explicit --min-ext-len 45 should only override min-ext-len: '$line'" >&2; exit 1; }
 echo "OK:   explicit -m/-y/--min-ext-len override only their field; rest of preset survives"
 
@@ -79,7 +84,9 @@ if "$bin" index --meth "$mdir/ref.fa" >/dev/null 2>&1; then
     line="$(grep -E '^\[M::main_mem\] --fast:' "$err" || true)"
     [[ "$line" == *"-s 2"* ]] \
         || { echo "FAIL: --fast --meth should resolve -s 2: '$line'" >&2; exit 1; }
-    echo "OK:   --fast --meth additionally sets -s 2"
+    [[ "$line" != *"--skip-contained-ext"* ]] \
+        || { echo "FAIL: --skip-contained-ext no-ops under --meth; must be absent from audit line: '$line'" >&2; exit 1; }
+    echo "OK:   --fast --meth additionally sets -s 2 (skip-contained-ext omitted, meth-gated)"
     # Explicit -s wins even under --meth (src/fastmap.cpp: -s 2 is gated on !opt0.split_width).
     "$bin" mem --meth --fast -s 7 -t 1 "$mdir/ref.fa" "$reads" >/dev/null 2>"$err" \
         || { echo "FAIL: mem --meth --fast -s 7 nonzero" >&2; cat "$err" >&2; exit 1; }


### PR DESCRIPTION
## Summary

Adds `--skip-contained-ext`, which skips the banded Smith-Waterman extension of seeds that are already dominated by a longer seed in the same chain. It is **byte-identical to the default** on standard single-end and paired-end reads (auto-gated off under `--meth`), and cuts ~10% of alignment CPU on long-read (SBX) inputs.

The flag remains an independent opt-in, and this PR **also enables it under the `--fast` preset** — `--skip-contained-ext` is the ideal `--fast` member because it adds speed with zero accuracy cost on the non-meth SE/PE path and safely no-ops under `--meth`.

> **Stacked on #189.** This PR is based on `feat/fast-preset` (PR #189), which introduces `--fast`. Review #189 first; #192's diff is computed against it. When #189 merges, this PR's base auto-follows to `main`.

## What it does

A seed `s` strictly contained — same diagonal, query subinterval — in a longer seed `t` of the same chain is dominated by `t`'s extension: the longest seed on a diagonal is always extended, its alnreg covers `s`'s region, so `s`'s own alnreg is purged post-extension anyway by the existing containment purge (`PE18`, in `mem_chain2aln_across_reads_V2`). This flag detects that case *before* extension and skips building `s`'s SW pair, marking its alnreg purged (`qb=qe=-1`) exactly as `PE18` would — but `s` stays in `c->seeds`, so `seedcov`/MAPQ are untouched.

## Why it is byte-identical

The skip set is a **proven subset** of `PE18`'s purge set:

1. Seed containment implies containment in the longer seed's (extension-grown) alnreg, so `PE18` would purge it.
2. The interference guard is replicated from `PE18` (a comparably-long seed overlapping `s` on a *different* diagonal forces extension) using seed coordinates only.
3. Dropping `s` as a container for other seeds is safe because the longest same-diagonal seed — always extended — is a superset container.

## Byte-identity sweep (off vs on, alignment records, GATK hg38, Apple M2 Max, `-t8`)

| dataset | reads | records | result |
|---|--:|--:|:--|
| SBX single-end | 200k | 202,951 | **byte-identical** |
| WGS single-end (150 bp) | 100k | 100,450 | **byte-identical** |
| WGS paired-end (mate rescue + pairing) | 100k pr | 200,969 | **byte-identical** |
| meth PE (`--meth`, twist-emseq) | 50k pr | 100,003 | diverged ~0.17% of pairs → **auto-gated off** |

`--meth`'s asymmetric C→T extension matrix breaks the dominance assumption (a contained seed can extend to a differently-scored alignment), so the optimization is gated off under `--meth` (`opt->skip_contained_ext && !opt->meth_mode`); with the gate, meth is byte-identical again.

## Speed (SBX single-end, alignment phase only, excludes index load, min of 3–5 reps)

| | default | `--skip-contained-ext` | Δ |
|---|--:|--:|--:|
| CPU sec | 52.48 | 47.41 | **−9.7%** |

On the same 200k SBX reads this skips ~417k redundant extensions (−13% of SW extension passes).

## Enabled under `--fast`

The second commit wires the lever into the `--fast` preset (from #189):

```
bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext
```

- Forced on unconditionally inside the `--fast` block, the same way `--smem-dedup` is (there is no opt-out flag). Explicit `-m/-y/--min-ext-len/-s` still win.
- Under `--fast --meth` it is set but no-ops via the internal `!opt->meth_mode` gate, so it is **omitted from the meth audit line** to keep that line to the effective levers. The non-meth audit line lists it: `[M::main_mem] --fast: -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext`.
- Usage text, generated CLI docs (`docs/_generated/cli/mem.txt`), and the prose docs (`cli/mem.md`, `best-practices/settings-profiles.md`, `whats-different/features.md`) are all updated to match.

## Tests / validation

- Byte-identity confirmed off-vs-on on SE, WGS SE, WGS PE (records md5-identical, 0 diff lines).
- `--meth` divergence characterized and gated; re-verified byte-identical with the gate.
- `test/fast_preset_test.sh` extended: asserts `--skip-contained-ext` resolves under `--fast` and is absent from the `--fast --meth` audit line. Full unit suite passes; mdbook docs build clean.
- No Smith-Waterman kernel file touched (`bandedSWA.cpp`/`kswv.cpp`/etc. unchanged), so no kernel-bench gate applies.

## Before merge

Because `--fast` runs this lever alongside `-m 10 -y 0 --min-ext-len 30`, the standalone byte-identity proof (which is relative to *default* settings) does not automatically carry into the `--fast` context. Run one `--fast` vs `--fast` (with the lever) concordance check — WGS SE/PE + a long-read sample + the `-x` preset modes — to confirm the combination introduces no divergence beyond `--fast`'s existing low-confidence tail. Standalone SE/PE remains byte-identical regardless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `--skip-contained-ext` flag to speed up supported non-methylation workflows.
  * Updated `--fast` to force `--skip-contained-ext` on by default for relevant runs.
* **Behavior Changes**
  * For non-`--meth` runs, the skip is byte-identical to the default behavior; for `--meth` it is a no-op.
* **Documentation**
  * Refreshed CLI, profile, and features docs to reflect the revised `--fast` preset and flag behavior.
* **Tests**
  * Extended preset/audit assertions for both standard and `--meth` modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->