### PR TITLE
feat(mem): add --max-extend-chains (Factor-1 chain-extension cap), bundle into --fast

### DIFF
--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -13,16 +13,18 @@ Options:
     -c INT        skip seeds with more than INT occurrences [500]
     --smem-dedup  dedup identical SMEMs before chaining: fewer SA lookups, ~10% fewer; opt-in, NOT byte-identical (changes XS/secondary on a small fraction of reads) [off]
     --skip-contained-ext  skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed; byte-identical (non-meth), ~10% less alignment CPU; no effect under --meth [off]
+    --max-extend-chains INT  cap chains extended per read to the top-INT by weight; ~23% less alignment CPU, high-confidence placement unaffected; ignored for reads with >4096 chains; opt-in, NOT byte-identical (0 = off) [0]
     -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [0.50]
     -W INT        discard a chain if seeded bases shorter than INT [0]
     -m INT        perform at most INT rounds of mate rescues for each read [50]
     -S            skip mate rescue
     -P            skip pairing; mate rescue performed unless -S also in use
     --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup
-                  --skip-contained-ext (and -s 2 under --meth). Opt-in; explicit
-                  flags override where applicable; --smem-dedup and
-                  --skip-contained-ext are always enabled. NOT byte-identical to
-                  the default (divergence confined to the low-confidence tail).
+                  --skip-contained-ext --max-extend-chains 5 (and -s 2 under
+                  --meth). Opt-in; explicit flags override where applicable;
+                  --smem-dedup and --skip-contained-ext are always enabled. NOT
+                  byte-identical to the default (divergence confined to the
+                  low-confidence tail).
 Scoring options:
    -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [1]
    -B INT        penalty for a mismatch [4]

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -44,11 +44,12 @@ bwa-mem3 mem -t <N> -m 10 -y 0 ref.fa R1.fq R2.fq > out.sam
 ```
 
 > **Shorthand:** `bwa-mem3 mem --fast` applies `-m 10 -y 0 --min-ext-len 30
-> --smem-dedup --skip-contained-ext` (and `-s 2` under `--meth`) in one flag.
-> Explicit flags still override individual levers where applicable; `--smem-dedup`
-> and `--skip-contained-ext` are forced on with no opt-out. `--skip-contained-ext`
-> no-ops under `--meth` (its own internal gate disables it there), so on a `--meth`
-> run the effective levers are `-m 10 -y 0 --min-ext-len 30 --smem-dedup -s 2`.
+> --smem-dedup --skip-contained-ext --max-extend-chains 5` (and `-s 2` under
+> `--meth`) in one flag. Explicit flags still override individual levers where
+> applicable; `--smem-dedup` and `--skip-contained-ext` are forced on with no
+> opt-out. `--skip-contained-ext` no-ops under `--meth` (its own internal gate
+> disables it there), so on a `--meth` run the effective levers are
+> `-m 10 -y 0 --min-ext-len 30 --smem-dedup --max-extend-chains 5 -s 2`.
 > See [`mem` → `--fast`](../cli/mem.md#--fast--speed-preset-opt-in-not-byte-identical).
 
 Use this for new pipelines, or once a drop-in migration is validated and you want bwa-mem3's best
@@ -248,6 +249,28 @@ figures and the golden-truth F1 sweep warrant a fresh
 [bwa-mem3-bench](../related-projects/bwa-mem3-bench.md) run (multi-thread, all regimes) to confirm
 these `--fast` accuracy figures genome-wide. `--min-ext-len` and `--fast` stay opt-in; the drop-in
 defaults are unchanged.
+
+## Chain extension cap: `--max-extend-chains 5`
+
+`--max-extend-chains INT` caps the number of chains that reach banded Smith–Waterman extension to the
+top-`INT` by chain weight (applied after `mem_chain_flt`); the dropped chains are the lowest-weight
+secondaries. It is the only lever that reduces the *number of chains extended* per read — the other
+`--fast` levers (`-y 0`, `--min-ext-len`, `--smem-dedup`) cut seeds and SW-per-chain but leave chains
+extended nearly unchanged — so it is orthogonal and adds a real marginal speedup on top of them. Off
+by default (`0` → byte-identical to baseline). As a safety fallback the cap is a no-op for pathological
+reads with more than 4096 chains (`MAX_EXTEND_CHAINS_CAP`): those reads extend all of their chains as
+usual, so the option has no effect on them.
+
+**Not byte-identical.** Dropping candidate chains removes low-weight secondaries, so `XS`, secondary
+alignments, and `MAPQ` can move on multi-mapping reads. High-confidence (uniquely-placed) reads are
+unaffected; the default path (`0`) is verified byte-identical to the base branch.
+
+**The accuracy/speed tradeoff is a smooth monotonic curve with a knee at `N = 4–5`.** On holodeck
+truth (`sim-wgs-place`, 10.7 M reads), standalone `N = 5` is **−23% total alignment CPU** at +20
+high-confidence (MAPQ ≥ 60) mismaps out of 9.5 M (1529 → 1549). Stacked on top of `--fast` it is
+**−15% marginal CPU** at +21 high-confidence mismaps (1559 → 1580, +0.0002% absolute; overall
+−0.045 pp). `N = 2` is too aggressive (+13.5% high-confidence mismaps), so `--fast` sets `5`.
+`--max-extend-chains` and `--fast` stay opt-in; the drop-in defaults are unchanged.
 
 ## Speed: drop-in and recommended
 

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -227,6 +227,23 @@ the recommended value. For the benchmarks, behavior details, and validation
 status, see
 [Settings profiles → `--min-ext-len 30`](../best-practices/settings-profiles.md#short-seed-extension---min-ext-len-30).
 
+#### `--max-extend-chains INT` — cap chains extended per read
+
+Off by default (`0`) → output byte-identical to baseline. When `INT > 0`, only the
+top-`INT` chains by weight (after chain filtering) reach banded Smith-Waterman
+extension; the remaining lower-weight chains are dropped before extension. This is
+the only lever that reduces the *number of chains extended* per read, so it is
+orthogonal to the seed- and SW-per-chain levers and adds a real marginal speedup on
+top of them (~15 % marginal alignment CPU on top of `--fast`, ~23 % standalone, at
+`5`). It is **not** byte-identical: dropping candidate chains removes low-weight
+secondaries, so `XS`, secondary alignments, and `MAPQ` can shift on multi-mapping
+reads. High-confidence (uniquely-placed) reads are unaffected. The cap is a safety
+no-op for pathological reads with more than 4096 chains (`MAX_EXTEND_CHAINS_CAP`):
+those reads extend all of their chains as usual, so `--max-extend-chains` has no
+effect on them. `--fast` sets `5`. For the accuracy/speed curve and validation status,
+see
+[Settings profiles → `--max-extend-chains 5`](../best-practices/settings-profiles.md#chain-extension-cap---max-extend-chains-5).
+
 #### `-h INT[,INT]` — secondary alignment reporting
 
 If there are fewer than `INT` hits with score exceeding `FLOAT` (see `-z`)
@@ -250,7 +267,7 @@ the alignment score and mapping quality for each secondary hit.
 `--fast` is a one-flag shorthand for the characterized speed levers:
 
 ```text
-bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext
+bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 5
 ```
 
 `--skip-contained-ext` is byte-identical to the default on non-meth single- and paired-end
@@ -263,8 +280,9 @@ MAPQ/placement at nearly the same speed. See
 [Settings profiles → Pass-2 re-seeding](../best-practices/settings-profiles.md#pass-2-re-seeding-under---meth--s-2).
 
 Each lever is applied only if you did not set it explicitly, so explicit flags
-win where applicable (`--fast -m 30` keeps `-m 30`); `--smem-dedup` and
-`--skip-contained-ext` are always enabled and cannot be opted back out of once
+win where applicable (`--fast -m 30` keeps `-m 30`; `--fast --max-extend-chains 8`
+keeps `8`); `--smem-dedup` and `--skip-contained-ext` are always enabled and
+cannot be opted back out of once
 `--fast` is set. Output is **not**
 byte-identical to the default; the accuracy cost of each lever is characterized in
 [Settings profiles](../best-practices/settings-profiles.md) and is confined to

--- a/docs/src/whats-different/features.md
+++ b/docs/src/whats-different/features.md
@@ -278,6 +278,7 @@ See [Optimization checklist → Reorder seeds longest-first](../best-practices/o
 | `--min-ext-len` short-seed extension filter | _pending_ | — | fork-only (opt-in, off by default) |
 | `--seed-order` seed reordering | [#186](https://github.com/fg-labs/bwa-mem3/pull/186) | — | fork-only (opt-in, off by default) |
 | `--skip-contained-ext` contained-seed extension skip | [#192](https://github.com/fg-labs/bwa-mem3/pull/192) | — | fork-only (opt-in, byte-identical non-meth, no-op under --meth) |
+| `--max-extend-chains` chain-extension cap | [#193](https://github.com/fg-labs/bwa-mem3/pull/193) | — | fork-only (opt-in, not byte-identical) |
 
 ---
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -261,6 +261,7 @@ mem_opt_t *mem_opt_init()
 
     o->min_seed_len = 19;
     o->min_ext_len = 0;   // off by default -> byte-identical to baseline
+    o->max_extend_chains = 0;   // off by default; opt-in speed lever (--max-extend-chains / --fast)
     o->seed_emit_order = SEED_ORDER_OFF;  // byte-identical default
     o->smem_dedup  = 0;   // off by default -> byte-identical to baseline; opt-in via --smem-dedup
     o->skip_contained_ext = 0;   // off by default; opt-in via --skip-contained-ext (byte-identical)
@@ -786,6 +787,35 @@ void mem_flt_chained_seeds(const mem_opt_t *opt, const bntseq_t *bns, const uint
         c->n = k;
     }
     free(meth_qbuf);  /* NULL outside --meth; free() is NULL-safe */
+}
+
+/* --max-extend-chains: cap the number of chains that reach banded-SW extension
+ * to the top `max_n` by chain weight (applied after mem_chain_flt). The dropped
+ * chains are the lowest-weight secondaries; on holodeck truth (sim-wgs-place)
+ * this keeps high-confidence placement accuracy essentially unchanged while
+ * cutting extension work -- errors it does add land in low-MAPQ multimappers,
+ * not confident calls. Opt-in speed lever (bundled into --fast); NOT
+ * byte-identical (drops candidate secondaries, so XS/secondary/MAPQ can move on
+ * multi-mapping reads). Always keeps >= 1 chain. Returns the new chain count. */
+#define MAX_EXTEND_CHAINS_CAP 4096
+static int mem_chain_cap_extend(mem_chain_t *a, int n, int max_n)
+{
+    if (max_n <= 0 || n <= max_n || n > MAX_EXTEND_CHAINS_CAP) return n;
+    int w[MAX_EXTEND_CHAINS_CAP];
+    for (int i = 0; i < n; i++) w[i] = a[i].w > 0 ? a[i].w : mem_chain_weight(&a[i]);
+    /* keep chain i iff fewer than max_n other chains outrank it by
+     * (weight desc, then original index asc) -- a stable top-max_n selection. */
+    int k = 0;
+    for (int i = 0; i < n; i++) {
+        int rank = 0;
+        for (int j = 0; j < n; j++) {
+            if (j == i) continue;
+            if (w[j] > w[i] || (w[j] == w[i] && j < i)) rank++;
+        }
+        if (rank < max_n) a[k++] = a[i];
+        else if (a[i].m > SEEDS_PER_CHAIN) free(a[i].seeds);
+    }
+    return k;
 }
 
 int mem_chain_flt(const mem_opt_t *opt, int n_chn_, mem_chain_t *a_, int tid)
@@ -1594,6 +1624,7 @@ int mem_kernel1_core(FMI_search *fmi,
     {
         chn = &chain_ar[l];
         chn->n = mem_chain_flt(opt, chn->n, chn->a, tid);
+        chn->n = mem_chain_cap_extend(chn->a, chn->n, opt->max_extend_chains);
     }
     printf_(VER, "7. Done mem_chain_flt..\n");
     // tprof[MEM_ALN_M1][tid] += __rdtsc() - tim;

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -104,6 +104,7 @@ typedef struct mem_opt_t {
     int flag;               // see MEM_F_* macros
     int min_seed_len;       // minimum seed length
     int min_ext_len;        // seeds shorter than this are not extended (0 = off)
+    int max_extend_chains;  // cap on chains extended per read: keep only the top-N by weight before banded-SW (0 = off). Opt-in speed lever; NOT byte-identical.
     seed_order_t seed_emit_order;  // --seed-order; SEED_ORDER_OFF = byte-identical
     int min_chain_weight;
     int max_chain_extend;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -934,16 +934,18 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -c INT        skip seeds with more than INT occurrences [%d]\n", opt->max_occ);
     fprintf(stderr, "    --smem-dedup  dedup identical SMEMs before chaining: fewer SA lookups, ~10%% fewer; opt-in, NOT byte-identical (changes XS/secondary on a small fraction of reads) [off]\n");
     fprintf(stderr, "    --skip-contained-ext  skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed; byte-identical (non-meth), ~10%% less alignment CPU; no effect under --meth [off]\n");
+    fprintf(stderr, "    --max-extend-chains INT  cap chains extended per read to the top-INT by weight; ~23%% less alignment CPU, high-confidence placement unaffected; ignored for reads with >4096 chains; opt-in, NOT byte-identical (0 = off) [%d]\n", opt->max_extend_chains);
     fprintf(stderr, "    -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [%.2f]\n", opt->drop_ratio);
     fprintf(stderr, "    -W INT        discard a chain if seeded bases shorter than INT [0]\n");
     fprintf(stderr, "    -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
     fprintf(stderr, "    -S            skip mate rescue\n");
     fprintf(stderr, "    -P            skip pairing; mate rescue performed unless -S also in use\n");
     fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup\n");
-    fprintf(stderr, "                  --skip-contained-ext (and -s 2 under --meth). Opt-in; explicit\n");
-    fprintf(stderr, "                  flags override where applicable; --smem-dedup and\n");
-    fprintf(stderr, "                  --skip-contained-ext are always enabled. NOT byte-identical to\n");
-    fprintf(stderr, "                  the default (divergence confined to the low-confidence tail).\n");
+    fprintf(stderr, "                  --skip-contained-ext --max-extend-chains 5 (and -s 2 under\n");
+    fprintf(stderr, "                  --meth). Opt-in; explicit flags override where applicable;\n");
+    fprintf(stderr, "                  --smem-dedup and --skip-contained-ext are always enabled. NOT\n");
+    fprintf(stderr, "                  byte-identical to the default (divergence confined to the\n");
+    fprintf(stderr, "                  low-confidence tail).\n");
     fprintf(stderr, "Scoring options:\n");
     fprintf(stderr, "   -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [%d]\n", opt->a);
     fprintf(stderr, "   -B INT        penalty for a mismatch [%d]\n", opt->b);
@@ -1117,6 +1119,7 @@ int main_mem(int argc, char *argv[])
         OPT_SUPP_REP_HARD_CAP,
         OPT_LEGACY_READER,
         OPT_MIN_EXT_LEN,
+        OPT_MAX_EXTEND_CHAINS,
         OPT_SEED_ORDER,
         OPT_SMEM_DEDUP,
         OPT_FAST,
@@ -1129,6 +1132,7 @@ int main_mem(int argc, char *argv[])
     static struct option long_opts[] = {
         {"bam",                      optional_argument, 0, OPT_BAM},
         {"min-ext-len",              required_argument, 0, OPT_MIN_EXT_LEN},
+        {"max-extend-chains",        required_argument, 0, OPT_MAX_EXTEND_CHAINS},
         {"smem-dedup",               no_argument,       0, OPT_SMEM_DEDUP},
         {"fast",                     no_argument,       0, OPT_FAST},
         {"skip-contained-ext",       no_argument,       0, OPT_SKIP_CONTAINED_EXT},
@@ -1153,6 +1157,7 @@ int main_mem(int argc, char *argv[])
     {
         if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
         else if (c == OPT_MIN_EXT_LEN) opt->min_ext_len = atoi(optarg), opt0.min_ext_len = 1;
+        else if (c == OPT_MAX_EXTEND_CHAINS) opt->max_extend_chains = atoi(optarg), opt0.max_extend_chains = 1;
         else if (c == '1') no_mt_io = 1;
         else if (c == 'x') mode = optarg;
         else if (c == 'w') opt->w = atoi(optarg), opt0.w = 1;
@@ -1426,7 +1431,7 @@ int main_mem(int argc, char *argv[])
 
     /* --fast: one-flag shorthand for the characterized speed levers
      *   -m 10  -y 0  --min-ext-len 30  --smem-dedup  --skip-contained-ext
-     *   (+ -s 2 under --meth).
+     *   --max-extend-chains 5  (+ -s 2 under --meth).
      * Mirrors the -x preset: each lever is applied only when the user did not
      * set it explicitly (opt0), so explicit flags win where applicable. The
      * exceptions are --smem-dedup and --skip-contained-ext, which are plain
@@ -1441,6 +1446,7 @@ int main_mem(int argc, char *argv[])
         if (!opt0.max_matesw)   opt->max_matesw   = 10;  /* -m 10 */
         if (!opt0.max_mem_intv) opt->max_mem_intv = 0;   /* -y 0  */
         if (!opt0.min_ext_len)  opt->min_ext_len  = 30;  /* --min-ext-len 30 */
+        if (!opt0.max_extend_chains) opt->max_extend_chains = 5;  /* --max-extend-chains 5 */
         opt->smem_dedup = 1;                             /* --smem-dedup (plain on/off) */
         opt->skip_contained_ext = 1;                     /* --skip-contained-ext (plain on/off;
                                                           * meth-gated internally) */
@@ -1565,11 +1571,11 @@ int main_mem(int argc, char *argv[])
         if (opt->meth_mode)
             /* --skip-contained-ext is set but no-ops under --meth (internal gate), so it is
              * intentionally omitted from the meth audit line to reflect the effective levers. */
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup -s %d\n",
-                    __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->split_width);
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --max-extend-chains %d -s %d\n",
+                    __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains, opt->split_width);
         else
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext\n",
-                    __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len);
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d\n",
+                    __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains);
     }
 
     /* Load bwt2/FMI index */

--- a/test/fast_preset_test.sh
+++ b/test/fast_preset_test.sh
@@ -2,10 +2,12 @@
 # test/fast_preset_test.sh
 #
 # Asserts that `bwa-mem3 mem --fast` resolves the characterized speed levers
-# (-m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext, plus -s 2
-# under --meth), that explicit user flags override the preset, and that the
-# default path is untouched when --fast is absent. --skip-contained-ext no-ops
-# under --meth (internal gate), so it is omitted from the meth audit line.
+# (-m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext
+# --max-extend-chains 5, plus -s 2 under --meth), that explicit user flags
+# override the preset, and that the default path is untouched when --fast is
+# absent. --skip-contained-ext no-ops under --meth (internal gate), so it is
+# omitted from the meth audit line; --max-extend-chains applies under --meth
+# too, so it stays in the meth audit line.
 #
 # The assertion surface is the audit line main_mem prints to stderr when
 # --fast is active: it reports the *resolved* mem_opt_t values, so an explicit
@@ -44,30 +46,40 @@ fast_line() {
 line="$(fast_line --fast)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
    && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
-   && "$line" == *"--skip-contained-ext"* ]] \
+   && "$line" == *"--skip-contained-ext"* \
+   && "$line" == *"--max-extend-chains 5"* ]] \
     || { echo "FAIL: --fast bundle wrong: '$line'" >&2; exit 1; }
 [[ "$line" != *"-s "* ]] \
     || { echo "FAIL: non-meth --fast must not set -s: '$line'" >&2; exit 1; }
-echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext"
+echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 5"
 
 # 2. Override precedence: an explicit flag wins *only* for its own field; the
 #    rest of the preset (including the unconditional --smem-dedup) must survive.
 line="$(fast_line --fast -m 30)"
 [[ "$line" == *"-m 30"* && "$line" == *"-y 0"* \
    && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
-   && "$line" == *"--skip-contained-ext"* ]] \
+   && "$line" == *"--skip-contained-ext"* \
+   && "$line" == *"--max-extend-chains 5"* ]] \
     || { echo "FAIL: explicit -m 30 should only override -m: '$line'" >&2; exit 1; }
 line="$(fast_line --fast -y 5)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 5"* \
    && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
-   && "$line" == *"--skip-contained-ext"* ]] \
+   && "$line" == *"--skip-contained-ext"* \
+   && "$line" == *"--max-extend-chains 5"* ]] \
     || { echo "FAIL: explicit -y 5 should only override -y: '$line'" >&2; exit 1; }
 line="$(fast_line --fast --min-ext-len 45)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
    && "$line" == *"--min-ext-len 45"* && "$line" == *"--smem-dedup"* \
-   && "$line" == *"--skip-contained-ext"* ]] \
+   && "$line" == *"--skip-contained-ext"* \
+   && "$line" == *"--max-extend-chains 5"* ]] \
     || { echo "FAIL: explicit --min-ext-len 45 should only override min-ext-len: '$line'" >&2; exit 1; }
-echo "OK:   explicit -m/-y/--min-ext-len override only their field; rest of preset survives"
+# --max-extend-chains is overridable under --fast (respects an explicit value).
+line="$(fast_line --fast --max-extend-chains 8)"
+[[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
+   && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
+   && "$line" == *"--max-extend-chains 8"* ]] \
+    || { echo "FAIL: explicit --max-extend-chains 8 should only override that lever: '$line'" >&2; exit 1; }
+echo "OK:   explicit -m/-y/--min-ext-len/--max-extend-chains override only their field; rest of preset survives"
 
 # 3. Default contract: no --fast => no audit line at all.
 "$bin" mem "$ref" "$reads" >/dev/null 2>"$err" || { echo "FAIL: plain mem nonzero" >&2; exit 1; }
@@ -86,7 +98,9 @@ if "$bin" index --meth "$mdir/ref.fa" >/dev/null 2>&1; then
         || { echo "FAIL: --fast --meth should resolve -s 2: '$line'" >&2; exit 1; }
     [[ "$line" != *"--skip-contained-ext"* ]] \
         || { echo "FAIL: --skip-contained-ext no-ops under --meth; must be absent from audit line: '$line'" >&2; exit 1; }
-    echo "OK:   --fast --meth additionally sets -s 2 (skip-contained-ext omitted, meth-gated)"
+    [[ "$line" == *"--max-extend-chains 5"* ]] \
+        || { echo "FAIL: --max-extend-chains applies under --meth; must be in audit line: '$line'" >&2; exit 1; }
+    echo "OK:   --fast --meth additionally sets -s 2 (skip-contained-ext omitted meth-gated, --max-extend-chains 5 still applies)"
     # Explicit -s wins even under --meth (src/fastmap.cpp: -s 2 is gated on !opt0.split_width).
     "$bin" mem --meth --fast -s 7 -t 1 "$mdir/ref.fa" "$reads" >/dev/null 2>"$err" \
         || { echo "FAIL: mem --meth --fast -s 7 nonzero" >&2; cat "$err" >&2; exit 1; }


### PR DESCRIPTION
> **Stacked on #189** (`feat/fast-preset`). Base this PR on #189; once #189 merges, retarget to `main`.

## Summary

Adds `--max-extend-chains N` — cap the number of chains that reach banded Smith-Waterman extension to the top-N by chain weight (applied after `mem_chain_flt`) — and bundles it into `--fast` at N=5. Opt-in, default off. It is the only lever that reduces **chains extended**, the "Factor 1" gap vs minibwa, so it is orthogonal to `--fast`'s existing levers and adds a real marginal speedup on top of them.

## Why it's orthogonal to `--fast`

`--fast`'s levers (`-y 0`, `--min-ext-len 30`, `--smem-dedup`) cut *seeds* and *SW-per-chain* but leave *chains extended* nearly unchanged (`-y 0` moves it only −1.8%). Instrumenting the extension stage on real reads, bwa-mem3 extends ~2.36× more chains than minibwa for the same output; `--max-extend-chains` is the lever that closes that, and the dropped chains are the lowest-weight secondaries.

## Speed — total alignment CPU (sim-wgs-place, 10.7M reads, summed across all batches)

| config | total align CPU | reduction |
|---|--:|--:|
| baseline | 1026.2 s | — |
| baseline + `--max-extend-chains 5` | 789.2 s | −23.1% (standalone) |
| `--fast` (lever off) | 570.9 s | — |
| **`--fast` + `--max-extend-chains 5`** | 486.0 s | **−14.9% marginal** |
| `--fast` + `--max-extend-chains 4` | 469.8 s | −17.7% marginal |

## Accuracy — holodeck truth (`holodeck eval`, sim-wgs-place, MAPQ-binned placement)

The tradeoff is a smooth monotonic curve (not invariant), knee at N=4–5. High-confidence (MAPQ 60+) mismaps vs baseline 1,529:

| N | 2 | 3 | 4 | 5 | 6 | 8 | 12 | 20 |
|---|--:|--:|--:|--:|--:|--:|--:|--:|
| 60+ mismap Δ | +206 | +58 | +31 | +20 | +15 | +13 | +6 | +3 |

N=2 is too aggressive (+13.5% high-conf mismaps); N≥4 stays within +1–2%. **Marginal on top of `--fast`** at N=5: +21 high-conf mismaps (1,559→1,580, +0.0002% absolute), overall −0.045pp — within the "no high-confidence accuracy loss" bar. N=5 chosen for `--fast`: meaningful marginal speedup, negligible high-conf cost.

A more aggressive "drop chains overlapping a higher-weight chain" variant was prototyped and **rejected**: it inflated MAPQ catastrophically (high-conf mismaps 1,529 → 175,797, 109×) — dropping overlapping chains removes the secondary evidence MAPQ depends on. Only the top-N-by-weight form is safe.

## Correctness

- Default path (no `--fast`, no flag) is a no-op (`max_extend_chains=0`) — verified **byte-identical** to the base branch (200,969 records, 0 diffs on WGS PE).
- Opt-in; NOT byte-identical when enabled (drops candidate secondaries, so XS/secondary/MAPQ can move on multi-mapping reads) — same profile as the other `--fast` levers.
- No Smith-Waterman kernel file touched.

## Notes

- `--fast` audit line now prints `--max-extend-chains 5`.
- Before default-on outside `--fast`: a `sim-wgs-vars` variant-representation run (the remaining accuracy arm the other `--fast` levers were graded on).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `--max-extend-chains INT` option to cap how many alignment chains are extended per read.
  * Updated the `--fast` preset to include `--max-extend-chains 5`, while keeping user-supplied values when explicitly set.
* **Documentation**
  * Documented how the cap affects multi-mapping outputs (secondary alignments and MAPQ) and the general speed/accuracy tradeoff, including default off behavior.
  * Added the new option to the “what’s different” features catalog.
* **Tests**
  * Expanded `--fast` preset tests to verify override precedence and behavior in both standard and methylation-aware modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->