### PR TITLE
feat(mem): add --adaptive-band (chain-geometry adaptive banding) for long reads

### DIFF
--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -21,9 +21,10 @@ Options:
     -S            skip mate rescue
     -P            skip pairing; mate rescue performed unless -S also in use
     --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup
-                  --skip-contained-ext --max-extend-chains 5 (and -s 2 under
-                  --meth). Opt-in; explicit flags override where applicable;
-                  --smem-dedup and --skip-contained-ext are always enabled. NOT
+                  --skip-contained-ext --max-extend-chains 5 --adaptive-band (and
+                  -s 2 under --meth). Opt-in; explicit flags override where
+                  applicable; --smem-dedup, --skip-contained-ext and
+                  --adaptive-band are always enabled. NOT
                   byte-identical to the default (divergence confined to the
                   low-confidence tail).
 Scoring options:

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -14,6 +14,7 @@ Options:
     --smem-dedup  dedup identical SMEMs before chaining: fewer SA lookups, ~10% fewer; opt-in, NOT byte-identical (changes XS/secondary on a small fraction of reads) [off]
     --skip-contained-ext  skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed; byte-identical (non-meth), ~10% less alignment CPU; no effect under --meth [off]
     --max-extend-chains INT  cap chains extended per read to the top-INT by weight; ~23% less alignment CPU, high-confidence placement unaffected; ignored for reads with >4096 chains; opt-in, NOT byte-identical (0 = off) [0]
+    --adaptive-band  adaptive banded-SW: start tight and expand each pair to its chain-geometry band on long-extension reads; long-read speedup (~1.3x on SBX), no-op on short reads; opt-in, NOT byte-identical [off]
     -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [0.50]
     -W INT        discard a chain if seeded bases shorter than INT [0]
     -m INT        perform at most INT rounds of mate rescues for each read [50]

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -44,12 +44,14 @@ bwa-mem3 mem -t <N> -m 10 -y 0 ref.fa R1.fq R2.fq > out.sam
 ```
 
 > **Shorthand:** `bwa-mem3 mem --fast` applies `-m 10 -y 0 --min-ext-len 30
-> --smem-dedup --skip-contained-ext --max-extend-chains 5` (and `-s 2` under
-> `--meth`) in one flag. Explicit flags still override individual levers where
-> applicable; `--smem-dedup` and `--skip-contained-ext` are forced on with no
-> opt-out. `--skip-contained-ext` no-ops under `--meth` (its own internal gate
-> disables it there), so on a `--meth` run the effective levers are
-> `-m 10 -y 0 --min-ext-len 30 --smem-dedup --max-extend-chains 5 -s 2`.
+> --smem-dedup --skip-contained-ext --max-extend-chains 5 --adaptive-band` (and
+> `-s 2` under `--meth`) in one flag. Explicit flags still override individual
+> levers where applicable; `--smem-dedup`, `--skip-contained-ext` and
+> `--adaptive-band` are forced on with no opt-out (`--adaptive-band` is a no-op on
+> short reads, a ~25% speedup on long-read runs). `--skip-contained-ext` no-ops
+> under `--meth` (its own internal gate disables it there), so on a `--meth` run
+> the effective levers are
+> `-m 10 -y 0 --min-ext-len 30 --smem-dedup --max-extend-chains 5 --adaptive-band -s 2`.
 > See [`mem` → `--fast`](../cli/mem.md#--fast--speed-preset-opt-in-not-byte-identical).
 
 Use this for new pipelines, or once a drop-in migration is validated and you want bwa-mem3's best

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -306,6 +306,28 @@ Caveats: this was measured on a single repeat-enriched truth set at the breakpoi
 end-to-end SV calls), so treat `20` as a sensible starting point for SV workflows rather than a
 universal recommendation. It has no effect on primary-alignment MAPQ or on non-SV pipelines.
 
+## Situational: `--adaptive-band` for long reads
+
+This is **not** part of the recommended (short-read) profile — it is a **long-read** lever, and the
+default (off) is correct for standard Illumina WGS/WES.
+
+`--adaptive-band` starts banded Smith-Waterman tight and expands each extension only to the band its
+chain's seed geometry implies, instead of the fixed `-w` band (100) for every extension. The band
+only constrains the DP matrix when the extension's reference window exceeds it — an intrinsically
+**long-read** condition — so:
+
+- **Use it for long reads:** SBX, PacBio HiFi, ONT, or any run whose reads are roughly ≥ 200 bp. On
+  SBX (HG002, 240 bp+) it cut alignment CPU by **~25 %**.
+- **No-op on short reads:** WGS (~150 bp) and WES (~76 bp) extensions are already smaller than the
+  band, so there is nothing to trim; those reads run on the 8-bit kernel, which the option leaves
+  untouched. Enabling it on a short-read run neither helps nor hurts.
+
+Accuracy is preserved: placement is identical to default on holodeck `sim-wgs-place` (MAPQ-60+ mismaps
+unchanged), and indel representation matches the `-w 100` default (indels up to the chaining limit
+still emit a single `D`/`I` CIGAR, so small/mid-size indel callers are unaffected). Like `--fast`, it
+is **not** byte-identical when enabled (it shifts a small number of borderline secondary alignments),
+which is why it is an opt-in flag rather than a default.
+
 ---
 
 **See also:**

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -292,12 +292,16 @@ the alignment score and mapping quality for each secondary hit.
 `--fast` is a one-flag shorthand for the characterized speed levers:
 
 ```text
-bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 5
+bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 5 --adaptive-band
 ```
 
 `--skip-contained-ext` is byte-identical to the default on non-meth single- and paired-end
 reads and no-ops under `--meth` (via its own internal gate), so it is pure upside where it
 applies (~10% lower alignment CPU on long-read inputs) and safe elsewhere.
+
+`--adaptive-band` (see above) is included because it is a strict no-op on short reads
+(the reads `--fast` primarily targets) and a ~25% alignment-CPU speedup on long-read
+(SBX/HiFi/ONT) runs, so bundling it only helps.
 
 Under `--meth` it additionally sets `-s 2` (light Pass-2 re-seeding). Earlier releases
 used `-s 0` (no re-seed), which inflated MAPQ on bisulfite reads; `-s 2` recovers the

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -244,6 +244,31 @@ effect on them. `--fast` sets `5`. For the accuracy/speed curve and validation s
 see
 [Settings profiles → `--max-extend-chains 5`](../best-practices/settings-profiles.md#chain-extension-cap---max-extend-chains-5).
 
+#### `--adaptive-band` — adaptive banded Smith-Waterman for long reads
+
+Off by default → output byte-identical to baseline. When set, banded extension
+starts at a tight band and expands each pair only to the band its chain's seed
+geometry actually needs (the inter-seed indel), rather than the fixed `-w` band
+(100) for every extension.
+
+**When to use it: long reads.** The band only constrains the DP matrix when the
+extension's reference window exceeds it (`ref_window > 2·w+1`), which happens for
+long reads. So this is a **long-read lever — SBX, PacBio HiFi, ONT, or any run
+whose reads are roughly ≥ 200 bp.** On SBX (HG002, 240 bp+) it cuts alignment CPU
+by **~25 %**. On short-read data (WGS ~150 bp, WES ~76 bp) the extension matrix is
+already smaller than the band, so there is nothing to trim: those reads run on the
+8-bit kernel, which this option deliberately leaves untouched, making it a **no-op
+on short reads** (enabling it on a WGS/WES run neither helps nor hurts).
+
+**Accuracy:** placement is unchanged (holodeck `sim-wgs-place`: MAPQ-60+ mismaps
+identical to default) and indel representation is preserved — indels up to the
+chaining limit still emit a single `D`/`I` CIGAR, matching the `-w 100` default,
+so small/mid-size indel callability is unaffected.
+
+**Not byte-identical when on.** Like `--fast`, enabling it shifts a small number of
+borderline secondary alignments (starting tight and expanding can change which of
+several near-tied placements wins). It is therefore an opt-in flag, not a default.
+
 #### `-h INT[,INT]` — secondary alignment reporting
 
 If there are fewer than `INT` hits with score exceeding `FLOAT` (see `-z`)

--- a/src/bandedSWA.h
+++ b/src/bandedSWA.h
@@ -240,6 +240,9 @@ typedef struct dnaSeqPair
     // LEFT tight_band assignment, or seeding paths that don't run
     // ungapped_analyze) start at the safe sentinel rather than indeterminate.
     int32_t tight_band = 0;
+    // --adaptive-band: per-pair band implied by the chain's seed diagonal spread
+    // (capped at opt->w). Retry-floor for adaptive banding; 0 when off/no indel.
+    int32_t chain_band = 0;
     // Q3 instrumentation: would-be ungapped extension score (full diagonal
     // walk, mirrors the HIT-path walk semantics). Computed at LEFT queue
     // time for non-HIT pairs; carried through SW retry-collect; read at

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -199,6 +199,21 @@ static inline int bsw8_envelope_ok(int len1, int len2, int w,
 #define flt_lt(a, b) ((a).w > (b).w)
 KSORT_INIT(mem_flt, mem_chain_t, flt_lt)
 PDQSORT_INIT(mem_flt, mem_chain_t, flt_lt)
+
+/* Chain-geometry adaptive band (--adaptive-band). Start the banded-SW tight at
+ * opt->band_start on the 16-bit and scalar (long-extension) tiers; carry each
+ * pair's chain_band (= its chain's seed diagonal spread, capped at opt->w = the
+ * implied inter-seed indel). ACCEPT_PAIR gates the score/max_off "converged"
+ * accepts on w >= chain_band, so a pair whose chain implies a larger indel keeps
+ * retrying to that band while a diagonal-hugging pair (chain_band=0) accepts in
+ * one tight pass. The 8-bit tier stays at opt->w (its int8 diagonal encoding caps
+ * at 127, and short extensions are sub-band so gain nothing). tight_band keeps its
+ * ungapped-estimate accept-early role. band_start<=0 (default): INIT_W==opt->w and
+ * ACCEPT_PAIR reduces to the original condition -> byte-identical. */
+#define INIT_W(w) (opt->band_start > 0 ? min_(opt->band_start, (w)) : (w))
+#define ACCEPT_PAIR(sc,pv,mo,w,tb,cb,i) \
+    ((i)+1==MAX_BAND_TRY || ((tb)>0 && (w)>=(tb)) || \
+     (((sc)==(pv) || (mo) < ((w)>>1)+((w)>>2)) && (opt->band_start <= 0 || (w) >= (cb))))
 //------------------------------------------------------------------
 // Alignment: Construct the alignment from a chain *
 
@@ -265,6 +280,7 @@ mem_opt_t *mem_opt_init()
     o->seed_emit_order = SEED_ORDER_OFF;  // byte-identical default
     o->smem_dedup  = 0;   // off by default -> byte-identical to baseline; opt-in via --smem-dedup
     o->skip_contained_ext = 0;   // off by default; opt-in via --skip-contained-ext (byte-identical)
+    o->band_start  = 0;   // off by default (adaptive chain-geometry band); opt-in via --adaptive-band
     o->split_width = 10;
     o->max_occ = 500;
     o->max_chain_gap = 10000;
@@ -3343,6 +3359,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             rmax[0] = l_pac<<1; rmax[1] = 0;
 
             int chain_max_n_hits = 1;
+            int64_t cb_lo=0, cb_hi=0; int cb_f=1, chain_band=0;
             for (int i = 0; i < c->n; ++i) {
                 int64_t b, e;
                 const mem_seed_t *t = &c->seeds[i];
@@ -3355,7 +3372,11 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                 rmax[1] = (rmax[1] > e)? rmax[1] : e;
                 if (t->len > max) max = t->len;
                 if (t->n_hits > chain_max_n_hits) chain_max_n_hits = t->n_hits;
+                if (opt->band_start > 0) { int64_t _d = t->rbeg - t->qbeg; if (cb_f){cb_lo=cb_hi=_d; cb_f=0;} else { if(_d<cb_lo)cb_lo=_d; if(_d>cb_hi)cb_hi=_d; } }
             }
+            int64_t cb_span = cb_hi - cb_lo;
+            if (cb_span > opt->w) cb_span = opt->w;
+            chain_band = (int)cb_span;
 
             rmax[0] = rmax[0] > 0? rmax[0] : 0;
             rmax[1] = rmax[1] < l_pac<<1? rmax[1] : l_pac<<1;
@@ -3541,7 +3562,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
                     sp.len2 = s->qbeg;
                     sp.len1 = tmp;
-                    sp.tight_band = 0;  // 0 sentinel: "no tight bound known"
+                    sp.tight_band = 0; sp.chain_band = chain_band;  // 0 sentinel: "no tight bound known"
                     int64_t minval;  // declared ahead of goto target for C++
 
                     // ungapped analysis.
@@ -3764,7 +3785,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
                     for (int i = 0; i < sp.len1; ++i) rs[i] = rseq[re + i]; //seq1
 
-                    sp.tight_band = 0;
+                    sp.tight_band = 0; sp.chain_band = chain_band;
                     sp.ugp_r_attempted = 0;
                     int64_t minval;  // declared ahead of goto target for C++
 
@@ -3967,7 +3988,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     // heuristic exits (a->score == prev / max_off < 3w/4) can then fire
     // on a suboptimal alignment found within the narrow band, breaking
     // chr22 parity.
-    int init_w = opt->w;
+    int init_w = INIT_W(opt->w);
 
     // scalar
     for ( i=0; i<MAX_BAND_TRY; i++)
@@ -3993,9 +4014,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             int prev = a->score;
             a->score = sp->score;
 
-            if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY ||
-                (sp->tight_band > 0 && w >= sp->tight_band))
+            if (ACCEPT_PAIR(a->score, prev, sp->max_off, w, sp->tight_band, sp->chain_band, i))
             {
                 ugp_record_left_outcome(sp, opt->a, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip5) {
@@ -4036,7 +4055,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar_aux = seqPairArrayAux;
 
     nump = numPairsLeft16;
-    init_w = opt->w;
+    init_w = INIT_W(opt->w);
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
         int32_t w = init_w << i;
@@ -4063,9 +4082,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             a->score = sp->score;
 
 
-            if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY ||
-                (sp->tight_band > 0 && w >= sp->tight_band))
+            if (ACCEPT_PAIR(a->score, prev, sp->max_off, w, sp->tight_band, sp->chain_band, i))
             {
                 ugp_record_left_outcome(sp, opt->a, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip5) {
@@ -4136,9 +4153,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             int prev = a->score;
             a->score = sp->score;
 
-            if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY ||
-                (sp->tight_band > 0 && w >= sp->tight_band))
+            if (ACCEPT_PAIR(a->score, prev, sp->max_off, w, sp->tight_band, sp->chain_band, i))
             {
                 ugp_record_left_outcome(sp, opt->a, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip5) {
@@ -4321,7 +4336,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar = seqPairArrayRight128 + numPairsRight128 + numPairsRight16;
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight1;
-    init_w = opt->w;
+    init_w = INIT_W(opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
@@ -4347,9 +4362,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             a->score = sp->score;
 
             // no further banding
-            if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY ||
-                (sp->tight_band > 0 && w >= sp->tight_band))
+            if (ACCEPT_PAIR(a->score, prev, sp->max_off, w, sp->tight_band, sp->chain_band, i))
             {
                 ugp_record_right_outcome(sp, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip3) {
@@ -4385,7 +4398,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     pair_ar = seqPairArrayRight128 + numPairsRight128;
     pair_ar_aux = seqPairArrayAux;
     nump = numPairsRight16;
-    init_w = opt->w;
+    init_w = INIT_W(opt->w);
 
     for ( i=0; i<MAX_BAND_TRY; i++)
     {
@@ -4414,9 +4427,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             a->score = sp->score;
 
             // no further banding
-            if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY ||
-                (sp->tight_band > 0 && w >= sp->tight_band))
+            if (ACCEPT_PAIR(a->score, prev, sp->max_off, w, sp->tight_band, sp->chain_band, i))
             {
                 ugp_record_right_outcome(sp, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip3) {
@@ -4484,9 +4495,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
             int prev = a->score;
             a->score = sp->score;
             // no further banding
-            if (a->score == prev || sp->max_off < (w >> 1) + (w >> 2) ||
-                i+1 == MAX_BAND_TRY ||
-                (sp->tight_band > 0 && w >= sp->tight_band))
+            if (ACCEPT_PAIR(a->score, prev, sp->max_off, w, sp->tight_band, sp->chain_band, i))
             {
                 ugp_record_right_outcome(sp, tid);
                 if (sp->gscore <= 0 || sp->gscore <= a->score - opt->pen_clip3) {

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -31,6 +31,9 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #ifndef BWAMEM_HPP
 #define BWAMEM_HPP
 
+/* --adaptive-band start band; the chain-geometry retry expands per pair from here */
+#define ADAPTIVE_BAND_START 20
+
 #include "bwt.h"
 #include "bntseq.h"
 #include "bwa.h"
@@ -147,6 +150,7 @@ typedef struct mem_opt_t {
     int    supp_rep_hard_cap; // supp alnregs whose chain's seeds share >=this many genome hits are forced to MAPQ=0; 0 disables
     int    smem_dedup;        // 1 = dedup fully-identical SMEMs before SA expansion (--smem-dedup); 0 = off (default, byte-identical to baseline)
     int    skip_contained_ext; // 1 = skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed (--skip-contained-ext); 0 = off. Byte-identical to baseline: the skip set is a subset of the post-extension containment purge (PE18).
+    int    band_start;       // >0 = adaptive chain-geometry banding active (start band; set to ADAPTIVE_BAND_START by --adaptive-band); 0 = off (byte-identical). Long-read speed lever; no-op on the 8-bit short-read tier.
 } mem_opt_t;
 
 

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -935,6 +935,7 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    --smem-dedup  dedup identical SMEMs before chaining: fewer SA lookups, ~10%% fewer; opt-in, NOT byte-identical (changes XS/secondary on a small fraction of reads) [off]\n");
     fprintf(stderr, "    --skip-contained-ext  skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed; byte-identical (non-meth), ~10%% less alignment CPU; no effect under --meth [off]\n");
     fprintf(stderr, "    --max-extend-chains INT  cap chains extended per read to the top-INT by weight; ~23%% less alignment CPU, high-confidence placement unaffected; ignored for reads with >4096 chains; opt-in, NOT byte-identical (0 = off) [%d]\n", opt->max_extend_chains);
+    fprintf(stderr, "    --adaptive-band  adaptive banded-SW: start tight and expand each pair to its chain-geometry band on long-extension reads; long-read speedup (~1.3x on SBX), no-op on short reads; opt-in, NOT byte-identical [%s]\n", opt->band_start? "on":"off");
     fprintf(stderr, "    -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [%.2f]\n", opt->drop_ratio);
     fprintf(stderr, "    -W INT        discard a chain if seeded bases shorter than INT [0]\n");
     fprintf(stderr, "    -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
@@ -1124,6 +1125,7 @@ int main_mem(int argc, char *argv[])
         OPT_SMEM_DEDUP,
         OPT_FAST,
         OPT_SKIP_CONTAINED_EXT,
+        OPT_ADAPTIVE_BAND,
 #ifdef STAGE_PROF
         OPT_PROFILE,
 #endif
@@ -1136,6 +1138,7 @@ int main_mem(int argc, char *argv[])
         {"smem-dedup",               no_argument,       0, OPT_SMEM_DEDUP},
         {"fast",                     no_argument,       0, OPT_FAST},
         {"skip-contained-ext",       no_argument,       0, OPT_SKIP_CONTAINED_EXT},
+        {"adaptive-band",            no_argument,       0, OPT_ADAPTIVE_BAND},
         {"meth",                     no_argument,       0, OPT_METH},
         {"meth-scoring",             required_argument, 0, OPT_METH_SCORING},
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
@@ -1336,6 +1339,7 @@ int main_mem(int argc, char *argv[])
         else if (c == OPT_SMEM_DEDUP) opt->smem_dedup = 1;
         else if (c == OPT_FAST) fast = 1;
         else if (c == OPT_SKIP_CONTAINED_EXT) opt->skip_contained_ext = 1;
+        else if (c == OPT_ADAPTIVE_BAND) opt->band_start = ADAPTIVE_BAND_START;
         else if (c == OPT_HELP) {
             usage(opt);
             free(opt);

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -942,9 +942,10 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -S            skip mate rescue\n");
     fprintf(stderr, "    -P            skip pairing; mate rescue performed unless -S also in use\n");
     fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup\n");
-    fprintf(stderr, "                  --skip-contained-ext --max-extend-chains 5 (and -s 2 under\n");
-    fprintf(stderr, "                  --meth). Opt-in; explicit flags override where applicable;\n");
-    fprintf(stderr, "                  --smem-dedup and --skip-contained-ext are always enabled. NOT\n");
+    fprintf(stderr, "                  --skip-contained-ext --max-extend-chains 5 --adaptive-band (and\n");
+    fprintf(stderr, "                  -s 2 under --meth). Opt-in; explicit flags override where\n");
+    fprintf(stderr, "                  applicable; --smem-dedup, --skip-contained-ext and\n");
+    fprintf(stderr, "                  --adaptive-band are always enabled. NOT\n");
     fprintf(stderr, "                  byte-identical to the default (divergence confined to the\n");
     fprintf(stderr, "                  low-confidence tail).\n");
     fprintf(stderr, "Scoring options:\n");
@@ -1454,6 +1455,9 @@ int main_mem(int argc, char *argv[])
         opt->smem_dedup = 1;                             /* --smem-dedup (plain on/off) */
         opt->skip_contained_ext = 1;                     /* --skip-contained-ext (plain on/off;
                                                           * meth-gated internally) */
+        opt->band_start = ADAPTIVE_BAND_START;           /* --adaptive-band: no-op on short reads
+                                                          * (8-bit tier untouched), ~25% faster on
+                                                          * long-read (SBX/HiFi/ONT) runs. */
         if (opt->meth_mode && !opt0.split_width)
             opt->split_width = 2;                        /* -s 2 (meth only): light Pass-2 reseed.
                                                           * -s 0 (no reseed) inflates MAPQ on bisulfite
@@ -1574,11 +1578,12 @@ int main_mem(int argc, char *argv[])
     if (fast) {
         if (opt->meth_mode)
             /* --skip-contained-ext is set but no-ops under --meth (internal gate), so it is
-             * intentionally omitted from the meth audit line to reflect the effective levers. */
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --max-extend-chains %d -s %d\n",
+             * intentionally omitted from the meth audit line to reflect the effective levers.
+             * --adaptive-band is set unconditionally and applies under --meth, so it stays. */
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --max-extend-chains %d --adaptive-band -s %d\n",
                     __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains, opt->split_width);
         else
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d\n",
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d --adaptive-band\n",
                     __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains);
     }
 


### PR DESCRIPTION
> **Stacked on #189** (`feat/fast-preset`). Base this PR on #189; once #189 merges, it retargets to `main`.
>
> **Now bundled into `--fast`** (last commit): `--adaptive-band` is a no-op on the short reads `--fast` targets and a ~25% long-read speedup, so `--fast` includes it. Audit line + docs updated.

## Summary

Adds opt-in `--adaptive-band`: start the banded Smith-Waterman tight and expand each pair to the band its **chain's seed geometry** implies, instead of a fixed `opt->w` (=100) for every extension. A long-read speedup (**~−25% alignment CPU on SBX**), a strict no-op on short reads, and byte-identical + zero-cost when off.

## Mechanism

For each chain, the seed **diagonal spread** (`max−min` of `rbeg−qbeg`, capped at `opt->w`) is exactly the inter-seed indel the extension must span — known *before* extension. We carry it per pair as `chain_band` and use it as a **retry-floor**: the `score==prev` / `max_off` "converged" accepts are gated on `w >= chain_band`, so a diagonal-hugging pair (`chain_band=0`) accepts in one tight pass while a pair whose chain implies a larger indel retries to exactly that band. `tight_band` keeps its original ungapped-estimate accept-early role, untouched.

This realizes the intent behind the (dead) `BUCKET_MAX_INIT_W` machinery — start tight, expand on demand — with the retry-floor the original lacked (which is why the original accepted truncated alignments early and shifted results).

## Why only the 16-bit / scalar tiers

Applied only on the 16-bit and scalar (long-extension) tiers. The **8-bit short-read tier stays at `opt->w`** — its int8 diagonal encoding caps the band at 127, so a tight start's retry ladder could otherwise feed it an out-of-envelope band. This is also *correct*, not just safe: adaptive banding can only help when the extension matrix is band-limited (`ref_window > 2w+1`), which is intrinsically a long-read condition — short-read matrices are already sub-band, so they gain nothing. So short-read (WGS/WES) runs are unaffected even with the flag on.

## Performance (Apple M2 Max, `-t10`, total alignment CPU)

| dataset | read len | default | `--adaptive-band` | Δ |
|---|--:|--:|--:|--:|
| SBX (HG002) | 240bp+ | 62.1s | 46.7s | **−25%** |
| WGS (1kg HG00096) | 150bp | — | ~neutral | (8-bit; untouched) |
| WES (1kg HG00100) | 76bp | — | ~neutral | (8-bit; untouched) |

Default (flag off) perf is unchanged: the chain-geometry computation is gated on the flag (WES 69.7s vs base 70.0s).

## Accuracy — validated on a principled indel-length benchmark + holodeck

Alignment accuracy for indels must be measured with a **split-aware placement metric** *and* a **single-CIGAR-vs-split representation metric** — placement-only benchmarks (MAPQ ROC, holodeck alone) are blind to indel *callability*. Built a controlled indel-length sweep (reads with known indels L ∈ 10–750bp from real chr20, aligned to hg38):

- **Placement:** flat ~93% / MAPQ 59 at every indel size, identical to default.
- **Representation:** single-CIGAR indels preserved *identically to the `w=100` default* up to the chaining limit (L ≤ ~100bp: e.g. 95.0/94.3/93.5/92.9% at L=30/50/75/100); ≥150bp correctly split, same as default.
- **holodeck `sim-wgs-place` (10.7M reads):** MAPQ-60+ mismaps **1529 = 1529** (identical to default); ALL +2 correct.

## Correctness

- **Default (flag off) is byte-identical** (WGS/SBX/WES vs base) and zero-cost: `INIT_W == opt->w`, geometry skipped, `ACCEPT_PAIR` reduces to the original condition.
- **When on it is intentionally *not* byte-identical** (shifts a small number of borderline secondary alignments) — which is exactly why it's an opt-in flag and not a default (the earlier `BUCKET_MAX_INIT_W` wiring was dropped from byte-identical PR #58 for this reason).
- No Smith-Waterman kernel file changed.

## Notes

- Internal start band `ADAPTIVE_BAND_START = 20` (the chain-geometry retry expands per pair from there); exposed as a boolean toggle so callers don't tune a magic number.
- Long-read/HiFi/ONT lever; a natural future addition to a long-read preset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--adaptive-band` to enable adaptive banded Smith–Waterman for long reads.
  * Updated the `--fast` preset to include `--adaptive-band`.
  * `--adaptive-band` is a no-op on short reads; targets long-read speedups with accuracy/indel representation unchanged (outputs may differ from baseline).
* **Documentation**
  * Extended CLI docs for `--adaptive-band`, including expected behavior and when to use it.
  * Added/updated best-practice guidance for long-read use cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->