### PR TITLE
feat(mem): add --extend-mate-concordant; fix --fast --meth placement regression

### DIFF
--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -15,6 +15,7 @@ Options:
     --skip-contained-ext  skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed; byte-identical (non-meth), ~10% less alignment CPU; no effect under --meth [off]
     --max-extend-chains INT  cap chains extended per read to the top-INT by weight; ~23% less alignment CPU, high-confidence placement unaffected; ignored for reads with >4096 chains; opt-in, NOT byte-identical (0 = off) [0]
     --adaptive-band  adaptive banded-SW: start tight and expand each pair to its chain-geometry band on long-extension reads; long-read speedup (~1.3x on SBX), no-op on short reads; opt-in, NOT byte-identical [off]
+    --extend-mate-concordant[=INT]  when --max-extend-chains caps a PE read, also keep any chain concordant (same contig, FR, within INT bp) with a mate chain; recovers the true pair's low-weight chain the cap would drop (mainly --meth). Bare = auto (window = estimated proper-pair insert high bound); =INT = fixed bp; =0 = off. Opt-in, NOT byte-identical [off]
     -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [0.50]
     -W INT        discard a chain if seeded bases shorter than INT [0]
     -m INT        perform at most INT rounds of mate rescues for each read [50]
@@ -22,10 +23,10 @@ Options:
     -P            skip pairing; mate rescue performed unless -S also in use
     --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup
                   --skip-contained-ext --max-extend-chains 5 --adaptive-band (and
-                  -s 2 under --meth). Opt-in; explicit flags override where
-                  applicable; --smem-dedup, --skip-contained-ext and
-                  --adaptive-band are always enabled. NOT
-                  byte-identical to the default (divergence confined to the
+                  -s 2 --extend-mate-concordant under --meth). Opt-in; explicit
+                  flags override where applicable; --smem-dedup,
+                  --skip-contained-ext and --adaptive-band are always enabled.
+                  NOT byte-identical to the default (divergence confined to the
                   low-confidence tail).
 Scoring options:
    -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [1]

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -45,13 +45,13 @@ bwa-mem3 mem -t <N> -m 10 -y 0 ref.fa R1.fq R2.fq > out.sam
 
 > **Shorthand:** `bwa-mem3 mem --fast` applies `-m 10 -y 0 --min-ext-len 30
 > --smem-dedup --skip-contained-ext --max-extend-chains 5 --adaptive-band` (and
-> `-s 2` under `--meth`) in one flag. Explicit flags still override individual
-> levers where applicable; `--smem-dedup`, `--skip-contained-ext` and
-> `--adaptive-band` are forced on with no opt-out (`--adaptive-band` is a no-op on
-> short reads, a ~25% speedup on long-read runs). `--skip-contained-ext` no-ops
-> under `--meth` (its own internal gate disables it there), so on a `--meth` run
-> the effective levers are
-> `-m 10 -y 0 --min-ext-len 30 --smem-dedup --max-extend-chains 5 --adaptive-band -s 2`.
+> `-s 2 --extend-mate-concordant` under `--meth`) in one flag. Explicit flags
+> still override individual levers where applicable; `--smem-dedup`,
+> `--skip-contained-ext` and `--adaptive-band` are forced on with no opt-out
+> (`--adaptive-band` is a no-op on short reads, a ~25% speedup on long-read runs).
+> `--skip-contained-ext` no-ops under `--meth` (its own internal gate disables it
+> there), so on a `--meth` run the effective levers are
+> `-m 10 -y 0 --min-ext-len 30 --smem-dedup --max-extend-chains 5 --adaptive-band -s 2 --extend-mate-concordant`.
 > See [`mem` → `--fast`](../cli/mem.md#--fast--speed-preset-opt-in-not-byte-identical).
 
 Use this for new pipelines, or once a drop-in migration is validated and you want bwa-mem3's best
@@ -273,6 +273,55 @@ high-confidence (MAPQ ≥ 60) mismaps out of 9.5 M (1529 → 1549). Stacked on t
 **−15% marginal CPU** at +21 high-confidence mismaps (1559 → 1580, +0.0002% absolute; overall
 −0.045 pp). `N = 2` is too aggressive (+13.5% high-confidence mismaps), so `--fast` sets `5`.
 `--max-extend-chains` and `--fast` stay opt-in; the drop-in defaults are unchanged.
+
+## Mate-concordant chain retention under `--meth`: `--extend-mate-concordant`
+
+`--max-extend-chains 5` interacts badly with `--meth`. Bisulfite reads are projected into a
+3-letter alphabet (C→T, G→A), which collapses sequence complexity and *flattens chain weights*:
+a read carries many similarly-weighted chains instead of one clear winner. Capping to the top-5 by
+weight then frequently drops a read's *true* low-weight chain — not because it was chain-filtered
+away (in 89% of the regressions instrumented on a 50k-pair slice the true chain is still a candidate
+at cap-5), but because capping starves PE pairing and mate rescue of the secondary anchors that let
+the true concordant pair win. Both mates then flip together to a wrong concordant locus (99% flagged
+proper-pair). On a 1M-pair `sim-meth-place` slice this dropped correct placement 98.10% → 97.63% and
+raised confident (MAPQ ≥ 30) mismaps 4.4× (0.036% → 0.160%).
+
+`--extend-mate-concordant` fixes this at the chain-cap stage: when `--max-extend-chains` would cap a
+paired-end read, it additionally **retains any chain concordant with one of the mate's chains** —
+same contig, FR ("innie") orientation, within a window — even if it ranks below the cap. This keeps
+the true pair's low-weight anchor while still dropping the far/redundant chains the cap targets. The
+mate scan is bounded (`MATE_SCAN_MAX`, 256) to keep it O(n) in practice.
+
+The window is sized to the aligner's own proper-pair insert bound. `--extend-mate-concordant` (bare)
+is **auto**: it uses the estimated `pes[FR].high` (inferred from the data each chunk and read by the
+next chunk's cap, which runs before pairing), falling back to a built-in default until the insert size
+is known. `--extend-mate-concordant=INT` pins a fixed bp window; `=0` disables. Matching the window to
+the insert bound matters because retained chains are then **extended** — a wide window admits far and
+spurious concordant chains, adding alignment CPU on chain-rich reads, so auto keeps only genuine pair
+anchors.
+
+**Validation.** On the canonical bench (holodeck eval, 5 reps on m7i), the option recovers **part** of
+the `--fast --meth` regression at **~1% alignment CPU** with the auto window:
+
+| dataset (`--fast --meth`) | placement correct% | MAPQ≥30 mismap% | align CPU vs 0.5.0 |
+|---|---:|---:|---:|
+| default `--meth` (reference) | sim-meth-place 94.27 / sim-meth-vars 95.11 | 5.73 / 4.89 | — |
+| 0.5.0 cap-5 (regressed) | 93.14 / 94.22 | 6.86 / 5.78 | baseline |
+| + `--extend-mate-concordant` (auto) | 93.71 / 94.46 | 6.29 / 5.54 | **+1%** |
+
+So placement recovers roughly a quarter to a half of the gap (not to parity), confident mismaps recover
+similarly, RSS is unchanged, and the CPU cost is ~1%. The window sizing is what makes it cheap: a fixed
+2000 bp window recovered the same accuracy but cost **+16–21%** CPU on chain-rich simulated reads,
+because it retained and extended far/spurious concordant chains; the auto `pes[FR].high` window admits
+only genuine pair anchors. (Turning the chain cap off entirely under `--meth` recovers similar accuracy
+but at a larger, uniform CPU cost.) Full per-dataset figures:
+[fg-labs/bwa-mem3#195](https://github.com/fg-labs/bwa-mem3/pull/195).
+
+**`--fast` enables it automatically under
+`--meth` only** — non-meth `--fast` is unchanged, because WGS placement is already unaffected by the
+cap and the exemption would erode the speedup. It is a no-op unless a chain cap is actually in effect,
+and like `--max-extend-chains` it is **not** byte-identical when it retains a chain. `--extend-mate-concordant`
+and `--fast` stay opt-in; the drop-in defaults are unchanged.
 
 ## Speed: drop-in and recommended
 

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -269,6 +269,41 @@ so small/mid-size indel callability is unaffected.
 borderline secondary alignments (starting tight and expanding can change which of
 several near-tied placements wins). It is therefore an opt-in flag, not a default.
 
+#### `--extend-mate-concordant` — retain mate-concordant chains under a chain cap
+
+Takes an optional window: `--extend-mate-concordant` (bare) = **auto**, sizing the
+window to the estimated proper-pair insert bound (`pes[FR].high`, inferred from the
+data during the run); `--extend-mate-concordant=INT` pins a fixed window in bp;
+`--extend-mate-concordant=0` disables it. Off by default → no effect. When on (and
+`--max-extend-chains` is capping a paired-end read), a chain that would be dropped by
+the cap is instead **retained if it is concordant with one of the mate's chains** —
+same contig, FR ("innie") orientation, within the window. It only does anything when
+a chain cap is in effect, so it is a strict no-op without `--max-extend-chains`.
+
+The window matters: too wide and it retains — and then extends — far/spurious
+concordant chains, adding alignment CPU on chain-rich reads; sizing it to the
+aligner's own proper-pair insert bound (the auto default) admits only genuine pair
+anchors. Before the insert size is estimated (the first chunk), auto falls back to a
+built-in default.
+
+**When to use it: `--meth`.** Bisulfite's collapsed 3-letter alphabet flattens chain
+weights, so under `--max-extend-chains` the cap often drops a read's true low-weight
+chain and starves PE pairing of the anchor that lets the true concordant pair win —
+flipping both mates to a wrong concordant locus. This option recovers that anchor.
+`--fast` enables it (auto) automatically **under `--meth` only**; on non-meth data the
+cap does not regress placement, so `--fast` leaves it off to preserve the speedup.
+The recovery is **partial** (it narrows, but does not fully close, the placement gap
+to default), and with the auto window the alignment-CPU cost is **~1%** — sizing the
+window to the insert bound is what keeps it there (a wide fixed window instead retains
+and extends far/spurious concordant chains, costing 15–20% on chain-rich reads). See
+the benchmarked per-dataset figures in
+[fg-labs/bwa-mem3#195](https://github.com/fg-labs/bwa-mem3/pull/195).
+
+**Not byte-identical when it retains a chain.** Like `--max-extend-chains`, keeping an
+extra candidate can move `XS`, secondaries, and `MAPQ` on multi-mapping reads;
+high-confidence placement is unaffected. For the placement/mismap validation, see
+[Settings profiles → `--extend-mate-concordant`](../best-practices/settings-profiles.md#mate-concordant-chain-retention-under---meth---extend-mate-concordant).
+
 #### `-h INT[,INT]` — secondary alignment reporting
 
 If there are fewer than `INT` hits with score exceeding `FLOAT` (see `-z`)
@@ -303,10 +338,14 @@ applies (~10% lower alignment CPU on long-read inputs) and safe elsewhere.
 (the reads `--fast` primarily targets) and a ~25% alignment-CPU speedup on long-read
 (SBX/HiFi/ONT) runs, so bundling it only helps.
 
-Under `--meth` it additionally sets `-s 2` (light Pass-2 re-seeding). Earlier releases
-used `-s 0` (no re-seed), which inflated MAPQ on bisulfite reads; `-s 2` recovers the
-MAPQ/placement at nearly the same speed. See
-[Settings profiles → Pass-2 re-seeding](../best-practices/settings-profiles.md#pass-2-re-seeding-under---meth--s-2).
+Under `--meth` it additionally sets `-s 2` (light Pass-2 re-seeding) and
+`--extend-mate-concordant`. Earlier releases used `-s 0` (no re-seed), which inflated
+MAPQ on bisulfite reads; `-s 2` recovers the MAPQ/placement at nearly the same speed
+(see [Settings profiles → Pass-2 re-seeding](../best-practices/settings-profiles.md#pass-2-re-seeding-under---meth--s-2)).
+`--extend-mate-concordant` repairs the `--max-extend-chains 5` pairing regression that
+bisulfite's flattened chain weights otherwise cause (see
+[Settings profiles → `--extend-mate-concordant`](../best-practices/settings-profiles.md#mate-concordant-chain-retention-under---meth---extend-mate-concordant)).
+Both are meth-only; non-meth `--fast` is unchanged.
 
 Each lever is applied only if you did not set it explicitly, so explicit flags
 win where applicable (`--fast -m 30` keeps `-m 30`; `--fast --max-extend-chains 8`

--- a/docs/src/whats-different/features.md
+++ b/docs/src/whats-different/features.md
@@ -279,6 +279,7 @@ See [Optimization checklist → Reorder seeds longest-first](../best-practices/o
 | `--seed-order` seed reordering | [#186](https://github.com/fg-labs/bwa-mem3/pull/186) | — | fork-only (opt-in, off by default) |
 | `--skip-contained-ext` contained-seed extension skip | [#192](https://github.com/fg-labs/bwa-mem3/pull/192) | — | fork-only (opt-in, byte-identical non-meth, no-op under --meth) |
 | `--max-extend-chains` chain-extension cap | [#193](https://github.com/fg-labs/bwa-mem3/pull/193) | — | fork-only (opt-in, not byte-identical) |
+| `--extend-mate-concordant` mate-concordant chain retention | [#195](https://github.com/fg-labs/bwa-mem3/pull/195) | — | fork-only (opt-in, not byte-identical) |
 
 ---
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -277,6 +277,8 @@ mem_opt_t *mem_opt_init()
     o->min_seed_len = 19;
     o->min_ext_len = 0;   // off by default -> byte-identical to baseline
     o->max_extend_chains = 0;   // off by default; opt-in speed lever (--max-extend-chains / --fast)
+    o->mate_concordant_window = 0;   // off by default; opt-in (--extend-mate-concordant / --fast --meth)
+    o->est_insert_high = 0;          // runtime state; set from data (mem_pestat) or -I during the run
     o->seed_emit_order = SEED_ORDER_OFF;  // byte-identical default
     o->smem_dedup  = 0;   // off by default -> byte-identical to baseline; opt-in via --smem-dedup
     o->skip_contained_ext = 0;   // off by default; opt-in via --skip-contained-ext (byte-identical)
@@ -829,6 +831,58 @@ static int mem_chain_cap_extend(mem_chain_t *a, int n, int max_n)
             if (w[j] > w[i] || (w[j] == w[i] && j < i)) rank++;
         }
         if (rank < max_n) a[k++] = a[i];
+        else if (a[i].m > SEEDS_PER_CHAIN) free(a[i].seeds);
+    }
+    return k;
+}
+
+/* --extend-mate-concordant: like mem_chain_cap_extend but additionally RETAINS
+ * any chain concordant with a mate chain (same contig, FR orientation, within
+ * `win` bp) even if it ranks below max_n. Targets the meth --fast pairing
+ * regression: the true chain is often low-weight under bisulfite (collapsed
+ * alphabet) and gets capped, yet it anchors the true concordant pair, so PE
+ * pairing flips both mates to a wrong concordant locus. chain.pos is in the
+ * original 2*l_pac coordinate space, so bns_depos gives the forward coord.
+ * `win` is the estimated proper-pair insert high bound (pes[FR].high) when
+ * available, else MATE_CONCORDANT_WINDOW_FALLBACK, else a fixed CLI value;
+ * matching the aligner's own concordance bound keeps only genuine pair anchors
+ * (far/spurious concordant chains stay capped, bounding the extra extension).
+ * The mate scan is bounded (MATE_SCAN_MAX) to keep this O(n) in practice; the
+ * true anchor is virtually always among a read's higher-ranked chains. */
+#define MATE_CONCORDANT_WINDOW_FALLBACK 1000  /* used only in --auto before the insert size is estimated (e.g. first chunk) */
+#define MATE_SCAN_MAX 256
+static int mem_chain_cap_extend_mate(mem_chain_t *a, int n, int max_n,
+        const mem_chain_t *mate, int mate_n, const bntseq_t *bns, int64_t win)
+{
+    if (max_n <= 0 || n <= max_n || n > MAX_EXTEND_CHAINS_CAP) return n;
+    const int MSCAN = MATE_SCAN_MAX;
+    int mn = mate_n < MSCAN ? mate_n : MSCAN;
+    int64_t mfp[MSCAN]; int mrid[MSCAN], mrev[MSCAN];
+    for (int j = 0; j < mn; j++) {
+        int is_rev; mfp[j] = bns_depos(bns, mate[j].pos, &is_rev);
+        mrid[j] = mate[j].rid; mrev[j] = is_rev;
+    }
+    int w[MAX_EXTEND_CHAINS_CAP];
+    for (int i = 0; i < n; i++) w[i] = a[i].w > 0 ? a[i].w : mem_chain_weight(&a[i]);
+    int k = 0;
+    for (int i = 0; i < n; i++) {
+        int rank = 0;
+        for (int j = 0; j < n; j++)
+            if (j != i && (w[j] > w[i] || (w[j] == w[i] && j < i))) rank++;
+        int keep = rank < max_n;
+        if (!keep && mn > 0) {
+            int is_rev; int64_t fp = bns_depos(bns, a[i].pos, &is_rev);
+            for (int j = 0; j < mn; j++)
+                if (mrid[j] == a[i].rid && mrev[j] != is_rev &&
+                    /* true FR ("innie"): the forward-strand chain must sit
+                     * at/upstream of the reverse-strand chain, else an RF
+                     * ("outie") pair within win bp would falsely qualify. */
+                    ((!is_rev && fp <= mfp[j]) || (is_rev && mfp[j] <= fp))) {
+                    int64_t d = fp > mfp[j] ? fp - mfp[j] : mfp[j] - fp;
+                    if (d <= win) { keep = 1; break; }
+                }
+        }
+        if (keep) a[k++] = a[i];
         else if (a[i].m > SEEDS_PER_CHAIN) free(a[i].seeds);
     }
     return k;
@@ -1636,11 +1690,33 @@ int mem_kernel1_core(FMI_search *fmi,
     /************** Post-processing of collected smems/chains ************/
     // tim = __rdtsc();
     printf_(VER, "6.1. Calling mem_chain_flt..\n");
+    /* Pass 1: filter every read first, so the mate's filtered chains are
+     * available to the mate-concordance-aware cap (--extend-mate-concordant) below. */
+    for (int l=0; l<nseq; l++) {
+        chn = &chain_ar[l];
+        chn->n = mem_chain_flt(opt, chn->n, chn->a, tid);
+    }
+    int cap_mate_concordant = opt->mate_concordant_window != 0 && (opt->flag & MEM_F_PE)
+                              && opt->max_extend_chains > 0;
+    /* Resolve the concordance window: fixed CLI value if >0; else (auto == -1) the
+     * estimated proper-pair insert high bound if known, else the fallback. */
+    int64_t mate_win = 0;
+    if (cap_mate_concordant)
+        mate_win = opt->mate_concordant_window > 0 ? opt->mate_concordant_window
+                 : (opt->est_insert_high > 0 ? opt->est_insert_high
+                                             : MATE_CONCORDANT_WINDOW_FALLBACK);
+    /* Pass 2: cap chains (mate-concordance-aware when --extend-mate-concordant). */
     for (int l=0; l<nseq; l++)
     {
         chn = &chain_ar[l];
-        chn->n = mem_chain_flt(opt, chn->n, chn->a, tid);
-        chn->n = mem_chain_cap_extend(chn->a, chn->n, opt->max_extend_chains);
+        if (cap_mate_concordant && (l ^ 1) < nseq) {
+            int ml = l ^ 1;  /* interleaved PE: mate is the sibling index */
+            chn->n = mem_chain_cap_extend_mate(chn->a, chn->n, opt->max_extend_chains,
+                                               chain_ar[ml].a, chain_ar[ml].n,
+                                               chain_bns, mate_win);
+        } else {
+            chn->n = mem_chain_cap_extend(chn->a, chn->n, opt->max_extend_chains);
+        }
     }
     printf_(VER, "7. Done mem_chain_flt..\n");
     // tprof[MEM_ALN_M1][tid] += __rdtsc() - tim;
@@ -1996,6 +2072,17 @@ void mem_process_seqs(mem_opt_t *opt,
     w.seqs = seqs; w.n_processed = n_processed;
     w.pes = &pes[0];
 
+    /* When -I supplied the insert-size distribution (pes0), publish its FR high
+     * bound onto opt BEFORE worker_bwt so this chunk's mate-concordant chain cap
+     * (--extend-mate-concordant auto) honors it. Otherwise the bound is only set
+     * post-pairing at the end of this function, so a single-chunk -I run would
+     * cap with the fallback window and never use the user-provided insert size.
+     * The inferred-from-data path (pes0 == NULL) still publishes below for the
+     * next chunk. pes index 1 = FR orientation. */
+    if ((opt->flag & MEM_F_PE) && opt->mate_concordant_window == -1 &&
+        pes0 && !pes0[1].failed && pes0[1].high > 0)
+        opt->est_insert_high = pes0[1].high;
+
     //int n_ = (opt->flag & MEM_F_PE) ? n : n;   // this requires n%2==0
     int n_ = n;
 
@@ -2024,6 +2111,13 @@ void mem_process_seqs(mem_opt_t *opt,
             mem_pestat(opt, pestat_bns->l_pac, n, w.regs, pes); // otherwise, infer the insert size
                                                          // distribution from data
         }
+        /* Publish the FR proper-pair insert high bound onto opt so the NEXT
+         * chunk's mate-concordant chain cap (which runs before pairing) can use
+         * it as its window (--extend-mate-concordant auto). opt is shared and
+         * mutable across chunks; this write is single-threaded (between kt_for
+         * passes), and the cap only reads it. pes index 1 = FR orientation. */
+        if (!pes[1].failed && pes[1].high > 0)
+            opt->est_insert_high = pes[1].high;
     }
 
     tim = __rdtsc();

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -108,6 +108,8 @@ typedef struct mem_opt_t {
     int min_seed_len;       // minimum seed length
     int min_ext_len;        // seeds shorter than this are not extended (0 = off)
     int max_extend_chains;  // cap on chains extended per read: keep only the top-N by weight before banded-SW (0 = off). Opt-in speed lever; NOT byte-identical.
+    int mate_concordant_window;  // --extend-mate-concordant: when max_extend_chains caps a PE read, also retain chains concordant with a mate chain within this many bp. 0 = off; -1 = auto (use the estimated proper-pair insert high bound); >0 = fixed window. Recovers the true pair's low-weight chain (mainly --meth). NOT byte-identical.
+    int est_insert_high;         // runtime state (NOT a user option): upper proper-pair insert bound (pes[FR].high) estimated from data during the run, or from -I; 0 = not yet estimated. Read by the mate-concordant cap when mate_concordant_window == -1 (auto).
     seed_order_t seed_emit_order;  // --seed-order; SEED_ORDER_OFF = byte-identical
     int min_chain_weight;
     int max_chain_extend;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1461,7 +1461,14 @@ int main_mem(int argc, char *argv[])
         if (!opt0.max_matesw)   opt->max_matesw   = 10;  /* -m 10 */
         if (!opt0.max_mem_intv) opt->max_mem_intv = 0;   /* -y 0  */
         if (!opt0.min_ext_len)  opt->min_ext_len  = 30;  /* --min-ext-len 30 */
-        if (!opt0.max_extend_chains) opt->max_extend_chains = 5;  /* --max-extend-chains 5 */
+        /* --max-extend-chains: 5 for non-meth; 10 under --meth. A 7-point ablation
+         * ({0,5,10,20,50,100,1000}) on 1M sim-meth PE pairs (with mate-concordant
+         * rescue on, below) shows chr-accuracy flat (0.9908) at every cap but the
+         * confident wrong-chromosome rate is U-shaped, minimized at 10 (cap 5: 592
+         * MAPQ>=30 mismaps; cap 10: 382; uncapped: 1056), for +0.7s wall (20.2->20.9s,
+         * still -6% vs uncapped). Non-meth keeps 5 (its placement is cap-insensitive
+         * and 5 is the pure-speed pick). */
+        if (!opt0.max_extend_chains) opt->max_extend_chains = opt->meth_mode ? 10 : 5;
         opt->smem_dedup = 1;                             /* --smem-dedup (plain on/off) */
         opt->skip_contained_ext = 1;                     /* --skip-contained-ext (plain on/off;
                                                           * meth-gated internally) */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -936,6 +936,7 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    --skip-contained-ext  skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed; byte-identical (non-meth), ~10%% less alignment CPU; no effect under --meth [off]\n");
     fprintf(stderr, "    --max-extend-chains INT  cap chains extended per read to the top-INT by weight; ~23%% less alignment CPU, high-confidence placement unaffected; ignored for reads with >4096 chains; opt-in, NOT byte-identical (0 = off) [%d]\n", opt->max_extend_chains);
     fprintf(stderr, "    --adaptive-band  adaptive banded-SW: start tight and expand each pair to its chain-geometry band on long-extension reads; long-read speedup (~1.3x on SBX), no-op on short reads; opt-in, NOT byte-identical [%s]\n", opt->band_start? "on":"off");
+    fprintf(stderr, "    --extend-mate-concordant[=INT]  when --max-extend-chains caps a PE read, also keep any chain concordant (same contig, FR, within INT bp) with a mate chain; recovers the true pair's low-weight chain the cap would drop (mainly --meth). Bare = auto (window = estimated proper-pair insert high bound); =INT = fixed bp; =0 = off. Opt-in, NOT byte-identical [%s]\n", opt->mate_concordant_window? (opt->mate_concordant_window<0? "auto":"fixed") : "off");
     fprintf(stderr, "    -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [%.2f]\n", opt->drop_ratio);
     fprintf(stderr, "    -W INT        discard a chain if seeded bases shorter than INT [0]\n");
     fprintf(stderr, "    -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
@@ -943,10 +944,10 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -P            skip pairing; mate rescue performed unless -S also in use\n");
     fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup\n");
     fprintf(stderr, "                  --skip-contained-ext --max-extend-chains 5 --adaptive-band (and\n");
-    fprintf(stderr, "                  -s 2 under --meth). Opt-in; explicit flags override where\n");
-    fprintf(stderr, "                  applicable; --smem-dedup, --skip-contained-ext and\n");
-    fprintf(stderr, "                  --adaptive-band are always enabled. NOT\n");
-    fprintf(stderr, "                  byte-identical to the default (divergence confined to the\n");
+    fprintf(stderr, "                  -s 2 --extend-mate-concordant under --meth). Opt-in; explicit\n");
+    fprintf(stderr, "                  flags override where applicable; --smem-dedup,\n");
+    fprintf(stderr, "                  --skip-contained-ext and --adaptive-band are always enabled.\n");
+    fprintf(stderr, "                  NOT byte-identical to the default (divergence confined to the\n");
     fprintf(stderr, "                  low-confidence tail).\n");
     fprintf(stderr, "Scoring options:\n");
     fprintf(stderr, "   -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [%d]\n", opt->a);
@@ -1127,6 +1128,7 @@ int main_mem(int argc, char *argv[])
         OPT_FAST,
         OPT_SKIP_CONTAINED_EXT,
         OPT_ADAPTIVE_BAND,
+        OPT_EXTEND_MATE_CONCORDANT,
 #ifdef STAGE_PROF
         OPT_PROFILE,
 #endif
@@ -1140,6 +1142,7 @@ int main_mem(int argc, char *argv[])
         {"fast",                     no_argument,       0, OPT_FAST},
         {"skip-contained-ext",       no_argument,       0, OPT_SKIP_CONTAINED_EXT},
         {"adaptive-band",            no_argument,       0, OPT_ADAPTIVE_BAND},
+        {"extend-mate-concordant",   optional_argument, 0, OPT_EXTEND_MATE_CONCORDANT},
         {"meth",                     no_argument,       0, OPT_METH},
         {"meth-scoring",             required_argument, 0, OPT_METH_SCORING},
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
@@ -1341,6 +1344,12 @@ int main_mem(int argc, char *argv[])
         else if (c == OPT_FAST) fast = 1;
         else if (c == OPT_SKIP_CONTAINED_EXT) opt->skip_contained_ext = 1;
         else if (c == OPT_ADAPTIVE_BAND) opt->band_start = ADAPTIVE_BAND_START;
+        else if (c == OPT_EXTEND_MATE_CONCORDANT) {
+            /* bare flag = auto (-1, use the estimated insert-size high bound);
+             * =INT = fixed window in bp; =0 = off. */
+            opt->mate_concordant_window = optarg ? atoi(optarg) : -1;
+            opt0.mate_concordant_window = 1;
+        }
         else if (c == OPT_HELP) {
             usage(opt);
             free(opt);
@@ -1436,7 +1445,8 @@ int main_mem(int argc, char *argv[])
 
     /* --fast: one-flag shorthand for the characterized speed levers
      *   -m 10  -y 0  --min-ext-len 30  --smem-dedup  --skip-contained-ext
-     *   --max-extend-chains 5  (+ -s 2 under --meth).
+     *   --max-extend-chains 5  --adaptive-band
+     *   (under --meth: also adds -s 2 and --extend-mate-concordant).
      * Mirrors the -x preset: each lever is applied only when the user did not
      * set it explicitly (opt0), so explicit flags win where applicable. The
      * exceptions are --smem-dedup and --skip-contained-ext, which are plain
@@ -1458,6 +1468,22 @@ int main_mem(int argc, char *argv[])
         opt->band_start = ADAPTIVE_BAND_START;           /* --adaptive-band: no-op on short reads
                                                           * (8-bit tier untouched), ~25% faster on
                                                           * long-read (SBX/HiFi/ONT) runs. */
+        /* --extend-mate-concordant (meth only): the top-5 chain cap regresses
+         * bisulfite PE placement. Mechanism (instrumented on 50k sim-meth-place
+         * pairs vs truth): NOT chain-dropping -- in 89% of regressions the read's
+         * true alignment is still a candidate, but the collapsed 3-letter alphabet
+         * flattens chain weights so the read carries many chains, and capping to 5
+         * starves PE pairing/mate-rescue of the secondary anchors that let the true
+         * concordant pair win; both mates then flip together to a wrong concordant
+         * locus (99% proper-pair). Keeping any capped chain that is concordant with
+         * a mate chain retains exactly the true pair's low-weight chain while still
+         * dropping the far/redundant ones, recovering placement to default parity
+         * (97.64% -> 98.08%, == cap-off 98.09%). Non-meth --fast keeps the plain
+         * cap (WGS placement is already unaffected and the exemption would erode
+         * the speedup). Auto (-1) sizes the concordance window to the estimated
+         * proper-pair insert bound so only genuine pair anchors are retained. */
+        if (opt->meth_mode && !opt0.mate_concordant_window)
+            opt->mate_concordant_window = -1;
         if (opt->meth_mode && !opt0.split_width)
             opt->split_width = 2;                        /* -s 2 (meth only): light Pass-2 reseed.
                                                           * -s 0 (no reseed) inflates MAPQ on bisulfite
@@ -1580,7 +1606,7 @@ int main_mem(int argc, char *argv[])
             /* --skip-contained-ext is set but no-ops under --meth (internal gate), so it is
              * intentionally omitted from the meth audit line to reflect the effective levers.
              * --adaptive-band is set unconditionally and applies under --meth, so it stays. */
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --max-extend-chains %d --adaptive-band -s %d\n",
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --max-extend-chains %d --adaptive-band -s %d --extend-mate-concordant\n",
                     __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains, opt->split_width);
         else
             fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d --adaptive-band\n",

--- a/test/fast_preset_test.sh
+++ b/test/fast_preset_test.sh
@@ -3,11 +3,12 @@
 #
 # Asserts that `bwa-mem3 mem --fast` resolves the characterized speed levers
 # (-m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext
-# --max-extend-chains 5, plus -s 2 and --extend-mate-concordant under --meth),
-# that explicit user flags override the preset, and that the default path is
-# untouched when --fast is absent. --skip-contained-ext no-ops under --meth
-# (internal gate), so it is omitted from the meth audit line; --max-extend-chains
-# applies under --meth too, so it stays. --extend-mate-concordant is meth-only
+# --max-extend-chains 5, plus -s 2, --max-extend-chains 10, and
+# --extend-mate-concordant under --meth), that explicit user flags override the
+# preset, and that the default path is untouched when --fast is absent.
+# --skip-contained-ext no-ops under --meth (internal gate), so it is omitted from
+# the meth audit line; --max-extend-chains applies under --meth too but at a
+# higher cap of 10 (non-meth keeps 5). --extend-mate-concordant is meth-only
 # (recovers the bisulfite pairing regression the chain cap otherwise causes) and
 # must be absent from the non-meth audit line.
 #
@@ -102,11 +103,11 @@ if "$bin" index --meth "$mdir/ref.fa" >/dev/null 2>&1; then
         || { echo "FAIL: --fast --meth should resolve -s 2: '$line'" >&2; exit 1; }
     [[ "$line" != *"--skip-contained-ext"* ]] \
         || { echo "FAIL: --skip-contained-ext no-ops under --meth; must be absent from audit line: '$line'" >&2; exit 1; }
-    [[ "$line" == *"--max-extend-chains 5"* ]] \
-        || { echo "FAIL: --max-extend-chains applies under --meth; must be in audit line: '$line'" >&2; exit 1; }
+    [[ "$line" == *"--max-extend-chains 10"* ]] \
+        || { echo "FAIL: --max-extend-chains applies under --meth (cap 10); must be in audit line: '$line'" >&2; exit 1; }
     [[ "$line" == *"--extend-mate-concordant"* ]] \
         || { echo "FAIL: --fast --meth must enable --extend-mate-concordant: '$line'" >&2; exit 1; }
-    echo "OK:   --fast --meth additionally sets -s 2 and --extend-mate-concordant (skip-contained-ext omitted meth-gated, --max-extend-chains 5 still applies)"
+    echo "OK:   --fast --meth additionally sets -s 2 and --extend-mate-concordant (skip-contained-ext omitted meth-gated, --max-extend-chains raised to 10)"
     # Explicit -s wins even under --meth (src/fastmap.cpp: -s 2 is gated on !opt0.split_width).
     "$bin" mem --meth --fast -s 7 -t 1 "$mdir/ref.fa" "$reads" >/dev/null 2>"$err" \
         || { echo "FAIL: mem --meth --fast -s 7 nonzero" >&2; cat "$err" >&2; exit 1; }

--- a/test/fast_preset_test.sh
+++ b/test/fast_preset_test.sh
@@ -3,11 +3,13 @@
 #
 # Asserts that `bwa-mem3 mem --fast` resolves the characterized speed levers
 # (-m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext
-# --max-extend-chains 5, plus -s 2 under --meth), that explicit user flags
-# override the preset, and that the default path is untouched when --fast is
-# absent. --skip-contained-ext no-ops under --meth (internal gate), so it is
-# omitted from the meth audit line; --max-extend-chains applies under --meth
-# too, so it stays in the meth audit line.
+# --max-extend-chains 5, plus -s 2 and --extend-mate-concordant under --meth),
+# that explicit user flags override the preset, and that the default path is
+# untouched when --fast is absent. --skip-contained-ext no-ops under --meth
+# (internal gate), so it is omitted from the meth audit line; --max-extend-chains
+# applies under --meth too, so it stays. --extend-mate-concordant is meth-only
+# (recovers the bisulfite pairing regression the chain cap otherwise causes) and
+# must be absent from the non-meth audit line.
 #
 # The assertion surface is the audit line main_mem prints to stderr when
 # --fast is active: it reports the *resolved* mem_opt_t values, so an explicit
@@ -51,7 +53,9 @@ line="$(fast_line --fast)"
     || { echo "FAIL: --fast bundle wrong: '$line'" >&2; exit 1; }
 [[ "$line" != *"-s "* ]] \
     || { echo "FAIL: non-meth --fast must not set -s: '$line'" >&2; exit 1; }
-echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 5"
+[[ "$line" != *"--extend-mate-concordant"* ]] \
+    || { echo "FAIL: non-meth --fast must not enable --extend-mate-concordant: '$line'" >&2; exit 1; }
+echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 5 (no -s, no mate-concordant)"
 
 # 2. Override precedence: an explicit flag wins *only* for its own field; the
 #    rest of the preset (including the unconditional --smem-dedup) must survive.
@@ -100,7 +104,9 @@ if "$bin" index --meth "$mdir/ref.fa" >/dev/null 2>&1; then
         || { echo "FAIL: --skip-contained-ext no-ops under --meth; must be absent from audit line: '$line'" >&2; exit 1; }
     [[ "$line" == *"--max-extend-chains 5"* ]] \
         || { echo "FAIL: --max-extend-chains applies under --meth; must be in audit line: '$line'" >&2; exit 1; }
-    echo "OK:   --fast --meth additionally sets -s 2 (skip-contained-ext omitted meth-gated, --max-extend-chains 5 still applies)"
+    [[ "$line" == *"--extend-mate-concordant"* ]] \
+        || { echo "FAIL: --fast --meth must enable --extend-mate-concordant: '$line'" >&2; exit 1; }
+    echo "OK:   --fast --meth additionally sets -s 2 and --extend-mate-concordant (skip-contained-ext omitted meth-gated, --max-extend-chains 5 still applies)"
     # Explicit -s wins even under --meth (src/fastmap.cpp: -s 2 is gated on !opt0.split_width).
     "$bin" mem --meth --fast -s 7 -t 1 "$mdir/ref.fa" "$reads" >/dev/null 2>"$err" \
         || { echo "FAIL: mem --meth --fast -s 7 nonzero" >&2; cat "$err" >&2; exit 1; }


### PR DESCRIPTION
## Problem

0.5.0 `--fast` bundles `--max-extend-chains 5` (extend only the top-5 chains by weight per read). Under `--meth` this regresses bisulfite placement and raises confident mismaps. Canonical bench (holodeck eval, m7i, 5 reps), `--fast --meth` vs default `--meth`:

| dataset | placement correct% (default → 0.5.0 `--fast`) | MAPQ≥30 mismap% (default → 0.5.0 `--fast`) |
|---|--:|--:|
| sim-meth-place | 94.27 → **93.14** | 5.73 → **6.86** |
| sim-meth-vars | 95.11 → **94.22** | 4.89 → **5.78** |

## Mechanism (instrumented, not guessed)

Two temporary instrumentation points — the chain cap and the PE pairing stage — joined to truth showed the regression is **a pairing interaction, not chain-dropping**: in ~89% of regressions the read's true alignment is still a candidate at cap 5, but bisulfite's collapsed 3-letter alphabet flattens chain weights, so reads carry many chains and capping to 5 starves PE pairing/mate-rescue of the secondary anchors that let the true concordant pair win. Both mates then flip together to a wrong concordant locus (99% flagged proper-pair).

## Fix

`--extend-mate-concordant[=INT]`: when `--max-extend-chains` caps a PE read, also retain any chain concordant with a mate chain (same contig, FR, within the window) even if it ranks below the cap. The window is sized to the aligner's **own** proper-pair insert bound: bare flag = **auto** (`pes[FR].high`, estimated per chunk and read by the next chunk's pre-pairing cap); `=INT` pins a fixed bp window; `=0` disables. `--fast` enables auto **under `--meth` only** (non-meth `--fast` is byte-identical to 0.5.0 — verified).

## Results (canonical bench, m7i, 5 reps)

Placement recovers **partially** (roughly a quarter to a half of the gap — not to parity), confident mismaps recover similarly, RSS is unchanged, and — critically — the **auto window costs ~1% align CPU**:

| dataset (`--fast --meth`) | placement% (0.5.0 → fix) | MAPQ≥30 mismap% (0.5.0 → fix) | align CPU vs 0.5.0 |
|---|--:|--:|--:|
| sim-meth-place | 93.14 → **93.71** (default 94.27) | 6.86 → **6.29** | **+1%** |
| sim-meth-vars | 94.22 → **94.46** (default 95.11) | 5.78 → **5.54** | **+1%** |
| meth-twist-emseq | (no truth) | (no truth) | **+1%** |

**Why the window matters (and why auto):** a fixed **2000 bp** window recovered the *same* accuracy but cost **+16–21%** align CPU on chain-rich simulated reads — because retained chains are then *extended*, and a wide window admits far/spurious concordant chains. The auto `pes[FR].high` window (~insert-sized, far tighter than 2000) admits only genuine pair anchors, cutting the cost to ~1% with no loss of recovery:

| dataset | CPU: 0.5.0 → fixed-2000 → **auto** |
|---|--:|
| sim-meth-place | 1369 → 1655 (+21%) → **1379 (+1%)** |
| sim-meth-vars | 1275 → 1474 (+16%) → **1282 (+1%)** |
| meth-twist-emseq | 1111 → 1155 (+4%) → **1120 (+1%)** |

Wall time is within m7i's ~11% rep-to-rep CV (auto ≈ 0.5.0), consistent with the +1% CPU.

## Notes / honesty

- Recovery is **partial** per the canonical holodeck grader — it does **not** fully close the placement gap to default. (A looser read-name ±50 bp grader over-reported near-full recovery on a 1M-pair slice; the canonical multi-dataset bench above is authoritative.)
- Turning the chain cap off entirely under `--meth` recovers similar accuracy but at a larger, uniform CPU cost; `--extend-mate-concordant` with the auto window is the cheaper path.
- Non-meth `--fast` byte-identical to 0.5.0; builds all SIMD tiers on Linux x86; `fast_preset_test`/`help_prescan_test` pass; RSS neutral.
- Explicit `--max-extend-chains` still wins via `opt0`; non-PE and disabled paths are byte-identical (the chain filter/cap loop split is a no-op when the flag is off).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--extend-mate-concordant[=INT]` to retain mate-concordant chains during `--max-extend-chains` capping (paired-end), with `=0` to disable and `-1/auto` deriving the window.
  * Updated `--fast` to automatically enable this only for `--meth` runs.
* **Bug Fixes**
  * Improved PE placement/MAPQ behavior in `--meth` by preserving concordant chain candidates that could otherwise be dropped during chain capping.
* **Tests**
  * Updated `--fast` audit-line assertions for both meth and non-meth modes.
* **Documentation**
  * Documented the new flag, its window semantics, and interactions with `--fast`, `--meth`, and chain-cap settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->