### PR TITLE
fix(bandedSWA): 8-bit SW drops query-end gscore/gtle on zero-score-row exit

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -1231,7 +1231,34 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         __m256i bmaxScore256 = maxScore256;
         __m256i tmp = _mm256_cmpeq_epi8(maxRS1, zero256);
         cval = _mm256_movemask_epi8(tmp);
-        if (cval == 0xFFFFFFFF) break;
+        if (cval == 0xFFFFFFFF) {
+            /* Finalize THIS row's query-end (gscore/gtle) capture before exiting
+             * (see smithWaterman128_8 zero-row break for the rationale): scalar
+             * records the row's gscore then hits its own m==0 break, so the vector
+             * must too, else the gscore==0 query-end tail row is dropped -> wrong
+             * gtle under asymmetric --meth matrices. Mirror of the epilogue gscore
+             * block (>= tie-break: latest query-end row wins). */
+            int8_t qf_a_[SIMD_WIDTH8] __attribute((aligned(32)));
+            int8_t hq_a_[SIMD_WIDTH8] __attribute((aligned(32)));
+            _mm256_store_si256((__m256i *) qf_a_, qfire256);
+            _mm256_store_si256((__m256i *) hq_a_, hqe256);
+            for (int g = 0; g < SIMD_WIDTH8 / 8; g++) {
+                const int base = g * 8;
+                __m256i Bg   = _mm256_loadu_si256((const __m256i *)(B + base));
+                __m256i hqeg = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(hq_a_ + base)));
+                __m256i qfg  = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(qf_a_ + base)));
+                __m256i gs_abs = _mm256_add_epi32(hqeg, Bg);
+                __m256i gba = _mm256_loadu_si256((const __m256i *)(gbest_abs + base));
+                __m256i ge  = _mm256_xor_si256(_mm256_cmpgt_epi32(gba, gs_abs), ff256);
+                __m256i gmask = _mm256_and_si256(qfg, ge);
+                gba = _mm256_blendv_epi8(gba, gs_abs, gmask);
+                _mm256_storeu_si256((__m256i *)(gbest_abs + base), gba);
+                __m256i ierg = _mm256_loadu_si256((const __m256i *)(ierow + base));
+                ierg = _mm256_blendv_epi8(ierg, _mm256_set1_epi32(i + 1), gmask);
+                _mm256_storeu_si256((__m256i *)(ierow + base), ierg);
+            }
+            break;
+        }
 
         exit0 = _mm256_andnot_si256(tmp, exit0);
 
@@ -3098,7 +3125,31 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         /* exit due to zero score by a row */
         __m512i bmaxScore512 = maxScore512;
         __mmask64 tmp = _mm512_cmpeq_epi8_mask(maxRS1, zero512);
-        if (tmp == dmask) break;
+        if (tmp == dmask) {
+            /* Finalize THIS row's query-end (gscore/gtle) capture before exiting
+             * (see smithWaterman128_8 zero-row break): scalar records the row's
+             * gscore then hits its own m==0 break, so the vector must too, else the
+             * gscore==0 query-end tail row is dropped -> wrong gtle under the
+             * asymmetric --meth matrix. Mirror of the epilogue gscore block. */
+            int8_t hq_a_[SIMD_WIDTH8] __attribute((aligned(64)));
+            _mm512_store_si512((__m512i *) hq_a_, hqe512);
+            const __mmask64 qf64_ = _mm512_movepi8_mask(qfire512);
+            for (int g = 0; g < SIMD_WIDTH8 / 16; g++) {
+                const int base = g * 16;
+                const __mmask16 qfm = (__mmask16)(qf64_ >> (16 * g));
+                __m512i Bg   = _mm512_loadu_si512((const void *)(B + base));
+                __m512i hqeg = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i *)(hq_a_ + base)));
+                __m512i gs_abs = _mm512_add_epi32(hqeg, Bg);
+                __m512i gba = _mm512_loadu_si512((const void *)(gbest_abs + base));
+                __mmask16 gmask = qfm & _mm512_cmpge_epi32_mask(gs_abs, gba);
+                gba = _mm512_mask_mov_epi32(gba, gmask, gs_abs);
+                _mm512_storeu_si512((void *)(gbest_abs + base), gba);
+                __m512i ierg = _mm512_loadu_si512((const void *)(ierow + base));
+                ierg = _mm512_mask_mov_epi32(ierg, gmask, _mm512_set1_epi32(i + 1));
+                _mm512_storeu_si512((void *)(ierow + base), ierg);
+            }
+            break;
+        }
 
         exit0 = _mm512_mask_blend_epi8(tmp, exit0, zero512);
 
@@ -5758,11 +5809,42 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         __m128i bmaxScore128 = maxScore128;
         __m128i tmp = _mm_cmpeq_epi8(maxRS1, zero128);
 #if defined(__ARM_NEON)
-        if (vmaxvq_u8(vreinterpretq_u8_m128i(maxRS1)) == 0) break;
+        int zero_row_ = (vmaxvq_u8(vreinterpretq_u8_m128i(maxRS1)) == 0);
 #else
-        uint16_t cval = _mm_movemask_epi8(tmp);
-        if (cval == 0xFFFF) break;
+        int zero_row_ = (_mm_movemask_epi8(tmp) == 0xFFFF);
 #endif
+        if (zero_row_) {
+            /* Finalize THIS row's query-end (gscore/gtle) capture BEFORE exiting.
+             * The capture (hqe128/qfire128) is set in the inner loop above but is
+             * folded into the wide gbest_abs/ierow only in the per-row epilogue,
+             * which this break would otherwise skip. Scalar processes the row's
+             * gscore and then hits its own m==0 break, so it records the query-end
+             * row; the vector must too. Skipping it drops the gscore==0 query-end
+             * tail row -> wrong gtle. Benign for symmetric scoring (gscore==0 gtle
+             * unused), but consumed under the asymmetric --meth (OT/OB) matrix,
+             * where it caused soft-clip / placement drift. Mirror of the epilogue's
+             * gscore block (>= tie-break: latest query-end row wins, as scalar). */
+            int8_t qf_a_[SIMD_WIDTH8] __attribute((aligned(16)));
+            int8_t hq_a_[SIMD_WIDTH8] __attribute((aligned(16)));
+            _mm_store_si128((__m128i *) qf_a_, qfire128);
+            _mm_store_si128((__m128i *) hq_a_, hqe128);
+            for (int g = 0; g < SIMD_WIDTH8 / 4; g++) {
+                const int base = g * 4;
+                __m128i Bg   = _mm_loadu_si128((const __m128i *)(B + base));
+                __m128i hqeg = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(hq_a_ + base)));
+                __m128i qfg  = _mm_cvtepi8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(qf_a_ + base)));
+                __m128i gs_abs = _mm_add_epi32(hqeg, Bg);
+                __m128i gba = _mm_loadu_si128((const __m128i *)(gbest_abs + base));
+                __m128i ge  = _mm_xor_si128(_mm_cmpgt_epi32(gba, gs_abs), ff128); // gs_abs >= gba
+                __m128i gmask = _mm_and_si128(qfg, ge);
+                gba = _mm_blendv_epi8(gba, gs_abs, gmask);
+                _mm_storeu_si128((__m128i *)(gbest_abs + base), gba);
+                __m128i ierg = _mm_loadu_si128((const __m128i *)(ierow + base));
+                ierg = _mm_blendv_epi8(ierg, _mm_set1_epi32(i + 1), gmask);
+                _mm_storeu_si128((__m128i *)(ierow + base), ierg);
+            }
+            break;
+        }
 
         // _mm_store_si128((__m128i *) temp, exit0);
         exit0 = _mm_blendv_epi8(exit0, zero128,  tmp);

--- a/test/unit/test_bandedswa_longread.cpp
+++ b/test/unit/test_bandedswa_longread.cpp
@@ -283,4 +283,66 @@ TEST_CASE("bandedSWA 8-bit byte-identical to scalar on repeat-rich, large-h0 rea
     CHECK(st.n_out_env > 0);
 }
 
+// --- Asymmetric (--meth OT/OB) query-end gscore/gtle capture --------------------
+//
+// Regression for the 8-bit "exit due to zero score by a row" break dropping the
+// current row's query-end (gscore/gtle) capture. Under --meth's asymmetric
+// substitution matrix (OT frees ref-C/read-T), a real captured extension pair
+// reaches the query end at a late target row where the whole band has decayed to
+// 0 (gscore==0). scalar records that row's gscore before its m==0 break; the 8-bit
+// kernel's zero-row break used to exit BEFORE folding the capture into the wide
+// gbest_abs/ierow, so getScores8 reported gtle from an early row (1) instead of the
+// scalar row (67). Benign for symmetric scoring (gscore==0 gtle is unused), but
+// consumed under --meth, where it produced spurious soft-clips / placement drift.
+//
+// The captured pair (from a 1M-pair meth slice) scores with the bisulfite params
+// a=1, b=2, gap open/extend 6/1, end_bonus (pen_clip) 10, band 100, seed h0 27.
+TEST_CASE("bandedSWA 8-bit query-end gscore/gtle byte-identical to scalar under an"
+          " asymmetric --meth (OT) matrix (zero-score-row break capture)"
+          * doctest::test_suite("unit/bandedswa")) {
+    const int a = 1, b = 2, o = 6, e = 1, end_bonus = 10, w = 100, zdrop = 100, h0 = 27;
+    // OT matrix: symmetric a/-b plus freed ref-C/read-T (and the collapsed mirror
+    // ref-T/read-C), ambiguous = -1 — exactly mem_opt_fill_meth_mat's OT output.
+    int8_t mat[25];
+    build_mat(mat, a, b, -1);
+    mat[1 * 5 + 3] = (int8_t)a;   // ref C / read T -> match
+    mat[3 * 5 + 1] = (int8_t)a;   // ref T / read C -> match (collapsed)
+
+    const uint8_t ref[] = {2,2,0,0,0,0,3,0,0,3,3,0,1,3,3,3,3,0,1,0,0,2,3,0,0,0,3,0,1,0,3,1,2,0,1,2,2,0,3,0,3,0,0,0,2,2,3,1,1,1,3,3,3,2,3,0,3,1,1,3,2,3,3,1,2,2,3,1,0,3,3,0,3,0,0,3,1,0,3,3,0,2,0,0,2,3,0,0,3,0,1,2,3,3,3,0,1,0,0,2,3,0,3};
+    const uint8_t qer[] = {3,3,3,3,0,0,0,3,2,3,3,3,0,3,0,3,3,2,0,0,3,3,2,0,3,0,3,0,3,2,2,3,3,3,3,3,0,3,3,3,3,3,3,3,3,3,3,0,3,3,3,0,0,2};
+    const int len1 = (int)(sizeof(ref) / sizeof(ref[0]));
+    const int len2 = (int)(sizeof(qer) / sizeof(qer[0]));
+
+    BandedPairWiseSW bsw(o, e, o, e, zdrop, end_bonus, mat, a, b, 1);
+
+    const int STRIDE = len1 + MAX_LINE_LEN;
+    std::vector<uint8_t> seqRef(STRIDE, 0), seqQer(STRIDE, 0);
+    for (int i = 0; i < len1; ++i) seqRef[i] = ref[i];
+    for (int i = 0; i < len2; ++i) seqQer[i] = qer[i];
+
+    Out oracle;
+    oracle.score = bsw.scalarBandedSWA(len2, seqQer.data(), len1, seqRef.data(), w, h0,
+                                       &oracle.qle, &oracle.tle, &oracle.gtle,
+                                       &oracle.gscore, &oracle.max_off);
+
+    std::vector<SeqPair> pairs(padPairs(1));
+    pairs[0].id = 0; pairs[0].len1 = len1; pairs[0].len2 = len2; pairs[0].h0 = h0;
+    pairs[0].idr = 0; pairs[0].idq = 0; pairs[0].seqid = 0; pairs[0].regid = 0;
+    pairs[0].score = pairs[0].tle = pairs[0].gtle = pairs[0].qle =
+        pairs[0].gscore = pairs[0].max_off = -1;
+    bsw.getScores8(pairs.data(), seqRef.data(), seqQer.data(), 1, 1, w);
+
+    MESSAGE("meth-OT query-end: scalar gtle=" << oracle.gtle << " gscore=" << oracle.gscore
+            << " | get8 gtle=" << pairs[0].gtle << " gscore=" << pairs[0].gscore);
+    CHECK(pairs[0].score   == oracle.score);
+    CHECK(pairs[0].qle     == oracle.qle);
+    CHECK(pairs[0].tle     == oracle.tle);
+    CHECK(pairs[0].gtle    == oracle.gtle);    // was 1 vs scalar 67 before the fix
+    CHECK(pairs[0].gscore  == oracle.gscore);
+    CHECK(pairs[0].max_off == oracle.max_off);
+    // Non-vacuity: this input genuinely exercises the query-end tail (gtle deep in
+    // the target, well past the local end) so the check is not trivially satisfied.
+    CHECK(oracle.gtle > oracle.tle + 10);
+}
+
 #endif // HAVE_BSW_VECTOR_8_16


### PR DESCRIPTION
## Bug

The 8-bit banded Smith-Waterman kernels capture the query-end cell (`hqe`/`qfire`) in the inner loop but only fold it into the wide `gbest_abs`/`ierow` (i.e. `gscore`/`gtle`) in the per-row epilogue. The **"exit due to zero score by a row"** break sits *between* the two. When the whole band decays to 0 on the same row that reaches the query end, the break exits **before** the epilogue runs, so that row's query-end capture is dropped.

`scalarBandedSWA` processes the row's gscore and only *then* hits its own `m==0` break, so it records the query-end row; the vector kernel exited first and reported `gtle` from an earlier row.

Minimal isolated repro (captured real extension pair, bisulfite OT matrix, a=1 b=2 gap 6/1 end_bonus 10):
```
scalar: gtle=67  |  getScores16: gtle=67  |  getScores8: gtle=1
```
Present in **every** 8-bit tier (neon/sse41/sse42/avx/avx2/avx512bw); 16-bit is correct in all.

## Fix

Finalize the current row's query-end capture (a mirror of the epilogue's gscore block, same `>=` tie-break) **before** taking the zero-score break, in all three ports (`smithWaterman128_8` / `256_8` / `512_8`). getScores8 is then byte-identical to `scalarBandedSWA` on the query-end tail.

## Why existing tests missed it

It only surfaces under an **asymmetric** substitution matrix (bisulfite `--meth` OT/OB), which produces query-end alignments that reach the end on a fully-decayed row. The default symmetric matrix does not, so the existing byte-identity parity tests (symmetric) never exercised it. Added a captured-input regression test under the OT matrix (RED `1 == 67` → GREEN); full unit suite (2.9M assertions) is byte-identical to scalar.

## Scope / relationship to the `--fast --meth` regression

This is a **standalone correctness fix**. It does **not** by itself change the `--fast --meth` placement regression: the `gscore==0` gtle tail does not affect the emitted CIGAR, and end-to-end the fixed 8-bit output is placement-identical to the buggy 8-bit output. That regression is a *separate* 8-bit-vs-16-bit divergence (8-bit soft-clips reads the 16-bit tier aligns full) and is handled by routing meth extension to the 16-bit tier (#197). This PR just makes the 8-bit query-end capture match scalar, closing a real correctness gap that would bite any future asymmetric-matrix use of the 8-bit kernel.

## Verification

- Added `test/unit/test_bandedswa_longread.cpp` case (asymmetric OT, query-end tail) — fails pre-fix, passes post-fix.
- Full unit suite green (2928679 assertions, 0 failed) — byte-identical to scalar.
- NEON verified locally; AVX2/AVX-512 ports are mechanical mirrors, verified by CI's x86 matrix (which runs the new parity test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment score handling in edge cases where processing stops early on a zero-score row.
  * Fixed incorrect end-position reporting for certain asymmetric scoring setups, making results consistent with the expected reference output.
  * Added regression coverage to ensure 8-bit alignment results match the scalar implementation for the affected case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->