### PR TITLE
fix(bandedSWA): getScores{8,16} must not scribble padding past numPairs

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -40,6 +40,41 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #endif
 
 // ------------------------------------------------------------------------------------
+// Sub-slice overshoot guard.
+//
+// The batched kernels (getScores8 / getScores16) round numPairs up to their
+// SIMD width and INITIALIZE the padding lanes pairArray[numPairs .. roundUp)
+// in place (len=0 dummy pairs). That is safe when the kernel owns the whole
+// array, but a caller may pass a SUB-SLICE of a larger array -- the --meth
+// per-hypothesis dispatch (bsw_run_tier) runs three CONTIGUOUS slices
+// (OT | OB | SYM) of one pair array back-to-back. Padding writes past numPairs
+// would zero the START of the next slice, and that slice's kernel call would
+// then score those real pairs as empty (score == h0, gscore == -1) -> a
+// spurious soft-clip / confident mismap on --meth reads. This RAII guard saves
+// pairArray[numPairs .. roundUp) on construction and restores it on scope exit,
+// so getScores{8,16} never leave a caller's pairs past numPairs modified. The
+// overshoot is at most (width - 1) <= SIMD_WIDTH8 - 1 pairs; callers of a whole
+// array over-allocate by MAX_LINE_LEN so the region is always addressable.
+namespace {
+struct BswOvershootGuard {
+    SeqPair *pa;
+    int base, nOver;
+    SeqPair saved[SIMD_WIDTH8];
+    BswOvershootGuard(SeqPair *pairArray, int numPairs, int width)
+        : pa(pairArray), base(numPairs) {
+        int roundUp = ((numPairs + width - 1) / width) * width;
+        nOver = roundUp - numPairs;
+        for (int s = 0; s < nOver; s++) saved[s] = pa[base + s];
+    }
+    ~BswOvershootGuard() {
+        for (int s = 0; s < nOver; s++) pa[base + s] = saved[s];
+    }
+    BswOvershootGuard(const BswOvershootGuard &) = delete;
+    BswOvershootGuard &operator=(const BswOvershootGuard &) = delete;
+};
+}  // namespace
+
+// ------------------------------------------------------------------------------------
 // MACROs for vector code
 extern uint64_t prof[10][112];
 #define AMBIG 4
@@ -534,8 +569,11 @@ void BandedPairWiseSW::getScores8(SeqPair *pairArray,
                                   int32_t w)
 {
     int64_t startTick, endTick;
-    
-    smithWatermanBatchWrapper8(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
+
+    {
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH8);
+        smithWatermanBatchWrapper8(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
+    }
 
 #if MAXI
     printf("AVX2 Vecor code: Writing output..\n");
@@ -1572,8 +1610,10 @@ void BandedPairWiseSW::getScores16(SeqPair *pairArray,
 {
     int64_t startTick, endTick;
 
-    smithWatermanBatchWrapper16(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
-
+    {
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH16);
+        smithWatermanBatchWrapper16(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
+    }
 
 #if MAXI
     printf("AVX2 Vecor code: Writing output..\n");
@@ -1805,11 +1845,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     swTicks += st4 - st3;
     sort2Ticks += st5 - st4;
 #endif
-    
+
     // free mem
     _mm_free(seq1SoA);
     _mm_free(seq2SoA);
-    
+
     return;
 }
 
@@ -2454,8 +2494,11 @@ void BandedPairWiseSW::getScores8(SeqPair *pairArray,
     int i;
     int64_t startTick, endTick;
 
-    smithWatermanBatchWrapper8(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
-    
+    {
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH8);
+        smithWatermanBatchWrapper8(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
+    }
+
 #if MAXI
     printf("AVX512/8 Vecor code: Writing output..\n");
     for (int l=0; l<numPairs; l++)
@@ -3453,8 +3496,11 @@ void BandedPairWiseSW::getScores16(SeqPair *pairArray,
     int i;
     int64_t startTick, endTick;
 
-    smithWatermanBatchWrapper16(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
-    
+    {
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH16);
+        smithWatermanBatchWrapper16(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
+    }
+
 #if MAXI
     printf("AVX512 Vecor code: Writing output..\n");
     for (int l=0; l<numPairs; l++)
@@ -3691,11 +3737,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     swTicks += st4 - st3;
     sort2Ticks += st5 - st4;
 #endif
-    
+
     // free mem
     _mm_free(seq1SoA);
     _mm_free(seq2SoA);
-    
+
     return;
 }
 
@@ -4286,9 +4332,12 @@ void BandedPairWiseSW::getScores16(SeqPair *pairArray,
                                    uint16_t numThreads,
                                    int32_t w)
 {
-    smithWatermanBatchWrapper16(pairArray, seqBufRef,
-                                seqBufQer, numPairs,
-                                numThreads, w);
+    {
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH16);
+        smithWatermanBatchWrapper16(pairArray, seqBufRef,
+                                    seqBufQer, numPairs,
+                                    numThreads, w);
+    }
 
 #if MAXI
     for (int l=0; l<numPairs; l++)
@@ -4299,7 +4348,7 @@ void BandedPairWiseSW::getScores16(SeqPair *pairArray,
 
     }
 #endif
-    
+
 }
 
 void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
@@ -4517,10 +4566,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
     swTicks += st4 - st3;
     sort2Ticks += st5 - st4;
 #endif
+
     // free mem
     _mm_free(seq1SoA);
     _mm_free(seq2SoA);
-    
+
     return;
 }
 
@@ -5107,9 +5157,11 @@ void BandedPairWiseSW::getScores8(SeqPair *pairArray,
                                   int32_t w)
 {
     assert(SIMD_WIDTH8 == 16 && SIMD_WIDTH16 == 8);
-    smithWatermanBatchWrapper8(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
+    {
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH8);
+        smithWatermanBatchWrapper8(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
+    }
 
-    
 #if MAXI
     printf("Vecor code: Writing output..\n");
     for (int l=0; l<numPairs; l++)

--- a/test/unit/test_bandedswa_longread.cpp
+++ b/test/unit/test_bandedswa_longread.cpp
@@ -345,4 +345,81 @@ TEST_CASE("bandedSWA 8-bit query-end gscore/gtle byte-identical to scalar under 
     CHECK(oracle.gtle > oracle.tle + 10);
 }
 
+// Regression test for the --meth per-hypothesis sub-slice overshoot bug.
+//
+// The batched kernels round numPairs up to their SIMD width and initialize the
+// padding lanes pairArray[numPairs .. roundUp) in place (len=0 dummy pairs).
+// A caller may legitimately invoke the kernel on a SUB-SLICE of a larger array
+// -- the --meth dispatch (bsw_run_tier) runs three contiguous slices
+// (OT | OB | SYM) of one pair array back-to-back. If the kernel scribbles
+// padding past numPairs it zeroes the START of the next slice; that slice's
+// kernel call then scores those real pairs as empty (score==h0, gscore==-1),
+// producing a spurious soft-clip / confident mismap on --meth reads. So the
+// kernels must not modify pairArray outside [0, numPairs).
+TEST_CASE("bandedSWA getScores16/getScores8 leave pairArray[numPairs..] untouched"
+          " (sub-slice overshoot safety)"
+          * doctest::test_suite("unit/bandedswa")) {
+    const int a = 1, b = 2, o = 6, e = 1, end_bonus = 10, w = 100, zdrop = 100;
+    int8_t mat[25];
+    build_mat(mat, a, b, -1);
+    BandedPairWiseSW bsw(o, e, o, e, zdrop, end_bonus, mat, a, b, 1);
+
+    // n deliberately NOT a multiple of any SIMD width so roundUp(n) > n and the
+    // kernel has padding lanes to initialize past numPairs.
+    const int n = 5;
+    const int GUARD = SIMD_WIDTH8;          // widest tier's overshoot
+    const int STRIDE = 64;
+    std::vector<uint8_t> ref((size_t)(n + GUARD) * STRIDE + MAX_LINE_LEN, 0);
+    std::vector<uint8_t> qer((size_t)(n + GUARD) * STRIDE + MAX_LINE_LEN, 0);
+    std::vector<SeqPair> pairs((size_t)(n + GUARD) + MAX_LINE_LEN, SeqPair());
+
+    // n real all-match pairs (ref A-run vs read A-run).
+    for (int c = 0; c < n; ++c) {
+        uint8_t *rs = &ref[(size_t)c * STRIDE];
+        uint8_t *qs = &qer[(size_t)c * STRIDE];
+        for (int i = 0; i < 20; ++i) rs[i] = 0;
+        for (int i = 0; i < 15; ++i) qs[i] = 0;
+        pairs[c].id = c; pairs[c].len1 = 20; pairs[c].len2 = 15; pairs[c].h0 = 30;
+        pairs[c].idr = (int64_t)c * STRIDE; pairs[c].idq = (int64_t)c * STRIDE;
+        pairs[c].seqid = c; pairs[c].regid = 0;
+        pairs[c].score = pairs[c].tle = pairs[c].gtle = pairs[c].qle =
+            pairs[c].gscore = pairs[c].max_off = -1;
+    }
+    // GUARD sentinel pairs occupying pairArray[n .. n+GUARD): stand-ins for the
+    // next slice's real pairs. Distinctive values so any kernel write is caught.
+    auto set_sentinel = [](SeqPair &p, int c) {
+        p.id = 1000 + c; p.len1 = 37; p.len2 = 21; p.h0 = 129;
+        p.idr = 700000 + c; p.idq = 800000 + c;
+        p.seqid = 500 + c; p.regid = 3;
+        p.score = 111; p.qle = 112; p.tle = 113;
+        p.gscore = 114; p.gtle = 115; p.max_off = 116;
+    };
+    std::vector<SeqPair> expected(GUARD);
+    for (int c = 0; c < GUARD; ++c) { set_sentinel(pairs[n + c], c); expected[c] = pairs[n + c]; }
+
+    auto sentinels_intact = [&](const char *which) {
+        for (int c = 0; c < GUARD; ++c) {
+            const SeqPair &g = pairs[n + c], &x = expected[c];
+            INFO("call=" << which << " sentinel=" << c);
+            CHECK(g.id == x.id); CHECK(g.len1 == x.len1); CHECK(g.len2 == x.len2);
+            CHECK(g.h0 == x.h0); CHECK(g.idr == x.idr); CHECK(g.idq == x.idq);
+            CHECK(g.seqid == x.seqid); CHECK(g.regid == x.regid);
+            CHECK(g.score == x.score); CHECK(g.gscore == x.gscore);
+            CHECK(g.qle == x.qle); CHECK(g.tle == x.tle);
+            CHECK(g.gtle == x.gtle); CHECK(g.max_off == x.max_off);
+        }
+    };
+
+    bsw.getScores16(pairs.data(), ref.data(), qer.data(), n, 1, w);
+    sentinels_intact("getScores16");
+
+    for (int c = 0; c < GUARD; ++c) set_sentinel(pairs[n + c], c);  // reset
+    for (int c = 0; c < n; ++c) {
+        pairs[c].score = pairs[c].tle = pairs[c].gtle = pairs[c].qle =
+            pairs[c].gscore = pairs[c].max_off = -1;
+    }
+    bsw.getScores8(pairs.data(), ref.data(), qer.data(), n, 1, w);
+    sentinels_intact("getScores8");
+}
+
 #endif // HAVE_BSW_VECTOR_8_16


### PR DESCRIPTION
## Summary

The batched banded-SW kernels (`getScores8` / `getScores16`) round `numPairs` up to their SIMD width and **initialize the padding lanes `pairArray[numPairs .. roundUp)` in place** (len=0 dummy pairs). That is safe when the kernel owns the whole array, but the `--meth` per-hypothesis dispatch (`bsw_run_tier`) invokes the kernel on three **contiguous sub-slices** of one pair array back-to-back — `[OT | OB | SYM]`. The padding write of an earlier slice overshoots up to `width-1` pairs into the **start of the next slice** and zeroes real pairs (`len1=len2=idr=idq=0`); that slice's kernel call then scores them as empty (`score==h0`, `gscore==-1`), collapsing the extension to a spurious soft-clip and, in a few cases, a confident wrong-chromosome mismap.

This was the true root cause of the `--fast --meth` soft-clip/mismap regression (superseding the #197 workaround, which only masked it by forcing a single all-16-bit grouping).

## Fix

Wrap each of the 6 `getScores{8,16}` tier variants' kernel call in an RAII guard (`BswOvershootGuard`) that saves `pairArray[numPairs .. roundUp)` on entry and restores it on scope exit — so the kernels never modify a caller's pairs outside `[0, numPairs)`. Whole-array callers are unaffected (they own the padding region). This also protects the other sub-slice caller (mate-SW in `bwamem_pair.cpp`).

## Validation

- New TDD unit test asserts the invariant for both `getScores16` and `getScores8` (RED→GREEN); full unit suite green (84 cases, 2.93M assertions), byte-identical to scalar.
- On the 1M-pair `--meth` slice: soft-clipped primaries **8683 → 3579** (−59%), matching the all-16-bit reference **while keeping the 8-bit fast path**; confident wrong-chromosome mismaps 1846 → 1778. `holodeck::70` R2 now maps `150M` (= truth) instead of `129M21S`.
- Validated on x86 (AVX2): all 5 tier variants compile; avx2 runtime output byte-identical to arm.
- Meth wall time unchanged (the 8-bit vs 16-bit tier is a ~2.5s-of-30s wash on this workload).

Supersedes #197.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where SIMD-based scoring could overwrite records just beyond the requested range, preventing accidental corruption of nearby results.
  * Improved stability when processing batches that do not align to SIMD widths.

* **Tests**
  * Added coverage to verify scoring functions leave out-of-range entries unchanged for non-multiple batch sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->