### PR TITLE
perf(seeding): fix ~12% x86 default-path regression from --seed-order (#186)

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1287,6 +1287,61 @@ static inline int meth_seed_to_orig(const bntseq_t *seed_bns,
     return 0;
 }
 
+/* Chain one fully-resolved seed into the per-read kbtree: find the closest
+ * existing chain and test_and_merge, else open a new chain. Extracted verbatim
+ * from mem_chain_seeds's per-seed body so the two seed-emit paths share it: the
+ * default (SEED_ORDER_OFF) streams each seed straight here as it is resolved
+ * (single pass, no buffering), while the opt-in reorder modes materialize all
+ * seeds, order them, then replay them through here. Behaviour is identical to
+ * the previous inline body; only the call site differs. */
+static inline void chain_add_one_seed(const mem_opt_t *opt, int64_t l_pac,
+                                      const bntseq_t *chain_bns, kbtree_t(chn) *tree,
+                                      mem_seed_t *seedBuf, int64_t *seedBufCount,
+                                      int64_t seedBufSize, int tid, int seqid,
+                                      int *num_seqid, const mem_seed_t *seed_in,
+                                      int rid, int8_t meth_hyp)
+{
+    mem_seed_t s = *seed_in;
+    mem_chain_t tmp, *lower, *upper;
+    int to_add = 0;
+    tmp.pos = s.rbeg;
+
+    if (kb_size(tree))
+    {
+        kb_intervalp(chn, tree, &tmp, &lower, &upper); // find the closest chain
+
+        if (!lower || !test_and_merge(opt, l_pac, lower, &s, rid, tid))
+            to_add = 1;
+    }
+    else to_add = 1;
+
+    if (to_add) // add the seed as a new chain
+    {
+        tmp.n = 1; tmp.m = SEEDS_PER_CHAIN;
+        if((*seedBufCount + tmp.m) > seedBufSize)
+        {
+            tmp.m += 1;
+            tmp.seeds = (mem_seed_t *)calloc (tmp.m, sizeof(mem_seed_t));
+            assert(tmp.seeds != NULL);
+            tprof[PE13][tid]++;
+        }
+        else {
+            tmp.seeds = seedBuf + *seedBufCount;
+            *seedBufCount += tmp.m;
+        }
+        memset((char*) (tmp.seeds), 0, tmp.m * sizeof(mem_seed_t));
+        tmp.seeds[0] = s;
+        tmp.rid = rid;
+        tmp.seqid = seqid;
+        /* is_alt indexes the chain-side bns (original in --meth). */
+        tmp.is_alt = !!chain_bns->anns[rid].is_alt;
+        /* D3: carry the OT/OB hypothesis on the chain (-1 non-meth). */
+        tmp.meth_hypothesis = meth_hyp;
+        kb_putp(chn, tree, &tmp);
+        (*num_seqid)++;
+    }
+}
+
 /** NEW ONE **/
 void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
                      const bntseq_t *bns,
@@ -1310,6 +1365,11 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
     const int meth_remap = (opt->meth_mode && meth_orig_bns != NULL);
     const bntseq_t *chain_bns = meth_remap ? meth_orig_bns : bns;
     int64_t l_pac = chain_bns->l_pac;
+    /* Seed-emit strategy. OFF (the default) streams each resolved seed straight
+     * into the kbtree in resolve order — no recs[] buffer, no order_seeds pass —
+     * which is byte-identical to, and as cheap as, the pre-seed-order baseline.
+     * Only a selected reorder mode needs the materialize/order/replay path. */
+    const int reorder = (opt->seed_emit_order != SEED_ORDER_OFF);
 
     int num[nseq];
     memset(num, 0, nseq*sizeof(int));
@@ -1369,18 +1429,31 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
             assert(sa_coord != NULL);
         }
 
-        /* Phase A buffer (Spec S4): ceiling = (#SMEMs this read) * max_occ, the
-         * same prefetch ceiling sa_coord is sized to. Grow with realloc, persist
-         * across reads. Reset nrec per read. */
+        /* Phase A buffer (Spec S4): resolved-seed records for the reorder path.
+         * Grow with realloc, persist across reads. Reset nrec per read. Only the
+         * opt-in reorder modes populate it; OFF streams straight to chaining. */
         int64_t nrec = 0;
-        int64_t recs_need = (pos - smem_ptr + 1) * (int64_t)opt->max_occ;
-        if (recs_need > recs_cap)
+        if (reorder)
         {
-            recs_cap = recs_need;
-            /* CodeRabbit: temp pointer so a NULL realloc doesn't leak recs. */
-            seed_rec_t *recs_new = (seed_rec_t *) realloc(recs, recs_cap * sizeof(seed_rec_t));
-            assert(recs_new != NULL);
-            recs = recs_new;
+            /* Tight ceiling: each SMEM contributes at most min(occ, max_occ)
+             * resolved seeds (the resolve loop below stops at the occurrence
+             * count and caps at max_occ), so summing that is a far snugger bound
+             * than the old (#SMEMs * max_occ) worst case whenever most SMEMs are
+             * low-occurrence. Still a strict upper bound on nrec. */
+            int64_t recs_need = 0;
+            for (int64_t si = smem_ptr; si <= pos; ++si)
+            {
+                int64_t occ = matchArray[si].s;
+                recs_need += occ < opt->max_occ ? occ : opt->max_occ;
+            }
+            if (recs_need > recs_cap)
+            {
+                recs_cap = recs_need;
+                /* CodeRabbit: temp pointer so a NULL realloc doesn't leak recs. */
+                seed_rec_t *recs_new = (seed_rec_t *) realloc(recs, recs_cap * sizeof(seed_rec_t));
+                assert(recs_new != NULL);
+                recs = recs_new;
+            }
         }
 
         int64_t id = 0, cnt_ = 0, mypos = 0;
@@ -1451,70 +1524,42 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
                 // don't discard it!!!
                 if (rid < 0) continue;
 
-                // Phase A: append the fully-resolved seed (drops above already
-                // consumed the SA slot). B1: copy the FULL mem_seed_t.
-                seed_rec_t *r = &recs[nrec++];
-                r->seed = s;
-                r->rid = rid;
-                r->meth_hyp = meth_hyp; // -1 when !meth_remap
-                r->orig_ix = (uint32_t)(nrec - 1);
+                if (!reorder)
+                {
+                    /* OFF (default): chain the seed immediately, in resolve
+                     * order — the single-pass streaming path. No recs[] write,
+                     * no order_seeds; byte-identical to buffering with the
+                     * identity order but without the double memory traffic. */
+                    chain_add_one_seed(opt, l_pac, chain_bns, tree, seedBuf,
+                                       &seedBufCount, seedBufSize, tid, l, &num[l],
+                                       &s, rid, meth_hyp);
+                }
+                else
+                {
+                    // Phase A: append the fully-resolved seed (drops above already
+                    // consumed the SA slot). B1: copy the FULL mem_seed_t.
+                    seed_rec_t *r = &recs[nrec++];
+                    r->seed = s;
+                    r->rid = rid;
+                    r->meth_hyp = meth_hyp; // -1 when !meth_remap
+                    r->orig_ix = (uint32_t)(nrec - 1);
+                }
             }
         } // seeds
 
-        // Phase B (order). Identity for SEED_ORDER_OFF; stable on orig_ix.
-        order_seeds(recs, nrec, opt->seed_emit_order);
-
-        // Phase C (chain). MOVED verbatim from the old per-seed body; sources
-        // s/rid/meth_hyp from the ordered buffer. S5: equal-pos insertion order
-        // into the kbtree is preserved (no dedup/compact beyond order_seeds).
-        for (int64_t ri = 0; ri < nrec; ++ri)
+        if (reorder)
         {
-            mem_seed_t s = recs[ri].seed;
-            int rid = recs[ri].rid;
-            int8_t meth_hyp = recs[ri].meth_hyp;
-            mem_chain_t tmp, *lower, *upper;
-            int to_add = 0;
-            tmp.pos = s.rbeg;
+            // Phase B (order). Stable on orig_ix.
+            order_seeds(recs, nrec, opt->seed_emit_order);
 
-            if (kb_size(tree))
-            {
-                kb_intervalp(chn, tree, &tmp, &lower, &upper); // find the closest chain
-
-                if (!lower || !test_and_merge(opt, l_pac, lower, &s, rid, tid))
-                    to_add = 1;
-            }
-            else to_add = 1;
-
-            //uint64_t tim = __rdtsc();
-            if (to_add) // add the seed as a new chain
-            {
-                tmp.n = 1; tmp.m = SEEDS_PER_CHAIN;
-                if((seedBufCount + tmp.m) > seedBufSize)
-                {
-                    tmp.m += 1;
-                    tmp.seeds = (mem_seed_t *)calloc (tmp.m, sizeof(mem_seed_t));
-                    assert(tmp.seeds != NULL);
-                    tprof[PE13][tid]++;
-                }
-                else {
-                    tmp.seeds = seedBuf + seedBufCount;
-                    seedBufCount += tmp.m;
-                }
-                memset((char*) (tmp.seeds), 0, tmp.m * sizeof(mem_seed_t));
-                tmp.seeds[0] = s;
-                tmp.rid = rid;
-                tmp.seqid = l;
-                /* is_alt indexes the chain-side bns (original in --meth). */
-                tmp.is_alt = !!chain_bns->anns[rid].is_alt;
-                /* D3: carry the OT/OB hypothesis on the chain (-1 non-meth).
-                 * All seeds of one read share a hypothesis (directional
-                 * R1→OT / R2→OB), so test_and_merge needs no hypothesis
-                 * guard; new chains for the same read get the same label. */
-                tmp.meth_hypothesis = meth_hyp;
-                kb_putp(chn, tree, &tmp);
-                num[l]++;
-            }
-        } // Phase C
+            // Phase C (chain). Replay the ordered buffer through the shared
+            // chaining helper. S5: equal-pos insertion order into the kbtree is
+            // preserved (no dedup/compact beyond order_seeds).
+            for (int64_t ri = 0; ri < nrec; ++ri)
+                chain_add_one_seed(opt, l_pac, chain_bns, tree, seedBuf,
+                                   &seedBufCount, seedBufSize, tid, l, &num[l],
+                                   &recs[ri].seed, recs[ri].rid, recs[ri].meth_hyp);
+        } // reorder
 
         smem_ptr = pos + 1;
         size = kb_size(tree);

--- a/src/seed_order.cpp
+++ b/src/seed_order.cpp
@@ -1,5 +1,6 @@
 #include "seed_order.h"
 #include <cassert>
+#include <climits>
 #include <string.h>
 #include <vector>
 
@@ -24,20 +25,43 @@ const char *seed_order_to_str(seed_order_t m) {
     return kNames[(int)m];
 }
 
-// Stable counting sort of recs[0..n) by key[i] in [0,maxk]. desc descends
-// (via maxk-key, preserving stability). scratch is reused across passes.
-static void counting_sort_by(seed_rec_t *recs, int n, std::vector<int> &key,
-                             int maxk, bool desc, std::vector<seed_rec_t> &scratch) {
+namespace {
+
+/* Reusable per-thread scratch. order_seeds runs once per read on each worker
+ * thread, so the buffers below would otherwise be malloc'd/freed millions of
+ * times over a run. thread_local keeps one set per worker, grown to the
+ * high-water mark and reused; nothing here is shared across threads. */
+struct OrderScratch {
+    std::vector<int>           perm;      // index permutation being sorted (4 B/elem)
+    std::vector<int>           tmp;       // stable-scatter target for perm
+    std::vector<int>           key;       // per-seed sort key, indexed by orig position
+    std::vector<int>           cnt;       // counting-sort histogram
+    std::vector<seed_rec_t>    applied;   // final materialization of the permutation
+    std::vector<unsigned char> mat;       // genomic modes: n x n absorb matrix
+    std::vector<int>           rowsum;    // genomic modes: per-seed absorb count
+    std::vector<char>          consumed;  // most-absorb: greedy consumed flags
+};
+thread_local OrderScratch g;
+
+/* Stable counting sort of the index permutation g.perm[0..n) by g.key[perm[i]]
+ * in [0,maxk]. desc descends via (maxk-key) while preserving stability. Only
+ * 4-byte indices move here; order_seeds applies the final permutation to recs
+ * once, so a full seed_rec_t is copied a single time regardless of pass count. */
+void sort_perm(int n, int maxk, bool desc) {
+    int *perm = g.perm.data();
+    int *key  = g.key.data();
     if (desc) for (int i = 0; i < n; ++i) key[i] = maxk - key[i];
-    std::vector<int> cnt(maxk + 2, 0);
-    for (int i = 0; i < n; ++i) ++cnt[key[i] + 1];
+    g.cnt.assign(maxk + 2, 0);
+    int *cnt = g.cnt.data();
+    for (int i = 0; i < n; ++i) ++cnt[key[perm[i]] + 1];
     for (int k = 1; k <= maxk + 1; ++k) cnt[k] += cnt[k - 1];   // start offsets
-    scratch.resize(n);
-    for (int i = 0; i < n; ++i) scratch[cnt[key[i]]++] = recs[i];  // stable, ascending
-    for (int i = 0; i < n; ++i) recs[i] = scratch[i];
+    g.tmp.resize(n);
+    int *tmp = g.tmp.data();
+    for (int i = 0; i < n; ++i) tmp[cnt[key[perm[i]]]++] = perm[i];  // stable, ascending
+    for (int i = 0; i < n; ++i) perm[i] = tmp[i];
 }
 
-static inline bool absorbs(const seed_rec_t &A, const seed_rec_t &B) {
+inline bool absorbs(const seed_rec_t &A, const seed_rec_t &B) {
     if (A.rid != B.rid) return false;  // seeds on different chromosomes/contigs can't absorb each other
     const mem_seed_t &a = A.seed, &b = B.seed;
     bool qin = (b.qbeg >= a.qbeg) && (b.qbeg + b.len <= a.qbeg + a.len);
@@ -47,82 +71,102 @@ static inline bool absorbs(const seed_rec_t &A, const seed_rec_t &B) {
     return A.orig_ix < B.orig_ix;                        // equal-size: lower ix wins
 }
 
-static int max_of(seed_rec_t *recs, int n, bool use_qbeg) {
+int max_of(const seed_rec_t *recs, int n, bool use_qbeg) {
     int m = 0;
     for (int i = 0; i < n; ++i) { int v = use_qbeg ? recs[i].seed.qbeg : recs[i].seed.len; if (v > m) m = v; }
     return m;
 }
 
+} // namespace
+
 void order_seeds(seed_rec_t *recs, int64_t n, seed_order_t mode) {
     if (mode == SEED_ORDER_OFF || n < 2) return;
     assert(n <= INT_MAX);
     int ni = (int)n;
-    std::vector<seed_rec_t> scratch;
-    std::vector<int> key(ni);
+
+    // perm starts as the identity => recs' current (orig_ix) order, which every
+    // stable pass below preserves as the final tiebreak.
+    g.perm.resize(ni);
+    for (int i = 0; i < ni; ++i) g.perm[i] = i;
+    g.key.resize(ni);
+
     switch (mode) {
     case SEED_ORDER_GLOBAL_LONGEST: {
         int mk = max_of(recs, ni, false);
-        for (int i = 0; i < ni; ++i) key[i] = recs[i].seed.len;
-        counting_sort_by(recs, ni, key, mk, /*desc=*/true, scratch);
+        for (int i = 0; i < ni; ++i) g.key[i] = recs[i].seed.len;
+        sort_perm(ni, mk, /*desc=*/true);
         break;
     }
     case SEED_ORDER_LOCAL_LONGEST: {
         int mklen = max_of(recs, ni, false), mkq = max_of(recs, ni, true);
-        for (int i = 0; i < ni; ++i) key[i] = recs[i].seed.len;          // LSD: secondary first
-        counting_sort_by(recs, ni, key, mklen, /*desc=*/true, scratch);
-        for (int i = 0; i < ni; ++i) key[i] = recs[i].seed.qbeg;         // then primary qbeg asc
-        counting_sort_by(recs, ni, key, mkq, false, scratch);
+        for (int i = 0; i < ni; ++i) g.key[i] = recs[i].seed.len;          // LSD: secondary first
+        sort_perm(ni, mklen, /*desc=*/true);
+        for (int i = 0; i < ni; ++i) g.key[i] = recs[i].seed.qbeg;         // then primary qbeg asc
+        sort_perm(ni, mkq, /*desc=*/false);
         break;
     }
     case SEED_ORDER_ABSORB_COUNT: {
         if (ni > GENOMIC_ORDER_MAX_N) {   // O(n^2) count too costly; longest-first is ~equivalent and O(n)
             order_seeds(recs, n, SEED_ORDER_GLOBAL_LONGEST);
-            break;
+            return;
         }
         for (int i = 0; i < ni; ++i) {
             int c = 0;
             for (int j = 0; j < ni; ++j)
                 if (j != i && absorbs(recs[i], recs[j])) ++c;
-            key[i] = c;
+            g.key[i] = c;
         }
-        counting_sort_by(recs, ni, key, ni - 1, /*desc=*/true, scratch);
+        sort_perm(ni, ni - 1, /*desc=*/true);
         break;
     }
     case SEED_ORDER_MOST_ABSORB: {
         if (ni > GENOMIC_ORDER_MAX_N) {        // guard: n x n matrix + O(n^2) too costly; fall back O(n)
             order_seeds(recs, n, SEED_ORDER_GLOBAL_LONGEST);
-            break;
+            return;
         }
-        std::vector<unsigned char> M((size_t)ni * ni, 0);
-        std::vector<int> rowsum(ni, 0);
+        g.mat.assign((size_t)ni * ni, 0);
+        g.rowsum.assign(ni, 0);
+        unsigned char *M = g.mat.data();
+        int *rowsum = g.rowsum.data();
         for (int i = 0; i < ni; ++i)
             for (int j = 0; j < ni; ++j)
                 if (j != i && absorbs(recs[i], recs[j])) { M[(size_t)i*ni + j] = 1; ++rowsum[i]; }
-        std::vector<char> consumed(ni, 0);
-        std::vector<seed_rec_t> out; out.reserve(ni);
+        g.consumed.assign(ni, 0);
+        char *consumed = g.consumed.data();
+        int np = 0;  // greedy pick order is written straight into perm
         for (int picked = 0; picked < ni; ++picked) {
             int best = -1;
-            // Phase A assigns orig_ix in append order, so the buffer is in orig_ix order on entry;
-            // iterating i=0..ni-1 therefore breaks ties by orig_ix (lower orig_ix wins), as required.
-            for (int i = 0; i < ni; ++i) {       // max rowsum, tiebreak orig_ix (i is in ix order)
+            // recs is in orig_ix order, so iterating i=0..ni-1 breaks rowsum ties
+            // by orig_ix (lower wins), as required.
+            for (int i = 0; i < ni; ++i) {
                 if (consumed[i]) continue;
                 if (best < 0 || rowsum[i] > rowsum[best]) best = i;
             }
             if (best < 0) break;
-            out.push_back(recs[best]);
+            g.perm[np++] = best;
             consumed[best] = 1;
+            // No need to decrement column `best` (live absorbers of best): at
+            // selection time no live seed can absorb best. Such a seed would
+            // absorb best plus everything best absorbs (containment + length
+            // order are transitive), giving rowsum >= rowsum[best]+1 > rowsum[best],
+            // so it would have been picked as best instead. rowsum thus stays an
+            // exact live-count for every still-live seed without this decrement.
             for (int j = 0; j < ni; ++j) {       // consume everything best absorbs
                 if (consumed[j] || !M[(size_t)best*ni + j]) continue;
                 consumed[j] = 1;
-                out.push_back(recs[j]);          // absorbed seeds still chained (dropped by chainer)
+                g.perm[np++] = j;                // absorbed seeds still chained (dropped by chainer)
                 for (int i = 0; i < ni; ++i)     // decrement live absorbers of j (column j)
                     if (!consumed[i] && M[(size_t)i*ni + j]) --rowsum[i];
             }
         }
-        assert((int)out.size() == ni);
-        for (int i = 0; i < ni; ++i) recs[i] = out[i];
+        assert(np == ni);
         break;
     }
-    default: assert(0 && "unhandled seed_order_t in order_seeds"); break;
+    default: assert(0 && "unhandled seed_order_t in order_seeds"); return;
     }
+
+    // Apply the permutation to recs exactly once — the only full seed_rec_t move.
+    g.applied.resize(ni);
+    for (int i = 0; i < ni; ++i) g.applied[i] = recs[g.perm[i]];
+    for (int i = 0; i < ni; ++i) recs[i] = g.applied[i];
 }


### PR DESCRIPTION
## Summary

bwa-mem3 0.5.0 regressed the **default alignment path** on x86 by ~12–13% CPU versus 0.4.0. This restores it, and additionally trims the opt-in reorder path.

## Root cause

#186 (`--seed-order`) refactored `mem_chain_seeds` from a single streaming pass (resolve a seed, chain it inline) into resolve → buffer → order → chain. Even with `--seed-order off` — the default, which `order_seeds` treats as a no-op — every resolved seed is materialized into a `recs[]` buffer and re-read in a second pass. On x86 the double memory traffic and lost cache locality cost ~12–13% CPU on the default path.

Bisected on a bare-metal c6a.4xlarge (AVX2, AMD EPYC 7R13 / Zen 3), 3 reps, kernel-only `PROCESS` CPU-sec on panel-twist-5M:

| commit | CPU-sec | vs 0.4.0 |
| --- | ---: | ---: |
| v0.4.0 `2681143b` | 1959.6 | — |
| **#186 `04749a1`** | **2222.2** | **+13.4%** |
| #187 `1384972` | 2235.1 | flat |
| #189 `a946af8` | 2270.3 | flat (noise) |
| main `c9ffef1` | 2282.2 | |

The step is entirely #186; everything after is flat within noise. It is x86-only — Graviton (NEON) was unaffected, which is why NEON-based local checks missed it.

## Fix

- **Commit 1 — restore the single-pass streaming path for `--seed-order off`.** Extract the per-seed chaining into a shared `chain_add_one_seed()` helper and chain each seed inline as it resolves when off (no `recs[]`, no `order_seeds`). The opt-in reorder modes keep the materialize/order/replay path through the same helper, so their behaviour is unchanged. `recs[]` is allocated only when a reorder mode is active, with its ceiling tightened from `#SMEMs * max_occ` to `Σ min(occ, max_occ)`.
- **Commit 2 — trim the opt-in reorder path.** Reuse per-thread scratch across reads (kills ~4 malloc/free per read in the sort) and sort a `uint32` index permutation instead of moving 48-byte `seed_rec_t` on every pass.

## Validation (bare-metal c6a, AVX2)

- **Perf:** panel-twist / c6a `2282 → 2009` median CPU-sec (**−12%**), back to the pre-#186 level.
- **Byte-identical output** on 7.9M real records, unfixed vs fixed, for **all five `--seed-order` modes** — off, global-longest, local-longest, absorb-count, most-absorb (records-only sorted md5 matched on each).
- Ordering invariants additionally covered by `test/unit/test_seed_order.cpp`.

## Note (out of scope)

The fixed default path (2009) is still ~2.5% above 0.4.0 (1959). That residual is a separate, much smaller effect from a different commit (most likely #199's `getScores` overshoot guard, which also runs on non-meth alignment) — a follow-up, not this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced temporary allocations during seed ordering and chaining, improving efficiency on reads with many candidate seeds.
* **Behavior Changes**
  * Seed processing can now either chain immediately or preserve ordering first, depending on the selected seed emission order.
  * Ordering results remain stable while using less per-call scratch space.
* **Bug Fixes**
  * Improved buffer sizing for reordered seed handling to better match actual needs and avoid excess resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->