### PR TITLE
perf(bandedSWA): gate the getScores overshoot guard to sub-slice (--meth OT/OB) callers

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -55,13 +55,22 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 // so getScores{8,16} never leave a caller's pairs past numPairs modified. The
 // overshoot is at most (width - 1) <= SIMD_WIDTH8 - 1 pairs; callers of a whole
 // array over-allocate by MAX_LINE_LEN so the region is always addressable.
+//
+// The save/restore is only needed for a SUB-SLICE caller (the --meth OT/OB
+// runs, whose overshoot lands in the next slice's live pairs). A whole-array
+// caller -- every non-meth extension, plus the last (SYM) --meth slice -- has
+// nothing but its own over-allocated padding past numPairs, so guarding it is
+// pure overhead on the hot path. It is therefore gated on `active`: only the
+// OT/OB kernel objects set it (via set_guard_overshoot); when false the guard
+// is a no-op (nOver stays 0, both loops empty).
 namespace {
 struct BswOvershootGuard {
     SeqPair *pa;
     int base, nOver;
     SeqPair saved[SIMD_WIDTH8];
-    BswOvershootGuard(SeqPair *pairArray, int numPairs, int width)
-        : pa(pairArray), base(numPairs) {
+    BswOvershootGuard(SeqPair *pairArray, int numPairs, int width, bool active)
+        : pa(pairArray), base(numPairs), nOver(0) {
+        if (!active) return;
         int roundUp = ((numPairs + width - 1) / width) * width;
         nOver = roundUp - numPairs;
         for (int s = 0; s < nOver; s++) saved[s] = pa[base + s];
@@ -571,7 +580,7 @@ void BandedPairWiseSW::getScores8(SeqPair *pairArray,
     int64_t startTick, endTick;
 
     {
-        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH8);
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH8, guard_overshoot_);
         smithWatermanBatchWrapper8(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
     }
 
@@ -1611,7 +1620,7 @@ void BandedPairWiseSW::getScores16(SeqPair *pairArray,
     int64_t startTick, endTick;
 
     {
-        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH16);
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH16, guard_overshoot_);
         smithWatermanBatchWrapper16(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
     }
 
@@ -2495,7 +2504,7 @@ void BandedPairWiseSW::getScores8(SeqPair *pairArray,
     int64_t startTick, endTick;
 
     {
-        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH8);
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH8, guard_overshoot_);
         smithWatermanBatchWrapper8(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
     }
 
@@ -3497,7 +3506,7 @@ void BandedPairWiseSW::getScores16(SeqPair *pairArray,
     int64_t startTick, endTick;
 
     {
-        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH16);
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH16, guard_overshoot_);
         smithWatermanBatchWrapper16(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
     }
 
@@ -4333,7 +4342,7 @@ void BandedPairWiseSW::getScores16(SeqPair *pairArray,
                                    int32_t w)
 {
     {
-        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH16);
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH16, guard_overshoot_);
         smithWatermanBatchWrapper16(pairArray, seqBufRef,
                                     seqBufQer, numPairs,
                                     numThreads, w);
@@ -5158,7 +5167,7 @@ void BandedPairWiseSW::getScores8(SeqPair *pairArray,
 {
     assert(SIMD_WIDTH8 == 16 && SIMD_WIDTH16 == 8);
     {
-        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH8);
+        BswOvershootGuard _g(pairArray, numPairs, SIMD_WIDTH8, guard_overshoot_);
         smithWatermanBatchWrapper8(pairArray, seqBufRef, seqBufQer, numPairs, numThreads, w);
     }
 

--- a/src/bandedSWA.h
+++ b/src/bandedSWA.h
@@ -349,6 +349,12 @@ public:
     /* SW_cells is a public field on BandedPairWiseSW today; expose as a getter
      * on the interface so non-virtual access through the unique_ptr works. */
     virtual uint64_t sw_cells() const = 0;
+
+    /* Enable getScores{8,16}'s sub-slice overshoot guard on this object. Off by
+     * default: only sub-slice callers (the --meth OT/OB kernels) need it, and
+     * for whole-array callers the guard is pure overhead. Set once at setup,
+     * before any (possibly multi-threaded) getScores call. */
+    virtual void set_guard_overshoot(bool on) = 0;
 };
 
 /* Factory: returns a per-tier concrete BandedPairWiseSW. Construction
@@ -396,6 +402,12 @@ public:
     BandedPairWiseSW& operator=(BandedPairWiseSW&&)      = delete;
 
     uint64_t sw_cells() const override { return SW_cells; }
+
+    // When true, getScores{8,16} save/restore the padding-lane overshoot past
+    // numPairs (needed only by sub-slice callers -- the --meth OT/OB kernels).
+    // Read-only during scoring; set once at setup via set_guard_overshoot.
+    bool guard_overshoot_ = false;
+    void set_guard_overshoot(bool on) override { guard_overshoot_ = on; }
 
     // Scalar code section
     int scalarBandedSWA(int qlen, const uint8_t *query, int tlen,

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -4065,6 +4065,14 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                                               opt->zdrop, opt->pen_clip3, m_ot, opt->a, opt->b, nthreads);
         bswRightOb = make_banded_pair_wise_sw(opt->o_del, opt->e_del, opt->o_ins, opt->e_ins,
                                               opt->zdrop, opt->pen_clip3, m_ob, opt->a, opt->b, nthreads);
+        /* OT/OB kernels score a SUB-SLICE of the pair array in bsw_run_tier, so
+         * their padding-lane overshoot would corrupt the next slice: enable the
+         * guard on exactly these objects. The SYM object (bswLeft/bswRight) is a
+         * whole-array / last-slice caller and stays unguarded. */
+        bswLeftOt->set_guard_overshoot(true);
+        bswLeftOb->set_guard_overshoot(true);
+        bswRightOt->set_guard_overshoot(true);
+        bswRightOb->set_guard_overshoot(true);
     }
 
     int i;

--- a/test/unit/test_bandedswa_longread.cpp
+++ b/test/unit/test_bandedswa_longread.cpp
@@ -363,6 +363,9 @@ TEST_CASE("bandedSWA getScores16/getScores8 leave pairArray[numPairs..] untouche
     int8_t mat[25];
     build_mat(mat, a, b, -1);
     BandedPairWiseSW bsw(o, e, o, e, zdrop, end_bonus, mat, a, b, 1);
+    // This test emulates a sub-slice caller (the --meth OT/OB kernels), for which
+    // the overshoot guard is enabled; it is off by default for whole-array callers.
+    bsw.set_guard_overshoot(true);
 
     // n deliberately NOT a multiple of any SIMD width so roundUp(n) > n and the
     // kernel has padding lanes to initialize past numPairs.


### PR DESCRIPTION
## Summary

The `BswOvershootGuard` added in #199 saves/restores the SIMD padding-lane overshoot around **every** `getScores{8,16}` call. It's only actually needed for a **sub-slice** caller — the `--meth` OT/OB runs in `bsw_run_tier`, whose overshoot past `numPairs` lands in the *next* slice's live pairs. Every non-meth extension (and the last `--meth` SYM slice) is a **whole-array** caller whose overshoot lands only in its own over-allocated padding, so the save/restore there is pure overhead on the hot banded-SW path.

This scopes the guard to exactly the callers that need it.

## Change

- `BswOvershootGuard` takes a `bool active`; when false it is a no-op (`nOver` stays 0, both loops empty).
- New `IBandedPairWiseSW::set_guard_overshoot(bool)` + a `guard_overshoot_` member on `BandedPairWiseSW`. `getScores{8,16}` pass that flag to the guard. **The hot `getScores` signature is unchanged.**
- Only the OT/OB kernel objects (`bswLeftOt/Ob`, `bswRightOt/Ob` — the sole sub-slice callers) opt in. The symmetric object and all non-meth callers leave it off.
- The sub-slice overshoot-safety unit test (`test_bandedswa_longread.cpp`) opts in explicitly, since it emulates an OT/OB run.

## Correctness

The `--meth` OT/OB sub-slice fix from #199 is preserved unchanged — those objects still guard. This only removes the guard from whole-array callers, where it never protected anything. The existing `test_bandedswa_longread` overshoot-safety case (now opting in) plus the byte-identical goldens cover it.

## Why

On the bare-metal c6a bisect for the #186 `--seed-order` regression (#200), the fixed default path still sat ~2.5% above 0.4.0. This guard — running per `getScores` call on non-meth alignment — is the leading suspect for that residual. Perf is measured separately in bwa-mem3-bench.

Depends on nothing; independent of #200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable safety guard for SIMD scoring paths, enabling protection only when needed.
* **Bug Fixes**
  * Prevented potential data corruption when scoring sub-slices by preserving and restoring overshoot lanes.
  * Reduced unnecessary overhead in standard scoring paths where overshoot is known to be safe.
* **Tests**
  * Updated regression coverage to explicitly exercise the guarded sub-slice scoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->