### PR TITLE
docs: retitle LICENSE for BWA-MEM3 and add Fulcrum copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
                            The MIT License
 
-   BWA-MEM2  (Sequence alignment using Burrows-Wheeler Transform),
+   BWA-MEM3  (Sequence alignment using Burrows-Wheeler Transform),
+   based on BWA-MEM2.
+   Copyright (C) 2026 Fulcrum Genomics LLC.
    Copyright (C) 2019 Intel Corporation, Heng Li.
 
    Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
The `LICENSE` file still carried only the BWA-MEM2 title and the 2019 Intel Corporation / Heng Li copyright. This retitles it to BWA-MEM3 (noting it is based on BWA-MEM2) and adds a Fulcrum Genomics LLC copyright line for the BWA-MEM3 work.

The original Intel / Heng Li notice is deliberately retained: BWA-MEM3 is a derivative work of BWA-MEM2, and the MIT license requires the original copyright notice be included in all copies and derivatives. So this is an *addition*, not a replacement — a straight `s/2/3` would have improperly stripped the upstream copyright.

The Fulcrum copyright line matches the convention used in sibling repos (fgbio, fgumi): `Fulcrum Genomics LLC`.

### Before
```
   BWA-MEM2  (Sequence alignment using Burrows-Wheeler Transform),
   Copyright (C) 2019 Intel Corporation, Heng Li.
```

### After
```
   BWA-MEM3  (Sequence alignment using Burrows-Wheeler Transform),
   based on BWA-MEM2.
   Copyright (C) 2026 Fulcrum Genomics LLC.
   Copyright (C) 2019 Intel Corporation, Heng Li.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the license notice to reflect the current project attribution and copyright holder.
  * Revised the referenced upstream component name in the license header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->