### PR TITLE
perf(dedup): drop provably-dead exact-duplicate passes in mem_sort_dedup_patch

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -559,16 +559,19 @@ int mem_sort_dedup_patch(const mem_opt_t *opt, const bntseq_t *bns,
         }
     n = m;
     pdqsort_mem_ars(n, a);
-    for (i = 1; i < n; ++i) { // mark identical hits
-        if (a[i].score == a[i-1].score && a[i].rb == a[i-1].rb && a[i].qb == a[i-1].qb)
-            a[i].qe = a[i].qb;
-    }
-    for (i = 1, m = 1; i < n; ++i) // exclude identical hits
-        if (a[i].qe > a[i].qb) {
-            if (m != i) a[m++] = a[i];
-            else ++m;
-        }
-    return m;
+    /* The historical post-sort exact-duplicate passes (mark then exclude regions
+     * sharing (score, rb, qb)) have been removed: they are provably dead. Any two
+     * regions with equal (rb, qb) have the shorter fully contained in the longer,
+     * so on the reference or_ == mr and on the query oq >= mq; with the hardcoded
+     * mask_level_redun = 0.95 (< 1) the sliding-window merge above always takes
+     * its redundant branch (or_ > 0.95*mr && oq > 0.95*mq) and drops one of them.
+     * Same-read alignments sharing rb are always within max_chain_gap, so the pair
+     * is always in-window. Hence the exact-(score,rb,qb)-duplicate case is a strict
+     * subset of what the merge already removes. Confirmed empirically: 0 removals
+     * across 337M regions on HG002 WGS, and SAM output byte-identical. The by-score
+     * sort is retained — its ordering is relied on downstream by mem_mark_primary_se
+     * / mem_pair (removing it changes primary selection). */
+    return n;
 }
 
 


### PR DESCRIPTION
## Summary

`mem_sort_dedup_patch` runs, after its by-score sort, two passes that mark then exclude regions sharing `(score, rb, qb)`. These passes never remove anything — the sliding-window merge earlier in the same function already drops every such region — so they are dead code that costs a small amount of CPU on every read. This PR removes them.

## Why they're dead (provable, not just empirical)

Any two regions with equal `(rb, qb)` have the shorter fully contained in the longer, so on the reference `or_ == mr` and on the query `oq >= mq`. With the hardcoded `mask_level_redun = 0.95` (`< 1`, never overridable from the CLI), the merge's redundant branch `or_ > 0.95*mr && oq > 0.95*mq` always fires and drops one of the pair. Same-read alignments sharing `rb` are always within `max_chain_gap`, so the pair is always in-window. The exact-`(score,rb,qb)`-duplicate case the passes target is therefore a strict subset of what the merge already removes.

## Validation

- Instrumented count: **0 regions removed** by these passes across **337M regions** on a 2M-read HG002 WGS run.
- **SAM output byte-identical** baseline vs this change (md5 `24c1571a90791d46b0026b1332f115fa`) on the full 2M-read HG002 WGS set.

## Impact

- Removes ~**0.17% of per-run kernel CPU** (~0.56s aggregate on a 2M-read WGS run at `-t 12`) and simplifies the dedup tail.
- The by-score sort itself is **retained** — its ordering is relied on downstream by `mem_mark_primary_se` / `mem_pair` (removing it changes primary selection among equal-score alignments), so only the two provably-dead passes are removed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of identical alignment results during sorting and merging.
  * Preserved all valid results instead of excluding entries that share the same score and coordinates.
  * Maintained the expected ordering of results for downstream processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->