### PR TITLE
perf(mem): pool per-read scratch in get_sa_entries_prefetch and mem_reg2aln

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -1592,11 +1592,32 @@ int64_t FMI_search::call_one_step(int64_t pos, int64_t &sa_entry, int64_t &offse
     } // else
 }
 
+/* Thread-local scratch for the pos_ar/map_ar staging buffers below. These were
+ * two _mm_malloc/_mm_free per call, and this function runs once per read — so on
+ * a WGS run that is tens of millions of aligned-allocation round-trips. The pair
+ * is pure scratch (no state carried between calls), so a per-thread grow-only
+ * holder reused across reads removes the churn. FMI_search is shared across
+ * worker threads, hence thread_local (not a member). Freed on thread exit. */
+namespace {
+struct SaPrefetchScratch {
+    int64_t *pos = nullptr, *map = nullptr;
+    int64_t  cap = 0;
+    void ensure(int64_t n) {
+        if (n <= cap) return;
+        _mm_free(pos); _mm_free(map);
+        pos = (int64_t *) _mm_malloc((size_t)n * sizeof(int64_t), 64);
+        map = (int64_t *) _mm_malloc((size_t)n * sizeof(int64_t), 64);
+        cap = n;
+    }
+    ~SaPrefetchScratch() { _mm_free(pos); _mm_free(map); }
+};
+} // namespace
+
 void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
                                          int64_t *coordCountArray, int64_t count,
                                          const int32_t max_occ, int tid, int64_t &id_)
 {
-    
+
     // uint32_t i;
     // totalCoordCount and id (below) both count entries staged into the int64
     // coordArray/pos_ar/map_ar buffers and are paired with the int64 mem_lim,
@@ -1617,11 +1638,13 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
         mem_lim += (smem.s > max_occ) ? max_occ : smem.s;
     }
 
-    size_t sa_ar_bytes = (size_t)mem_lim * sizeof(int64_t);
-    int64_t *pos_ar = (int64_t *) _mm_malloc( sa_ar_bytes, 64);
-    assert_not_null(pos_ar, sa_ar_bytes, sa_ar_bytes);
-    int64_t *map_ar = (int64_t *) _mm_malloc( sa_ar_bytes, 64);
-    assert_not_null(map_ar, sa_ar_bytes, (size_t)2 * sa_ar_bytes);
+    /* Reuse the per-thread staging buffers, grown to the high-water mem_lim.
+     * mem_lim == 0 leaves the pointers null, but the staging loop below writes
+     * nothing in that case (id stays 0), so they are never dereferenced. */
+    static thread_local SaPrefetchScratch t_sa;
+    t_sa.ensure(mem_lim);
+    int64_t *pos_ar = t_sa.pos;
+    int64_t *map_ar = t_sa.map;
 
     for(int i = 0; i < count; i++)
     {
@@ -1721,7 +1744,5 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
             }
         }
     }
-    
-    _mm_free(pos_ar);
-    _mm_free(map_ar);
+    /* pos_ar/map_ar are the reused thread-local scratch — no free here. */
 }

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -2625,8 +2625,12 @@ mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *
     const int use_meth_orig = (opt->meth_mode && meth_orig_query != NULL
                                && ar->meth_hypothesis >= 0);
     const char *regen_query = use_meth_orig ? meth_orig_query : query_;
-    query = (uint8_t*) malloc(l_query);
-    assert(query != NULL);
+    /* Reuse a per-thread nt4 scratch instead of a malloc/free per region. The
+     * buffer is consumed within this call (copied into a.cigar via the DP), so
+     * one live instance per thread is safe; grown to the high-water l_query. */
+    static thread_local u8vec_scratch_t t_query;
+    if (t_query.v.m < (size_t)l_query) kv_resize(uint8_t, t_query.v, (size_t)l_query);
+    query = t_query.v.a;
     for (i = 0; i < l_query; ++i) // convert to the nt4 encoding
         query[i] = regen_query[i] < 5? regen_query[i] : nst_nt4_table[(int)regen_query[i]];
     a.mapq = ar->secondary < 0? mem_approx_mapq_se(opt, ar) : 0;
@@ -2713,7 +2717,7 @@ mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *
     a.pos = pos - bns->anns[a.rid].offset;
     a.score = ar->score; a.sub = ar->sub > ar->csub? ar->sub : ar->csub;
     a.is_alt = ar->is_alt; a.alt_sc = ar->alt_sc;
-    free(query);
+    /* query is the reused thread-local nt4 scratch — no free here. */
     return a;
 }
 


### PR DESCRIPTION
## Summary

Two functions heap-allocated pure scratch on every call:

- `FMI_search::get_sa_entries_prefetch` — two `_mm_malloc`/`_mm_free` of the `pos_ar`/`map_ar` SA-staging buffers, **once per read**.
- `mem_reg2aln` — one `malloc`/`free` of the nt4 `query` buffer, **once per output region**.

Neither buffer carries state between calls. This replaces both with per-thread grow-only scratch reused across calls, matching the existing `thread_local` idiom in this tree (`u8vec_scratch_t`, `PacFetchScratch`, `LockstepSmemCache`). `FMI_search` is shared across worker threads, so the SA-prefetch scratch is a file-scope `static thread_local` (not a member), freed on thread exit; `mem_reg2aln` reuses the existing `u8vec_scratch_t`.

Part of the incremental-perf audit ("Tier B"), independent of #206 (Tier A) and #207 (sortSMEMs).

## Correctness

`bwa-mem3 mem -t 8` vs `origin/main` (`089a956`), hg38 — byte-for-byte identical SAM on both single-end and paired-end:

- **1M single-end reads:** SAM md5 matches baseline.
- **500k paired-end pairs** (wgsim, fixed seed): SAM md5 matches baseline.

## Performance — honest result

On this **mimalloc** build the change is **instruction-neutral (~0%, within run-to-run noise)**:

| workload | reduction |
|----------|-----------|
| SE 1M    | −0.005% |
| PE 500k  | −0.048% / −0.008% |

mimalloc's thread-local malloc/free fast path is only a handful of instructions, so removing ~2 allocations/read barely moves the instruction count (predicted ≈0.003%, observed ≈0). This is expected and worth stating plainly.

**Why land it anyway:** the change removes allocator round-trips (less pressure/fragmentation, and less arena/lock contention at high thread counts where even mimalloc serializes) — a benefit a 12-core laptop instruction count cannot surface. It is also a strict simplification, byte-identical, and reduces heap traffic for non-mimalloc builds (`USE_MIMALLOC=0`). A bench-fleet wall-clock A/B at `-t 32/64` is the right way to quantify the contention benefit.

Reviewers who want measurable-only wins may prefer to defer this; it is included as a low-risk cleanup that composes with the rest of the Tier B set.

## Test plan

- [x] Builds clean.
- [x] 1M SE + 500k PE SAM byte-identical vs `origin/main`.
- [x] Instruction count confirmed neutral (expected under mimalloc).
- [ ] High-thread-count wall-clock A/B on the bench fleet (follow-up).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved search and alignment performance by reusing temporary memory across operations.
  * Reduced repeated memory allocation and cleanup during sequence processing.
  * Maintained existing search and alignment behavior while lowering allocation overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->