### PR TITLE
perf(mem): unique-mapper fast paths in mem_chain_flt and mem_mark_primary_se

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -909,6 +909,19 @@ int mem_chain_flt(const mem_opt_t *opt, int n_chn_, mem_chain_t *a_, int tid)
         else a_[k++] = *c;
     }
     n_chn_ = k;
+
+    /* Fast path for the dominant single-chain (unique-mapper) case. With one
+     * surviving chain the range split is a single [0,1) range and the pairwise-
+     * overlap pass reduces to `a_[0].kept = 3` (set unconditionally, kept through
+     * compaction) returning 1 — but the general path still builds a std::vector,
+     * a kvec, and calls ks_introsort to get there. a_[0].first was already reset
+     * to -1 in the weight-filter loop above. (Only n_chn_ == 1 is short-circuited;
+     * n_chn_ == 0 falls through to preserve the existing general-path behavior.) */
+    if (n_chn_ == 1) {
+        a_[0].kept = 3;
+        return 1;
+    }
+
     std::vector<std::pair<int, int> > range;
     std::pair<int, int> pr;
     int pseqid = a_[0].seqid;
@@ -2210,6 +2223,20 @@ int mem_mark_primary_se(const mem_opt_t *opt, int n, mem_alnreg_t *a, int64_t id
     int i, n_pri;
     int_v z = {0,0,0};
     if (n == 0) return 0;
+
+    /* Fast path for the dominant unique-mapper case. With a single region the
+     * general path below still runs two ks_introsort calls and a kv_push in
+     * mem_mark_primary_se_core (which heap-allocates z.a) only to leave a[0]
+     * with these exact values: mem_mark_primary_se_core touches nothing for
+     * n==1 (its inner loop starts at i=1), the first rewrite loop sets
+     * secondary_all to the rank 0 then normalizes it to secondary (-1), and
+     * sub_n is never touched here. Reproduce that directly. */
+    if (n == 1) {
+        a[0].sub = a[0].alt_sc = 0;
+        a[0].secondary = a[0].secondary_all = -1;
+        a[0].hash = hash_64(id);
+        return a[0].is_alt ? 0 : 1;
+    }
 
     for (i = n_pri = 0; i < n; ++i)
     {

--- a/test/unit/test_unique_mapper_fastpath.cpp
+++ b/test/unit/test_unique_mapper_fastpath.cpp
@@ -1,0 +1,98 @@
+// test/unit/test_unique_mapper_fastpath.cpp
+//
+// Pin the single-item fast paths added to mem_chain_flt and
+// mem_mark_primary_se. Both are algebraically equivalent to the general path
+// for the single-element case, but that equivalence rests on a manual trace
+// (mem_mark_primary_se_core's inner loop starting at i=1, the
+// secondary_all/secondary normalization sequencing, mem_chain_flt's one-range
+// [0,1) split collapsing to `kept = 3`). These tests lock the exact
+// post-conditions so a future refactor of either function preserves the
+// single-element semantics.
+
+#include "doctest/doctest.h"
+
+#include <climits>
+#include <cstdint>
+#include <cstdlib>
+
+#include "bwamem.h"
+#include "utils.h"  // hash_64
+
+// mem_chain_flt is a non-static (external) symbol in bwamem.cpp but is not
+// declared in bwamem.h; forward-declare it here with the matching C++
+// signature so the linker resolves it against libbwa.a.
+int mem_chain_flt(const mem_opt_t *opt, int n_chn_, mem_chain_t *a_, int tid);
+
+namespace {
+
+// Build a single chain carrying one seed. With opt->min_chain_weight == 0 the
+// chain always survives the weight filter, so mem_chain_flt reaches its
+// n_chn_ == 1 fast path.
+mem_chain_t make_single_chain(mem_seed_t *seed_slot, int is_alt) {
+    seed_slot->qbeg = 0;
+    seed_slot->rbeg = 1000;
+    seed_slot->len = 100;
+    seed_slot->score = 100;
+
+    mem_chain_t chain{};
+    chain.seqid = 0;
+    chain.rid = 0;
+    chain.n = 1;
+    chain.m = 1;  // <= SEEDS_PER_CHAIN, so the drop path never frees seeds
+    chain.seeds = seed_slot;
+    chain.first = 7;  // sentinel: the filter loop must reset this to -1
+    chain.kept = 0;
+    chain.is_alt = is_alt ? 1 : 0;
+    return chain;
+}
+
+}  // namespace
+
+TEST_CASE("mem_chain_flt: single-chain fast path keeps the sole chain") {
+    mem_opt_t *opt = mem_opt_init();
+    REQUIRE(opt->min_chain_weight == 0);
+
+    for (int is_alt = 0; is_alt <= 1; ++is_alt) {
+        mem_seed_t seed{};  // abc() ctor: n_hits = 1, rest zeroed
+        mem_chain_t chain = make_single_chain(&seed, is_alt);
+
+        int ret = mem_chain_flt(opt, 1, &chain, /*tid=*/0);
+
+        int kept = chain.kept;  // copy out of the bitfield: doctest binds a ref
+        CHECK(ret == 1);            // sole surviving chain is returned
+        CHECK(kept == 3);           // marked kept unconditionally
+        CHECK(chain.first == -1);   // sentinel cleared by the weight-filter loop
+    }
+
+    free(opt);
+}
+
+TEST_CASE("mem_mark_primary_se: single-region fast path normalizes the sole hit") {
+    mem_opt_t *opt = mem_opt_init();
+    const int64_t id = 12345;
+
+    for (int is_alt = 0; is_alt <= 1; ++is_alt) {
+        mem_alnreg_t a{};
+        a.is_alt = is_alt ? 1 : 0;
+        // Sentinels: the fast path must overwrite sub/alt_sc/secondary/
+        // secondary_all/hash and must leave sub_n untouched.
+        a.sub = 999;
+        a.alt_sc = 999;
+        a.secondary = 999;
+        a.secondary_all = 999;
+        a.hash = 0;
+        a.sub_n = 42;
+
+        int ret = mem_mark_primary_se(opt, 1, &a, id);
+
+        CHECK(ret == (is_alt ? 0 : 1));         // n_pri: primary hits only
+        CHECK(a.sub == 0);
+        CHECK(a.alt_sc == 0);
+        CHECK(a.secondary == -1);
+        CHECK(a.secondary_all == -1);
+        CHECK(a.hash == hash_64((uint64_t)id));  // id, not id + rank
+        CHECK(a.sub_n == 42);                    // untouched by the fast path
+    }
+
+    free(opt);
+}


### PR DESCRIPTION
## Summary

Adds fast paths for the dominant **unique-mapper** case to the two per-read functions that shape a read's alignment regions:

- **`mem_chain_flt`** — with a single surviving chain, the range split is one `[0,1)` range and the pairwise-overlap pass reduces to `a_[0].kept = 3` (return 1). The general path still builds a `std::vector`, a `kvec`, and calls `ks_introsort` to reach that. Short-circuit `n_chn_ == 1` directly. (`n_chn_ == 0` deliberately falls through to preserve the existing general-path behavior for that edge case.)
- **`mem_mark_primary_se`** — with a single region, the general path runs two `ks_introsort` calls plus a `kv_push` in `mem_mark_primary_se_core` (which heap-allocates `z.a`) only to leave `a[0]` with `sub=alt_sc=0`, `secondary=secondary_all=-1`, `hash=hash_64(id)`, `sub_n` untouched, returning `is_alt?0:1`. Reproduce directly.

Part of the incremental-perf audit ("Tier B"), independent of #206, #207, #208.

## Correctness

`bwa-mem3 mem -t 8` vs `origin/main` (`089a956`), hg38 — byte-for-byte identical SAM:
- **1M single-end reads:** SAM md5 matches baseline.
- **500k paired-end pairs:** SAM md5 matches baseline.

The `n==1`/`n_chn_==1` results were traced field-by-field against the general path (including that `mem_mark_primary_se_core` writes nothing for a single element and `sub_n` is left untouched).

## Performance

The fast paths fire in proportion to how many reads are unique 1-chain/1-region mappers, so the effect is dataset-dependent. Instructions retired (`/usr/bin/time -l`), `-t 8`, 3 runs:

| dataset | character | reduction |
|---------|-----------|-----------|
| sbx 1M (SE) | telomere/satellite repeat-rich (few unique mappers) | ~0% (noise) |
| wgsim 500k (PE) | random-position, unique-mapper-dominated | −0.19% / +0.05% / −0.17% (~−0.13% mean) |

Modest and noisy on this hardware, but real on the unique-mapper case — which dominates typical WGS far more than either synthetic set here. A bench-fleet wall-clock A/B on a real WGS sample is the right confirmation. Even where instruction-neutral, the change removes per-read allocations (a `std::vector` + `kvec` in `mem_chain_flt`, a `z.a` heap buffer in `mem_mark_primary_se`) from the common path.

## Test plan

- [x] Builds clean.
- [x] 1M SE + 500k PE SAM byte-identical vs `origin/main`.
- [x] Instruction count measured on both repeat-rich and unique-mapper data.
- [ ] Real-WGS wall-clock A/B on the bench fleet (follow-up).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster handling when filtering leaves exactly one chain by skipping extra post-processing steps and returning immediately.
  * Faster primary/secondary marking for single-element regions by directly initializing key normalization fields.
  * Existing behavior is preserved for scenarios involving multiple chains or alignments.
* **Tests**
  * Added unit tests to lock down the new single-item fast-path behaviors for chain filtering and primary/secondary marking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->