### PR TITLE
perf(seed): vectorize backwardExt occ-counting on arm64 (NEON) + hoist invariants

### DIFF
--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -276,16 +276,51 @@ private:
         __attribute__((always_inline)) inline
         SMEM backwardExt(SMEM smem, uint8_t a) const
         {
-            uint8_t b;
-            int64_t k[4], l[4], s[4];
-            for (b = 0; b < 4; b++) {
-                int64_t sp = (int64_t)(smem.k);
-                int64_t ep = (int64_t)(smem.k) + (int64_t)(smem.s);
-                GET_OCC(sp, b, occ_id_sp, y_sp, occ_sp, one_hot_bwt_str_c_sp, match_mask_sp);
-                GET_OCC(ep, b, occ_id_ep, y_ep, occ_ep, one_hot_bwt_str_c_ep, match_mask_ep);
-                k[b] = count[b] + occ_sp;
-                s[b] = occ_ep - occ_sp;
+            /* sp/ep and their checkpoint block + one-hot mask do not depend on
+             * the base b, so hoist them out of the per-base occ computation.
+             * Only k[a] and s[a] are consumed for the result, but all four s[b]
+             * feed the l cumulation below, so the full 4-lane occ is computed. */
+            const int64_t sp = (int64_t)smem.k;
+            const int64_t ep = (int64_t)smem.k + (int64_t)smem.s;
+            const CP_OCC &blk_sp = cp_occ[sp >> CP_SHIFT];
+            const CP_OCC &blk_ep = cp_occ[ep >> CP_SHIFT];
+            const uint64_t mask_sp = one_hot_mask_array[sp & CP_MASK];
+            const uint64_t mask_ep = one_hot_mask_array[ep & CP_MASK];
+
+            int64_t occ_sp[4], s[4], l[4];
+
+#if defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)
+            /* arm64 has no scalar popcount instruction, so the scalar GET_OCC
+             * path pays a GPR<->SIMD round-trip for every __builtin_popcountl
+             * (eight per call). Compute all four bases in-lane instead: AND the
+             * one-hot BWT words with the position mask, popcount each 64-bit
+             * lane (cnt + pairwise-add reduction), and add the checkpoint
+             * counts. Bit-identical to the scalar popcount, no cross-domain
+             * moves, one load per checkpoint block. */
+            const uint64x2_t msp = vdupq_n_u64(mask_sp);
+            const uint64x2_t mep = vdupq_n_u64(mask_ep);
+            #define BWA3_PC64(v) vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(vcntq_u8(vreinterpretq_u8_u64(v)))))
+            const uint64x2_t psp01 = BWA3_PC64(vandq_u64(vld1q_u64(&blk_sp.one_hot_bwt_str[0]), msp));
+            const uint64x2_t psp23 = BWA3_PC64(vandq_u64(vld1q_u64(&blk_sp.one_hot_bwt_str[2]), msp));
+            const uint64x2_t pep01 = BWA3_PC64(vandq_u64(vld1q_u64(&blk_ep.one_hot_bwt_str[0]), mep));
+            const uint64x2_t pep23 = BWA3_PC64(vandq_u64(vld1q_u64(&blk_ep.one_hot_bwt_str[2]), mep));
+            #undef BWA3_PC64
+            const uint64x2_t occ_sp01 = vaddq_u64(vld1q_u64((const uint64_t*)&blk_sp.cp_count[0]), psp01);
+            const uint64x2_t occ_sp23 = vaddq_u64(vld1q_u64((const uint64_t*)&blk_sp.cp_count[2]), psp23);
+            const uint64x2_t occ_ep01 = vaddq_u64(vld1q_u64((const uint64_t*)&blk_ep.cp_count[0]), pep01);
+            const uint64x2_t occ_ep23 = vaddq_u64(vld1q_u64((const uint64_t*)&blk_ep.cp_count[2]), pep23);
+            vst1q_u64((uint64_t*)&occ_sp[0], occ_sp01);
+            vst1q_u64((uint64_t*)&occ_sp[2], occ_sp23);
+            vst1q_u64((uint64_t*)&s[0], vsubq_u64(occ_ep01, occ_sp01));
+            vst1q_u64((uint64_t*)&s[2], vsubq_u64(occ_ep23, occ_sp23));
+#else
+            for (uint8_t b = 0; b < 4; b++) {
+                int64_t occ_s = blk_sp.cp_count[b] + _mm_countbits_64(blk_sp.one_hot_bwt_str[b] & mask_sp);
+                int64_t occ_e = blk_ep.cp_count[b] + _mm_countbits_64(blk_ep.one_hot_bwt_str[b] & mask_ep);
+                occ_sp[b] = occ_s;
+                s[b]      = occ_e - occ_s;
             }
+#endif
 
             int64_t sentinel_offset = 0;
             if ((smem.k <= sentinel_index) && ((smem.k + smem.s) > sentinel_index))
@@ -295,7 +330,7 @@ private:
             l[1] = l[2] + s[2];
             l[0] = l[1] + s[1];
 
-            smem.k = k[a];
+            smem.k = count[a] + occ_sp[a];
             smem.l = l[a];
             smem.s = s[a];
             return smem;


### PR DESCRIPTION
## Summary

`backwardExt` is the hottest function in the aligner (~10⁹ calls per 5M-pair WGS run). Its 4-base loop recomputed the `b`-invariant `sp`/`ep` positions, checkpoint-block indices, and one-hot position masks every iteration, and ran **eight scalar `__builtin_popcountl`** calls (sp+ep × 4 bases). On arm64 there is no scalar popcount instruction, so each is a GPR→SIMD move + `cnt` + `addv` + move-back — the cross-domain moves dominate.

Two changes, both bit-identical to the scalar path:

1. **Hoist** `sp`, `ep`, the two `CP_OCC` block references, and the two one-hot masks out of the per-base loop (none depends on the base).
2. **NEON vector popcount** (arm64): AND the one-hot BWT words with the position mask, popcount each 64-bit lane via `cnt` + a pairwise-add reduction, add the checkpoint counts — all in-lane, one load per checkpoint block, no GPR↔SIMD traffic. x86/other retain the scalar popcount path (reading the hoisted blocks).

A native **AVX-512-VPOPCNTDQ** path (Ice Lake / Zen4) is a separate follow-up — it needs an x86 host with that ISA to validate, so it's out of scope here. Highest single upside from the audit; this lands the portable + arm64 portion.

Part of the incremental-perf audit ("Tier B"); independent of #206–#209.

## Correctness

`bwa-mem3 mem -t 8` vs `origin/main` (`089a956`), hg38 — byte-for-byte identical SAM:
- **1M single-end reads:** SAM md5 matches baseline.
- **500k paired-end pairs:** SAM md5 matches baseline.

Popcount is popcount, so the NEON reduction is numerically identical; the byte-identity gate confirms the port (lane order, mask broadcast, reduction) is exact.

## Performance

Instructions retired (`/usr/bin/time -l`), Apple Silicon (arm64/NEON), `-t 8`:

| workload | runs | reduction |
|----------|------|-----------|
| SE 1M    | 3    | −0.174% / −0.182% / −0.143% (~6e9 fewer) |
| PE 500k  | 2    | −0.203% / −0.237% (~4e9 fewer) |

Consistent (not noise). Modest relative to the function's share because `backwardExt` is **memory-latency-bound** on the `cp_occ` checkpoint loads — the lockstep SMEM driver overlaps those misses, so the removed popcount compute is partly hidden and the instruction saving under-predicts (or over-predicts) the wall-clock effect. The concrete win is the eliminated GPR↔SIMD traffic.

A **bench-fleet wall-clock/cycles A/B** is the right way to quantify the real-time delta, and a follow-up **x86 VPOPCNTDQ tier** should show a larger reduction on Ice Lake/Zen4 (where the scalar path already uses hardware `POPCNT`, so the vector win is ISA-gated).

## Test plan

- [x] Builds clean (arm64).
- [x] 1M SE + 500k PE SAM byte-identical vs `origin/main`.
- [x] Consistent instruction reduction on both.
- [ ] Bench-fleet wall-clock/cycles A/B (follow-up).
- [ ] x86 build + byte-identity on an AVX2/AVX-512 host (scalar path unchanged there; sanity only).
- [ ] AVX-512-VPOPCNTDQ tier (separate PR, needs Ice Lake/Zen4).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved search performance by optimizing checkpoint occurrence calculations.
  * Added ARM/NEON-optimized processing with a scalar fallback for broader compatibility.
* **Compatibility**
  * Preserved all existing public search APIs and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->