### PR TITLE
perf(bsw): drop dead per-row H1/H2 setup stores in the SW batch wrappers

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -735,21 +735,24 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 for(k = 0; k < sp.len1; k++)
                 {
                     mySeq1SoA[k * SIMD_WIDTH8 + j] = seq1[k] /* PR16: N stays 4 */;
-                    H2[k * SIMD_WIDTH8 + j] = 0;
                 }
                 qlen[j] = sp.len2 * max;
                 if(maxLen1 < sp.len1) maxLen1 = sp.len1;
             }
-            
+
             for(j = 0; j < SIMD_WIDTH8; j++)
             {
                 SeqPair sp = pairArray[i + j];
                 for(k = sp.len1; k <= maxLen1; k++) //removed "="
                 {
                     mySeq1SoA[k * SIMD_WIDTH8 + j] = DUMMY1;
-                    H2[k * SIMD_WIDTH8 + j] = DUMMY1;
                 }
             }
+            /* B5: only the boundary row H2[maxLen1] survives the h0-prefix
+             * deletion seed below (which overwrites rows [0, maxLen1)); write
+             * just that row here, before the seed, instead of the dead per-row
+             * fills removed above. */
+            _mm256_store_si256((__m256i *)(H2 + maxLen1 * SIMD_WIDTH8), _mm256_set1_epi8((char)DUMMY1));
 
 //--------------------
             __m256i h0_256 = _mm256_load_si256((__m256i*) h0);
@@ -784,7 +787,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 for(k = 0; k < sp.len2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k]==AMBIG ? 8 : seq2[k]) /* PR16: query N→8 */;
-                    H1[k * SIMD_WIDTH8 + j] = 0;                    
                 }
                 if(maxLen2 < sp.len2) maxLen2 = sp.len2;
             }
@@ -795,9 +797,12 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 for(k = sp.len2; k <= maxLen2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH8 + j] = DUMMY2;
-                    H1[k * SIMD_WIDTH8 + j] = 0;
                 }
             }
+            /* B5: only the boundary row H1[maxLen2] (value 0) survives the
+             * h0-prefix insertion seed below; write just that row, before the
+             * seed so its unconditional H1[0]/H1[1] stores still win. */
+            _mm256_store_si256((__m256i *)(H1 + maxLen2 * SIMD_WIDTH8), _mm256_setzero_si256());
 
 //------------------------
             _mm256_store_si256((__m256i *) H1, h0_256);
@@ -1735,21 +1740,22 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                 for(k = 0; k < sp.len1; k++)
                 {
                     mySeq1SoA[k * SIMD_WIDTH16 + j] = (seq1[k] == AMBIG?0xFFFF:seq1[k]);
-                    H2[k * SIMD_WIDTH16 + j] = 0;
                 }
                 qlen[j] = sp.len2 * max;
                 if(maxLen1 < sp.len1) maxLen1 = sp.len1;
             }
-        
+
             for(j = 0; j < SIMD_WIDTH16; j++)
             {
                 SeqPair sp = pairArray[i + j];
                 for(k = sp.len1; k <= maxLen1; k++) //removed "="
                 {
                     mySeq1SoA[k * SIMD_WIDTH16 + j] = DUMMY1;
-                    H2[k * SIMD_WIDTH16 + j] = DUMMY1;
                 }
             }
+            /* B5: only the boundary row H2[maxLen1] survives the h0-prefix
+             * deletion seed below; write just that row, before the seed. */
+            _mm256_store_si256((__m256i *)(H2 + maxLen1 * SIMD_WIDTH16), _mm256_set1_epi16((short)DUMMY1));
 //--------------------
             __m256i h0_256 = _mm256_load_si256((__m256i*) h0);
             _mm256_store_si256((__m256i *) H2, h0_256);
@@ -1775,7 +1781,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                 for(k = 0; k < sp.len2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH16 + j] = (seq2[k]==AMBIG?0xFFFF:seq2[k]);
-                    H1[k * SIMD_WIDTH16 + j] = 0;                   
                 }
                 if(maxLen2 < sp.len2) maxLen2 = sp.len2;
             }
@@ -1786,9 +1791,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                 for(k = sp.len2; k <= maxLen2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH16 + j] = DUMMY2;
-                    H1[k * SIMD_WIDTH16 + j] = 0;
                 }
             }
+            /* B5: only boundary row H1[maxLen2]=0 survives the seed below. */
+            _mm256_store_si256((__m256i *)(H1 + maxLen2 * SIMD_WIDTH16), _mm256_setzero_si256());
 //------------------------
             _mm256_store_si256((__m256i *) H1, h0_256);
             __m256i cmp256 = _mm256_cmpgt_epi16(h0_256, oe_ins256);
@@ -2652,7 +2658,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 for(k = 0; k < sp.len1; k++)
                 {
                     mySeq1SoA[k * SIMD_WIDTH8 + j] = seq1[k] /* PR16: N stays 4 */;
-                    H2[k * SIMD_WIDTH8 + j] = 0;
                 }
                 qlen[j] = sp.len2 * max;
                 if(maxLen1 < sp.len1) maxLen1 = sp.len1;
@@ -2664,9 +2669,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 for(k = sp.len1; k <= maxLen1; k++)
                 {
                     mySeq1SoA[k * SIMD_WIDTH8 + j] = DUMMY1;
-                    H2[k * SIMD_WIDTH8 + j] = DUMMY1;
                 }
             }
+            /* B5: only boundary row H2[maxLen1] survives the seed below; write just that row. */
+            _mm512_store_si512((__m512i *)(H2 + maxLen1 * SIMD_WIDTH8), _mm512_set1_epi8((char)DUMMY1));
 //--------------------
             __m512i h0_512 = _mm512_load_si512((__m512i*) h0);
             _mm512_store_si512((__m512i *) H2, h0_512);
@@ -2692,7 +2698,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 for(k = 0; k < sp.len2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k]==AMBIG ? 8 : seq2[k]) /* PR16: query N→8 */;
-                    H1[k * SIMD_WIDTH8 + j] = 0;                    
                 }
                 if(maxLen2 < sp.len2) maxLen2 = sp.len2;
             }
@@ -2703,9 +2708,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 for(k = sp.len2; k <= maxLen2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH8 + j] = DUMMY2;
-                    H1[k * SIMD_WIDTH8 + j] = 0;
                 }
             }
+            /* B5: only boundary row H1[maxLen2]=0 survives the seed below. */
+            _mm512_store_si512((__m512i *)(H1 + maxLen2 * SIMD_WIDTH8), _mm512_setzero_si512());
 //------------------------
             _mm512_store_si512((__m512i *) H1, h0_512);
             // h0-prefix insertion seed, unsigned-saturating [0,255]:
@@ -3624,7 +3630,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                 for(k = 0; k < sp.len1; k++)
                 {
                     mySeq1SoA[k * SIMD_WIDTH16 + j] = (seq1[k] == AMBIG ? dmask4:seq1[k]);
-                    H2[k * SIMD_WIDTH16 + j] = 0;
                 }
                 
                 qlen[j] = sp.len2 * max;
@@ -3637,9 +3642,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                 for(k = sp.len1; k <= maxLen1; k++)
                 {
                     mySeq1SoA[k * SIMD_WIDTH16 + j] = DUMMY1;
-                    H2[k * SIMD_WIDTH16 + j] = DUMMY1;
                 }
             }
+            /* B5: only boundary row H2[maxLen1] survives the seed below. */
+            _mm512_store_si512((__m512i *)(H2 + maxLen1 * SIMD_WIDTH16), _mm512_set1_epi16((short)DUMMY1));
 //--------------------
             __m512i h0_512 = _mm512_load_si512((__m512i*) h0);
             _mm512_store_si512((__m512i *) H2, h0_512);
@@ -3665,7 +3671,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                 for(k = 0; k < sp.len2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH16 + j] = (seq2[k]==AMBIG?dmask4:seq2[k]);
-                    H1[k * SIMD_WIDTH16 + j] = 0;                   
                 }
                 if(maxLen2 < sp.len2) maxLen2 = sp.len2;
             }
@@ -3676,9 +3681,10 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                 for(k = sp.len2; k <= maxLen2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH16 + j] = DUMMY2;
-                    H1[k * SIMD_WIDTH16 + j] = 0;
                 }
             }
+            /* B5: only boundary row H1[maxLen2]=0 survives the seed below. */
+            _mm512_store_si512((__m512i *)(H1 + maxLen2 * SIMD_WIDTH16), _mm512_setzero_si512());
 //------------------------
             _mm512_store_si512((__m512i *) H1, h0_512);
             __mmask32 mask512 = _mm512_cmpgt_epi16_mask(h0_512, oe_ins512);
@@ -4456,7 +4462,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                 for(k = 0; k < sp.len1; k++)
                 {
                     mySeq1SoA[k * SIMD_WIDTH16 + j] = (seq1[k] == AMBIG?0xFFFF:seq1[k]);
-                    H2[k * SIMD_WIDTH16 + j] = 0;
                 }
                 qlen[j] = sp.len2 * max;
                 if(maxLen1 < sp.len1) maxLen1 = sp.len1;
@@ -4468,9 +4473,13 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                 for(k = sp.len1; k <= maxLen1; k++) //removed "="
                 {
                     mySeq1SoA[k * SIMD_WIDTH16 + j] = DUMMY1;
-                    H2[k * SIMD_WIDTH16 + j] = DUMMY1;
                 }
             }
+            /* B5: only the boundary row H2[maxLen1] survives the h0-prefix
+             * deletion seed below (which overwrites rows [0, maxLen1)); write
+             * just that row here instead of the dead per-row fills removed
+             * above, before the seed to preserve store ordering. */
+            _mm_store_si128((__m128i *)(H2 + maxLen1 * SIMD_WIDTH16), _mm_set1_epi16((short)DUMMY1));
 //--------------------
             __m128i h0_128 = _mm_load_si128((__m128i*) h0);
             _mm_store_si128((__m128i *) H2, h0_128);
@@ -4496,20 +4505,22 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
                 for(k = 0; k < sp.len2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH16 + j] = (seq2[k]==AMBIG?0xFFFF:seq2[k]);
-                    H1[k * SIMD_WIDTH16 + j] = 0;                   
                 }
                 if(maxLen2 < sp.len2) maxLen2 = sp.len2;
             }
-            
+
             for(j = 0; j < SIMD_WIDTH16; j++)
             {
                 SeqPair sp = pairArray[i + j];
                 for(k = sp.len2; k <= maxLen2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH16 + j] = DUMMY2;
-                    H1[k * SIMD_WIDTH16 + j] = 0;
                 }
             }
+            /* B5: only the boundary row H1[maxLen2] (value 0) survives the
+             * h0-prefix insertion seed below; write just that row, before the
+             * seed so its unconditional H1[0]/H1[1] stores still win. */
+            _mm_store_si128((__m128i *)(H1 + maxLen2 * SIMD_WIDTH16), _mm_setzero_si128());
 //------------------------
             _mm_store_si128((__m128i *) H1, h0_128);
             __m128i cmp128 = _mm_cmpgt_epi16(h0_128, oe_ins128);
@@ -5306,7 +5317,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 for(k = 0; k < sp.len1; k++)
                 {
                     mySeq1SoA[k * SIMD_WIDTH8 + j] = seq1[k] /* PR16: N stays 4 */;
-                    H2[k * SIMD_WIDTH8 + j] = 0;
                 }
                 qlen[j] = sp.len2 * max;
                 if(maxLen1 < sp.len1) maxLen1 = sp.len1;
@@ -5318,9 +5328,15 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 for(k = sp.len1; k <= maxLen1; k++) //removed "="
                 {
                     mySeq1SoA[k * SIMD_WIDTH8 + j] = DUMMY1;
-                    H2[k * SIMD_WIDTH8 + j] = DUMMY1;
                 }
             }
+            /* B5: the h0-prefix deletion seed below fully overwrites H2 rows
+             * [0, maxLen1); only the boundary row H2[maxLen1] survives to be read
+             * as the column edge. Write just that row (all lanes = DUMMY1) here
+             * instead of the dead per-row 0/DUMMY fills removed above. Placed
+             * before the seed so the seed's unconditional H2[0] store still wins,
+             * matching the original store ordering for every maxLen1. */
+            _mm_store_si128((__m128i *)(H2 + maxLen1 * SIMD_WIDTH8), _mm_set1_epi8((char)DUMMY1));
 //--------------------
             __m128i h0_128 = _mm_load_si128((__m128i*) h0);
             _mm_store_si128((__m128i *) H2, h0_128);
@@ -5343,22 +5359,26 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 for(k = 0; k < sp.len2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k]==AMBIG ? 8 : seq2[k]) /* PR16: query N→8 */;
-                    H1[k * SIMD_WIDTH8 + j] = 0;                    
                 }
                 if(maxLen2 < sp.len2) maxLen2 = sp.len2;
             }
-            
+
             //maxLen2 = ((maxLen2  + 3) >> 2) * 4;
-            
+
             for(j = 0; j < SIMD_WIDTH8; j++)
             {
                 SeqPair sp = pairArray[i + j];
                 for(k = sp.len2; k <= maxLen2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH8 + j] = DUMMY2;
-                    H1[k * SIMD_WIDTH8 + j] = 0;
                 }
             }
+            /* B5: the h0-prefix insertion seed below fully overwrites H1 rows
+             * [0, maxLen2); only the boundary row H1[maxLen2] survives as the row
+             * edge (value 0). Write just that row here instead of the dead
+             * per-row zero fills removed above; before the seed so its
+             * unconditional H1[0]/H1[1] stores still win for small maxLen2. */
+            _mm_store_si128((__m128i *)(H1 + maxLen2 * SIMD_WIDTH8), _mm_setzero_si128());
 //------------------------
             _mm_store_si128((__m128i *) H1, h0_128);
             // h0-prefix insertion seed, unsigned-saturating [0,255]:

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -2582,7 +2582,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         int32_t bsize = 0;
         
         int8_t *H1 = H8_ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
-        int8_t *H2 = H8__ + tid * SIMD_WIDTH16 * MAX_SEQ_LEN8;
+        int8_t *H2 = H8__ + tid * SIMD_WIDTH8 * MAX_SEQ_LEN8;
 
         __m512i zero512   = _mm512_setzero_si512();
         __m512i o_ins512  = _mm512_set1_epi8(o_ins);


### PR DESCRIPTION
## Summary

Each banded-SW batch wrapper's SoA-transpose setup zero-fills (and DUMMY-pads) the `H1`/`H2` DP rails **one row at a time** — but the h0-prefix seed that runs immediately after fully overwrites rows `[0, maxLen)`. Only the single boundary row (`H2[maxLen1] = DUMMY1`, `H1[maxLen2] = 0`) survives to be read as the column/row edge. This replaces the dead per-row fills with **one vector store of just the boundary row**, placed before the seed so the seed's unconditional `H[0]`/`H[1]` stores still win (preserving store ordering for every `maxLen`).

Applied to all six wrappers: NEON/SSE-128 (8b+16b), AVX2 (8b+16b), AVX-512 (8b+16b).

Part of the incremental-perf audit ("Tier B"); independent of the other Tier B PRs.

## Correctness — byte-identical on all four SIMD tiers

- **NEON** (Apple Silicon): `bwa-bsw-bench` golden gate (60k pairs byte-identical) **+** full-aligner SAM diff — 1M single-end and 500k paired-end, matching SAM md5.
- **sse41 / avx2 / avx512bw** (c7i.4xlarge, `BWAMEM3_FORCE_TIER` sweep): `bwa-bsw-bench` golden gate, **60k pairs byte-identical per tier**.

## Performance

`bwa-bsw-bench` extend mode, c7i.4xlarge, 15 reps. The bench's ksw2 reference (unchanged code) stayed stable between the baseline and modified runs, so the mb3 delta is trustworthy. The win is largest on the **8-bit (short-read) tier** and on **AVX-512**, which had the widest per-row store traffic to remove:

| tier | len100 (8-bit) | len150 (16-bit) | len250 (16-bit) |
|------|----------------|-----------------|-----------------|
| sse41 | **+4.9%** | +0.1% | −0.0% |
| avx2 | **+2.8%** | +0.4% | +0.2% |
| avx512bw | **+7.2%** | **+5.6%** | +1.8% |

On arm64/NEON the same change is throughput-neutral (the setup store traffic is a smaller share of the kernel there) — but it is byte-identical regardless, so it costs nothing.

Short-read extension frequently uses the 8-bit tier, so the 8-bit-tier speedup (up to +7.2% on AVX-512) is the relevant one for typical WGS on modern x86.

## Test plan

- [x] Builds clean on arm64 (NEON) and x86 (sse41/avx2/avx512bw).
- [x] Golden gate byte-identical on all four tiers.
- [x] Full-aligner SAM byte-identical (NEON, 1M SE + 500k PE).
- [x] Per-tier throughput A/B on a dedicated c7i host, ksw2-stability-checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed banded sequence-alignment initialization to correctly handle padding and boundary overwrite order across supported SIMD architectures.
  * Corrected an AVX-512BW scratch-buffer stride used during `H2` setup, preventing width/offset mismatches.
  * Reduced redundant initialization work during the alignment prep phase while preserving correctness for prefix-seed boundaries, improving reliability and potentially performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->