### PR TITLE
refactor(mem): static cleanup — dead code + int64 format warnings

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -274,7 +274,7 @@ void FMI_search::load_index(bool load_pac)
     assert(reference_seq_len > 0);
     assert(reference_seq_len <= 0x7fffffffffL);
 
-    fprintf(stderr, "* Reference seq len for bi-index = %ld\n", reference_seq_len);
+    fprintf(stderr, "* Reference seq len for bi-index = %lld\n", (long long)reference_seq_len);
 
     // create checkpointed occ
     int64_t cp_occ_size = (reference_seq_len >> CP_SHIFT) + 1;
@@ -330,7 +330,7 @@ void FMI_search::load_index(bool load_pac)
     sentinel_index = -1;
     #if SA_COMPRESSION
     err_fread_noeof(&sentinel_index, sizeof(int64_t), 1, cpstream);
-    fprintf(stderr, "* sentinel-index: %ld\n", sentinel_index);
+    fprintf(stderr, "* sentinel-index: %lld\n", (long long)sentinel_index);
     #endif
     fclose(cpstream);
 
@@ -351,13 +351,13 @@ void FMI_search::load_index(bool load_pac)
         }
         #endif
     }
-    fprintf(stderr, "\nsentinel_index: %ld\n", x);    
+    fprintf(stderr, "\nsentinel_index: %lld\n", (long long)x);
     #endif
 
     fprintf(stderr, "* Count:\n");
     for(x = 0; x < 5; x++)
     {
-        fprintf(stderr, "%ld,\t%lu\n", x, (unsigned long)count[x]);
+        fprintf(stderr, "%lld,\t%lld\n", (long long)x, (long long)count[x]);
     }
     fprintf(stderr, "\n");  
 
@@ -1155,181 +1155,6 @@ int64_t FMI_search::bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,
         }
     }
     return numTotalSeed;
-}
-
-
-void FMI_search::getSMEMs(uint8_t *enc_qdb,
-        int32_t numReads,
-        int32_t batch_size,
-        int32_t readlength,
-        int32_t minSeedLen,
-        int32_t nthreads,
-        SMEM *matchArray,
-        int64_t *numTotalSmem)
-{
-    const size_t smem_arr_bytes = (size_t)nthreads * (size_t)readlength * sizeof(SMEM);
-    SMEM *prevArray = (SMEM *)_mm_malloc(smem_arr_bytes, 64);
-    assert_not_null(prevArray, smem_arr_bytes, smem_arr_bytes);
-    SMEM *currArray = (SMEM *)_mm_malloc(smem_arr_bytes, 64);
-    assert_not_null(currArray, smem_arr_bytes, (size_t)2 * smem_arr_bytes);
-
-
-// #pragma omp parallel num_threads(nthreads)
-    {
-        int tid = 0; //omp_get_thread_num();   // removed omp
-        numTotalSmem[tid] = 0;
-        SMEM *myPrevArray = prevArray + tid * readlength;
-        SMEM *myCurrArray = currArray + tid * readlength;
-
-        int32_t perThreadQuota = (numReads + (nthreads - 1)) / nthreads;
-        int32_t first = tid * perThreadQuota;
-        int32_t last  = (tid + 1) * perThreadQuota;
-        if(last > numReads) last = numReads;
-        SMEM *myMatchArray = matchArray + first * readlength;
-
-        uint32_t i;
-        // Perform SMEM for original reads
-        for(i = first; i < last; i++)
-        {
-            int x = readlength - 1;
-            int numPrev = 0;
-            int numSmem = 0;
-
-            while (x >= 0)
-            {
-                // Forward search
-                SMEM smem;
-                smem.rid = i;
-                smem.m = x;
-                smem.n = x;
-                uint8_t a = enc_qdb[i * readlength + x];
-
-                if(a > 3)
-                {
-                    x--;
-                    continue;
-                }
-                smem.k = count[a];
-                smem.l = count[3 - a];
-                smem.s = count[a+1] - count[a];
-
-                int j;
-                for(j = x + 1; j < readlength; j++)
-                {
-                    a = enc_qdb[i * readlength + j];
-                    if(a < 4)
-                    {
-                        SMEM smem_ = smem;
-
-                        // Forward extension is backward extension with the BWT of reverse complement
-                        smem_.k = smem.l;
-                        smem_.l = smem.k;
-                        SMEM newSmem_ = backwardExt(smem_, 3 - a);
-                        SMEM newSmem = newSmem_;
-                        newSmem.k = newSmem_.l;
-                        newSmem.l = newSmem_.k;
-                        newSmem.n = j;
-
-                        if(newSmem.s != smem.s)
-                        {
-                            myPrevArray[numPrev] = smem;
-                            numPrev++;
-                        }
-                        smem = newSmem;
-                        if(newSmem.s == 0)
-                        {
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        myPrevArray[numPrev] = smem;
-                        numPrev++;
-                        break;
-                    }
-                }
-                if(smem.s != 0)
-                {
-                    myPrevArray[numPrev++] = smem;
-                }
-
-                SMEM *curr, *prev;
-                prev = myPrevArray;
-                curr = myCurrArray;
-
-                int p;
-                for(p = 0; p < (numPrev/2); p++)
-                {
-                    SMEM temp = prev[p];
-                    prev[p] = prev[numPrev - p - 1];
-                    prev[numPrev - p - 1] = temp;
-                }
-
-                int next_x = x - 1;
-
-                // Backward search
-                int cur_j = readlength;
-                for(j = x - 1; j >= 0; j--)
-                {
-                    int numCurr = 0;
-                    int curr_s = -1;
-                    a = enc_qdb[i * readlength + j];
-                    //printf("a = %d\n", a);
-                    if(a > 3)
-                    {
-                        next_x = j - 1;
-                        break;
-                    }
-                    for(p = 0; p < numPrev; p++)
-                    {
-                        SMEM smem = prev[p];
-                        SMEM newSmem = backwardExt(smem, a);
-                        newSmem.m = j;
-
-                        if(newSmem.s == 0)
-                        {
-                            if((numCurr == 0) && (j < cur_j))
-                            {
-                                cur_j = j;
-                                if((smem.n - smem.m + 1) >= minSeedLen)
-                                    myMatchArray[numTotalSmem[tid] + numSmem++] = smem;
-                            }
-                        }
-                        if((newSmem.s != 0) && (newSmem.s != curr_s))
-                        {
-                            curr_s = newSmem.s;
-                            curr[numCurr++] = newSmem;
-                        }
-                    }
-                    SMEM *temp = prev;
-                    prev = curr;
-                    curr = temp;
-                    numPrev = numCurr;
-                    if(numCurr == 0)
-                    {
-                        next_x = j;
-                        break;
-                    }
-                    else
-                    {
-                        next_x = j - 1;
-                    }
-                }
-                if(numPrev != 0)
-                {
-                    SMEM smem = prev[0];
-                    if((smem.n - smem.m + 1) >= minSeedLen)
-                        myMatchArray[numTotalSmem[tid] + numSmem++] = smem;
-                    numPrev = 0;
-                }
-                x = next_x;
-            }
-            numTotalSmem[tid] += numSmem;
-        }
-    }
-
-    _mm_free(prevArray);
-    _mm_free(currArray);
 }
 
 

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -149,15 +149,6 @@ class FMI_search: public indexEle
      * Writing past the pre-sized capacity is undefined behavior. The actual
      * number of SMEMs written is reported via *__numTotalSmem (or the
      * int64_t return value on bwtSeedStrategyAllPosOneThread). */
-    void getSMEMs(uint8_t *enc_qdb,
-                  int32_t numReads,
-                  int32_t batch_size,
-                  int32_t readlength,
-                  int32_t minSeedLengh,
-                  int32_t numthreads,
-                  SMEM *matchArray,
-                  int64_t *numTotalSmem);
-
     /* matchArray must hold at least numReads * max_readlength SMEMs (caller-sized). */
     void getSMEMsOnePosOneThread(uint8_t *enc_qdb,
                                  int32_t *query_pos_array,

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -229,9 +229,9 @@ int64_t BandedPairWiseSW::getTicks()
 {
     //printf("oneCount = %ld, totalCount = %ld\n", oneCount, totalCount);
     int64_t totalTicks = sort1Ticks + setupTicks + swTicks + sort2Ticks;
-    printf("cost breakup: %ld, %ld, %ld, %ld, %ld\n",
-            sort1Ticks, setupTicks, swTicks, sort2Ticks,
-            totalTicks);
+    printf("cost breakup: %lld, %lld, %lld, %lld, %lld\n",
+            (long long)sort1Ticks, (long long)setupTicks, (long long)swTicks,
+            (long long)sort2Ticks, (long long)totalTicks);
 
     return totalTicks;
 }
@@ -2617,8 +2617,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             int32_t j, k;
             int maxLen1 = 0;
             int maxLen2 = 0;
-            uint8_t minLen1 = MAX_SEQ_LEN8 + 1;
-            uint8_t minLen2 = MAX_SEQ_LEN8 + 1;
             bsize = w;
             
             uint64_t tim;
@@ -3605,8 +3603,6 @@ void BandedPairWiseSW::smithWatermanBatchWrapper16(SeqPair *pairArray,
             int32_t j, k;
             uint16_t maxLen1 = 0;
             uint16_t maxLen2 = 0;
-            uint16_t minLen1 = MAX_SEQ_LEN16 + 1;
-            uint16_t minLen2 = MAX_SEQ_LEN16 + 1;
             bsize = w;
 
             for(j = 0; j < SIMD_WIDTH16; j++)

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -65,20 +65,6 @@ extern uint64_t tprof[LIM_R][LIM_C];
 #define chain_cmp(a, b) (((b).pos < (a).pos) - ((a).pos < (b).pos))
 KBTREE_INIT(chn, mem_chain_t, chain_cmp)
 
-/* mem_intv: primary sort by `info` (composite (m,n) key). Tie-break on
- * x[0] then x[1] extends to a strict total order so the dedup loop in
- * mem_collect_intv walking adjacent equal-info intervals sees a
- * deterministic order regardless of sort algorithm. Without these tie-
- * breaks, klib introsort vs pdqsort produce different equal-info
- * neighbor orderings in repetitive regions, which propagates to SAM
- * via different chain compositions. Matches the mem_ars2 stabilization
- * rationale. */
-#define intv_lt(a, b) \
-    ((a).info < (b).info || ((a).info == (b).info && \
-     ((a).x[0] < (b).x[0] || ((a).x[0] == (b).x[0] && \
-      (a).x[1] < (b).x[1]))))
-KSORT_INIT(mem_intv, bwtintv_t, intv_lt)
-PDQSORT_INIT(mem_intv, bwtintv_t, intv_lt)
 #define intv_lt1(a, b) ((((uint64_t)(a).m) <<32 | ((uint64_t)(a).n)) < (((uint64_t)(b).m) <<32 | ((uint64_t)(b).n)))  // trial
 KSORT_INIT(mem_intv1, SMEM, intv_lt1)  // debug
 
@@ -198,7 +184,6 @@ static inline int bsw8_envelope_ok(int len1, int len2, int w,
 
 #define flt_lt(a, b) ((a).w > (b).w)
 KSORT_INIT(mem_flt, mem_chain_t, flt_lt)
-PDQSORT_INIT(mem_flt, mem_chain_t, flt_lt)
 
 /* Chain-geometry adaptive band (--adaptive-band). Start the banded-SW tight at
  * opt->band_start on the 16-bit and scalar (long-extension) tiers; carry each
@@ -1516,8 +1501,8 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
                 // Propagate SMEM SA-count so chain_n_hits gates --supp-rep-hard-cap.
                 s.n_hits = static_cast<int32_t>(p->s);
                 if (s.rbeg < 0 || s.len < 0)
-                    fprintf(stderr, "rbeg: %ld, slen: %d, cnt: %d, n: %d, m: %d, num_smem: %ld\n",
-                            s.rbeg, s.len, cnt-1, p->n, p->m, num_smem);
+                    fprintf(stderr, "rbeg: %lld, slen: %d, cnt: %d, n: %d, m: %d, num_smem: %lld\n",
+                            (long long)s.rbeg, s.len, cnt-1, p->n, p->m, (long long)num_smem);
 
                 /* D3 (--meth, PR-3) seed→original remap (spec §5.2). The SA coord
                  * just decoded (s.rbeg) is in SEED (f/r-doubled) coordinates. Map
@@ -1725,11 +1710,11 @@ int mem_kernel1_core(FMI_search *fmi,
     // Exact-fit (num_smem == *wsize_mem) is valid: the last write lands at
     // matchArray[*wsize_mem - 1]. Trip only on a true overrun.
     if (num_smem > *wsize_mem){
-        fprintf(stderr, "Error [bug]: num_smem: %ld are more than allocated space %ld.\n",
-                num_smem, *wsize_mem);
+        fprintf(stderr, "Error [bug]: num_smem: %lld are more than allocated space %lld.\n",
+                (long long)num_smem, (long long)*wsize_mem);
         exit(EXIT_FAILURE);
     }
-    printf_(VER, "6. Done! mem_collect_smem, num_smem: %ld\n", num_smem);
+    printf_(VER, "6. Done! mem_collect_smem, num_smem: %lld\n", (long long)num_smem);
     tprof[MEM_COLLECT][tid] += __rdtsc() - tim;
 
 
@@ -2168,7 +2153,7 @@ void mem_process_seqs(mem_opt_t *opt,
              * now in ORIGINAL doubled-pac space, so use the ORIGINAL l_pac. */
             const bntseq_t *pestat_bns = mem_aln_bns(&w);
             fprintf(stderr, "[0000] Inferring insert size distribution of PE reads from data, "
-                    "l_pac: %ld, n: %d\n", pestat_bns->l_pac, n);
+                    "l_pac: %lld, n: %d\n", (long long)pestat_bns->l_pac, n);
             mem_pestat(opt, pestat_bns->l_pac, n, w.regs, pes); // otherwise, infer the insert size
                                                          // distribution from data
         }
@@ -4733,8 +4718,8 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     {   // refine it!
         fprintf(stderr, "Error: Unexpected behaviour!!!\n");
         fprintf(stderr, "Error: assert failed for seqPair size, "
-                "numPairsLeft: %d, numPairsRight %d, lim: %d\nExiting.\n",
-                numPairsLeft, numPairsRight, *wsize_pair);
+                "numPairsLeft: %d, numPairsRight %d, lim: %lld\nExiting.\n",
+                numPairsLeft, numPairsRight, (long long)*wsize_pair);
         exit(EXIT_FAILURE);
     }
     /* Discard seeds and hence their alignemnts */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -376,8 +376,8 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
             ret->prof.n_bp = sz;
         }
 
-        fprintf(stderr, "[0000] read_chunk: %ld, work_chunk_size: %ld, nseq: %d\n",
-                aux->task_size, sz, ret->n_seqs);
+        fprintf(stderr, "[0000] read_chunk: %lld, work_chunk_size: %lld, nseq: %d\n",
+                (long long)aux->task_size, (long long)sz, ret->n_seqs);
 
         if (ret->seqs == 0) {
             free(ret);


### PR DESCRIPTION
Output-preserving static cleanup of the aligner: removes dead code and silences all `-Wformat` warnings, with zero change to alignment output.

## What changed

**Dead code removed**
- `bandedSWA.cpp`: unread `minLen1`/`minLen2` locals in the 8-bit and 16-bit banded-SW batch wrappers. The 8-bit `uint8_t` pair also tripped `-Woverflow` (`MAX_SEQ_LEN8 + 1` does not fit `uint8_t`).
- `bwamem.cpp`: the never-called `PDQSORT_INIT(mem_flt)` wrapper, and the fully unused `KSORT_INIT`/`PDQSORT_INIT(mem_intv)` pair together with their `intv_lt` comparator. Their doc comment described `mem_collect_intv` — a function that no longer exists anywhere in the tree. The live `mem_flt` `ks_introsort` (chain filtering) and the `mem_intv1` SMEM sort are untouched.
- `FMI_search.{cpp,h}`: the dead `getSMEMs` method (183 lines), superseded by the `getSMEMs*OneThread` family; it had no callers.

**Format warnings (`-Wformat`)**
Fixed the 17 `int64_t`-vs-`%ld` mismatches using the repo’s existing `(long long)` + `%lld` idiom (as already used in `bntseq.cpp`, `bwa_shm.cpp`, `bam_writer.cpp`, `bwtindex.cpp`): `bandedSWA::getTicks()`, plus `stderr`/verbose diagnostic prints in `bwamem.cpp`, `fastmap.cpp`, and `FMI_search.cpp`. These are diagnostic paths only. The build drops from 17 `-Wformat` warnings to 0 on the Apple-clang/arm64 toolchain (where `int64_t` is `long long`).

An audit for other always-on instrumentation on hot paths (per-read/per-pair) found nothing further to gate: the one expensive case (UGP profiling) was already gated in #206, and the remainder are cheap per-stage/per-batch counters that #206 intentionally left compiled in.

## Validation

All gates green, byte-identical to `origin/main`:

| Gate | Result |
|------|--------|
| Build `-Wformat` | 17 → **0** |
| Build `-Woverflow` | **0** |
| `mem` SAM, 1M single-end | md5 **identical** (`f13762be…`) |
| `mem` SAM, 500k paired-end | md5 **identical** (`00521df9…`) |
| sw-kernel-bench golden, extend | **GOLDEN CHECK PASS** (60k pairs, neon) |
| sw-kernel-bench golden, rescue | **GOLDEN CHECK PASS** (60k pairs, neon) |

The kernel golden gate was run per the repo convention for changes touching `bandedSWA.cpp`, baselined against a fresh `origin/main` (`1700aab`) build to isolate this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic output to safely handle large values for sequence lengths, index/count metrics, workload sizing, and timing.
  * Enhanced selected debug/error messages with additional contextual fields.
  * Removed obsolete SMEM generation entry points and legacy SMEM-related paths.
  * Simplified vectorized alignment wrapper setup by eliminating unused initializations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->