### PR TITLE
perf(kswv): remove write-only Hmax scratch buffer from batched SW kernels

### DIFF
--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -166,13 +166,11 @@ kswv::kswv(const int o_del, const int e_del, const int o_ins,
     F16     = (int16_t *)_mm_malloc(this->maxQerLen * SIMD_WIDTH16 * numThreads * sizeof(int16_t), 64);
     H16_0   = (int16_t *)_mm_malloc(this->maxQerLen * SIMD_WIDTH16 * numThreads * sizeof(int16_t), 64);
     H16_1   = (int16_t *)_mm_malloc(this->maxQerLen * SIMD_WIDTH16 * numThreads * sizeof(int16_t), 64);
-    H16_max = (int16_t *)_mm_malloc(this->maxQerLen * SIMD_WIDTH16 * numThreads * sizeof(int16_t), 64);
     rowMax16 = (int16_t *)_mm_malloc(this->maxRefLen * SIMD_WIDTH16 * numThreads * sizeof(int16_t), 64);
 
     F8 = (uint8_t*) F16;
     H8_0 = (uint8_t*) H16_0;
     H8_1 = (uint8_t*) H16_1;
-    H8_max = (uint8_t*) H16_max;
     rowMax8 = (uint8_t*) rowMax16;
 }
 
@@ -252,7 +250,7 @@ kswv::kswv(const int o_del, const int e_del, const int o_ins,
 
 // destructor 
 kswv::~kswv() {
-    _mm_free(F16); _mm_free(H16_0); _mm_free(H16_max); _mm_free(H16_1);
+    _mm_free(F16); _mm_free(H16_0); _mm_free(H16_1);
     _mm_free(rowMax16);
 }
 
@@ -518,7 +516,6 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
     tid = 0;
     uint8_t *H0 = H8_0 + tid * SIMD_WIDTH8 * this->maxQerLen;
     uint8_t *H1 = H8_1 + tid * SIMD_WIDTH8 * this->maxQerLen;
-    uint8_t *Hmax = H8_max + tid * SIMD_WIDTH8 * this->maxQerLen;
     uint8_t *F = F8 + tid * SIMD_WIDTH8 * this->maxQerLen;
     uint8_t *rowMax = rowMax8 + tid * SIMD_WIDTH8 * this->maxRefLen;
 
@@ -536,7 +533,6 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
     for (int i = 0; i <= ncol; i++)
     {
         vst1q_u8(H0 + i * SIMD_WIDTH8, zero_vec);
-        vst1q_u8(Hmax + i * SIMD_WIDTH8, zero_vec);
         vst1q_u8(F + i * SIMD_WIDTH8, zero_vec);
     }
 
@@ -1130,7 +1126,6 @@ int kswv::kswv_neon_16_impl(int16_t seq1SoA[],
     tid = 0;
     int16_t *H0     = H16_0    + tid * SIMD_WIDTH16 * this->maxQerLen;
     int16_t *H1     = H16_1    + tid * SIMD_WIDTH16 * this->maxQerLen;
-    int16_t *Hmax   = H16_max  + tid * SIMD_WIDTH16 * this->maxQerLen;
     int16_t *F      = F16      + tid * SIMD_WIDTH16 * this->maxQerLen;
     int16_t *rowMax = rowMax16 + tid * SIMD_WIDTH16 * this->maxRefLen;
 
@@ -1145,7 +1140,6 @@ int kswv::kswv_neon_16_impl(int16_t seq1SoA[],
 
     for (int i = 0; i <= ncol; i++) {
         vst1q_s16(H0   + i * SIMD_WIDTH16, zero_vec);
-        vst1q_s16(Hmax + i * SIMD_WIDTH16, zero_vec);
         vst1q_s16(F    + i * SIMD_WIDTH16, zero_vec);
     }
     vst1q_s16(H0, zero_vec);
@@ -1568,7 +1562,6 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
     tid = 0;
     uint8_t *H0     = H8_0    + tid * SIMD_WIDTH8 * this->maxQerLen;
     uint8_t *H1     = H8_1    + tid * SIMD_WIDTH8 * this->maxQerLen;
-    uint8_t *Hmax   = H8_max  + tid * SIMD_WIDTH8 * this->maxQerLen;
     uint8_t *F      = F8      + tid * SIMD_WIDTH8 * this->maxQerLen;
     uint8_t *rowMax = rowMax8 + tid * SIMD_WIDTH8 * this->maxRefLen;
 
@@ -1582,7 +1575,6 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
 
     for (int i = 0; i <= ncol; i++) {
         _mm256_storeu_si256((__m256i*)(H0   + i * SIMD_WIDTH8), zero_vec);
-        _mm256_storeu_si256((__m256i*)(Hmax + i * SIMD_WIDTH8), zero_vec);
         _mm256_storeu_si256((__m256i*)(F    + i * SIMD_WIDTH8), zero_vec);
     }
     _mm256_storeu_si256((__m256i*)H0, zero_vec);
@@ -2048,7 +2040,6 @@ int kswv::kswv256_16_impl(int16_t seq1SoA[],
     tid = 0;
     int16_t *H0     = H16_0    + tid * SIMD_WIDTH16 * this->maxQerLen;
     int16_t *H1     = H16_1    + tid * SIMD_WIDTH16 * this->maxQerLen;
-    int16_t *Hmax   = H16_max  + tid * SIMD_WIDTH16 * this->maxQerLen;
     int16_t *F      = F16      + tid * SIMD_WIDTH16 * this->maxQerLen;
     int16_t *rowMax = rowMax16 + tid * SIMD_WIDTH16 * this->maxRefLen;
 
@@ -2062,7 +2053,6 @@ int kswv::kswv256_16_impl(int16_t seq1SoA[],
 
     for (int i = 0; i <= ncol; i++) {
         _mm256_storeu_si256((__m256i*)(H0   + i * SIMD_WIDTH16), zero_vec);
-        _mm256_storeu_si256((__m256i*)(Hmax + i * SIMD_WIDTH16), zero_vec);
         _mm256_storeu_si256((__m256i*)(F    + i * SIMD_WIDTH16), zero_vec);
     }
     _mm256_storeu_si256((__m256i*)H0, zero_vec);
@@ -2691,7 +2681,6 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
     tid = 0;  // no threading for now !!
     uint8_t *H0     = H8_0 + tid * SIMD_WIDTH8 * this->maxQerLen;
     uint8_t *H1     = H8_1 + tid * SIMD_WIDTH8 * this->maxQerLen;
-    uint8_t *Hmax   = H8_max + tid * SIMD_WIDTH8 * this->maxQerLen;
     uint8_t *F      = F8 + tid * SIMD_WIDTH8 * this->maxQerLen;
     uint8_t *rowMax = rowMax8 + tid * SIMD_WIDTH8 * this->maxRefLen;
 
@@ -2708,7 +2697,6 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
     for (int i=0; i <=ncol; i++)
     {
         _mm512_store_si512((__m512*) (H0 + i * SIMD_WIDTH8), zero512);
-        _mm512_store_si512((__m512*) (Hmax + i * SIMD_WIDTH8), zero512);
         _mm512_store_si512((__m512*) (F + i * SIMD_WIDTH8), zero512);
     }
 
@@ -3282,7 +3270,6 @@ int kswv::kswv512_16_impl(int16_t seq1SoA[],
     tid = 0;  // no threading here.
     int16_t *H0     = H16_0 + tid * SIMD_WIDTH16 * this->maxQerLen;
     int16_t *H1     = H16_1 + tid * SIMD_WIDTH16 * this->maxQerLen;
-    int16_t *Hmax   = H16_max + tid * SIMD_WIDTH16 * this->maxQerLen;
     int16_t *F      = F16 + tid * SIMD_WIDTH16 * this->maxQerLen;
     int16_t *rowMax = rowMax16 + tid * SIMD_WIDTH16 * this->maxRefLen;
     
@@ -3293,7 +3280,6 @@ int kswv::kswv512_16_impl(int16_t seq1SoA[],
 
     for (int i=ncol; i >= 0; i--) {
         _mm512_store_si512((__m512*) (H0 + i * SIMD_WIDTH16), zero512);
-        _mm512_store_si512((__m512*) (Hmax + i * SIMD_WIDTH16), zero512);
         _mm512_store_si512((__m512*) (F + i * SIMD_WIDTH16), zero512);
     }
 

--- a/src/kswv.h
+++ b/src/kswv.h
@@ -552,11 +552,11 @@ private:
 	int8_t w_extend;
 	int8_t w_ambig;
 	uint8_t *F8;
-	uint8_t *H8_0, *H8_max, *H8_1;
+	uint8_t *H8_0, *H8_1;
 	uint8_t *rowMax8;
 	
 	int16_t *F16;
-	int16_t *H16_0, *H16_max, *H16_1;
+	int16_t *H16_0, *H16_1;
 	int16_t *rowMax16;
 	int32_t maxRefLen, maxQerLen;
 	


### PR DESCRIPTION
Removes a dead scratch buffer from the batched Smith-Waterman (`kswv`) kernels. Output-preserving.

## What

Each of the six `kswv` batch kernels (NEON / AVX2 / AVX-512, 8- and 16-bit) declared an `Hmax` pointer and zeroed it once per strip in the init loop — right next to the live `H0` and `F` stores — but never read it back. The backing buffer `H16_max` (aliased to `H8_max`) is allocated, zeroed, and freed, yet never loaded anywhere in `kswv.cpp`: write-only dead scratch.

Removed:
- the six per-kernel `Hmax` pointer decls and their init-loop zeroing stores (each kernel’s per-strip init loop drops from 3 vector stores per column — `H0`, `Hmax`, `F` — to 2),
- the `H16_max` allocation, the `H8_max` alias, and the free,
- the two member declarations in `kswv.h`.

The striped `ksw_u8` / `ksw_i16` kernels keep their own `q->Hmax` (a genuinely-read max-tracking buffer used by the traceback) — that is unrelated and untouched.

## Validation — byte-identical

Per the repo convention for `kswv` kernel changes, gated with the sw-kernel-bench byte-identity golden and verified end-to-end:

| Check | Result |
|-------|--------|
| Golden **rescue** (kswv): neon, avx2, avx512bw | **PASS**, 60k pairs byte-identical/tier |
| Golden **extend** (bandedSWA, sanity): neon, sse41, avx2, avx512bw | **PASS**, 60k pairs byte-identical/tier |
| Golden failures (total) | **0** |
| `mem` SAM, 1M single-end | md5 **unchanged** (`f13762be…`) |
| `mem` SAM, 500k paired-end | md5 **unchanged** (`00521df9…`) |

x86 tiers validated on a throwaway c7i.4xlarge (Sapphire Rapids), baselined against a fresh `origin/main` (`1700aab`) build; NEON on Apple Silicon. (Rescue is AVX2+/NEON only — there is no SSE-tier batched `kswv` kernel — so it is gated on those tiers; extend covers sse41 as well.)

## Performance

Isolated-kernel GCUPS (`mb3 Mc/s`, rescue) is unchanged within run-to-run noise across avx2/avx512bw — the removed store was in the per-strip **init** loop, not the DP inner loop. This is a dead-work + dead-allocation removal, not a measurable throughput gain; its value is code hygiene and a slightly smaller init cost, in the spirit of the incremental-cleanup campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management for sequence alignment processing.
  * Removed unnecessary intermediate score storage across supported SIMD processing paths.
  * Preserved existing score tracking while reducing internal memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->