### PR TITLE
perf(mem): drop redundant per-call scratch allocations in mem_gen_alt

### DIFF
--- a/src/bwamem_extra.cpp
+++ b/src/bwamem_extra.cpp
@@ -134,11 +134,20 @@ char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 	int i, k, r, *cnt, tot;
 	kstring_t *aln = 0, str = {0,0,0};
 	char **XA = 0, *has_alt;
+	/* mem_gen_alt runs once per read (twice per pair) and, for the common
+	 * unique-mapper case, exits early at `tot == 0` after only allocating these
+	 * scratch arrays. Keep the small ones off the heap: has_alt is a per-read
+	 * transient sized to a->n (typically a handful of alnregs), so a stack
+	 * buffer with a heap fallback for the rare large-a->n read avoids a
+	 * calloc/free round-trip on every call. */
+	enum { HAS_ALT_STACK_N = 256 };
+	char has_alt_stack[HAS_ALT_STACK_N];
 
 	cnt = (int *) calloc(a->n, sizeof(int));
     assert(cnt != NULL);
-	has_alt = (char *) calloc(a->n, 1);
+	has_alt = a->n <= HAS_ALT_STACK_N ? has_alt_stack : (char *) malloc(a->n);
     assert(has_alt != NULL);
+	memset(has_alt, 0, a->n);
 	for (i = 0, tot = 0; i < a->n; ++i) {
 		r = get_pri_idx(opt->XA_drop_ratio, a->a, i);
 		if (r >= 0) {
@@ -148,13 +157,10 @@ char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 	}
 	// Publish per-primary hit counts for HN:i emission before the XA_hits cap
 	// can truncate the XA string; HN should reflect what *would* have been in
-	// XA, not what was actually emitted.
-	if (out_hn) {
-		int *hn = (int *) calloc(a->n, sizeof(int));
-		assert(hn != NULL);
-		for (i = 0; i < a->n; ++i) hn[i] = cnt[i];
-		*out_hn = hn;
-	}
+	// XA, not what was actually emitted. cnt already holds exactly these counts
+	// and is not needed after this function, so hand it to the caller directly
+	// rather than allocating and copying a second array (caller owns/frees it).
+	if (out_hn) *out_hn = cnt;
 	if (tot == 0) goto end_gen_alt;
 	aln = (kstring_t*) calloc(a->n, sizeof(kstring_t));
     assert(aln != NULL);
@@ -193,6 +199,8 @@ char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 		XA[k] = aln[k].s;
 
 end_gen_alt:
-	free(has_alt); free(cnt); free(aln); free(str.s);
+	if (has_alt != has_alt_stack) free(has_alt);
+	if (!out_hn) free(cnt); // else cnt was handed to *out_hn; caller frees it
+	free(aln); free(str.s);
 	return XA;
 }


### PR DESCRIPTION
## What

`mem_gen_alt` (XA:Z / HN:i generation) runs once per read (twice per pair). For the common unique-mapper case it exits early once no primary has a reportable secondary hit, but even on that early-exit path it made **three** heap allocations per call: `cnt`, `has_alt`, and a separate `hn` copy of `cnt`.

This PR removes two of them:

- **`has_alt` → stack**, with a heap fallback for the rare read whose alnreg count exceeds the buffer. Removes a `calloc`/`free` round-trip on every call.
- **Hand `cnt` to the caller as the HN:i count array** instead of allocating a second array and copying `cnt` into it. `cnt` already holds exactly those per-primary counts and is unused after the function, so the caller takes ownership and frees it — exactly as it already did for the copy. `cnt` is still freed locally on the `out_hn == NULL` path.

## Why

Profiling the SAM stage on paired-end WGS showed `mem_gen_alt` is ~0.6–0.7% of wall time with 86–89% of calls taking the early-exit path — so the per-call allocation overhead falls on nearly every read while doing no XA work. This trims that overhead and removes a redundant per-call array copy.

## Correctness

Byte-identical SAM output (md5 of records, `@PG` stripped) against hg38:

| dataset | md5 | vs baseline |
|---|---|---|
| SE 500k | `0b4811712bbe318695cde5e3f88ce55c` | unchanged |
| SE 1M | `f13762be45db09738c07324979b6333b` | unchanged |
| PE 500k | `00521df944e1c23748ea165874134d76` | unchanged |

Ownership is unchanged from the caller's perspective: it already freed the returned HN array; it now frees `cnt` under that same pointer (no double-free — `mem_gen_alt` no longer frees `cnt` when it is transferred).

## Performance

Whole-aligner instruction count (thermal-independent, `/usr/bin/time -l`, PE, `-t 8`) is **neutral within noise** (±0.08%) on the mimalloc build — the removed `calloc`s are cheap there. This is primarily allocation hygiene plus removal of a redundant copy; the benefit is larger under a plain-`malloc` build or allocation pressure. No regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory allocation overhead during processing, improving efficiency for typical workloads.
  * Added adaptive memory handling for larger inputs.

* **Reliability**
  * Improved output memory ownership handling to prevent unnecessary copying and cleanup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->