### PR TITLE
feat(version): report whether mimalloc is the active allocator

### DIFF
--- a/docs/_generated/cli/version.txt
+++ b/docs/_generated/cli/version.txt
@@ -1,2 +1,2 @@
-mimalloc 3.3.0
 v<MAJOR.MINOR>-<N>-g<COMMIT>
+mimalloc 3.3.0 (active)

--- a/docs/src/user-guide/allocator.md
+++ b/docs/src/user-guide/allocator.md
@@ -27,10 +27,13 @@ The linkage strategy differs by OS:
 > **Warning — macOS: keep libmimalloc.dylib next to the binary**
 >
 > On macOS, `libmimalloc.dylib` must remain in the same directory as the
-> `bwa-mem3` binary (or be reachable via the embedded rpath). If you move
-> `bwa-mem3` without also moving `libmimalloc.dylib`, the binary will fall back
-> to the system allocator silently — `bwa-mem3 version` will not print a mimalloc
-> line, which is the indicator that the allocator is active.
+> `bwa-mem3` binary (or be reachable via the embedded rpath). The binary carries
+> a hard dynamic dependency on `libmimalloc.dylib`; if you move `bwa-mem3`
+> without it, dyld can no longer resolve the library and the binary fails to
+> launch (`dyld: Library not loaded`) rather than silently running on the system
+> allocator. Whenever mimalloc *is* linked and loaded, `bwa-mem3 version` reports
+> its status explicitly — see
+> [Verifying that mimalloc is active](#verifying-that-mimalloc-is-active) below.
 
 ## Verifying that mimalloc is active
 
@@ -40,13 +43,29 @@ Run:
 ./bwa-mem3 version
 ```
 
-When mimalloc is linked and loaded, the output includes a line like:
+The `version` output always carries a mimalloc line whenever the library is
+linked, with a status suffix reporting whether it is actually intercepting the
+standard allocator:
 
 ```text
-mimalloc 3.x.x
+mimalloc 3.x.x (active)
 ```
 
-If that line is absent, mimalloc is not active.
+`(active)` means a standard `malloc` allocation was routed to mimalloc — the
+allocator is doing its job. If instead you see:
+
+```text
+mimalloc 3.x.x (linked but NOT overriding malloc)
+```
+
+then a libmimalloc that exports only the `mi_*` API is linked — e.g. a
+distro/conda `libmimalloc` built without the malloc override — and every real
+`malloc`/`free` is still going to the system allocator. If the mimalloc line is
+absent entirely, the binary was built with `USE_MIMALLOC=0`.
+
+The status is probed at runtime by allocating through the standard `malloc` and
+asking mimalloc whether the pointer lives in one of its heap regions, so it
+reflects the allocator that is genuinely in effect — not merely what was linked.
 
 ## Opting out
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -194,7 +194,25 @@ int main(int argc, char* argv[])
 #ifdef USE_MIMALLOC
         {
             int mv = mi_version();
-            fprintf(stderr, "mimalloc %d.%d.%d\n", mv / 10000, (mv / 100) % 100, mv % 100);
+            // Report whether mimalloc is actually intercepting the standard
+            // allocator, not merely linked. mi_version() resolves as long as
+            // libmimalloc is on the link line, so the version alone is a
+            // false-positive signal: a build that links a libmimalloc which
+            // exports only the mi_* API (e.g. some distro/conda libmimalloc.so
+            // built without the malloc override) prints a version here while
+            // every real malloc/free still goes to the system allocator.
+            // Probe by allocating through the standard malloc and asking
+            // mimalloc whether the pointer lives in one of its heap regions —
+            // true only when malloc was routed to mimalloc.
+            void *probe = malloc(64);
+            int active = (probe != NULL) && mi_is_in_heap_region(probe);
+            free(probe);
+            // Emit on stdout so the whole `version` block stays on one stream
+            // (PACKAGE_VERSION and the SIMD lines above also go to stdout);
+            // downstream scripts that capture stdout can then parse it.
+            fprintf(stdout, "mimalloc %d.%d.%d (%s)\n",
+                    mv / 10000, (mv / 100) % 100, mv % 100,
+                    active ? "active" : "linked but NOT overriding malloc");
         }
 #endif
         return 0;

--- a/test/mimalloc_loaded_test.sh
+++ b/test/mimalloc_loaded_test.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # test/mimalloc_loaded_test.sh
 #
-# Asserts that a bwa-mem3 binary built with USE_MIMALLOC=1 reports a
-# mimalloc version line from the `version` subcommand. Used in CI to prove
-# the allocator isn't silently absent on a given build.
+# Asserts that a bwa-mem3 binary built with USE_MIMALLOC=1 reports mimalloc as
+# the *active* allocator from the `version` subcommand. The version line now
+# always carries a status suffix — "(active)" when standard malloc is routed to
+# mimalloc, or "(linked but NOT overriding malloc)" when the library is linked
+# but not intercepting malloc. Used in CI to prove the allocator isn't silently
+# absent or merely linked-but-inert on a given build.
 #
 # Usage: test/mimalloc_loaded_test.sh <path-to-bwa-mem3>
 
@@ -17,10 +20,14 @@ fi
 bin="$1"
 out="$("$bin" version 2>&1 || true)"
 
-if grep -Eq '^mimalloc [0-9]+\.[0-9]+\.[0-9]+$' <<<"$out"; then
-    echo "PASS: $bin reports mimalloc"
+if grep -Eq '^mimalloc [0-9]+\.[0-9]+\.[0-9]+ \(active\)$' <<<"$out"; then
+    echo "PASS: $bin reports mimalloc as the active allocator"
     grep '^mimalloc' <<<"$out"
     exit 0
+elif grep -Eq '^mimalloc [0-9]+\.[0-9]+\.[0-9]+ ' <<<"$out"; then
+    echo "FAIL: $bin links mimalloc but it is NOT the active allocator"
+    grep '^mimalloc' <<<"$out"
+    exit 1
 else
     echo "FAIL: $bin does not report mimalloc in 'version' output"
     echo "---- actual output ----"


### PR DESCRIPTION
## Summary

`bwa-mem3 version` printed the linked mimalloc version whenever `libmimalloc` was on the link line, because `mi_version()` resolves regardless of whether mimalloc's `malloc`/`free` override is actually in effect. That makes the line a **false-positive signal**: a build that links a `libmimalloc` exporting only the `mi_*` API — e.g. a distro or conda-forge `libmimalloc.so` built without the ELF malloc override — prints a version here while every real `malloc`/`free` still goes to the system allocator.

This PR probes the *actual* allocator: allocate through the standard `malloc`, then ask mimalloc (`mi_is_in_heap_region`) whether the pointer lives in one of its heap regions — true only when `malloc` was routed to mimalloc. The version line now reads:

- `mimalloc 3.3.0 (active)` — mimalloc is the process allocator, or
- `mimalloc 3.3.2 (linked but NOT overriding malloc)` — linked but inert; hot-path allocations fall back to the system allocator.

## Why

This surfaced from a real regression: the bioconda 0.5.0 Linux package links conda-forge's `libmimalloc.so`, which exports only `mi_*` (no overriding `malloc`), so the packaged binary loads mimalloc but allocates through glibc — ~30% slower on multi-threaded WGS than a build that statically whole-archives the bundled `MI_OVERRIDE=ON` allocator. The old `version` line printed `mimalloc 3.3.2` in both cases, hiding the problem. This probe makes a crippled allocator link visible from `version` alone.

## Validation

Built the same source two ways on a Linux/AVX2 host and ran `version`:

| link | `version` output |
|------|------------------|
| vendored `libmimalloc.a`, `--whole-archive` | `mimalloc 3.3.0 (active)` |
| conda-forge `-lmimalloc` (dynamic) | `mimalloc 3.3.2 (linked but NOT overriding malloc)` |

Cross-checked against `MIMALLOC_SHOW_STATS=1` on a real alignment (active build reserves arenas; inert build emits no mimalloc stats). No behavior change beyond the `version` string; the probe is a single 64-byte alloc/free.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `version` command to clearly indicate whether mimalloc is actively overriding the standard memory allocator.
  * Added distinct status reporting for active use versus being linked without overriding allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->