### PR TITLE
fix(fast): enable --extend-mate-concordant and raise chain cap to 20 for non-meth --fast

### DIFF
--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -22,8 +22,9 @@ Options:
     -S            skip mate rescue
     -P            skip pairing; mate rescue performed unless -S also in use
     --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup
-                  --skip-contained-ext --max-extend-chains 5 --adaptive-band (and
-                  -s 2 --extend-mate-concordant under --meth). Opt-in; explicit
+                  --skip-contained-ext --max-extend-chains 20 --adaptive-band
+                  --extend-mate-concordant (under --meth: --max-extend-chains 10,
+                  -s 2). Opt-in; explicit
                   flags override where applicable; --smem-dedup,
                   --skip-contained-ext and --adaptive-band are always enabled.
                   NOT byte-identical to the default (divergence confined to the

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -44,14 +44,15 @@ bwa-mem3 mem -t <N> -m 10 -y 0 ref.fa R1.fq R2.fq > out.sam
 ```
 
 > **Shorthand:** `bwa-mem3 mem --fast` applies `-m 10 -y 0 --min-ext-len 30
-> --smem-dedup --skip-contained-ext --max-extend-chains 5 --adaptive-band` (and
-> `-s 2 --extend-mate-concordant` under `--meth`) in one flag. Explicit flags
+> --smem-dedup --skip-contained-ext --max-extend-chains 20 --adaptive-band
+> --extend-mate-concordant` (plus `-s 2` and a lower `--max-extend-chains 10`
+> under `--meth`) in one flag. Explicit flags
 > still override individual levers where applicable; `--smem-dedup`,
 > `--skip-contained-ext` and `--adaptive-band` are forced on with no opt-out
 > (`--adaptive-band` is a no-op on short reads, a ~25% speedup on long-read runs).
 > `--skip-contained-ext` no-ops under `--meth` (its own internal gate disables it
 > there), so on a `--meth` run the effective levers are
-> `-m 10 -y 0 --min-ext-len 30 --smem-dedup --max-extend-chains 5 --adaptive-band -s 2 --extend-mate-concordant`.
+> `-m 10 -y 0 --min-ext-len 30 --smem-dedup --max-extend-chains 10 --adaptive-band -s 2 --extend-mate-concordant`.
 > See [`mem` → `--fast`](../cli/mem.md#--fast--speed-preset-opt-in-not-byte-identical).
 
 Use this for new pipelines, or once a drop-in migration is validated and you want bwa-mem3's best
@@ -252,7 +253,7 @@ figures and the golden-truth F1 sweep warrant a fresh
 these `--fast` accuracy figures genome-wide. `--min-ext-len` and `--fast` stay opt-in; the drop-in
 defaults are unchanged.
 
-## Chain extension cap: `--max-extend-chains 5`
+## Chain extension cap: `--max-extend-chains`
 
 `--max-extend-chains INT` caps the number of chains that reach banded Smith–Waterman extension to the
 top-`INT` by chain weight (applied after `mem_chain_flt`); the dropped chains are the lowest-weight
@@ -271,12 +272,14 @@ unaffected; the default path (`0`) is verified byte-identical to the base branch
 truth (`sim-wgs-place`, 10.7 M reads), standalone `N = 5` is **−23% total alignment CPU** at +20
 high-confidence (MAPQ ≥ 60) mismaps out of 9.5 M (1529 → 1549). Stacked on top of `--fast` it is
 **−15% marginal CPU** at +21 high-confidence mismaps (1559 → 1580, +0.0002% absolute; overall
-−0.045 pp). `N = 2` is too aggressive (+13.5% high-confidence mismaps), so `--fast` sets `5`.
+−0.045 pp). `N = 2` is too aggressive (+13.5% high-confidence mismaps). `--fast` sets `20` and
+pairs it with `--extend-mate-concordant` (below): the standalone MAPQ ≥ 1 tail rises 3.8× at cap 5,
+but mate-concordant retention closes most of that at cap 20 for ~−20% aligner CPU (fg-labs/bwa-mem3#202).
 `--max-extend-chains` and `--fast` stay opt-in; the drop-in defaults are unchanged.
 
-## Mate-concordant chain retention under `--meth`: `--extend-mate-concordant`
+## Mate-concordant chain retention: `--extend-mate-concordant`
 
-`--max-extend-chains 5` interacts badly with `--meth`. Bisulfite reads are projected into a
+The chain cap interacts badly with paired-end pairing, most acutely under `--meth`. Bisulfite reads are projected into a
 3-letter alphabet (C→T, G→A), which collapses sequence complexity and *flattens chain weights*:
 a read carries many similarly-weighted chains instead of one clear winner. Capping to the top-5 by
 weight then frequently drops a read's *true* low-weight chain — not because it was chain-filtered
@@ -317,9 +320,12 @@ only genuine pair anchors. (Turning the chain cap off entirely under `--meth` re
 but at a larger, uniform CPU cost.) Full per-dataset figures:
 [fg-labs/bwa-mem3#195](https://github.com/fg-labs/bwa-mem3/pull/195).
 
-**`--fast` enables it automatically under
-`--meth` only** — non-meth `--fast` is unchanged, because WGS placement is already unaffected by the
-cap and the exemption would erode the speedup. It is a no-op unless a chain cap is actually in effect,
+**`--fast` enables it automatically** for both non-meth and `--meth` runs. The
+non-meth case (fg-labs/bwa-mem3#202): the top-`INT` cap inflates the confident (MAPQ ≥ 1) mis-placement
+tail 3.8× on `sim-wgs-place` (3,626 → 13,921 vs uncapped) by the same mechanism — the true chain is
+low-weight but mate-concordant in ~98% of cap-dropped reads. Paired with `--max-extend-chains 20`,
+mate-concordant retention closes most of that tail (→ ~4,450, verified on a rebuilt `--fast`) at
+~−20% aligner CPU. It is a no-op unless a chain cap is actually in effect,
 and like `--max-extend-chains` it is **not** byte-identical when it retains a chain. `--extend-mate-concordant`
 and `--fast` stay opt-in; the drop-in defaults are unchanged.
 

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -240,9 +240,9 @@ secondaries, so `XS`, secondary alignments, and `MAPQ` can shift on multi-mappin
 reads. High-confidence (uniquely-placed) reads are unaffected. The cap is a safety
 no-op for pathological reads with more than 4096 chains (`MAX_EXTEND_CHAINS_CAP`):
 those reads extend all of their chains as usual, so `--max-extend-chains` has no
-effect on them. `--fast` sets `5`. For the accuracy/speed curve and validation status,
+effect on them. `--fast` sets `20`. For the accuracy/speed curve and validation status,
 see
-[Settings profiles → `--max-extend-chains 5`](../best-practices/settings-profiles.md#chain-extension-cap---max-extend-chains-5).
+[Settings profiles → `--max-extend-chains`](../best-practices/settings-profiles.md#chain-extension-cap---max-extend-chains).
 
 #### `--adaptive-band` — adaptive banded Smith-Waterman for long reads
 
@@ -302,7 +302,7 @@ the benchmarked per-dataset figures in
 **Not byte-identical when it retains a chain.** Like `--max-extend-chains`, keeping an
 extra candidate can move `XS`, secondaries, and `MAPQ` on multi-mapping reads;
 high-confidence placement is unaffected. For the placement/mismap validation, see
-[Settings profiles → `--extend-mate-concordant`](../best-practices/settings-profiles.md#mate-concordant-chain-retention-under---meth---extend-mate-concordant).
+[Settings profiles → `--extend-mate-concordant`](../best-practices/settings-profiles.md#mate-concordant-chain-retention---extend-mate-concordant).
 
 #### `-h INT[,INT]` — secondary alignment reporting
 
@@ -327,7 +327,7 @@ the alignment score and mapping quality for each secondary hit.
 `--fast` is a one-flag shorthand for the characterized speed levers:
 
 ```text
-bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 5 --adaptive-band
+bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 20 --adaptive-band --extend-mate-concordant
 ```
 
 `--skip-contained-ext` is byte-identical to the default on non-meth single- and paired-end
@@ -338,14 +338,15 @@ applies (~10% lower alignment CPU on long-read inputs) and safe elsewhere.
 (the reads `--fast` primarily targets) and a ~25% alignment-CPU speedup on long-read
 (SBX/HiFi/ONT) runs, so bundling it only helps.
 
-Under `--meth` it additionally sets `-s 2` (light Pass-2 re-seeding) and
-`--extend-mate-concordant`. Earlier releases used `-s 0` (no re-seed), which inflated
+`--extend-mate-concordant` repairs the chain-cap pairing regression — the true, low-weight but
+mate-concordant chain the cap would otherwise drop — and is included for both non-meth and `--meth`
+`--fast` (see
+[Settings profiles → `--extend-mate-concordant`](../best-practices/settings-profiles.md#mate-concordant-chain-retention---extend-mate-concordant)).
+
+Under `--meth` it additionally sets `-s 2` (light Pass-2 re-seeding) and lowers the chain cap to `10`.
+Earlier releases used `-s 0` (no re-seed), which inflated
 MAPQ on bisulfite reads; `-s 2` recovers the MAPQ/placement at nearly the same speed
 (see [Settings profiles → Pass-2 re-seeding](../best-practices/settings-profiles.md#pass-2-re-seeding-under---meth--s-2)).
-`--extend-mate-concordant` repairs the `--max-extend-chains 5` pairing regression that
-bisulfite's flattened chain weights otherwise cause (see
-[Settings profiles → `--extend-mate-concordant`](../best-practices/settings-profiles.md#mate-concordant-chain-retention-under---meth---extend-mate-concordant)).
-Both are meth-only; non-meth `--fast` is unchanged.
 
 Each lever is applied only if you did not set it explicitly, so explicit flags
 win where applicable (`--fast -m 30` keeps `-m 30`; `--fast --max-extend-chains 8`

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -943,8 +943,9 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -S            skip mate rescue\n");
     fprintf(stderr, "    -P            skip pairing; mate rescue performed unless -S also in use\n");
     fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup\n");
-    fprintf(stderr, "                  --skip-contained-ext --max-extend-chains 5 --adaptive-band (and\n");
-    fprintf(stderr, "                  -s 2 --extend-mate-concordant under --meth). Opt-in; explicit\n");
+    fprintf(stderr, "                  --skip-contained-ext --max-extend-chains 20 --adaptive-band\n");
+    fprintf(stderr, "                  --extend-mate-concordant (under --meth: --max-extend-chains 10,\n");
+    fprintf(stderr, "                  -s 2). Opt-in; explicit\n");
     fprintf(stderr, "                  flags override where applicable; --smem-dedup,\n");
     fprintf(stderr, "                  --skip-contained-ext and --adaptive-band are always enabled.\n");
     fprintf(stderr, "                  NOT byte-identical to the default (divergence confined to the\n");
@@ -1445,8 +1446,8 @@ int main_mem(int argc, char *argv[])
 
     /* --fast: one-flag shorthand for the characterized speed levers
      *   -m 10  -y 0  --min-ext-len 30  --smem-dedup  --skip-contained-ext
-     *   --max-extend-chains 5  --adaptive-band
-     *   (under --meth: also adds -s 2 and --extend-mate-concordant).
+     *   --max-extend-chains 20  --adaptive-band  --extend-mate-concordant
+     *   (under --meth: --max-extend-chains 10 and also adds -s 2).
      * Mirrors the -x preset: each lever is applied only when the user did not
      * set it explicitly (opt0), so explicit flags win where applicable. The
      * exceptions are --smem-dedup and --skip-contained-ext, which are plain
@@ -1466,9 +1467,12 @@ int main_mem(int argc, char *argv[])
          * rescue on, below) shows chr-accuracy flat (0.9908) at every cap but the
          * confident wrong-chromosome rate is U-shaped, minimized at 10 (cap 5: 592
          * MAPQ>=30 mismaps; cap 10: 382; uncapped: 1056), for +0.7s wall (20.2->20.9s,
-         * still -6% vs uncapped). Non-meth keeps 5 (its placement is cap-insensitive
-         * and 5 is the pure-speed pick). */
-        if (!opt0.max_extend_chains) opt->max_extend_chains = opt->meth_mode ? 10 : 5;
+         * still -6% vs uncapped). Non-meth uses 20 + --extend-mate-concordant
+         * (below): the non-meth sweep in #202 shows the plain cap 5 inflates the
+         * confident (MAPQ>=1) mis-placement tail 3.8x on sim-wgs-place (3,626 ->
+         * 13,921 vs uncapped); cap 20 + mate-concordant lands within +827 of that
+         * floor (verified --fast) while keeping ~-20% aligner CPU. */
+        if (!opt0.max_extend_chains) opt->max_extend_chains = opt->meth_mode ? 10 : 20;
         opt->smem_dedup = 1;                             /* --smem-dedup (plain on/off) */
         opt->skip_contained_ext = 1;                     /* --skip-contained-ext (plain on/off;
                                                           * meth-gated internally) */
@@ -1485,11 +1489,15 @@ int main_mem(int argc, char *argv[])
          * locus (99% proper-pair). Keeping any capped chain that is concordant with
          * a mate chain retains exactly the true pair's low-weight chain while still
          * dropping the far/redundant ones, recovering placement to default parity
-         * (97.64% -> 98.08%, == cap-off 98.09%). Non-meth --fast keeps the plain
-         * cap (WGS placement is already unaffected and the exemption would erode
-         * the speedup). Auto (-1) sizes the concordance window to the estimated
-         * proper-pair insert bound so only genuine pair anchors are retained. */
-        if (opt->meth_mode && !opt0.mate_concordant_window)
+         * (97.64% -> 98.08%, == cap-off 98.09%). Non-meth --fast benefits too:
+         * the same top-5 cap inflates confident (MAPQ>=1) mismaps 3.8x on
+         * sim-wgs-place (3,626 -> 13,921 vs uncapped), for the same reason -- the
+         * true chain is low-weight but mate-concordant in 98% of cap-dropped reads.
+         * Mate-concordant retention recovers ~60% of that (-> 5,521) at ~neutral
+         * CPU, so it is enabled for non-meth --fast as well (fg-labs/bwa-mem3#202).
+         * Auto (-1) sizes the concordance window to the estimated proper-pair
+         * insert bound so only genuine pair anchors are retained. */
+        if (!opt0.mate_concordant_window)
             opt->mate_concordant_window = -1;
         if (opt->meth_mode && !opt0.split_width)
             opt->split_width = 2;                        /* -s 2 (meth only): light Pass-2 reseed.
@@ -1616,7 +1624,7 @@ int main_mem(int argc, char *argv[])
             fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --max-extend-chains %d --adaptive-band -s %d --extend-mate-concordant\n",
                     __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains, opt->split_width);
         else
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d --adaptive-band\n",
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d --adaptive-band --extend-mate-concordant\n",
                     __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains);
     }
 

--- a/test/fast_preset_test.sh
+++ b/test/fast_preset_test.sh
@@ -3,14 +3,14 @@
 #
 # Asserts that `bwa-mem3 mem --fast` resolves the characterized speed levers
 # (-m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext
-# --max-extend-chains 5, plus -s 2, --max-extend-chains 10, and
-# --extend-mate-concordant under --meth), that explicit user flags override the
+# --max-extend-chains 20 --extend-mate-concordant, plus -s 2 and a lower
+# --max-extend-chains 10 under --meth), that explicit user flags override the
 # preset, and that the default path is untouched when --fast is absent.
 # --skip-contained-ext no-ops under --meth (internal gate), so it is omitted from
 # the meth audit line; --max-extend-chains applies under --meth too but at a
-# higher cap of 10 (non-meth keeps 5). --extend-mate-concordant is meth-only
-# (recovers the bisulfite pairing regression the chain cap otherwise causes) and
-# must be absent from the non-meth audit line.
+# lower cap of 10 (non-meth uses 20). --extend-mate-concordant recovers the
+# chain-cap pairing regression and is now enabled for both non-meth and --meth
+# --fast (fg-labs/bwa-mem3#202), so it must be present on both audit lines.
 #
 # The assertion surface is the audit line main_mem prints to stderr when
 # --fast is active: it reports the *resolved* mem_opt_t values, so an explicit
@@ -50,13 +50,13 @@ line="$(fast_line --fast)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
    && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
    && "$line" == *"--skip-contained-ext"* \
-   && "$line" == *"--max-extend-chains 5"* ]] \
+   && "$line" == *"--max-extend-chains 20"* \
+   && "$line" == *"--adaptive-band"* \
+   && "$line" == *"--extend-mate-concordant"* ]] \
     || { echo "FAIL: --fast bundle wrong: '$line'" >&2; exit 1; }
 [[ "$line" != *"-s "* ]] \
     || { echo "FAIL: non-meth --fast must not set -s: '$line'" >&2; exit 1; }
-[[ "$line" != *"--extend-mate-concordant"* ]] \
-    || { echo "FAIL: non-meth --fast must not enable --extend-mate-concordant: '$line'" >&2; exit 1; }
-echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 5 (no -s, no mate-concordant)"
+echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 20 --adaptive-band --extend-mate-concordant (no -s)"
 
 # 2. Override precedence: an explicit flag wins *only* for its own field; the
 #    rest of the preset (including the unconditional --smem-dedup) must survive.
@@ -64,27 +64,32 @@ line="$(fast_line --fast -m 30)"
 [[ "$line" == *"-m 30"* && "$line" == *"-y 0"* \
    && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
    && "$line" == *"--skip-contained-ext"* \
-   && "$line" == *"--max-extend-chains 5"* ]] \
+   && "$line" == *"--max-extend-chains 20"* \
+   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* ]] \
     || { echo "FAIL: explicit -m 30 should only override -m: '$line'" >&2; exit 1; }
 line="$(fast_line --fast -y 5)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 5"* \
    && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
    && "$line" == *"--skip-contained-ext"* \
-   && "$line" == *"--max-extend-chains 5"* ]] \
+   && "$line" == *"--max-extend-chains 20"* \
+   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* ]] \
     || { echo "FAIL: explicit -y 5 should only override -y: '$line'" >&2; exit 1; }
 line="$(fast_line --fast --min-ext-len 45)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
    && "$line" == *"--min-ext-len 45"* && "$line" == *"--smem-dedup"* \
    && "$line" == *"--skip-contained-ext"* \
-   && "$line" == *"--max-extend-chains 5"* ]] \
+   && "$line" == *"--max-extend-chains 20"* \
+   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* ]] \
     || { echo "FAIL: explicit --min-ext-len 45 should only override min-ext-len: '$line'" >&2; exit 1; }
 # --max-extend-chains is overridable under --fast (respects an explicit value).
 line="$(fast_line --fast --max-extend-chains 8)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
    && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
-   && "$line" == *"--max-extend-chains 8"* ]] \
+   && "$line" == *"--skip-contained-ext"* \
+   && "$line" == *"--max-extend-chains 8"* \
+   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* ]] \
     || { echo "FAIL: explicit --max-extend-chains 8 should only override that lever: '$line'" >&2; exit 1; }
-echo "OK:   explicit -m/-y/--min-ext-len/--max-extend-chains override only their field; rest of preset survives"
+echo "OK:   explicit -m/-y/--min-ext-len/--max-extend-chains override only their field; rest of preset (--adaptive-band, --extend-mate-concordant, ...) survives"
 
 # 3. Default contract: no --fast => no audit line at all.
 "$bin" mem "$ref" "$reads" >/dev/null 2>"$err" || { echo "FAIL: plain mem nonzero" >&2; exit 1; }


### PR DESCRIPTION
## Summary

`--fast` degrades the short-read ROC (as @lh3 reported in #202): its top-5 chain cap (`--max-extend-chains 5`) inflates confident (MAPQ ≥ 1) mis-placements **3.8×** — 3,626 → 13,921 on holodeck-simulated WGS truth (`sim-wgs-place`, 5M pairs) — while aggregate accuracy barely moves (correct% 95.17 → 95.11), which is exactly why it hides in headline numbers but shows up in the ROC tail.

This PR enables `--extend-mate-concordant` for non-meth `--fast` (it was gated to `--meth`) and loosens the cap 5 → 20. **Verified on a rebuilt `--fast`: confident mis-placements drop 13,921 → 4,453 (−68%), correct% 95.15** — within +827 of the uncapped floor (3,626) — at ~−20% aligner CPU.

## Root cause

Add-one-to-default lever ablation isolates it to the chain cap alone (other `--fast` levers are ≤ +510; `--adaptive-band`/`--skip-contained-ext` are exactly neutral on short reads):

| lever added to default | Δ confident-wrong | 
|---|---:|
| `--max-extend-chains 5` | **+10,295** |
| `-m 10` | +510 |
| all others | ≤ +42 |

A per-chain dump against truth (1M reads / 4.4M chains) shows why mate-concordance is the right fix: the true chain is already top-weight for 97.5% of reads; when the cap drops it, **98% of the time the true chain is low-weight but concordant with a mate chain** — the exact case `--extend-mate-concordant` already retains for `--meth`.

## Cap sweep, with vs without `--extend-mate-concordant`

| `--max-extend-chains` | wrong≥1 no mate | wrong≥1 **+mate** | CPU-s +mate |
|---:|---:|---:|---:|
| 0 (uncapped floor) | 3,626 | 3,626 | 1,337 |
| **5 (old `--fast`)** | 13,921 | 5,521 | 977 |
| 10 | 7,862 | 4,611 | 1,025 |
| **20 (this PR)** | 5,400 | 4,152 | 1,076 |
| 50 | 4,177 | 3,856 | 1,120 |

Mate-concordance Pareto-dominates the plain cap at every value. cap 20 is the knee — near-uncapped accuracy, still ~−20% CPU.

## The residual is irreducible

The remaining ~0.01% (≈208 per 1M pairs) are **repeat multimappers**: the true chain is a full-length copy weight-tied with 20+ identical alignments, and its mate is discordant/absent. Tested three further retention signals — query coverage (`qlen`), a wider mate window, and a soft (weight-gap) cap — none separate the true chain except by readmitting the entire repeat family (junk retained 736k → 1.27M chains). There is no additional signal to exploit.

## Change

`src/fastmap.cpp`: drop the `opt->meth_mode` guard on `mate_concordant_window` and set the non-meth `--fast` cap to 20 (`--max-extend-chains 10` and `-s 2` stay `--meth`-specific). Comment/banner/help updated. One functional guard change + one constant.

## Verification

Rebuilt at the current release and run directly on `sim-wgs-place`:
- `--fast` (cap 5 + mate, wiring check) → wrong≥1 = 5,543 == explicit `cap5+mate` arm (5,521), 0.4% agreement.
- `--fast` (cap 20 + mate, shipped) → **wrong≥1 = 4,453, correct% 95.15**.

Refs #202.

## Tests & docs

- `test/fast_preset_test.sh` — updated the non-meth `--fast` audit-line assertions to expect `--max-extend-chains 20` and `--extend-mate-concordant` (the meth case is unchanged: cap 10, `-s 2`, mate-concordant).
- `docs/_generated/cli/mem.txt`, `docs/src/cli/mem.md`, `docs/src/best-practices/settings-profiles.md` — synced the `--fast` preset expansion, corrected the "`--extend-mate-concordant` is `--meth`-only" framing to non-meth + meth, and fixed the affected cross-links (also corrected a pre-existing doc error listing the meth cap as 5 instead of 10).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the `--fast` preset to raise the chain-extension limit for standard runs to `--max-extend-chains 20`.
  * Automatically includes `--extend-mate-concordant` for both standard and methylation runs (with `--meth` using `--max-extend-chains 10`).
  * Preserves the existing methylation-focused speed setup while adjusting the chain limit accordingly.

* **Documentation**
  * Updated CLI and settings-profile docs to match the revised `--fast` effective options and trade-offs.

* **Tests**
  * Adjusted fast-preset validation and override-precedence expectations for the new resolved settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->