### PR TITLE
fix(meth): recover repeat placement via both-hypothesis mate rescue + PE MAPQ hardening

### DIFF
--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -762,8 +762,12 @@ static inline void revseq(int l, uint8_t *s)
 static bool meth_batched_rescue_enabled()
 {
     static const bool enabled = []() {
+        /* Default OFF: meth mate rescue uses the scalar path that scores BOTH
+         * bisulfite hypotheses (OT and OB) and keeps the better alignment. The
+         * single-hypothesis batched SIMD path mis-scores a repeat mate whose true
+         * copy needs the opposite matrix; opt into it with =1 for benchmarking. */
         const char *e = getenv("BWAMEM3_METH_BATCHED_RESCUE");
-        return !(e != NULL && strcmp(e, "0") == 0);
+        return (e != NULL && strcmp(e, "1") == 0);
     }();
     return enabled;
 }
@@ -1546,6 +1550,7 @@ int mem_matesw_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
         if (a->rid == rid && re - rb >= opt->min_seed_len) { // no funny things happening
             kswr_t aln;
             mem_alnreg_t b;
+            int meth_won_hyp = (a->meth_hypothesis < 0) ? -1 : !a->meth_hypothesis;
             int tmp, xtra = KSW_XSUBO | KSW_XSTART | (l_ms * opt->a < 250? KSW_XBYTE : 0) | (opt->min_seed_len * opt->a);
 
             //aln = **myaln;
@@ -1564,9 +1569,29 @@ int mem_matesw_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
                 uint8_t *ref_rw = (uint8_t*) malloc((size_t)ref_len);
                 assert(ref_rw != NULL);
                 memcpy(ref_rw, ref, (size_t)ref_len);
-                aln = ksw_align2(l_ms, seq, ref_len, ref_rw, 5,
-                                 sw_mat, opt->o_del, opt->e_del,
-                                 opt->o_ins, opt->e_ins, xtra, 0);
+                if (opt->meth_mode) {
+                    /* D3: the single seed-derived bisulfite hypothesis can cripple
+                     * a repeat mate's TRUE-locus rescue (its conversions unfreed ->
+                     * partial), so a decoy concordant pair wins and both mates flip
+                     * to a wrong chromosome. Score under BOTH OT/OB matrices and
+                     * keep the better, mirroring bwameth's both-strand alignment. */
+                    const int8_t *m0 = mem_opt_meth_mat(opt, 0);
+                    const int8_t *m1 = mem_opt_meth_mat(opt, 1);
+                    // ref is still in scope, read-only, and holds the same
+                    // slice bytes, so restore ref_rw directly from it between
+                    // the two hypotheses instead of an extra ref_bak copy.
+                    kswr_t a0 = ksw_align2(l_ms, seq, ref_len, ref_rw, 5, m0,
+                                           opt->o_del, opt->e_del, opt->o_ins, opt->e_ins, xtra, 0);
+                    memcpy(ref_rw, ref, (size_t)ref_len);
+                    kswr_t a1 = ksw_align2(l_ms, seq, ref_len, ref_rw, 5, m1,
+                                           opt->o_del, opt->e_del, opt->o_ins, opt->e_ins, xtra, 0);
+                    if (a0.score >= a1.score) { aln = a0; meth_won_hyp = 0; }
+                    else                      { aln = a1; meth_won_hyp = 1; }
+                } else {
+                    aln = ksw_align2(l_ms, seq, ref_len, ref_rw, 5,
+                                     sw_mat, opt->o_del, opt->e_del,
+                                     opt->o_ins, opt->e_ins, xtra, 0);
+                }
                 free(ref_rw);
             }
             else
@@ -1585,8 +1610,7 @@ int mem_matesw_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
                  * it is fully γ-correct, not symmetric/projected.)
                  * Coordinates are already ORIGINAL (l_pac is the original l_pac via
                  * the original bns), so the 6a coordinate fix holds. */
-                b.meth_hypothesis = (a->meth_hypothesis < 0) ? -1
-                                                             : !a->meth_hypothesis;
+                b.meth_hypothesis = meth_won_hyp;
                 b.qb = is_rev? l_ms - (aln.qe + 1) : aln.qb;
                 b.qe = is_rev? l_ms - aln.qb : aln.qe + 1;
                 b.rb = is_rev? (l_pac<<1) - (rb + aln.te + 1) : rb + aln.tb;

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -1094,7 +1094,21 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
         score_un = a[0].a[0].score + a[1].a[0].score - opt->pen_unpaired;
         //q_pe = o && subo < o? (int)(MEM_MAPQ_COEF * (1. - (double)subo / o) * log(a[0].a[z[0]].seedcov + a[1].a[z[1]].seedcov) + .499) : 0;
         subo = subo > score_un? subo : score_un;
-        q_pe = raw_mapq(o - subo, opt->a);
+        {
+            /* Meth PE MAPQ hardening (dragmap-style, cf. minibwa r404): fold each
+             * end's SECOND-best single-end hit into the pair MAPQ so a repeat on
+             * either end deflates confidence even when one paired alignment looks
+             * clean. Meth-gated so non-meth PE MAPQ is byte-identical. */
+            int qdiff = o - subo;
+            if (opt->meth_mode) {
+                int se2_0 = (n_pri[0] > 1) ? a[0].a[1].score : 0;
+                int se2_1 = (n_pri[1] > 1) ? a[1].a[1].score : 0;
+                int cap = o + 4 * opt->a - (se2_0 + se2_1);
+                if (qdiff > cap) qdiff = cap;
+            }
+            if (qdiff < 0) qdiff = 0;
+            q_pe = raw_mapq(qdiff, opt->a);
+        }
 
         if (n_sub > 0) q_pe -= (int)(4.343 * log(n_sub+1) + .499);
         if (q_pe < 0) q_pe = 0;


### PR DESCRIPTION
On methylation (`--meth`, D3) data, the default mode places repeat reads on the **wrong chromosome at confident MAPQ** far more than bwameth or minibwa — the meth analog of the ROC tail @lh3 reported in #202. On `sim-meth-place` (holodeck truth, 10.7M reads): confident wrong-chromosome (MAPQ≥30) is **2,741** vs bwameth **30**, minibwa **107**.

## Root cause (instrumented)

D3 mate rescue scored the rescued mate under a *single* seed-derived bisulfite hypothesis (the anchor's opposite strand). When that guess is wrong for a repeat mate's true locus, its C→T / G→A conversions count as mismatches and cripple the true alignment to a partial (e.g. AS 41 vs bwameth's 147). A spurious concordant *decoy* pair then outscores the true pair, and both mates flip to a wrong chromosome at confident MAPQ.

This is distinct from the non-meth `--fast` chain-cap issue in #218 — here nothing is capped; the true copy is *mis-scored*. (Confirmed: adding a chain cap + `--extend-mate-concordant` to meth default does not help, since the rescue fix below already recovers the concordant pair.)

## Fix

1. **Score the rescued mate under both OT and OB matrices and keep the better** (mirrors bwameth's both-converted-strand search). Implemented on the scalar rescue path, now the meth default; `BWAMEM3_METH_BATCHED_RESCUE=1` opts into the legacy single-hypothesis batched SIMD path for benchmarking. A both-hypothesis batched-SIMD port is future work.
2. **Harden PE MAPQ with a dragmap-style second-best single-end cap** (as adopted by minibwa r404): fold each end's second-best single-end hit into the pair MAPQ, so a repeat on either end deflates confidence even when one paired alignment looks clean.

Both changes are meth-gated — non-meth output is byte-identical. They are also `--meth-scoring`-agnostic, so they improve placement for both COLLAPSED (default, bwameth-compatible) and GENOMIC (variant-aware) modes without touching the scoring matrices.

## Results (`sim-meth-place`, full 10.7M reads)

| aligner | wrongCHR@60 | wrongCHR@30 | wrong@30 |
|---|--:|--:|--:|
| D3 `--meth` (before) | 20 | 2,741 | 5,595 |
| **D3 `--meth` (this PR)** | 24 | **88** | **2,297** |
| bwameth | 0 | 30 | 2,197 |
| minibwa r387 | 0 | 107 | 1,488 |

Confident wrong-chromosome placements drop **2,741 → 88** (below minibwa, approaching bwameth); confident mis-placements (wrong≥30) reach bwameth parity. ~+6% aligner wall (scalar rescue path). The residual ~88 are hard repeat multimappers (weight-tied true copy, discordant mate) — the meth analog of #218's irreducible residual.

Refs #202.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bisulfite paired-end mapping quality scoring in meth mode for more accurate confidence estimates.
  * Enhanced mate rescue by rescoring rescue candidates against both bisulfite hypotheses and keeping the higher-scoring result.
  * Tightened batched bisulfite mate-rescue activation so it runs only when explicitly enabled, restoring predictable default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->