### PR TITLE
fix(meth): drop cross-chemistry seeds by read number

### DIFF
--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -65,6 +65,10 @@ static inline void kseq2bseq1(const kseq_t *ks, bseq1_t *s)
     // start well-defined — the output loop at fastmap.cpp free()s them
     // unconditionally, so garbage from realloc would otherwise be freed.
     memset(s, 0, sizeof(*s));
+    /* Honor the bseq1_t.meth_base_ot -1 sentinel ("non-meth") from bwa.h: the
+     * memset above would otherwise leave it 0, which the seed-chemistry filter
+     * reads as OB. --meth ingest overwrites it with the read-number 0/1. */
+    s->meth_base_ot = -1;
     s->name = strdup(ks->name.s);
     s->comment = ks->comment.l? strdup(ks->comment.s) : 0;
     s->seq = strdup(ks->seq.s);

--- a/src/bwa.h
+++ b/src/bwa.h
@@ -85,6 +85,10 @@ typedef struct {
 	 * SAM/XM emitters. Storing `seq` projected-forward while CIGAR/MD describe
 	 * the original (or vice versa) yields an internally inconsistent BAM. */
 	char  *meth_orig_seq;
+	/* --meth (D3) only: the read's bisulfite chemistry from read number
+	 * (R1 = 1 = OT/C->T, R2 = 0 = OB/G->A; SE = R1). -1 for non-meth. Used by the
+	 * seed-chemistry filter in meth_seed_to_orig to drop cross-chemistry seeds. */
+	int8_t meth_base_ot;
 } bseq1_t;
 
 extern int bwa_verbose;

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1244,9 +1244,27 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
  * original remap + OT/OB PE/strand placement regression tests
  * (test/regression/meth_seed_index.sh and the live mem --meth placement tests).
  */
+/* --meth seed-chemistry filter (default ON; BWAMEM3_METH_SEED_FILTER=0 disables).
+ * A directional read is projected under a single chemistry by read number
+ * (R1=OT/C->T, R2=OB/G->A). Its true seeds therefore only land on converted
+ * copies whose implied chemistry matches: a seed on copy parity P at genomic
+ * strand S implies chemistry (P XOR S), and the true locus always satisfies
+ * (P XOR S) == read#. A seed that disagrees is a paralog/low-complexity
+ * coincidence on the wrong converted copy; dropping it stops it from seeding a
+ * confident wrong-chromosome placement (the #202 tail). */
+static inline bool meth_seed_filter_enabled()
+{
+    static const bool on = []() {
+        const char *e = getenv("BWAMEM3_METH_SEED_FILTER");
+        return !(e != NULL && strcmp(e, "0") == 0);
+    }();
+    return on;
+}
+
 static inline int meth_seed_to_orig(const bntseq_t *seed_bns,
                                     const bntseq_t *orig_bns,
                                     int64_t seed_rbeg, int32_t seed_len,
+                                    int read_meth_base_ot,
                                     int64_t *orig_rbeg, int *orig_rid,
                                     int8_t *hypothesis)
 {
@@ -1263,6 +1281,15 @@ static inline int meth_seed_to_orig(const bntseq_t *seed_bns,
     int o_rid = seed_rid >> 1;
     if (o_rid < 0 || o_rid >= orig_bns->n_seqs) return -1;
     *hypothesis = (int8_t)(seed_rid & 1); /* 1=f=OT(C→T), 0=r=OB(G→A) */
+
+    /* Drop cross-chemistry seeds by read number (see meth_seed_filter_enabled).
+     * parity = seed_rid & 1 (which converted copy: 1=OT/f, 0=OB/r); seed_is_rev =
+     * genomic strand; read# = read_meth_base_ot (R1=1/OT, R2=0/OB). Keep iff the
+     * seed's implied chemistry (parity XOR strand) equals the read number. */
+    if (read_meth_base_ot >= 0 && meth_seed_filter_enabled()) {
+        if ((((int)(seed_rid & 1)) ^ seed_is_rev) != (read_meth_base_ot & 1))
+            return -1; /* cross-chemistry seed: drop */
+    }
 
     /* f/r seed contigs are forward projections of the original, so the seed-local
      * offset is the original-local offset. Reject seeds that bridge the contig
@@ -1529,8 +1556,9 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
                 if (meth_remap) {
                     int64_t o_rbeg = 0; int o_rid = -1;
                     if (meth_seed_to_orig(bns, meth_orig_bns, s.rbeg, s.len,
+                                          seq_[l].meth_base_ot,
                                           &o_rbeg, &o_rid, &meth_hyp) != 0)
-                        continue; /* un-remappable (bridge/range): drop the seed */
+                        continue; /* un-remappable, or cross-chemistry: drop the seed */
                     s.rbeg = o_rbeg;
                     rid = o_rid;
                 } else {

--- a/src/fast_reader_bseq.c
+++ b/src/fast_reader_bseq.c
@@ -52,6 +52,10 @@ static inline char *fr_dup_field(const char *src, size_t len)
 static inline void fr_rec_to_bseq1(const fr_fastq_rec_t *r, bseq1_t *s)
 {
     memset(s, 0, sizeof(*s));
+    /* Honor the bseq1_t.meth_base_ot -1 sentinel ("non-meth") from bwa.h: the
+     * memset above would otherwise leave it 0, which the seed-chemistry filter
+     * reads as OB. --meth ingest overwrites it with the read-number 0/1. */
+    s->meth_base_ot = -1;
     size_t name_l = fr_trim_readno_len(r->name, r->name_l);
     s->name    = fr_dup_field(r->name, name_l);
     s->comment = r->comment_l ? fr_dup_field(r->comment, r->comment_l) : 0;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -455,6 +455,9 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                  * loop below alongside s->seq. */
                 s->meth_orig_seq = strdup(s->seq);
                 assert(s->meth_orig_seq != NULL);
+                /* --meth: read-number chemistry (R1=OT=1, R2=OB=0) for the
+                 * seed-chemistry filter in meth_seed_to_orig. */
+                s->meth_base_ot = is_r2 ? 0 : 1;
                 /* Project in place. */
                 for (int j = 0; j < l; ++j) {
                     char c = s->seq[j];


### PR DESCRIPTION
## What

Drops cross-chemistry seeds by read number in `--meth`, eliminating the confident wrong-chromosome tail from #202. Builds on the single-matrix mate rescue from #224 (now in main).

## Why

A directional `--meth` read is projected under a single bisulfite chemistry fixed by read number (R1 = OT / C→T, R2 = OB / G→A). Its true seeds therefore only land on converted copies whose implied chemistry matches. A seed on copy parity `P` at genomic strand `S` implies chemistry `P XOR S`, and the read's true locus always satisfies `P XOR S == read#`.

A seed that disagrees is a paralog / low-complexity coincidence on the *wrong* converted copy. Left in, it can seed a **confident wrong-chromosome placement**: the decoy's clean (wrong-chemistry) match out-scores the true locus, whose real conversions are penalized under the mismatched matrix.

## Change

Drop those seeds in `meth_seed_to_orig`, keyed on the read's chemistry captured at ingest (`bseq1_t.meth_base_ot`). Keep iff `(seed_rid&1) XOR seed_is_rev == read#`. Default on; `BWAMEM3_METH_SEED_FILTER=0` disables. (+36/−1 across `bwa.h`, `fastmap.cpp`, `bwamem.cpp`.)

The strand term is required: bwa-mem3's 2-copy doubled index encodes chemistry (parity) and genomic strand separately, so the consistent predicate is `parity XOR strand == read#`, not `parity == read#` (the latter drops legitimate reverse-strand seeds).

## Validation (sim-meth-place, 10.7M reads, holodeck truth)

Relative to current main:

| MAPQ≥ | wrongCHR before | wrongCHR after |
|---|---|---|
| 60 | 24 | **0** |
| 40 | 65 | **2** |
| 30 | 88 | **16** |
| 20 | 117 | **22** |

Every `wrong@MAPQ` band also improves (`@60` 1,853→1,808; `@1` 4,082→3,813); total wrong 573,829→573,311; sensitivity 94.6494%→94.6543%. Net +518 reads correctly placed (888 fixed, 370 regress to non-confident positions — none resurface as confident errors).

**Speed:** neutral — filter on vs off, median of 3 interleaved reps (user CPU, m7i): 2330.4s vs 2338.5s (−0.3%, within noise).

## Testing

`test/regression/meth_*.sh` all pass (incl. `meth_rescue_batched_identical`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `--meth` read handling by tracking bisulfite chemistry per read.
  * Added optional seed filtering to drop seeds whose implied chemistry doesn’t match the read’s chemistry.
  * Introduced an environment setting to disable chemistry-based seed filtering.
* **Bug Fixes**
  * Fixed incorrect bisulfite chemistry initialization for non-meth and duplicated reads to prevent improper seed remapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->