### PR TITLE
docs(meth): correct --meth override claims and document -T 40 split filtering

### DIFF
--- a/docs/src/best-practices/methylation.md
+++ b/docs/src/best-practices/methylation.md
@@ -58,10 +58,15 @@ bwa-mem3 mem --meth --chimera-qc -t 16 ref.fa R1.fq.gz R2.fq.gz \
 
 > **Note — Overrides are positional**
 >
-> Flags supplied after `--meth` on the command line override the defaults set by
-> `--meth`. For example, `bwa-mem3 mem --meth -B 4 ...` uses `-B 4` (not 2).
+> Scoring flags supplied after `--meth` on the command line override the defaults
+> set by `--meth`. For example, `bwa-mem3 mem --meth -B 4 ...` uses `-B 4` (not 2).
 > Flags supplied before `--meth` are silently overwritten by `--meth`'s defaults,
 > so always place overrides after `--meth`.
+>
+> This applies to `-B`, `-L`, `-U`, and `-T`. It does **not** apply to `-M` and
+> `-C`: bwa has no option that unsets either one, so `--meth` sets them
+> unconditionally and they cannot be turned off from the command line. See
+> [Flags → `-M` and split alignments](../methylation/flags.md#-m-and-split-alignments).
 
 ## Downstream tool compatibility
 

--- a/docs/src/methylation/bwameth-mapping.md
+++ b/docs/src/methylation/bwameth-mapping.md
@@ -80,7 +80,9 @@ pass. Output is uncompressed BAM (`wb0`) that `samtools sort` reads natively.
 **bwameth-aligned defaults (collapsed).** `--meth-scoring collapsed` applies
 `-B 2 -L 10 -U 100 -T 40 -M -C`, mirroring bwameth's `bwa mem -T 40 -B 2 -L 10
 -CM` (plus `-U 100` for paired-end). `genomic` uses the same set but keeps
-`-B 4`. All parameters can be overridden.
+`-B 4`. The scoring parameters (`-B`, `-L`, `-U`, `-T`) can be overridden on the
+command line after `--meth`. `-M` and `-C` cannot: bwa has no option that unsets
+them, so `--meth` applies them unconditionally.
 
 ## What stays the same (collapsed mode)
 

--- a/docs/src/methylation/flags.md
+++ b/docs/src/methylation/flags.md
@@ -130,6 +130,31 @@ bwameth.py's chimera logic always runs.
 | `--set-as-failed` strand matches | Yes | No | No |
 | Both `--chimera-qc` + `--set-as-failed` active | Yes | Yes | Yes (≤1) |
 
+## `-M` and split alignments
+
+`--meth` sets `-M` and `-C` unconditionally (bwa has no option that unsets
+either), so unlike the scoring defaults these two cannot be overridden.
+
+`-M` changes how a split (chimeric) hit is **flagged**, not whether it is
+emitted: supplementary (`0x800`) becomes secondary (`0x100`). The record is
+otherwise identical — `SA:Z`, SEQ, QUAL, `NM`/`MD` and the methylation tags are
+all retained. So `samtools flagstat` on a `--meth` BAM always reports
+`0 supplementary`, and anything selecting split-read evidence by the `0x800` bit
+will miss it. Methylation calling is unaffected.
+
+> **Note — on short reads, `-T 40` filters far more split hits than `-M` does**
+>
+> A split arm covers only part of the read, so its score scales with arm length;
+> below `T` it is dropped outright, before `-M` is consulted. On 1M Twist EM-seq
+> pairs (75 bp) vs hg38, `--meth` emitted 94 split records against 4039 at
+> `-T 30` — and of those 4039, 3945 scored `AS < 40` versus 94 at `AS >= 40`,
+> exactly the default-threshold survivors. (`-L 10` accounts for ~18 more.)
+>
+> The effect shrinks with read length — a 150 bp read splits into ~75 bp arms
+> scoring well clear of 40 — though that has not been measured. To recover
+> chimeric evidence for SV calling, pass `-T 30` (optionally `-L 5`) after
+> `--meth` and accept divergence from bwameth placement.
+
 ## `-V` reference annotation `XR:Z` is suppressed under `--meth`
 
 `bwa-mem3 mem -V` normally emits the contig annotation as an `XR:Z`

--- a/docs/src/methylation/overview.md
+++ b/docs/src/methylation/overview.md
@@ -105,7 +105,9 @@ bwa-mem3 mem --meth --meth-scoring genomic -t 16 ref.fa R1.fq.gz R2.fq.gz \
 > `--meth` applies `-L 10 -U 100 -T 40 -M -C` in both modes, plus the
 > mode-dependent mismatch penalty: `-B 2` for `collapsed`, `-B 4` for `genomic`.
 > These mirror bwameth's `bwa mem -T 40 -B 2 -L 10 -CM` (with `-U 100` for
-> paired-end). Any value can be overridden on the command line after `--meth`.
+> paired-end). The scoring values (`-B`, `-L`, `-U`, `-T`) can be overridden on
+> the command line after `--meth`. `-M` and `-C` cannot — bwa has no option that
+> unsets them, so `--meth` applies them unconditionally.
 
 ---
 


### PR DESCRIPTION
Docs-only. Prompted by a report that `--meth` "discards supplementary alignments" — it doesn't, but the docs gave no way to work that out.

**Corrects a false claim.** `bwameth-mapping.md`, `overview.md` and `best-practices/methylation.md` all say every `--meth` default can be overridden. True for the scoring parameters, which have `opt0` sentinels; false for `-M` and `-C`, which the `--meth` block in `main_mem` sets unconditionally because bwa has no option that unsets them. Each claim is now scoped to the flags that honour it. (The `-B` override note in `flags.md` is correct and untouched.)

**Documents `-M`.** New section in `flags.md`. `-M` changes how a split hit is flagged, not whether it's emitted — the supplementary branch in `mem_reg2sam` is a ternary picking `0x10000` over `0x800`, both branches emit, and the record keeps `SA:Z`, SEQ, QUAL, `NM`/`MD` and the meth tags. So `flagstat` always reports `0 supplementary` under `--meth`, and anything selecting split evidence by the `0x800` bit will miss it. Methylation calling is unaffected.

**Documents `-T 40`.** The real cause of the reported symptom, on short reads. A split arm covers part of the read, so its score scales with arm length; below `T` it's dropped by the `score < opt->T` gate at the top of `mem_reg2sam`, before `-M` is consulted. Measured on 1M Twist EM-seq pairs (75 bp) vs hg38, built at this PR's base (`6e21a37`):

| run | split records |
|---|---|
| `--meth` (defaults `-T 40 -L 10`) | 94 |
| `--meth -L 5` | 112 |
| `--meth -T 30` | 4039 |

Of the 4039 recovered at `-T 30`, 3945 scored `AS < 40` and 94 scored `AS >= 40` — exactly the default-threshold survivors. The effect shrinks with read length and should be minor at 150 bp; the docs say so and note it hasn't been measured there. `-T 30` is documented as the escape hatch, at the cost of diverging from bwameth.

No defaults change — `-T 40 -L 10 -M` are verbatim bwameth.

`mdbook build` passes with `linkcheck2`; the new cross-link anchor resolves. The six `Potential incomplete link` warnings are pre-existing in `reference/pr-catalog.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified which scoring options can override `--meth` defaults and where those options must appear on the command line.
  - Documented that `-M` and `-C` are always enabled by `--meth` and cannot be unset.
  - Added guidance on how `-M` affects split alignments and how filtering with `-T` may impact chimeric evidence.
  - Updated methylation mapping and overview documentation with the corrected override rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->