### PR TITLE
fix(meth): scale --meth scoring defaults with the match score

### DIFF
--- a/docs/src/best-practices/methylation.md
+++ b/docs/src/best-practices/methylation.md
@@ -56,12 +56,12 @@ bwa-mem3 mem --meth --chimera-qc -t 16 ref.fa R1.fq.gz R2.fq.gz \
   | samtools sort -@ 4 -o out.bam -
 ```
 
-> **Note — Overrides are positional**
+> **Note — Overriding scoring defaults**
 >
-> Scoring flags supplied after `--meth` on the command line override the defaults
-> set by `--meth`. For example, `bwa-mem3 mem --meth -B 4 ...` uses `-B 4` (not 2).
-> Flags supplied before `--meth` are silently overwritten by `--meth`'s defaults,
-> so always place overrides after `--meth`.
+> Scoring flags supplied on the command line override the defaults set by
+> `--meth`. For example, `bwa-mem3 mem --meth -B 4 ...` uses `-B 4` (not 2).
+> Order does not matter: the defaults are applied after the whole command line
+> is parsed, so `-B 4 --meth` and `--meth -B 4` behave identically.
 >
 > This applies to `-B`, `-L`, `-U`, and `-T`. It does **not** apply to `-M` and
 > `-C`: bwa has no option that unsets either one, so `--meth` sets them

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -166,8 +166,14 @@ individual flags are unaffected.
 > When `--meth` is active, bwa-mem3 applies `-L 10 -U 100 -T 40 -M -C` plus a
 > mode-dependent mismatch penalty: `-B 2` for `--meth-scoring collapsed` (default,
 > bwameth-compatible) and `-B 4` for `--meth-scoring genomic`. This mirrors
-> bwameth's `bwa mem -T 40 -B 2 -L 10 -CM` (with `-U 100` for paired-end). Any of
-> these can still be overridden by passing the flag explicitly after `--meth`.
+> bwameth's `bwa mem -T 40 -B 2 -L 10 -CM` (with `-U 100` for paired-end). The
+> scoring values (`-B`, `-L`, `-U`, `-T`) can still be overridden by passing the
+> flag explicitly, in any position relative to `--meth`; `-M` and `-C` cannot,
+> since bwa has no option that unsets them.
+>
+> Those constants are quoted at bwameth's match score (`-A 1`) and scale with
+> `-A` like every other score-derived default above: under `-A 2` the effective
+> values are `-L 20 -U 200 -T 80` and `-B 4` (collapsed) / `-B 8` (genomic).
 
 ### Paired-end
 

--- a/docs/src/methylation/bwameth-mapping.md
+++ b/docs/src/methylation/bwameth-mapping.md
@@ -81,8 +81,13 @@ pass. Output is uncompressed BAM (`wb0`) that `samtools sort` reads natively.
 `-B 2 -L 10 -U 100 -T 40 -M -C`, mirroring bwameth's `bwa mem -T 40 -B 2 -L 10
 -CM` (plus `-U 100` for paired-end). `genomic` uses the same set but keeps
 `-B 4`. The scoring parameters (`-B`, `-L`, `-U`, `-T`) can be overridden on the
-command line after `--meth`. `-M` and `-C` cannot: bwa has no option that unsets
-them, so `--meth` applies them unconditionally.
+command line, in any position relative to `--meth`. `-M` and `-C` cannot: bwa
+has no option that unsets them, so `--meth` applies them unconditionally.
+
+These constants are quoted at bwa's default match score (`-A 1`, what bwameth
+runs). Like every other score-derived default, they scale with `-A`: under
+`-A 2` the effective values are `-L 20 -U 200 -T 80` and `-B 4` (collapsed) /
+`-B 8` (genomic).
 
 ## What stays the same (collapsed mode)
 

--- a/docs/src/methylation/flags.md
+++ b/docs/src/methylation/flags.md
@@ -49,9 +49,9 @@ the aligner to distinguish real variants from conversions.
 > **Note — `-B` follows the mode, but you can override it**
 >
 > `collapsed` sets `-B 2` and `genomic` keeps `-B 4` by default. An explicit
-> `-B` after `--meth` overrides the mode default and still reaches the per-strand
-> matrices. The other `--meth` defaults (`-L 10 -U 100 -T 40 -M -C`) are the same
-> in both modes.
+> `-B` overrides the mode default and still reaches the per-strand matrices,
+> whether it appears before or after `--meth`. The other `--meth` defaults
+> (`-L 10 -U 100 -T 40 -M -C`) are the same in both modes.
 
 ## `--set-as-failed {f|r}`
 
@@ -151,9 +151,16 @@ will miss it. Methylation calling is unaffected.
 > exactly the default-threshold survivors. (`-L 10` accounts for ~18 more.)
 >
 > The effect shrinks with read length — a 150 bp read splits into ~75 bp arms
-> scoring well clear of 40 — though that has not been measured. To recover
-> chimeric evidence for SV calling, pass `-T 30` (optionally `-L 5`) after
-> `--meth` and accept divergence from bwameth placement.
+> scoring well clear of 40 — though that has not been measured. Passing `-T 30`
+> (optionally `-L 5`) alongside `--meth` recovers those dropped split records,
+> at the cost of divergence from bwameth placement.
+>
+> **This is not a substitute for supplementary alignments.** `-M` is still
+> unconditional, so the recovered records are flagged secondary (`0x100`), not
+> supplementary (`0x800`) — an SV caller that selects split-read evidence by the
+> `0x800` bit will ignore them no matter how low `-T` goes. Lowering `-T` is
+> useful for manual inspection, or for callers that accept `0x100` records and
+> read `SA:Z` directly.
 
 ## `-V` reference annotation `XR:Z` is suppressed under `--meth`
 

--- a/docs/src/methylation/overview.md
+++ b/docs/src/methylation/overview.md
@@ -106,8 +106,12 @@ bwa-mem3 mem --meth --meth-scoring genomic -t 16 ref.fa R1.fq.gz R2.fq.gz \
 > mode-dependent mismatch penalty: `-B 2` for `collapsed`, `-B 4` for `genomic`.
 > These mirror bwameth's `bwa mem -T 40 -B 2 -L 10 -CM` (with `-U 100` for
 > paired-end). The scoring values (`-B`, `-L`, `-U`, `-T`) can be overridden on
-> the command line after `--meth`. `-M` and `-C` cannot — bwa has no option that
-> unsets them, so `--meth` applies them unconditionally.
+> the command line, in any position relative to `--meth`. `-M` and `-C` cannot —
+> bwa has no option that unsets them, so `--meth` applies them unconditionally.
+>
+> These constants are quoted at bwa's default match score (`-A 1`, what bwameth
+> runs). Like every other score-derived default, they scale with `-A`: under
+> `-A 2` the effective values are `-L 20 -U 200 -T 80` and `-B 4`/`-B 8`.
 
 ---
 

--- a/docs/src/methylation/post-processing.md
+++ b/docs/src/methylation/post-processing.md
@@ -95,8 +95,10 @@ meth_bam_group_propagate_qcfail(group, n)
 This function scans all records in the group. If any record has `0x200` set, it
 propagates that flag to every other record in the group and clears `0x2`
 (proper pair) on all of them. This ensures that a chimeric or strand-filtered
-primary alignment also marks its supplementary alignments and the mate as
-QC-failed, preventing inconsistent flag states in the output BAM.
+primary alignment also marks its split hits and the mate as QC-failed,
+preventing inconsistent flag states in the output BAM. (Under `--meth` those
+split hits carry `0x100`, not `0x800` — see
+[`-M` and split alignments](flags.md#-m-and-split-alignments).)
 
 ## `@PG ID:bwa-mem3-meth` insertion
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -320,6 +320,22 @@ void mem_opt_fill_meth_mat(mem_opt_t *o) {
     }
 }
 
+/* See bwamem.h for the contract. The `* opt->a` factors are the fix for -A
+ * being discarded under --meth: bwameth's constants assume a == 1, and bwa
+ * scales every other score-derived default by opt->a in update_a(). */
+void mem_opt_apply_meth_defaults(mem_opt_t *opt, const mem_opt_t *opt0)
+{
+    if (!opt0->pen_clip5)    opt->pen_clip5    = 10 * opt->a;   /* bwameth -L 10 */
+    if (!opt0->pen_clip3)    opt->pen_clip3    = 10 * opt->a;
+    if (!opt0->pen_unpaired) opt->pen_unpaired = 100 * opt->a;  /* bwameth -U 100 (paired) */
+    if (!opt0->T)            opt->T            = 40 * opt->a;   /* bwameth -T 40 */
+    opt->flag |= MEM_F_NO_MULTI;                                /* -M */
+    if (opt->meth_scoring == MEM_METH_SCORING_COLLAPSED) {
+        if (!opt0->b) opt->b = 2 * opt->a;                      /* bwameth's lenient -B 2 */
+    }
+    /* GENOMIC keeps bwa's default b (already scaled by update_a): variant-aware. */
+}
+
 /******************************
  * De-overlap single-end hits *
  ******************************/

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -393,6 +393,22 @@ void mem_fill_scmat(int a, int b, int8_t mat[25]);
  * scoring tracks the user's options instead of the init-time defaults. */
 void mem_opt_fill_meth_mat(mem_opt_t *opt);
 
+/* Apply the --meth scoring defaults to `opt`, honouring the user's explicit
+ * settings recorded as sentinels in `opt0` (non-zero field == user supplied).
+ *
+ * The constants are bwameth's (`bwa-mem2 mem -T 40 -B 2 -L 10 -CM`, plus
+ * -U 100 for paired), and bwameth runs bwa at its default match score a == 1.
+ * They are therefore SCALED BY opt->a here: every one of these options is
+ * expressed in units of the match score, and bwa's update_a() scales the
+ * non-meth defaults the same way. Applying them flat would silently discard
+ * -A -- `--meth -A 2` would leave T at 40 while the alignment scores it gates
+ * had doubled. At the default a == 1 the scaling is a no-op, so this is
+ * byte-identical to the historical behaviour for every run that does not pass
+ * -A.
+ *
+ * Must be called AFTER -A/-B/-T/-L/-U parsing and after update_a(). */
+void mem_opt_apply_meth_defaults(mem_opt_t *opt, const mem_opt_t *opt0);
+
 // Skip-short-seed extension filter: drop seeds shorter than min_ext_len from a
 // chain in place (stable; surviving seeds keep their order). Returns the new
 // seed count. min_ext_len <= 0 is a no-op. See mem_opt_t::min_ext_len.

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1524,18 +1524,15 @@ int main_mem(int argc, char *argv[])
      *     1.8 vs 2.1).
      * pen_unpaired is only consulted for paired-end rescue, so setting it
      * unconditionally is a no-op for single-end. -A/-B always override and reach
-     * the matrices (mem_opt_fill_meth_mat below). */
+     * the matrices (mem_opt_fill_meth_mat below).
+     * NB: those constants are quoted at bwameth's match score (a == 1) and are
+     * scaled by opt->a inside mem_opt_apply_meth_defaults — see bwamem.h. Before
+     * that, they were applied flat and silently discarded -A. */
     if (opt->meth_mode) {
-        if (!opt0.pen_clip5)    opt->pen_clip5   = 10;
-        if (!opt0.pen_clip3)    opt->pen_clip3   = 10;
-        if (!opt0.pen_unpaired) opt->pen_unpaired = 100;  /* bwameth -U 100 (paired) */
-        if (!opt0.T)            opt->T           = 40;
-        opt->flag |= MEM_F_NO_MULTI;   /* -M */
+        /* Scored defaults live in mem_opt_apply_meth_defaults so they scale with
+         * -A (bwameth's constants assume a==1) and can be unit-tested. */
+        mem_opt_apply_meth_defaults(opt, &opt0);
         aux.copy_comment = 1;          /* -C, needed for YS:Z/YC:Z passthrough */
-        if (opt->meth_scoring == MEM_METH_SCORING_COLLAPSED) {
-            if (!opt0.b) opt->b = 2;   /* bwameth's lenient mismatch */
-        }
-        /* GENOMIC keeps bwa's default b=4 (variant-aware). */
     }
 
     /* Matrix for SWA */

--- a/test/unit/test_meth_defaults_scaling.cpp
+++ b/test/unit/test_meth_defaults_scaling.cpp
@@ -1,0 +1,121 @@
+// Unit tests for mem_opt_apply_meth_defaults — the --meth scoring defaults.
+//
+// bwa scales score-derived options by the match score: `update_a()` multiplies
+// T, pen_clip5/3, pen_unpaired, b, gap penalties and zdrop by opt->a whenever
+// the user passes -A and has not set the option explicitly. Every one of those
+// values is expressed in units of the match score, so a bare constant is only
+// meaningful at a == 1.
+//
+// The --meth defaults are borrowed verbatim from bwameth
+// (`bwa-mem2 mem -T 40 -B 2 -L 10 -CM`, plus -U 100 for paired), and bwameth
+// runs bwa at its default a == 1. Applying those constants FLAT therefore
+// silently discards -A: `--meth -A 2` produced T=40 where every other
+// score-derived option had doubled, making the output threshold half as strict
+// relative to the alignment scores it is compared against.
+//
+// Contract pinned here:
+//   * a == 1  -> exactly bwameth's constants (byte-identical to prior behaviour)
+//   * a  > 1  -> the same constants scaled by a (self-consistent scoring)
+//   * user-supplied values (opt0 sentinel set) always win, at any a
+
+#include "doctest/doctest.h"
+#include "bwamem.h"
+
+#include <cstdlib>
+
+namespace {
+
+// Fresh default opt with the match score forced to `a`, mirroring how main_mem
+// has already parsed -A by the time the meth defaults are applied.
+mem_opt_t *opt_with_a(int a)
+{
+    mem_opt_t *o = mem_opt_init();
+    o->a = a;
+    o->meth_mode = 1;
+    return o;
+}
+
+}  // namespace
+
+TEST_CASE("meth defaults at a=1 are bwameth's constants verbatim") {
+    mem_opt_t *o = opt_with_a(1);
+    mem_opt_t o0;                      // no sentinel set => nothing user-supplied
+    memset(&o0, 0, sizeof(o0));
+    o->meth_scoring = MEM_METH_SCORING_COLLAPSED;
+
+    mem_opt_apply_meth_defaults(o, &o0);
+
+    CHECK(o->T            == 40);      // bwameth -T 40
+    CHECK(o->pen_clip5    == 10);      // bwameth -L 10
+    CHECK(o->pen_clip3    == 10);
+    CHECK(o->pen_unpaired == 100);     // bwameth -U 100
+    CHECK(o->b            == 2);       // bwameth -B 2 (collapsed only)
+    free(o);
+}
+
+TEST_CASE("meth defaults scale with -A so scoring stays self-consistent") {
+    mem_opt_t *o = opt_with_a(2);
+    mem_opt_t o0;
+    memset(&o0, 0, sizeof(o0));
+    o->meth_scoring = MEM_METH_SCORING_COLLAPSED;
+
+    mem_opt_apply_meth_defaults(o, &o0);
+
+    CHECK(o->T            == 80);      // 40 * 2
+    CHECK(o->pen_clip5    == 20);      // 10 * 2
+    CHECK(o->pen_clip3    == 20);
+    CHECK(o->pen_unpaired == 200);     // 100 * 2
+    CHECK(o->b            == 4);       // 2 * 2
+    free(o);
+}
+
+TEST_CASE("explicit user values are never overwritten, at any match score") {
+    mem_opt_t *o = opt_with_a(3);
+    mem_opt_t o0;
+    memset(&o0, 0, sizeof(o0));
+    // User passed -T/-L/-U/-B explicitly: sentinels set, values already parsed.
+    o0.T = 1;            o->T            = 55;
+    o0.pen_clip5 = 1;    o->pen_clip5    = 7;
+    o0.pen_clip3 = 1;    o->pen_clip3    = 8;
+    o0.pen_unpaired = 1; o->pen_unpaired = 9;
+    o0.b = 1;            o->b            = 6;
+    o->meth_scoring = MEM_METH_SCORING_COLLAPSED;
+
+    mem_opt_apply_meth_defaults(o, &o0);
+
+    CHECK(o->T            == 55);
+    CHECK(o->pen_clip5    == 7);
+    CHECK(o->pen_clip3    == 8);
+    CHECK(o->pen_unpaired == 9);
+    CHECK(o->b            == 6);
+    free(o);
+}
+
+TEST_CASE("genomic scoring keeps bwa's variant-aware mismatch, scaled") {
+    // COLLAPSED adopts bwameth's lenient -B 2; GENOMIC deliberately keeps bwa's
+    // default b (4 at a=1), which update_a has already scaled. So the meth
+    // block must not touch b under GENOMIC.
+    mem_opt_t *o = opt_with_a(2);
+    mem_opt_t o0;
+    memset(&o0, 0, sizeof(o0));
+    o->meth_scoring = MEM_METH_SCORING_GENOMIC;
+    o->b = 8;                          // as update_a would leave it (4 * 2)
+
+    mem_opt_apply_meth_defaults(o, &o0);
+
+    CHECK(o->b == 8);                  // untouched by the meth block
+    CHECK(o->T == 80);                 // other defaults still scale
+    free(o);
+}
+
+TEST_CASE("meth defaults set -M (no multi) regardless of match score") {
+    mem_opt_t *o = opt_with_a(2);
+    mem_opt_t o0;
+    memset(&o0, 0, sizeof(o0));
+    o->meth_scoring = MEM_METH_SCORING_COLLAPSED;
+
+    mem_opt_apply_meth_defaults(o, &o0);
+
+    CHECK((o->flag & MEM_F_NO_MULTI) != 0);
+    free(o);
+}


### PR DESCRIPTION
The `--meth` defaults are bwameth’s constants (`-T 40 -B 2 -L 10`, plus `-U 100` for paired-end), and bwameth runs bwa at its default match score `a == 1`. They were applied flat, so `update_a()`’s `-A` scaling was silently discarded for `T`, `pen_clip5/3`, `pen_unpaired` and `b`.

`update_a()` multiplies every score-derived default by `opt->a`; the `--meth` block in `main_mem` then overwrote four of them with bare constants. Since all four are expressed in units of the match score, `--meth -A 2` left `T` at 40 while every alignment score it gates had doubled — halving the effective output stringency.

## Measured effect

50k pairs, hg38, `--meth -A 2`:

| build | records emitted | lowest `AS:i:` |
|---|---|---|
| before | 103,406 | **40** (an `a==1`-equivalent of 20, vs a documented threshold of 40) |
| after | 103,367 | **204** (above the correctly scaled `T` of 80) |

The 39 extra records are sub-threshold alignments that `-T 40` should have rejected.

## Change

Extracts the block to `mem_opt_apply_meth_defaults()` — unit-testable outside `main_mem`, which the inline block was not — and scales each constant by `opt->a`.

## Compatibility

At the default `a == 1` the scaling is a no-op. Verified byte-identical to the previous build on 50k pairs (`--meth`, hg38): md5 `083bd00f5f1d87848cbd94c3235bd1c0`, 103,367 lines both. Only runs that combine `-A` with `--meth` change behaviour.

`--meth-scoring genomic` still leaves `b` untouched (variant-aware, already scaled by `update_a`), and explicit user `-T/-L/-U/-B` continue to win at any match score.

## Tests

Five new cases in `test/unit/test_meth_defaults_scaling.cpp`, written test-first and confirmed failing before the implementation existed:

- `a=1` yields bwameth’s constants verbatim (backward-compat pin)
- `a=2` yields them scaled (40→80, 10→20, 100→200, 2→4)
- explicit user values are never overwritten, at any `a`
- `genomic` does not touch `b`
- `-M` is set regardless of match score

Full suite green: 91/91 unit cases, 2,929,166 assertions, plus integration and regression targets (`make test`, exit 0).

## Notes for review

The scaled `pen_unpaired` under `-A 2` is **200** (bwameth’s 100 scaled), not 34 (bwa’s default 17 scaled). Preserving bwameth’s intent seemed right, since dropping to 34 would discard the `-U 100` default entirely — but it is a judgement call and easy to change if you disagree.

Separately, `pen_unpaired` does double duty — pairing penalty (the `score_un` computation in `mem_pair_resolve` and `mem_sam_pe_batch_post`) and mate-rescue admission width (the candidate-admission test in `mem_pair_resolve`, `mem_sam_pe_batch_pre` and `mem_sam_pe_batch_post`) — so `--meth` widens the rescue window 5.9x as a side effect. Out of scope here; worth its own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified `--meth` scoring override behavior: `-B`, `-L`, `-U`, and `-T` are overrideable regardless of whether they appear before/after `--meth`, with values scaling relative to `-A`.
  - Stated `-M` and `-C` are always applied (not unsettable), refined chimeric split recovery guidance with updated `-T` wording, and clarified split-hit QC-fail marking under `--meth`.

- **Bug Fixes**
  - Made `--meth` default scoring application consistent across collapsed vs genomic modes while preserving user-supplied scoring values.

- **Tests**
  - Added unit tests covering default constants, `-A` scaling, override preservation, scoring-mode differences, and enforced `-M` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->