### PR TITLE
feat(rescue): add absolute mate-rescue admission floor (--rescue-admit)

### DIFF
--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -158,7 +158,7 @@ individual flags are unaffected.
 | `-O INT[,INT]` | 6,6 | Gap open penalty for deletions and insertions respectively. |
 | `-E INT[,INT]` | 1,1 | Gap extension penalty per base. A gap of length k costs `-O + -E * k`. |
 | `-L INT[,INT]` | 5,5 | Clipping penalty for 5' and 3' ends. |
-| `-U INT` | 17 | Penalty for an unpaired read pair (affects mate-rescue scoring). |
+| `-U INT` | 17 | Penalty for an unpaired read pair. Also sets the mate-rescue admission margin (as in bwa); use [`--rescue-margin`](#--rescue-margin-int--rescue-admission-margin) to set the two independently. |
 | `-T INT` | 30 | Minimum alignment score to output. Alignments below this threshold are not reported. |
 
 > **Note — --meth overrides scoring defaults**
@@ -185,6 +185,37 @@ Maximum number of mate-rescue attempts per read. Reduce to speed up alignment
 on data where the default (50) wastes time on unrescuable pairs. See
 [Settings profiles](../best-practices/settings-profiles.md) for the benchmarked
 `-m 10` recommendation.
+
+#### `--rescue-admit off|abs:N|frac:F` — absolute floor on rescue admission
+
+Adds an absolute plausibility floor to mate-rescue admission. By default an anchor is a rescue candidate if it scores within `--rescue-margin` of the read's own best alignment. That bar is *relative*, so it falls as alignment quality falls: a clean 150 bp read (best ≈ 150) admits anchors ≥ 133, while a marginally-mappable read (best ≈ 25) admits anchors ≥ 8. Degraded input therefore generates more rescue work, not less.
+
+With a floor set, an anchor must additionally clear an absolute score:
+
+| mode | floor | notes |
+|------|-------|-------|
+| `off` | none | default; identical to previous behaviour |
+| `abs:N` | `N` | fixed score, tuned for short reads |
+| `frac:F` | `F * read_len * -A` | fraction of the perfect score; length-normalised |
+
+On clean data the floor is inert by construction — the relative bar already admits only near-perfect anchors, well above any sensible floor — so it engages only where alignment is genuinely marginal: a wrong or diverged reference, related-species contamination, or bisulfite data run **without** `--meth`.
+
+Measured on 100k simulated pairs vs GRCh38 with `--rescue-admit=abs:30`:
+
+| input | effect |
+|-------|--------|
+| clean | output unchanged, no measurable time difference |
+| 15% diverged (wrong-reference proxy) | 1.19x faster; −93 confident-correct, −110 confident-mismapped |
+
+On the same data `-m 10` gives 1.28x while moving only 6 confident reads, so **the count cap is the better lever at moderate divergence**. The floor's advantage is that it is provably inert on clean data and that its benefit scales with how degraded the input is.
+
+This is opt-in and **not** byte-identical when enabled.
+
+> **Not a substitute for `--meth`.** Bisulfite data aligned *without* `--meth` shows extreme rescue fan-out (34.66 candidates per read end vs 2.55 with `--meth`), and a floor speeds that up substantially — but that configuration is a mistake, not a workload. The fix is to add `--meth`, which takes placement from 14.7% to 95.4% correct. Do not reach for `--rescue-admit` to paper over a missing `--meth`.
+
+#### `--rescue-margin INT` — rescue admission margin
+
+Rescue anchors scoring within INT of the read's best alignment. Defaults to `-U`, which sets both this and the unpaired penalty — matching bwa, where the two are the same knob. Set `--rescue-margin` explicitly to control admission independently of the paired-vs-unpaired scoring decision.
 
 #### `-S` — skip mate rescue
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -255,6 +255,13 @@ mem_opt_t *mem_opt_init()
     o->T = 30;
     o->zdrop = 100;
     o->pen_unpaired = 17;
+    /* Mate-rescue admission. rescue_margin defaults to the value pen_unpaired
+     * used to supply, and the floor defaults to OFF, so the predicate reduces
+     * to upstream's `score >= best - 17` and the default path is unchanged. */
+    o->rescue_margin = 17;
+    o->rescue_floor_mode = MEM_RESCUE_FLOOR_OFF;
+    o->rescue_floor_abs = 0;
+    o->rescue_floor_frac = 0.0f;
     o->pen_clip5 = o->pen_clip3 = 5;
 
     o->max_mem_intv = 20;

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -67,6 +67,13 @@ typedef struct __smem_i smem_i;
 #define MEM_F_ALL       0x8
 #define MEM_F_NO_MULTI  0x10
 #define MEM_F_NO_RESCUE 0x20
+
+/* Absolute-floor mode for mate-rescue admission (mem_opt_t::rescue_floor_mode).
+ * OFF reproduces upstream behaviour exactly and is the default. See
+ * reports/2026-07-20-design-rescue-admission-criterion.md. */
+#define MEM_RESCUE_FLOOR_OFF  0
+#define MEM_RESCUE_FLOOR_ABS  1
+#define MEM_RESCUE_FLOOR_FRAC 2
 #define MEM_F_REF_HDR   0x100
 #define MEM_F_SOFTCLIP  0x200
 #define MEM_F_SMARTPE   0x400
@@ -96,7 +103,20 @@ typedef struct mem_opt_t {
     int a, b;               // match score and mismatch penalty
     int o_del, e_del;
     int o_ins, e_ins;
-    int pen_unpaired;       // phred-scaled penalty for unpaired reads
+    int pen_unpaired;       // phred-scaled penalty for unpaired reads. Used ONLY for the
+                            // paired-vs-unpaired decision (score_un). It is deliberately NOT
+                            // used to gate mate-rescue admission -- see rescue_margin.
+    int rescue_margin;      // mate-rescue admission margin: an anchor is a rescue candidate only
+                            // if score >= best - rescue_margin. Defaults to 17, the value
+                            // pen_unpaired used to supply, so the default path is unchanged.
+                            // Split out because pen_unpaired answers a different question
+                            // ("is pairing worth this much?") and --meth sets it to 100 for
+                            // bwameth compat, which silently widened rescue admission 6x.
+    int rescue_floor_mode;  // MEM_RESCUE_FLOOR_*: absolute plausibility floor on rescue
+                            // admission. OFF (default) = byte-identical to baseline.
+    int rescue_floor_abs;   // ABS mode: minimum absolute anchor score to be rescued from.
+    float rescue_floor_frac;// FRAC mode: minimum anchor score as a fraction of perfect score
+                            // (l_seq * a); length-normalized alternative to rescue_floor_abs.
     int pen_clip5,pen_clip3;// clipping penalty. This score is not deducted from the DP score.
     int w;                  // band width
     int zdrop;              // Z-dropoff

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -75,6 +75,24 @@ int mem_infer_dir(int64_t l_pac, int64_t b1, int64_t b2, int64_t *dist)
     return (r1 == r2? 0 : 1) ^ (p2 > b1? 0 : 3);
 }
 
+/* Mate-rescue admission: is this anchor worth spending a rescue SW on?
+ *
+ * Extracted verbatim from the three identical copies that previously lived in
+ * mem_pair_resolve, mem_sam_pe_batch_pre and mem_sam_pe_batch_post.
+ *
+ * PURITY CONSTRAINT: mem_sam_pe_batch_pre and mem_sam_pe_batch_post walk this
+ * same candidate list and pair their results BY INDEX. The predicate must
+ * therefore be pure and depend only on values stable between the two passes --
+ * no batch state, no allocation-order effects. A divergence between them does
+ * not fail loudly; it silently misassigns rescue results to the wrong anchors.
+ * Keeping one definition makes that divergence structurally impossible rather
+ * than merely discouraged by comment. */
+static inline int mem_rescue_admit(const mem_opt_t *opt, const mem_alnreg_t *r,
+                                   int best_score)
+{
+    return r->score >= best_score - opt->pen_unpaired;
+}
+
 static int cal_sub(const mem_opt_t *opt, mem_alnreg_v *r)
 {
     int j;
@@ -482,7 +500,7 @@ int mem_pair_resolve(const mem_opt_t *opt, const bntseq_t *bns,
         kv_init(b[0]); kv_init(b[1]);
         for (i = 0; i < 2; ++i)
             for (j = 0; j < a[i].n; ++j)
-                if (a[i].a[j].score >= a[i].a[0].score  - opt->pen_unpaired)
+                if (mem_rescue_admit(opt, &a[i].a[j], a[i].a[0].score))
                     kv_push(mem_alnreg_t, b[i], a[i].a[j]);
 
         #if MATE_SORT
@@ -749,7 +767,7 @@ int mem_sam_pe_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
         kv_init(b[0]); kv_init(b[1]);
         for (i = 0; i < 2; ++i)
             for (j = 0; j < a[i].n; ++j)
-                if (a[i].a[j].score >= a[i].a[0].score  - opt->pen_unpaired)
+                if (mem_rescue_admit(opt, &a[i].a[j], a[i].a[0].score))
                     kv_push(mem_alnreg_t, b[i], a[i].a[j]);
 
         // NEW, batching
@@ -1034,7 +1052,7 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
         kv_init(b[0]); kv_init(b[1]);
         for (i = 0; i < 2; ++i)
             for (j = 0; j < a[i].n; ++j)
-                if (a[i].a[j].score >= a[i].a[0].score  - opt->pen_unpaired)
+                if (mem_rescue_admit(opt, &a[i].a[j], a[i].a[0].score))
                     kv_push(mem_alnreg_t, b[i], a[i].a[j]);
                 
         for (int l=0; l<a[0].n; l++)

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -75,22 +75,46 @@ int mem_infer_dir(int64_t l_pac, int64_t b1, int64_t b2, int64_t *dist)
     return (r1 == r2? 0 : 1) ^ (p2 > b1? 0 : 3);
 }
 
-/* Mate-rescue admission: is this anchor worth spending a rescue SW on?
+/* ---------------------------------------------------------------------------
+ * Mate-rescue admission.
  *
- * Extracted verbatim from the three identical copies that previously lived in
- * mem_pair_resolve, mem_sam_pe_batch_pre and mem_sam_pe_batch_post.
+ * An anchor is worth a mate-rescue SW only if it is BOTH near this read's best
+ * AND plausible in absolute terms. The relative term alone (upstream bwa's
+ * `score >= best - pen_unpaired`) inverts under degradation: as the best score
+ * falls, the bar falls with it and admits MORE junk, so marginally-mappable
+ * input (bisulfite/EM-seq 3-letter collapse, wrong or diverged reference,
+ * related-species contamination) drives fan-out to the max_matesw cap.
+ * See reports/2026-07-20-marginal-mappability-mate-rescue-pathology.md.
+ *
+ * On a clean read the relative term already binds far above any sane floor
+ * (best ~150 admits only >=133), so the floor cannot bind there by
+ * construction: this is a no-op exactly where current behaviour is fine.
  *
  * PURITY CONSTRAINT: mem_sam_pe_batch_pre and mem_sam_pe_batch_post walk this
- * same candidate list and pair their results BY INDEX. The predicate must
- * therefore be pure and depend only on values stable between the two passes --
- * no batch state, no allocation-order effects. A divergence between them does
- * not fail loudly; it silently misassigns rescue results to the wrong anchors.
- * Keeping one definition makes that divergence structurally impossible rather
- * than merely discouraged by comment. */
-static inline int mem_rescue_admit(const mem_opt_t *opt, const mem_alnreg_t *r,
-                                   int best_score)
+ * same candidate list and pair results BY INDEX. The predicate must therefore
+ * be pure and depend only on values stable between the two passes -- no batch
+ * state, no allocation-order effects. A divergence silently misassigns rescue
+ * results to the wrong anchors rather than failing loudly.
+ * ------------------------------------------------------------------------- */
+static inline int mem_rescue_floor(const mem_opt_t *opt, int l_seq)
 {
-    return r->score >= best_score - opt->pen_unpaired;
+    switch (opt->rescue_floor_mode) {
+    case MEM_RESCUE_FLOOR_ABS:
+        return opt->rescue_floor_abs;
+    case MEM_RESCUE_FLOOR_FRAC:
+        return (int)(opt->rescue_floor_frac * (float)l_seq * (float)opt->a + .499f);
+    case MEM_RESCUE_FLOOR_OFF:
+    default:
+        return 0;
+    }
+}
+
+static inline int mem_rescue_admit(const mem_opt_t *opt, const mem_alnreg_t *r,
+                                   int best_score, int l_seq)
+{
+    if (r->score < best_score - opt->rescue_margin) return 0;
+    if (opt->rescue_floor_mode == MEM_RESCUE_FLOOR_OFF) return 1;
+    return r->score >= mem_rescue_floor(opt, l_seq);
 }
 
 static int cal_sub(const mem_opt_t *opt, mem_alnreg_v *r)
@@ -500,7 +524,7 @@ int mem_pair_resolve(const mem_opt_t *opt, const bntseq_t *bns,
         kv_init(b[0]); kv_init(b[1]);
         for (i = 0; i < 2; ++i)
             for (j = 0; j < a[i].n; ++j)
-                if (mem_rescue_admit(opt, &a[i].a[j], a[i].a[0].score))
+                if (mem_rescue_admit(opt, &a[i].a[j], a[i].a[0].score, s[i].l_seq))
                     kv_push(mem_alnreg_t, b[i], a[i].a[j]);
 
         #if MATE_SORT
@@ -767,7 +791,7 @@ int mem_sam_pe_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
         kv_init(b[0]); kv_init(b[1]);
         for (i = 0; i < 2; ++i)
             for (j = 0; j < a[i].n; ++j)
-                if (mem_rescue_admit(opt, &a[i].a[j], a[i].a[0].score))
+                if (mem_rescue_admit(opt, &a[i].a[j], a[i].a[0].score, s[i].l_seq))
                     kv_push(mem_alnreg_t, b[i], a[i].a[j]);
 
         // NEW, batching
@@ -1052,7 +1076,7 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
         kv_init(b[0]); kv_init(b[1]);
         for (i = 0; i < 2; ++i)
             for (j = 0; j < a[i].n; ++j)
-                if (mem_rescue_admit(opt, &a[i].a[j], a[i].a[0].score))
+                if (mem_rescue_admit(opt, &a[i].a[j], a[i].a[0].score, s[i].l_seq))
                     kv_push(mem_alnreg_t, b[i], a[i].a[j]);
                 
         for (int l=0; l<a[0].n; l++)

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -917,6 +917,10 @@ static void update_a(mem_opt_t *opt, const mem_opt_t *opt0)
         if (!opt0->pen_clip5) opt->pen_clip5 *= opt->a;
         if (!opt0->pen_clip3) opt->pen_clip3 *= opt->a;
         if (!opt0->pen_unpaired) opt->pen_unpaired *= opt->a;
+        /* rescue_margin must scale with -A exactly as pen_unpaired does: it
+         * inherited pen_unpaired's role in rescue admission, so any divergence
+         * here would change admission under a non-default -A. */
+        if (!opt0->rescue_margin) opt->rescue_margin *= opt->a;
     }
 }
 
@@ -943,6 +947,8 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [%.2f]\n", opt->drop_ratio);
     fprintf(stderr, "    -W INT        discard a chain if seeded bases shorter than INT [0]\n");
     fprintf(stderr, "    -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
+    fprintf(stderr, "    --rescue-admit off|abs:N|frac:F  absolute floor on mate-rescue admission: an anchor is only rescued from if it also scores >= N (abs) or >= F * read_len * -A (frac). The default relative bar (best - margin) falls as read quality falls, so marginally-mappable input (wrong/diverged reference, contamination, bisulfite without --meth) inflates rescue work; a floor is inert on clean reads and prunes hardest exactly there. Opt-in, NOT byte-identical when enabled [%s]\n", opt->rescue_floor_mode == MEM_RESCUE_FLOOR_OFF? "off" : (opt->rescue_floor_mode == MEM_RESCUE_FLOOR_ABS? "abs":"frac"));
+    fprintf(stderr, "    --rescue-margin INT  mate-rescue admission margin: rescue anchors scoring within INT of the read's best. Defaults to -U, which sets both this and the unpaired penalty (as in bwa); set this to separate the two [%d]\n", opt->rescue_margin);
     fprintf(stderr, "    -S            skip mate rescue\n");
     fprintf(stderr, "    -P            skip pairing; mate rescue performed unless -S also in use\n");
     fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup\n");
@@ -1127,6 +1133,8 @@ int main_mem(int argc, char *argv[])
         OPT_LEGACY_READER,
         OPT_MIN_EXT_LEN,
         OPT_MAX_EXTEND_CHAINS,
+        OPT_RESCUE_MARGIN,
+        OPT_RESCUE_ADMIT,
         OPT_SEED_ORDER,
         OPT_SMEM_DEDUP,
         OPT_FAST,
@@ -1142,6 +1150,8 @@ int main_mem(int argc, char *argv[])
         {"bam",                      optional_argument, 0, OPT_BAM},
         {"min-ext-len",              required_argument, 0, OPT_MIN_EXT_LEN},
         {"max-extend-chains",        required_argument, 0, OPT_MAX_EXTEND_CHAINS},
+        {"rescue-margin",            required_argument, 0, OPT_RESCUE_MARGIN},
+        {"rescue-admit",             required_argument, 0, OPT_RESCUE_ADMIT},
         {"smem-dedup",               no_argument,       0, OPT_SMEM_DEDUP},
         {"fast",                     no_argument,       0, OPT_FAST},
         {"skip-contained-ext",       no_argument,       0, OPT_SKIP_CONTAINED_EXT},
@@ -1169,14 +1179,39 @@ int main_mem(int argc, char *argv[])
         if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
         else if (c == OPT_MIN_EXT_LEN) opt->min_ext_len = atoi(optarg), opt0.min_ext_len = 1;
         else if (c == OPT_MAX_EXTEND_CHAINS) opt->max_extend_chains = atoi(optarg), opt0.max_extend_chains = 1;
+        else if (c == OPT_RESCUE_MARGIN) opt->rescue_margin = atoi(optarg), opt0.rescue_margin = 1;
+        else if (c == OPT_RESCUE_ADMIT) {
+            /* --rescue-admit=off | abs:N | frac:F  (experimental sweep knob) */
+            if (strcmp(optarg, "off") == 0) {
+                opt->rescue_floor_mode = MEM_RESCUE_FLOOR_OFF;
+            } else if (strncmp(optarg, "abs:", 4) == 0) {
+                opt->rescue_floor_mode = MEM_RESCUE_FLOOR_ABS;
+                opt->rescue_floor_abs = atoi(optarg + 4);
+            } else if (strncmp(optarg, "frac:", 5) == 0) {
+                opt->rescue_floor_mode = MEM_RESCUE_FLOOR_FRAC;
+                opt->rescue_floor_frac = (float)atof(optarg + 5);
+            } else {
+                fprintf(stderr, "[E::%s] --rescue-admit expects off | abs:N | frac:F, got '%s'\n",
+                        __func__, optarg);
+                return 1;
+            }
+        }
         else if (c == '1') no_mt_io = 1;
         else if (c == 'x') mode = optarg;
         else if (c == 'w') opt->w = atoi(optarg), opt0.w = 1;
         else if (c == 'A') opt->a = atoi(optarg), opt0.a = 1, assert(opt->a >= INT_MIN && opt->a <= INT_MAX);
         else if (c == 'B') opt->b = atoi(optarg), opt0.b = 1, assert(opt->b >= INT_MIN && opt->b <= INT_MAX);
         else if (c == 'T') opt->T = atoi(optarg), opt0.T = 1, assert(opt->T >= INT_MIN && opt->T <= INT_MAX);
-        else if (c == 'U')
-            opt->pen_unpaired = atoi(optarg), opt0.pen_unpaired = 1, assert(opt->pen_unpaired >= INT_MIN && opt->pen_unpaired <= INT_MAX);
+        else if (c == 'U') {
+            /* -U keeps its documented meaning, which in upstream bwa covers BOTH the
+             * paired-vs-unpaired decision and the mate-rescue admission margin
+             * (docs/src/cli/mem.md: "affects mate-rescue scoring"). Setting both here
+             * preserves that behaviour exactly, so existing -U users see no change.
+             * --rescue-margin exists for callers who want to separate the two. */
+            opt->pen_unpaired = atoi(optarg), opt0.pen_unpaired = 1;
+            assert(opt->pen_unpaired >= INT_MIN && opt->pen_unpaired <= INT_MAX);
+            if (!opt0.rescue_margin) opt->rescue_margin = opt->pen_unpaired;
+        }
         else if (c == 't')
             opt->n_threads = atoi(optarg), opt->n_threads = opt->n_threads > 1? opt->n_threads : 1, assert(opt->n_threads >= INT_MIN && opt->n_threads <= INT_MAX);
         else if (c == 'o' || c == 'f')
@@ -1528,7 +1563,18 @@ int main_mem(int argc, char *argv[])
     if (opt->meth_mode) {
         if (!opt0.pen_clip5)    opt->pen_clip5   = 10;
         if (!opt0.pen_clip3)    opt->pen_clip3   = 10;
-        if (!opt0.pen_unpaired) opt->pen_unpaired = 100;  /* bwameth -U 100 (paired) */
+        /* bwameth -U 100 (paired). In upstream bwa this also widens the mate-rescue
+         * admission margin, and bwameth invokes real bwa -- so reproducing BOTH is
+         * what makes --meth a faithful bwameth drop-in. rescue_margin is therefore
+         * set to match, preserving current behaviour exactly.
+         * This is deliberate, not an oversight: measurement shows --meth fan-out is
+         * ~2.5 candidates/end (vs 34.7 for the same reads in plain mode), so the wide
+         * margin costs nothing here -- there is no pathology to fix under --meth.
+         * See reports/2026-07-20-design-rescue-admission-criterion.md. */
+        if (!opt0.pen_unpaired) {
+            opt->pen_unpaired = 100;                            /* bwameth -U 100 */
+            if (!opt0.rescue_margin) opt->rescue_margin = 100;  /* keep bwa's coupling */
+        }
         if (!opt0.T)            opt->T           = 40;
         opt->flag |= MEM_F_NO_MULTI;   /* -M */
         aux.copy_comment = 1;          /* -C, needed for YS:Z/YC:Z passthrough */


### PR DESCRIPTION
> **Draft.** Real-data validation (5M-pair WGS + WES) is running now. Promoting to ready once those land — see *Pending* at the bottom.

## Problem

Mate-rescue admission is gated relative to the read's own best score (`score >= best - pen_unpaired`, previously duplicated at three call sites). Because the bar is *relative*, it falls as alignment quality falls — so degraded input generates **more** rescue work, bounded only by `max_matesw` (50 per end).

Measured fan-out, 100k pairs vs GRCh38 (instrumented build):

| input | cands/end | regions/end | ends with >10 anchors | median best score | admission bar |
|---|---|---|---|---|---|
| clean | 1.79 | 3.93 | 0.99% | ~145 | ≥128 |
| 15% diverged | 9.65 | 32.6 | 13.6% | ~70 | ≥53 |
| bisulfite, no `--meth` | 34.66 | 43.6 | 75.1% | ~25 | ≥8 |

A 16x lower bar applied to an 11x larger pool. This affects non-meth marginal input: a wrong or diverged reference, or related-species contamination.

## What this does

Adds an optional absolute floor, so admission also requires the anchor to be plausible in absolute terms:

```
admit(r) = r->score >= best - rescue_margin        (relative, existing)
        && r->score >= rescue_floor(opt, l_seq)    (absolute, new, default off)
```

- `--rescue-admit=off|abs:N|frac:F` — `off` is the default and reproduces current behaviour exactly.
- `--rescue-margin INT` — the admission margin, separable from `-U`.
- The predicate is extracted into one `mem_rescue_admit()` replacing three copies.

## End-user impact: none by default

| invocation | pen_unpaired | rescue_margin | floor | vs current |
|---|---|---|---|---|
| default | 17 | 17 | off | identical |
| `-U 50` | 50 | 50 | off | identical |
| `--meth` | 100 | 100 | off | identical |

`-U` keeps its documented meaning and continues to set **both** the unpaired penalty and the rescue margin, matching upstream bwa. `--meth` continues to apply bwameth's `-U 100` to both, preserving drop-in fidelity. Nothing changes unless a new flag is passed.

Verified byte-identical vs `origin/main` on clean input (sorted SAM, 200k records):

| config | baseline | this branch |
|---|---|---|
| default | `527f3754d13df1952dbe8a2670549fe1` | `527f3754d13df1952dbe8a2670549fe1` |
| `-U 50` | `beb4b26a24c810165158b7d045277a31` | `beb4b26a24c810165158b7d045277a31` |

## Honest scope of the benefit

The dramatic numbers come from bisulfite reads aligned **without** `--meth` (3.19x at `abs:30`). That is a **misconfiguration, not a workload** — its correct fix is adding `--meth`, which takes placement from 14.7% to 95.4% correct. It is a stress case that proves the mechanism, not a use case.

On a scenario a user is actually in — 15% diverged reference — the honest figure is **1.19x**, and there `-m 10` is better on both axes (1.28x, −6 confident-correct vs the floor's −93).

The case for the floor rests on two things, not on raw speed:
1. **It is inert on clean data by construction.** No admitted candidate on clean input scores below 80, so a floor of 30 cannot bind. Every floor arm is output-identical to baseline; `-m 10` moves 6 confident reads.
2. **Its benefit scales with degradation**, so it protects against a failure mode users cannot detect in advance, at zero cost when absent.

## Not in scope

- **Default stays `off`.** Flipping to `abs:30` needs the real-data and long-read validation tracked in the follow-up issue.
- **No `settings-profiles.md` change.** `--meth` was measured and does not exhibit the pathology (2.55 cands/end vs 34.66 for the same reads in plain mode), so the bisulfite profile is correct as written.
- Diagnostic fan-out instrumentation used to produce these numbers is deliberately **not** included.

## Testing

- Byte-identity vs pristine `origin/main`, default and `-U 50`.
- `--rescue-admit=off` exercised as a distinct arm, so the no-change guarantee is tested rather than assumed.

## Pending before ready

- Real-data byte-identity: 5M-pair WGS (HG00096) + WES (HG00100). The clean-data no-op claim rests on simulated reads; real reads have indels, repeats and quality dropoff, and if any real candidate scores below the floor it is no longer free.
- Unit tests for the predicate (floor-off reproduces the prior expression; relative term binds on clean scores; floor binds on marginal scores; `frac` scales with read length; boundary equality).
- `batch_pre`/`batch_post` lockstep test.
- `mdbook build` and anchor-link check for the new `mem.md` sections.

## Reading order

1. `caeb315` — mechanical extraction, byte-identical
2. `96b37a7` — the new behaviour
