### PR TITLE
fix(ext): tighten ungapped fast-path mismatch bound to the strict form

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -3470,12 +3470,40 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     int64_t leftRefOffset = 0, rightRefOffset = 0;
     int64_t leftQerOffset = 0, rightQerOffset = 0;
 
-    // ungapped fast-path threshold, computed once per call from
-    // the scoring model. See ungapped_fastpath_walk docstring.
+    // Ungapped fast-path threshold, computed once per call from the scoring
+    // model: the largest mismatch count X for which an ungapped diagonal is
+    // provably optimal, so ungapped_analyze may return FP_STATUS_HIT and skip
+    // the banded SW entirely.
+    //
+    // An ungapped walk carrying X mismatches scores X*(a+b) below the all-match
+    // diagonal. The cheapest gapped alternative pays at least one gap open plus
+    // extend, o_min + e_min, and can at best convert every one of those X
+    // mismatches back into a match. So the ungapped walk is safe only while it
+    // wins STRICTLY:
+    //
+    //     X * (a + b) < o_min + e_min   =>   X <= (o_min + e_min - 1) / (a + b)
+    //
+    // Strictness is load-bearing, not pedantry: on an exact tie the gapped path
+    // scores the same, and ksw_extend2 breaks ties with `if (m > max)` -- the
+    // cell reached first keeps the max -- so the DP can return the gapped CIGAR
+    // while this fast path returns the ungapped one.
+    //
+    // This previously read o_min / (a + b - e_min), which coincides with the
+    // correct bound at bwa's defaults (6/4 == 1 and (6+1-1)/5 == 1) but is too
+    // permissive elsewhere. At -B 3 it admitted X = 2, yet 2*(1+3) = 8 > 6+1, so
+    // a single deletion beats that diagonal: measured 51 of 501,821 records
+    // (0.010%) differing from the DP on 250k HG002 WGS pairs, the fast path
+    // emitting e.g. 151M where the DP finds 138M1D13M. Defaults are unchanged,
+    // so this costs no fast-path coverage on a stock run.
     const int fp_o_min = opt->o_del < opt->o_ins ? opt->o_del : opt->o_ins;
     const int fp_e_min = opt->e_del < opt->e_ins ? opt->e_del : opt->e_ins;
-    const int fp_denom = opt->a + opt->b - fp_e_min;
-    const int fp_x_threshold = (fp_denom > 0) ? (fp_o_min / fp_denom) : -1;
+    // Cheapest single gap the scoring scheme allows; a degenerate scheme that
+    // makes gaps free (or a non-positive a+b) leaves nothing provable, so the
+    // fast path is disabled with -1 rather than guessed at.
+    const int fp_gap_min = fp_o_min + fp_e_min;
+    const int fp_denom   = opt->a + opt->b;
+    const int fp_x_threshold =
+        (fp_denom > 0 && fp_gap_min > 0) ? ((fp_gap_min - 1) / fp_denom) : -1;
     // (fp_o_min, fp_e_min above are reused directly by ungapped_analyze.)
 
     int srt_size = MAX_SEEDS_PER_READ, fac = FAC;


### PR DESCRIPTION
## Summary

The ungapped fast path (`ungapped_analyze` → `FP_STATUS_HIT`) skips banded SW when a diagonal carries at most `x_threshold` mismatches. That bound was `o_min / (a + b - e_min)`, which is too permissive, so at non-default scoring the fast path can return an ungapped alignment where the DP finds a strictly better gapped one.

An ungapped walk with `X` mismatches scores `X*(a+b)` below the all-match diagonal. The cheapest gapped alternative pays at least one gap open+extend, `o_min + e_min`, and can at best convert every one of those `X` mismatches back to a match. So the walk is provably optimal only while it wins **strictly**:

```
X * (a + b) < o_min + e_min   =>   X <= (o_min + e_min - 1) / (a + b)
```

Strictness is load-bearing on its own. At an exact tie the gapped path scores the same, and `ksw_extend2` breaks ties with `if (m > max)` — the cell reached first keeps the max — so the DP can return the gapped CIGAR while the fast path returns the ungapped one.

## Impact

The two forms agree at bwa's defaults (`6/4 == 1` and `(6+1-1)/5 == 1`), so **stock runs are unaffected and no fast-path coverage is lost**.

## Validation

250k HG002 WGS pairs against hg38, `-t 8 -K 10000000`, compared against a build with the fast path disabled entirely — i.e. always running the DP, which is what bwa-mem2 does (it has no ungapped fast path at all).

| scoring | arm | md5 of SAM records | result |
|---|---|---|---|
| defaults | before | `74fc410d…` | — |
| defaults | **after** | `74fc410d…` | byte-identical |
| `-B 3` | fast path off (ground truth) | `e163264f…` | — |
| `-B 3` | old bound | `b1d193e9…` | **51 / 501,821 differ (0.010%)** |
| `-B 3` | **new bound** | `e163264f…` | byte-identical to the DP |
| `-A1 -B1 -O1 -E1` | fast path off (ground truth) | `35c1d91f…` | — |
| `-A1 -B1 -O1 -E1` | old bound | `84d53f61…` | **1,522 / 501,091 differ (0.30%)** |
| `-A1 -B1 -O1 -E1` | **new bound** | `35c1d91f…` | byte-identical to the DP |

**`-B 3`** — old bound admits `X = 2`, but `2*(1+3) = 8 > 6+1`, so one deletion beats the diagonal. CIGAR differs in all 51 records, POS in 27, MAPQ and RNAME in none. The fast path emits e.g. `151M` and `148M3S` where the DP finds `138M1D13M` and `148M1D3M`.

**`-A1 -B1 -O1 -E1`** — old bound admits `X = 1` and `1*(1+1) == 1+1` exactly: the tie case. 1,522 records differ, including 10 MAPQ changes. This is 30× the `-B 3` rate.

### Long reads: protected incidentally, not by proof

`-A1 -B1 -O1 -E1` is exactly what `-x pacbio` and `-x ont2d` set. 2,000 HG002 HiFi reads under `-x pacbio` are byte-identical across all three arms — but that is because `FP_N_MAX` caps the fast path at 128 columns and HiFi extensions are far longer, so the path never fires. The table above shows the same scoring scheme *is* unsound once the path is reachable. Raising `FP_N_MAX` would expose it.

### `--meth`

Unaffected. The fast path is already disabled under `--meth` at all three call sites (`bwamem.cpp:3753`, `:3983`, `:4414`) because `ungapped_analyze` hardcodes symmetric `opt->a`/`opt->b` and cannot express the asymmetric OT/OB matrix, so `fp_x_threshold` is computed but never consumed there.

## Performance

None expected, and none is claimed. The new bound is never larger than the old one, so it can only admit fewer pairs to the fast path. At defaults the two expressions evaluate to the same constant, so the code path is bit-identical — a proof, not a measurement. At `-B 3`, single-rep wall times were 11.97 s (old) vs 11.71 s (new), i.e. within noise and directionally meaningless.

## Also in this change

- Disable the fast path (`x_threshold = -1`) under a degenerate scheme with free gaps or non-positive `a + b`, where nothing is provable.
- Replace the stale comment pointing at `ungapped_fastpath_walk` — a function that does not exist in this tree — with the derivation itself.

## Provenance

The strict form matches the bound used by the `bwa-mem3-rs` reimplementation, which hit the same divergence independently (`4M1D146M` at `-B 3`) and tightened its threshold for the same reason.