### PR TITLE
docs(best-practices): add anti-patterns for marginally-mappable input

### DIFF
--- a/docs/src/best-practices/anti-patterns.md
+++ b/docs/src/best-practices/anti-patterns.md
@@ -98,6 +98,56 @@ Use `--bam=0` (uncompressed BAM) for all pipe-to-sort workflows. See
 [Output format](output-format.md) for the full explanation and recommended
 pipeline.
 
+## Aligning bisulfite / EM-seq data without `--meth`
+
+Symptoms: alignment several times slower than expected, a low mapping rate, and
+a high mismapping rate.
+
+Both chemistries — bisulfite treatment and the enzymatic conversion used by
+EM-seq — turn nearly every unmodified C into T, so the reads are effectively a
+three-letter alphabet. Queried against the normal four-letter index they match
+only marginally — enough to generate abundant weak seeds, not enough to place
+confidently. Measured on simulated EM-seq (100,000 pairs vs GRCh38, `holodeck`
+truth):
+
+| | placement correct | unmapped | confident (MAPQ ≥ 30) mismappings |
+|---|---:|---:|---:|
+| plain mode | 14.7% | 30.9% | 46,672 |
+| `--meth` | **95.4%** | **0.0%** | **41** |
+
+Plain mode is also roughly 4.5× slower: mate-rescue fan-out rises from 2.55 to
+34.7 candidate anchors per read end, because the rescue admission bar is
+relative to each read's own best score and therefore *falls* as placement
+quality falls.
+
+**The slowness is the visible symptom; the wrong answers are the real cost.**
+Do not reach for `-m` or other speed flags to recover the runtime — add
+`--meth`, which is both faster and correct.
+
+`--meth` requires a methylation-aware index. Build it once per reference with
+`bwa-mem3 index --meth ref.fa` — that writes the normal index at the bare prefix
+plus the converted seed index under `ref.fa.meth.*`; at alignment time still
+pass the original `ref.fa` path. See
+[Indexing → Methylation index](../user-guide/indexing.md#methylation-index---meth)
+and [Methylation](methylation.md).
+
+## Tuning performance flags when the reads don't match the reference
+
+The same mechanism applies well beyond bisulfite. Mate-rescue cost rises sharply
+on any *marginally mappable* input — a wrong or diverged reference build, an
+unexpected species, or contamination — because the admission bar for rescue
+candidates is relative to each read's best alignment, so degraded placement
+admits more work rather than less.
+
+Note that genuinely *unmappable* reads are cheap: reads with no homology fail at
+seeding and never reach rescue. It is the in-between case — homologous but
+degraded — that is expensive.
+
+So an unexpectedly slow run **with a low mapping rate** is usually a data or
+reference problem, not a tuning problem. Check `samtools flagstat` mapping rate
+first. Reaching for speed flags in that situation makes a misconfigured run
+finish sooner without making it correct.
+
 ---
 
 **See also:**


### PR DESCRIPTION
## Problem

Two related failure modes were undocumented, and both present as *slowness* — which invites exactly the wrong fix.

## Aligning bisulfite/EM-seq without `--meth`

Nothing in the docs warned about this. It is catastrophic, and the visible symptom is a slow run rather than a wrong one.

Measured on simulated EM-seq (100k pairs vs GRCh38, holodeck truth):

| | placement correct | unmapped | confident (MAPQ ≥ 30) mismappings |
|---|---:|---:|---:|
| plain mode | 14.7% | 30.9% | 46,672 |
| `--meth` | **95.4%** | **0.0%** | **41** |

Plain mode is also ~4.5x slower: mate-rescue fan-out rises from 2.55 to 34.7 candidate anchors per read end.

A user who notices only the runtime may reach for `-m` or other speed flags, which makes a misconfigured run finish sooner without making it correct. The doc says so explicitly.

## Tuning performance flags when reads don't match the reference

The same mechanism generalises. Rescue admission is gated relative to each read's own best score, so the bar *falls* as placement quality falls — measured as ≥128 on clean reads versus ≥8 on marginal ones, against an 11x larger candidate pool. Any marginally-mappable input inflates rescue work: wrong or diverged reference build, unexpected species, contamination.

Worth stating because it is counter-intuitive: genuinely *unmappable* reads are **cheap** — they fail at seeding and never reach rescue. Uniformly random reads align faster than clean ones. It is the homologous-but-degraded middle that is expensive, so cost peaks in the middle of the mappability range rather than at the bottom.

The practical guidance: an unexpectedly slow run *with a low mapping rate* is a data or reference problem, not a tuning problem. Check `samtools flagstat` before touching performance flags.

## Scope

Documentation only. No code, no behaviour change, no new flags.

Deliberately **not** included: no change to the `-m 10` recommendation in `settings-profiles.md`, which is already well evidenced and correctly framed as opt-in.

## Testing

`mdbook build` passes; both sections render and the `methylation.md` cross-link resolves. The one build warning is pre-existing, in `CHANGELOG.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an anti-pattern section for bisulfite and EM-seq alignment, noting that aligning without `--meth` can cause slow runs and poor placement quality, with guidance to use a methylation-aware index.
  * Added follow-on guidance for unexpectedly slow runs with low mapping rates, emphasizing data/reference mismatch as the common cause and recommending checking mapping statistics before tuning performance flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->