### PR TITLE
docs(ext): record the measured evidence behind the ungapped fast-path bound

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -3490,11 +3490,33 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
     //
     // This previously read o_min / (a + b - e_min), which coincides with the
     // correct bound at bwa's defaults (6/4 == 1 and (6+1-1)/5 == 1) but is too
-    // permissive elsewhere. At -B 3 it admitted X = 2, yet 2*(1+3) = 8 > 6+1, so
-    // a single deletion beats that diagonal: measured 51 of 501,821 records
-    // (0.010%) differing from the DP on 250k HG002 WGS pairs, the fast path
-    // emitting e.g. 151M where the DP finds 138M1D13M. Defaults are unchanged,
-    // so this costs no fast-path coverage on a stock run.
+    // permissive elsewhere. Measured on 250k HG002 WGS pairs vs hg38 against a
+    // build with the fast path disabled outright, i.e. always running the DP
+    // (what bwa-mem2 does -- it has no ungapped fast path at all):
+    //
+    //   -B 3             old bound admits X = 2, yet 2*(1+3) = 8 > 6+1, so one
+    //                    deletion beats the diagonal:    51/501,821 records
+    //                    (0.010%) differ from the DP -- CIGAR in all 51, POS in
+    //                    27, MAPQ in none. The fast path emits e.g. 151M and
+    //                    148M3S where the DP finds 138M1D13M and 148M1D3M.
+    //   -A1 -B1 -O1 -E1  old bound admits X = 1 and 1*(1+1) == 1+1 exactly, the
+    //                    tie case:                    1,522/501,091 records
+    //                    (0.30%) differ, including 10 MAPQ changes.
+    //
+    // Defaults are unchanged in both directions, so this costs no fast-path
+    // coverage on a stock run.
+    //
+    // That second scheme is what -x pacbio and -x ont2d set, but long reads
+    // never reached it: FP_N_MAX caps the fast path at 128 columns and their
+    // extensions are longer, so 2,000 HG002 HiFi reads under -x pacbio come out
+    // byte-identical with the bound either way. Note the cap is a coverage
+    // limit, not a correctness guard -- the bound above is sound at every
+    // scoring scheme tested, so raising FP_N_MAX does not reopen this.
+    //
+    // The fast path is disabled entirely under --meth (see the three call sites
+    // below), since ungapped_analyze hardcodes symmetric opt->a/opt->b and
+    // cannot express the asymmetric OT/OB matrix. This bound is not consulted
+    // there.
     const int fp_o_min = opt->o_del < opt->o_ins ? opt->o_del : opt->o_ins;
     const int fp_e_min = opt->e_del < opt->e_ins ? opt->e_del : opt->e_ins;
     // Cheapest single gap the scoring scheme allows; a degenerate scheme that


### PR DESCRIPTION
Comment-only follow-up to #231. **No functional change** — the diff touches only comment lines (verified: filtering the diff to non-`//` lines is empty).

#231 landed the corrected bound citing the `-B 3` case. Two further questions were flagged as untested in that PR's description and have since been answered; this folds the results into the in-tree derivation so it matches what was actually measured.

## 1. `-x pacbio` / `-x ont2d`: real, and 30× larger than `-B 3`

Those presets set `-A1 -B1 -O1 -E1`, where the old bound admitted `X = 1` and `1*(1+1) == 1+1` exactly — the tie case. Same three-arm method as #231 (each bound compared against a build with the fast path disabled entirely, i.e. always running the DP), 250k HG002 WGS pairs vs hg38:

| scoring | old bound | new bound |
|---|---|---|
| `-B 3` | 51 / 501,821 differ (0.010%) | byte-identical to the DP |
| `-A1 -B1 -O1 -E1` | **1,522 / 501,091 differ (0.30%)**, incl. 10 MAPQ changes | byte-identical to the DP |

`-A1 -B1 -O1 -E1` is the only scheme tested where MAPQ moves.

**Long reads were never affected, but not for the reason it looks like.** 2,000 HG002 HiFi reads under `-x pacbio` are byte-identical with either bound — because `FP_N_MAX` caps the fast path at 128 columns and HiFi extensions are longer, so the path never fires. That null result on its own proves nothing about the formula; running the preset's *scoring* on 150 bp reads, where the path does fire, is what exposed the 0.30%.

Worth being explicit that the cap is a **coverage limit, not a correctness guard**: with the corrected bound — sound at every scheme tested — raising `FP_N_MAX` does not reopen this. The comment now says so, since the opposite is an easy inference to draw.

## 2. `--meth`: not applicable

All three `ungapped_analyze` call sites (`bwamem.cpp:3753`, `:3983`, `:4414`) are gated on `!opt->meth_mode`, because `ungapped_analyze` hardcodes symmetric `opt->a`/`opt->b` and cannot express the asymmetric OT/OB matrix. `fp_x_threshold` is computed but never consumed there, so the bound cannot affect methylation mode. No change needed — the D3/PR-4 work already handled it.

## Full write-up

`reports/2026-07-20-ungapped-fastpath-x-threshold-soundness.md`, including the reusable bit: for any future fast-path change, A/B each candidate against **fast-path-disabled** rather than against the other candidate, so a difference is unambiguously "the shortcut returned something the real alignment wouldn't."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for the ungapped alignment fast path, including threshold behavior, scoring parameters, long-read handling, and methylation mode limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->