### PR TITLE
chore(test): fail fast when test binaries are built standalone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -612,7 +612,8 @@ test-binaries: $(BWA_LIB) $(HTS_LIB)
 	    COVERAGE=$(COVERAGE) \
 	    ARCH_FLAGS_FROM_PARENT='$(ARCH_FLAGS)' \
 	    HTSLIB_static_LIBS='$(HTSLIB_static_LIBS)' \
-	    HTSLIB_static_LDFLAGS='$(HTSLIB_static_LDFLAGS)'
+	    HTSLIB_static_LDFLAGS='$(HTSLIB_static_LDFLAGS)' \
+	    FROM_PARENT_MAKE=1
 
 shm_section_find_test: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_section_find_test.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/shm_section_find_test.o $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) -o $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,6 +22,32 @@ EXE = fmi_test smem2_test bwt_seed_strategy_test sa2ref_test xeonbsw bandedswa_z
 # `run_unit_tests.sh` keep working during the framework-scaffolding PR.
 DOCTEST_BINS = bwa_mem3_tests_unit bwa_mem3_tests_integration
 
+# Guard: refuse a standalone link, point at the supported entry point.
+#
+# Every binary here links libhts.a, whose own dependencies (libdeflate, lzma,
+# bz2, ...) are whatever htslib's configure detected on this host. Those arrive
+# only as HTSLIB_static_LIBS/_LDFLAGS, propagated by the parent's
+# `test-binaries` recipe -- see the parent Makefile's htslib_static.mk include
+# for why they cannot be resolved here. Standalone they are empty, and the link
+# dies in a wall of undefined libdeflate_*/hts_* symbols that says nothing about
+# the actual mistake. Fail immediately with the fix instead.
+#
+# Non-linking goals (notably `clean`, which the parent also invokes directly)
+# stay available standalone.
+FROM_PARENT_MAKE ?=
+LINK_GOALS         := all framework unit integration $(DOCTEST_BINS) $(EXE)
+REQUESTED_LINK_GOALS := $(filter $(LINK_GOALS),$(or $(MAKECMDGOALS),all))
+
+ifeq ($(strip $(FROM_PARENT_MAKE)),)
+ifneq ($(strip $(REQUESTED_LINK_GOALS)),)
+$(error Building test binaries directly from test/ is not supported. \
+Run `make test-binaries` (or `make test`) from the repository root instead: \
+the htslib static-link flags are resolved by the parent Makefile and are \
+empty here, so linking $(REQUESTED_LINK_GOALS) would fail with undefined \
+libdeflate_*/hts_* symbols)
+endif
+endif
+
 UNAME_M := $(shell uname -m)
 UNAME_S := $(shell uname -s)
 IS_ARM  := $(filter $(UNAME_M),arm64 aarch64)


### PR DESCRIPTION
## Problem

Running `make -C test unit` (or any other linking goal) directly from `test/` fails with nine undefined-symbol errors that give no hint about the real mistake:

```
/usr/bin/ld: ext/htslib/bgzf.c:602: undefined reference to `libdeflate_crc32'
/usr/bin/ld: ext/htslib/bgzf.c:577: undefined reference to `libdeflate_alloc_compressor'
... 7 more
collect2: error: ld returned 1 exit status
```

Every binary under `test/` links `libhts.a`, whose own dependencies (libdeflate, lzma, bz2, …) are whatever htslib's `configure` detected on the host. Those reach `test/Makefile` only as `HTSLIB_static_LIBS`/`HTSLIB_static_LDFLAGS`, propagated by the parent's `test-binaries` recipe — see the parent `Makefile`'s `htslib_static.mk` include block for why they cannot be resolved inside `test/`. Standalone they are empty and the link dies.

This is working as designed (`test/Makefile` already documents it), but the failure mode is hostile. It is especially easy to hit on Amazon Linux 2023, where there is no `libdeflate-devel` package at all, so libdeflate must be built from source and the symbols are guaranteed to be unresolved.

## Change

Guard the linking goals on a `FROM_PARENT_MAKE` sentinel set by the parent recipe, and name the supported entry point:

```
Makefile:43: *** Building test binaries directly from test/ is not supported.
Run `make test-binaries` (or `make test`) from the repository root instead:
the htslib static-link flags are resolved by the parent Makefile and are empty
here, so linking unit would fail with undefined libdeflate_*/hts_* symbols.  Stop.
```

Two design notes:

- **A sentinel, not an emptiness test.** Keying off `$(HTSLIB_static_LIBS)` being empty would false-alarm on hosts where htslib's configure genuinely finds no extra dependencies.
- **Only linking goals are guarded.** `clean` in particular must keep working standalone, because the parent itself invokes `make -C test clean` (`Makefile:827`). The guard scopes to `$(filter $(LINK_GOALS),$(or $(MAKECMDGOALS),all))`.

## Verification

Checked on both macOS/arm64 and Amazon Linux 2023/arm64 (Graviton):

| # | invocation | expected | result |
|---|---|---|---|
| 1 | `make -C test unit` | fail fast | ✅ error names the goal (“linking **unit** would fail”) |
| 2 | `make -C test` (default `all`) | fail fast | ✅ |
| 3 | `make -C test clean` | still works | ✅ runs normally |
| 4 | `make -C test unit FROM_PARENT_MAKE=1` | guard silent | ✅ proceeds to compile |
| 5 | `make test-binaries` from repo root | still builds | ✅ exit 0, `test/bwa_mem3_tests_unit` produced |

No source files touched, no SW kernel involvement, so no `bwa-bsw-bench` run is applicable.
