### PR TITLE
fix(mem): size sa_coord realloc in elements, not SMEM count

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1466,9 +1466,21 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
         // assert(pos - smem_ptr + 1 < 6000);
         if (pos - smem_ptr + 1 >= smem_buf_size)
         {
-            int csize = smem_buf_size;
-            smem_buf_size *= 2;
-            sa_coord = (int64_t *) _mm_realloc(sa_coord, csize, opt->max_occ * smem_buf_size,
+            /* csize is in ELEMENTS, matching nsize (see _mm_realloc). sa_coord
+             * holds max_occ entries per SMEM, so the old element count is
+             * max_occ * smem_buf_size -- not smem_buf_size, which understated it
+             * by a factor of max_occ and left the tail of the buffer uncopied.
+             * Harmless today only because sa_coord's contents are dead here (the
+             * resolve that fills it runs after this grow), but it silently
+             * corrupts any caller that makes them live across the grow. */
+            int64_t csize = (int64_t)opt->max_occ * smem_buf_size;
+            /* A single read can yield more than 2x the current SMEM count, so
+             * one doubling may not be enough -- grow until the buffer holds the
+             * whole run, or the subsequent get_sa_entries* writes overrun it. */
+            while (pos - smem_ptr + 1 >= smem_buf_size)
+                smem_buf_size *= 2;
+            sa_coord = (int64_t *) _mm_realloc(sa_coord, csize,
+                                               (int64_t)opt->max_occ * smem_buf_size,
                                                sizeof(int64_t));
             assert(sa_coord != NULL);
         }


### PR DESCRIPTION
Found while investigating cross-read SA resolution; unrelated to that change, so raising it on its own.

## The bug

`_mm_realloc(ptr, csize, nsize, dsize)` takes `csize` in **elements**, matching `nsize` — its own comment says so, and it does `memcpy(nptr, ptr, csize * dsize)`.

The `sa_coord` grow in `mem_chain_seeds` passed `smem_buf_size` (a **SMEM count**) as `csize`, while `nsize` was `opt->max_occ * smem_buf_size` (an **element count**). The two arguments were in different units, understating the old size by a factor of `max_occ` (default 500) and copying only 1/500th of the live buffer across the grow.

```c
int csize = smem_buf_size;                    // SMEM count
smem_buf_size *= 2;
sa_coord = _mm_realloc(sa_coord, csize,
                       opt->max_occ * smem_buf_size,   // element count
                       sizeof(int64_t));
```

## Why it is harmless today

The grow runs *before* the `get_sa_entries_prefetch` call that fills `sa_coord` for the current read, so the tail that fails to copy is dead data. Nothing reads it.

It is still worth fixing: the mismatch is invisible at the call site, and it silently corrupts any caller that makes `sa_coord`'s contents live across the grow. A cross-read resolve does exactly that, which is how this surfaced.

Also widens `csize` to `int64_t` to match the parameter type and avoid an `int` overflow after repeated doublings.

## Validation

Byte-identical alignments on 1M-read PE and SE smoke sets (hg38) against the pre-fix build. The only SAM difference is the `@PG` line, which records the build path and a `-dirty` version suffix.

Note the realloc path itself is not exercised by normal data — it needs a single read with `>= 6000` SMEMs — so this is a correctness fix by inspection, not one a benchmark would catch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a reliability issue when internal seed-coordinate buffers expanded, ensuring existing contents are preserved correctly during growth.
  * Improved reliability for operations that require larger SMEM-heavy working buffers, preventing incomplete preservation in long or larger runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->