### PR TITLE
perf(mem): resolve SA lookups across reads, not per read

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1433,6 +1433,55 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
     // filter seq at early stage than this!, shifted to collect!!!
     // if (len < opt->min_seed_len) return chain; // if the query is shorter than the seed length, no match
 
+    /* Cross-read SA resolution (default ON; BWA3_SA_PER_READ=1 restores the
+     * per-read call for A/B).
+     *
+     * get_sa_entries_prefetch is a 20-lane refill pipeline over independent
+     * compressed-SA walks. Calling it once per read starves it: the median read
+     * supplies ~13 positions, so mean lane occupancy is only 10.5/20 and ~20% of
+     * all walk rounds run with a SINGLE lane active (fully serialized DRAM
+     * latency). The whole batch's SMEMs are already resident in matchArray,
+     * rid-sorted and rid-grouped, so resolving a run of reads per call keeps the
+     * lanes full. Measured -21..-28% on MEM_SA / -2.0..-2.4% on kernel time,
+     * byte-identical, across Graviton4 / Sapphire Rapids / Zen3.
+     *
+     * Order-preserving by construction: the per-read loop below consumes SMEM
+     * runs contiguously in matchArray order, and the staging loop inside
+     * get_sa_entries_prefetch enumerates each SMEM's occurrences with the
+     * identical stride/cap rule. A chunk's coordArray is therefore the exact
+     * concatenation of the per-read ones it covers, so each read's positions stay
+     * in that read's order and `mypos` is a simple cursor from the chunk base. */
+#if SA_COMPRESSION
+    /* Treat an explicit "0" as off, matching meth_seed_filter_enabled(): a
+     * presence-only check would let BWA3_SA_PER_READ=0 silently flip on per-read
+     * mode and quietly invalidate an A/B comparison run. */
+    static const int sa_per_read = []() {
+        const char *e = getenv("BWA3_SA_PER_READ");
+        return e != NULL && strcmp(e, "0") != 0;
+    }();
+    const int sa_across = !sa_per_read;
+#else
+    /* The walk inside get_sa_entries_prefetch assumes the compressed-SA index
+     * layout; an uncompressed build resolves via get_sa_entries below instead. */
+    const int sa_across = 0;
+#endif
+    /* Resolve in read-run-aligned chunks rather than one whole-batch call. Two
+     * independent reasons, and the tighter one sets the size:
+     *   1. Memory. A whole-batch position count is unbounded on repetitive input,
+     *      and get_sa_entries_prefetch's staging (t_sa) is thread_local and
+     *      grow-only, so one pathological batch would pin that high-water for the
+     *      life of the process.
+     *   2. Cache. Staging is 16 B/position across pos_ar+map_ar. Per-read it was
+     *      L1-resident; a whole batch (~58k positions) is ~930 KB and spills L2.
+     * 16k positions = 256 KB of staging, still three orders of magnitude more than
+     * the ~13-57 a single read supplies -- far past where occupancy saturates.
+     * A chunk sweep (1k..256k) is flat, so this is a comfortable default, not a
+     * tuned one. */
+    constexpr int64_t sa_chunk_positions = 16384;
+    int64_t mypos = 0;          /* cursor into sa_coord, relative to chunk start */
+    int64_t chunk_end = 0;      /* exclusive SMEM index resolved so far */
+    int64_t sa_cap = (int64_t)opt->max_occ * smem_buf_size;   /* sa_coord elements */
+
     uint64_t tim = __rdtsc();
     for (int l=0; l<nseq && pos < num_smem - 1; l++)
     {
@@ -1464,7 +1513,9 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
 
         // bwt_sa
         // assert(pos - smem_ptr + 1 < 6000);
-        if (pos - smem_ptr + 1 >= smem_buf_size)
+        /* sa_across grows sa_coord per chunk below; a grow here would move the
+         * buffer out from under the chunk it already filled. */
+        if (!sa_across && pos - smem_ptr + 1 >= smem_buf_size)
         {
             int csize = smem_buf_size;
             smem_buf_size *= 2;
@@ -1500,12 +1551,62 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
             }
         }
 
-        int64_t id = 0, cnt_ = 0, mypos = 0;
+        int64_t id = 0, cnt_ = 0;
         #if SA_COMPRESSION
-        uint64_t tim = __rdtsc();
-        fmi->get_sa_entries_prefetch(&matchArray[smem_ptr], sa_coord, &cnt_,
-                                     pos - smem_ptr + 1, opt->max_occ, tid, id);  // sa compressed prefetch
-        tprof[MEM_SA][tid] += __rdtsc() - tim;
+        if (sa_across)
+        {
+            /* Start a new chunk when this read's run falls outside the resolved
+             * one. Chunk boundaries are read-run boundaries, so a read's
+             * positions are never split across two calls and `mypos` stays a
+             * simple cursor from the chunk's base. */
+            if (smem_ptr >= chunk_end)
+            {
+                int64_t need = 0, si = smem_ptr;
+                while (si < num_smem)
+                {
+                    /* Extend by one whole read-run (matchArray is rid-grouped). */
+                    int64_t run_start = si, run_need = 0;
+                    int32_t rid_cur = matchArray[si].rid;
+                    while (si < num_smem && matchArray[si].rid == rid_cur)
+                    {
+                        int64_t occ = matchArray[si].s;
+                        run_need += occ < opt->max_occ ? occ : opt->max_occ;
+                        si++;
+                    }
+                    /* Always take at least one run, even if it alone exceeds the
+                     * budget -- a single read must never be split. */
+                    if (need > 0 && need + run_need > sa_chunk_positions)
+                    {
+                        si = run_start;
+                        break;
+                    }
+                    need += run_need;
+                    if (need >= sa_chunk_positions) break;
+                }
+                chunk_end = si;
+                if (need > sa_cap)
+                {
+                    sa_coord = (int64_t *) _mm_realloc(sa_coord, sa_cap, need, sizeof(int64_t));
+                    assert(sa_coord != NULL);
+                    sa_cap = need;
+                }
+                uint64_t tim_sa = __rdtsc();
+                fmi->get_sa_entries_prefetch(&matchArray[smem_ptr], sa_coord, &cnt_,
+                                             chunk_end - smem_ptr, opt->max_occ, tid, id);
+                tprof[MEM_SA][tid] += __rdtsc() - tim_sa;
+                mypos = 0;
+            }
+        }
+        else
+        {
+            mypos = 0;   /* per-read path: sa_coord is rewritten for each read */
+            uint64_t tim = __rdtsc();
+            fmi->get_sa_entries_prefetch(&matchArray[smem_ptr], sa_coord, &cnt_,
+                                         pos - smem_ptr + 1, opt->max_occ, tid, id);  // sa compressed prefetch
+            tprof[MEM_SA][tid] += __rdtsc() - tim;
+        }
+        #else
+        mypos = 0;
         #endif
 
         for (i = smem_ptr; i <= pos; i++)


### PR DESCRIPTION
Credit to Benjamin Demaille, who found this in his Rust port ([`bwa-mem3-rs` 1c8e92c](https://github.com/IPNP-BIPN/bwa-mem3-rs)) and measured `get_sa_batch` at 18.8% of genome-scale `-t1` runtime. This is the C++ equivalent, with the diagnosis re-derived on this codebase because the two kernels differ (see below).

## The problem

`FMI_search::get_sa_entries_prefetch` is a 20-lane software-pipelined refill loop over independent compressed-SA walks — each lane prefetches its next `cp_occ`/SA line while the others advance, overlapping ~20 DRAM misses. `mem_chain_seeds` called it **once per read**.

Instrumenting it (hg38, 1M smoke, `-t8`) showed the pipeline is starved, not saturated:

```
pos/call = 57.0 (mean)   occupancy = 10.47 / 20 lanes

rounds by active lanes:
   1 lane : 20.2%    <- fully serialized DRAM latency
   2 lanes: 10.3%
   ...
  20 lanes: 39.9%
```

The mean of 57 is a mirage — the distribution is heavily skewed and **59% of calls supply fewer positions than there are lanes**, so refill has nothing to draw from and the pipeline drains into a serialized tail.

Note this is a *different* diagnosis from the Rust port. Rust `get_sa_batch` is a fixed 32-slot window with no refill (42 positions = 1.3 windows, never reaches steady state). The C++ kernel is the better design — it refills — but it is still supply-starved because the supply is one read at a time.

> This also corrects the conclusion of an earlier internal finding that swept the lane *width* {12,20,32,40}, found it flat, and closed the axis as "MLP saturated." The sweep was correct but varied width against a starved per-read *supply* — you cannot fill 20 lanes from a pool of 8 positions. Width and supply are independent; only width had been tested.

## The change

`mem_chain_seeds` already receives the whole kt_for batch (512/1024 reads) in `matchArray`, rid-sorted and rid-grouped — per-read scoping was just loop nesting. The fix resolves a **read-run-aligned chunk** of reads per call, capped at 16k positions, and lets `mypos` run as a cursor from the chunk base instead of resetting per read.

Chunking (rather than one whole-batch call) is required for two independent reasons:
1. **Memory** — a whole-batch resolve is unbounded on repetitive input, and `get_sa_entries_prefetch`'s staging is grow-only `thread_local`, so one bad batch would pin a large high-water for the process lifetime.
2. **Cache** — whole-batch staging (~930 KB) spills L2.

A chunk sweep from 1k to 256k positions is flat, so 16k is a comfortable default, not a tuned one. `BWA3_SA_PER_READ=1` restores the per-read call for A/B; the chunk size is a compile-time `constexpr`.

## Correctness — byte-identical

Byte-identical **by construction**: the staging loop enumerates each SMEM's occurrences with the same stride/cap rule the consumer uses, and chunk boundaries fall on read-run boundaries, so a chunk's `coordArray` is the exact concatenation of the per-read ones it covers. The invariant does not depend on `matchArray`'s sort order. A read skipped for `l_seq < min_seed_len` provably owns zero SMEMs (every emitter gates on `(n-m+1) >= min_seed_len`), so the cursor cannot desync.

Verified: 10,030,797-record WGS SAM `cmp`-clean vs `BWA3_SA_PER_READ=1` on **four machines** (arm64 macOS M2, Graviton4, Sapphire Rapids, Zen3), at chunk sizes 1, 64, 1024, 16384, 262144. Also byte-identical on PE and SE smoke sets.

## Performance

hg38, WGS 5M PE, `-t16`, on quiet dedicated hosts, 4 interleaved reps each, every run validated on exit code + record count, per-arm ranges non-overlapping:

| Host | µarch | SMT | MEM_SA | Kernel |
|---|---|---|---|---|
| c8g.4xlarge | Graviton4 / NEON | no | **−27.6%** | **−2.4%** |
| c7i.4xlarge | Sapphire Rapids / AVX-512 | 2 | **−23.6%** | **−2.1%** |
| c6a.4xlarge | EPYC Zen3 / AVX2 | 2 | **−21.2%** | **−2.0%** |

The SMT ordering is what the mechanism predicts — a sibling hyperthread already supplies some MLP, so there is less starvation to recover. The effect shrinks on SMT x86 but does not invert, so this ships **unconditional** (unlike `bwtSeedStrategyAllPosOneThread_lockstep`, which does regress on SMT x86 and is arch-gated).

Kernel is ~53% of wall in this config, so the wall effect (~1.3%) sits under the ±2s run-to-run noise from SAM writing and gzip input — **the kernel number is the one to quote.**

## Notes

- No SW-kernel code is touched, so the bsw-bench gate does not apply.
- **Position sorting was tried and does not pay off here — not pursued.** Resolving the pooled positions in ascending BWT-row order (`BWA3_SA_SORT` in the Rust port, where it was the larger `-t1` lever) was implemented and measured at `-t16` on Graviton4 and Sapphire Rapids: it *regresses* MEM_SA by +22% / +27% vs plain pooling, nearly erasing the cross-read win on Intel. The walk is already MLP-saturated (a lane-width sweep confirms the knee is <=20), so improving per-miss locality cannot shorten the critical path, while the O(n log n) sort + scatter/gather is pure added work that all 16 threads contend on. The Rust `-t1` win does not transfer to the saturated multi-thread regime this fork targets. (A separate `-t1` SE workload does still show residual SA-stage margin over the Rust port, so sorting may help single-threaded; that regime is out of scope here.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved SAM/SA hit resolution by prefetching and processing SA information in larger read-aligned chunks.
  * Added a runtime option to switch between per-read processing and cross-read chunk processing to optimize throughput.
  * Chunked prefetching includes bounded staging to keep processing efficient while maintaining ordering.
* **Bug Fixes**
  * Improved robustness and safety when handling SA-coordinate data across multiple reads, including safer buffer growth behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->