### PR TITLE
fix(mem): guard extension-buffer growth against int32 offset overflow

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -2807,6 +2807,21 @@ static inline int get_rlen(int n_cigar, const uint32_t *cigar)
 /************************ New functions, version2*****************************************/
 #define _get_pac(pac, l) ((pac)[(l)>>2]>>((~(l)&3)<<1)&3)
 
+void seqbuf_capacity_fatal(const char *buf_name, const char *func,
+                           int64_t current) {
+    fprintf(stderr,
+            "ERROR: %s in %s cannot grow past the int32 offset range "
+            "(at %lld bytes).\n"
+            "  The extension buffers are sized on a short-read model, so a "
+            "block of very long reads\n"
+            "  (HiFi/ONT) can exhaust them. Reduce the reads per block "
+            "(lower -K, or fewer threads),\n"
+            "  or split the input. Continuing would index outside the "
+            "allocation.\n",
+            buf_name, func, (long long)current);
+    exit(EXIT_FAILURE);
+}
+
 void* _mm_realloc(void *ptr, int64_t csize, int64_t nsize, int16_t dsize) {
     if (nsize <= csize)
     {
@@ -3756,9 +3771,11 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                         fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufQers in %s (left)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_qer;
-                        *wsize_buf_qer *= 2;
+                        *wsize_buf_qer = seqbuf_grow_capacity(tmp);
+                        if (*wsize_buf_qer == SEQBUF_CAPACITY_OVERFLOW)
+                            seqbuf_capacity_fatal("seqBufQer", __func__, tmp);
                         assert(*wsize_buf_qer > leftQerOffset);
-                        
+
                         uint8_t *seqBufQer_ = (uint8_t*)
                             _mm_realloc(seqBufLeftQer, tmp, *wsize_buf_qer, sizeof(uint8_t));
                         mmc->seqBufLeftQer[tid*CACHE_LINE] = seqBufLeftQer = seqBufQer_;
@@ -3778,7 +3795,10 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                         fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufRefs in %s (left)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_ref;
-                        *wsize_buf_ref *= 2;
+                        *wsize_buf_ref = seqbuf_grow_capacity(tmp);
+                        if (*wsize_buf_ref == SEQBUF_CAPACITY_OVERFLOW)
+                            seqbuf_capacity_fatal("seqBufRef", __func__, tmp);
+                        assert(*wsize_buf_ref > leftRefOffset);
                         uint8_t *seqBufRef_ = (uint8_t*)
                             _mm_realloc(seqBufLeftRef, tmp, *wsize_buf_ref, sizeof(uint8_t));
                         mmc->seqBufLeftRef[tid*CACHE_LINE] = seqBufLeftRef = seqBufRef_;
@@ -3988,9 +4008,11 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                         fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufQers in %s (right)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_qer;
-                        *wsize_buf_qer *= 2;
+                        *wsize_buf_qer = seqbuf_grow_capacity(tmp);
+                        if (*wsize_buf_qer == SEQBUF_CAPACITY_OVERFLOW)
+                            seqbuf_capacity_fatal("seqBufQer", __func__, tmp);
                         assert(*wsize_buf_qer > rightQerOffset);
-                        
+
                         uint8_t *seqBufQer_ = (uint8_t*)
                             _mm_realloc(seqBufLeftQer, tmp, *wsize_buf_qer, sizeof(uint8_t));
                         mmc->seqBufLeftQer[tid*CACHE_LINE] = seqBufLeftQer = seqBufQer_;
@@ -4006,7 +4028,10 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                         fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufRefs in %s (right)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_ref;
-                        *wsize_buf_ref *= 2;
+                        *wsize_buf_ref = seqbuf_grow_capacity(tmp);
+                        if (*wsize_buf_ref == SEQBUF_CAPACITY_OVERFLOW)
+                            seqbuf_capacity_fatal("seqBufRef", __func__, tmp);
+                        assert(*wsize_buf_ref > rightRefOffset);
                         uint8_t *seqBufRef_ = (uint8_t*)
                             _mm_realloc(seqBufLeftRef, tmp, *wsize_buf_ref, sizeof(uint8_t));
                         mmc->seqBufLeftRef[tid*CACHE_LINE] = seqBufLeftRef = seqBufRef_;

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -45,6 +45,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include <stdio.h>
 #include <assert.h>
 #include <limits.h>
+#include <stdint.h>   /* INT32_MAX -- seqbuf_grow_capacity() bound */
 #include <math.h>
 #include <vector>
 #include "kstring.h"
@@ -440,6 +441,35 @@ int mem_kernel2_core(FMI_search *fmi, const mem_opt_t *opt,
                      const uint8_t  *meth_orig_pac = NULL);
 
 void* _mm_realloc(void *ptr, int64_t csize, int64_t nsize, int16_t dsize);
+
+/* Sentinel returned by seqbuf_grow_capacity() when the doubled capacity could
+ * no longer be addressed by an int32 offset. */
+#define SEQBUF_CAPACITY_OVERFLOW ((int64_t)-1)
+
+/* Double a seqBuf* capacity, refusing to exceed the int32 offset range.
+ *
+ * Offsets into the extension buffers reach the SW kernels via SeqPair.idr/.idq
+ * (src/bandedSWA.h), which are int32_t, while the accumulators that feed them
+ * are int64_t. A capacity above INT32_MAX therefore yields offsets that narrow
+ * to a negative index on assignment, and the kernel then indexes outside the
+ * allocation. Long-read blocks reach this in ~5 doublings because the buffers
+ * are sized on a short-read model (MAX_SEQ_LEN_REF bytes of reference span per
+ * seed), so returning the sentinel here is what stops silent corruption.
+ *
+ * Returns the doubled capacity, or SEQBUF_CAPACITY_OVERFLOW if it would exceed
+ * what an int32 offset can address. */
+static inline int64_t seqbuf_grow_capacity(int64_t current) {
+    if (current > ((int64_t)INT32_MAX) / 2) return SEQBUF_CAPACITY_OVERFLOW;
+    return current * 2;
+}
+
+/* Report an unrepresentable seqBuf* growth and abort.
+ *
+ * Bounding memory properly requires flushing the accumulated SW batch when the
+ * buffers fill rather than growing without limit; until that exists, failing
+ * loudly with an actionable message beats corrupting the heap. */
+void seqbuf_capacity_fatal(const char *buf_name, const char *func,
+                           int64_t current);
 
 void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                                    const uint8_t *pac, bseq1_t *seq_, int nseq,

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -1445,7 +1445,10 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
                     fprintf(stderr, "[0000][%0.4d] Re-allocating (doubling) seqBufRefs in %s\n",
                             tid, __func__);
                     int64_t tmp = *wsize_buf_ref;
-                    *wsize_buf_ref *= 2;
+                    *wsize_buf_ref = seqbuf_grow_capacity(tmp);
+                    if (*wsize_buf_ref == SEQBUF_CAPACITY_OVERFLOW)
+                        seqbuf_capacity_fatal("seqBufRef", __func__, tmp);
+                    assert(*wsize_buf_ref > refOffset + sp.len1);
 
                     uint8_t *seqBufRef_ = (uint8_t*)
                         _mm_realloc(seqBufRef, tmp, *wsize_buf_ref, sizeof(uint8_t)); 
@@ -1462,7 +1465,10 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
                     fprintf(stderr, "[0000][%0.4d] Re-allocating (doubling) seqBufQers in %s\n",
                             tid, __func__);
                     int64_t tmp = *wsize_buf_qer;
-                    *wsize_buf_qer *= 2;
+                    *wsize_buf_qer = seqbuf_grow_capacity(tmp);
+                    if (*wsize_buf_qer == SEQBUF_CAPACITY_OVERFLOW)
+                        seqbuf_capacity_fatal("seqBufQer", __func__, tmp);
+                    assert(*wsize_buf_qer > qerOffset + sp.len2);
 
                     uint8_t *seqBufQer_ = (uint8_t*)
                         _mm_realloc(seqBufQer, tmp, *wsize_buf_qer, sizeof(uint8_t)); 

--- a/test/unit/test_seqbuf_capacity_guard.cpp
+++ b/test/unit/test_seqbuf_capacity_guard.cpp
@@ -1,0 +1,66 @@
+// test/unit/test_seqbuf_capacity_guard.cpp
+//
+// Regression test for silent int32 truncation of seqBuf* offsets.
+//
+// The extension buffers (seqBufLeftRef/Qer, seqBufRightRef/Qer) grow by
+// doubling as a read block accumulates per-seed spans. The offsets into those
+// buffers are handed to the SW kernels through SeqPair.idr/.idq, which are
+// int32_t (src/bandedSWA.h). The accumulators feeding them
+// (leftRefOffset/leftQerOffset, bwamem.cpp) are int64_t.
+//
+// Once a buffer doubles past INT32_MAX the narrowing assignment silently
+// produces a negative index, and `seqBufLeftRef + sp.idr` then reads and
+// writes outside the allocation. Long reads reach this: the ref buffer starts
+// at BATCH_SIZE * SEEDS_PER_READ * MAX_SEQ_LEN_REF and a HiFi/ONT block needs
+// far more span per seed than the 256-byte-per-seed model assumes.
+//
+// seqbuf_grow_capacity() is the single choke point: it refuses to report a
+// capacity that cannot be addressed by an int32 offset.
+
+#include "doctest/doctest.h"
+#include "../../src/bwamem.h"
+#include "../../src/bandedSWA.h"
+#include "../../src/macro.h"
+
+#include <cstdint>
+
+TEST_CASE("seqbuf_grow_capacity: ordinary growth doubles") {
+    CHECK(seqbuf_grow_capacity(1024) == 2048);
+    CHECK(seqbuf_grow_capacity(131072000LL) == 262144000LL);  // initial ref buf
+}
+
+TEST_CASE("seqbuf_grow_capacity: refuses growth past the int32 offset range") {
+    // Largest capacity that still leaves every in-range offset representable.
+    const int64_t kMax = (int64_t)INT32_MAX;
+
+    // Doubling from just under half the range is still fine.
+    CHECK(seqbuf_grow_capacity(kMax / 4) == kMax / 4 * 2);
+
+    // Doubling past INT32_MAX must be refused, not silently returned.
+    CHECK(seqbuf_grow_capacity((int64_t)1 << 30) == SEQBUF_CAPACITY_OVERFLOW);
+    CHECK(seqbuf_grow_capacity(kMax) == SEQBUF_CAPACITY_OVERFLOW);
+}
+
+TEST_CASE("seqbuf_grow_capacity: SeqPair offset fields are the constraint") {
+    // The guard exists because these fields are 32-bit. If they are ever
+    // widened, the guard threshold must be revisited (and this test updated)
+    // rather than left silently over-restrictive.
+    SeqPair sp;
+    CHECK(sizeof(sp.idr) == 4);
+    CHECK(sizeof(sp.idq) == 4);
+}
+
+TEST_CASE("seqbuf_grow_capacity: the overflow is reachable from real sizes") {
+    // Documents reachability rather than asserting a policy: starting from the
+    // shipped initial ref-buffer size, count doublings until the guard trips.
+    // This is what a long-read block actually walks through.
+    int64_t cap = (int64_t)BATCH_SIZE * SEEDS_PER_READ * MAX_SEQ_LEN_REF;
+    int doublings = 0;
+    while (cap != SEQBUF_CAPACITY_OVERFLOW) {
+        cap = seqbuf_grow_capacity(cap);
+        ++doublings;
+        REQUIRE(doublings < 64);  // must terminate
+    }
+    // Reached in a handful of doublings -- not a theoretical concern.
+    CHECK(doublings <= 6);
+}


### PR DESCRIPTION
## Problem

`bwa-mem3 mem` at default settings crashes or corrupts memory on long reads (HiFi/ONT). Reproduced on Graviton4 / AL2023 against hg38:

- **300 ONT reads, `-t 16`:** SIGSEGV (exit 139).
- **10k HiFi/ONT reads, `-t 16`:** OOM-killed (anon-rss 31.7 GB on a 30 GB box, 63.9 GB on a 61 GB box).

## Root cause

The per-thread extension buffers (`seqBufLeftRef/Qer`, `seqBufRightRef/Qer`) grow by doubling as a read block accumulates per-seed spans (`bwamem.cpp` ~3771–4036). Offsets into those buffers reach the SW kernels through `SeqPair.idr`/`.idq`, which are **`int32_t`** (`bandedSWA.h:229`), while the accumulators that feed them (`leftRefOffset`, `leftQerOffset`, …) are `int64_t`.

Once a buffer doubles past `INT32_MAX` (~2 GB), the narrowing assignment `sp.idr = leftRefOffset` silently produces a **negative** index, and the kernel then reads/writes outside the allocation.

This is reachable at default settings because the buffers are sized on a short-read model — `MAX_SEQ_LEN_REF = 256` bytes of reference span *per seed* — and a single long read needs far more, so the buffers double into the overflow range in a handful of steps. Which symptom you get depends on thread count:

- **High thread count** (16): the doubled buffers exceed RAM first → OOM.
- **Low thread count**: the doubled buffer still fits → the negative-index write **silently corrupts the heap**.

## Fix

Route every doubling site through a single choke point:

```c
static inline int64_t seqbuf_grow_capacity(int64_t current) {
    if (current > ((int64_t)INT32_MAX) / 2) return SEQBUF_CAPACITY_OVERFLOW;
    return current * 2;
}
```

On overflow, `seqbuf_capacity_fatal()` aborts with an actionable message instead of proceeding into the out-of-bounds access. The ref-side sites also gain the `> offset` assert the qer sites already had.

**Scope — this does not make long reads work.** It converts silent corruption / SIGSEGV into a loud, immediate failure:

```
ERROR: seqBufQer in mem_chain2aln_across_reads_V2 cannot grow past the int32 offset range (at 2097152000 bytes).
  The extension buffers are sized on a short-read model, so a block of very long reads
  (HiFi/ONT) can exhaust them. Reduce the reads per block (lower -K, or fewer threads),
  or split the input. Continuing would index outside the allocation.
```

Properly *bounding* memory for long reads requires flushing the accumulated SW batch mid-block, which the left→right `h0` dependency in `mem_chain2aln_across_reads_V2` prevents (right-extension `h0` is the final left-extension alnreg score, patched only after all left SW completes — `bwamem.cpp:3975` vs `4470`). That redesign is filed separately.

## Verification (Graviton4 / AL2023)

**End-to-end, 300 ONT reads:**

| binary | result |
|---|---|
| `origin/main` | exit 139 (SIGSEGV) |
| this branch | exit 1, prints the error above at 2,097,152,000 bytes (= 2 GB, the `INT32_MAX` boundary) |

**Short-read output unaffected** — the guard never trips below 2 GB. Byte-identical (records + non-`@PG` header md5 + record count) on:

| dataset | records | verdict |
|---|---|---|
| WGS 5M PE (1kg HG00096) | 10,030,797 | identical |
| HiC 1M PE (HG002) | 2,383,236 | identical |
| ALT/HLA-enriched PE (117,636 pairs) | 238,992 | identical |

**Unit tests:** `test/unit/test_seqbuf_capacity_guard.cpp` (4 cases) covers the doubling threshold, the overflow refusal, the `int32` field-width invariant, and reachability from the shipped initial buffer size. Full suite: **90/90 pass, 2,902,904 assertions**.

No SW kernel file (`bandedSWA.cpp`, `kswv.cpp`, `ksw.cpp`, `neon_utils.h`, `simd_compat.h`) is touched, so no `bwa-bsw-bench` run applies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented sequence buffer capacity growth from silently exceeding supported offset limits during alignment and mate-rescue processing.
  - Added explicit overflow detection with a fatal error when growth would be unrepresentable in 32-bit offsets.

- **Tests**
  - Added regression coverage for normal growth, overflow detection, and enforcement of 32-bit offset constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->