### PR TITLE
perf(seed): prefetch the correct cp_occ lines in the bwtSeed third round

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -897,28 +897,32 @@ struct FMI_search::BwtSeedSlot {
     SMEM   *match_buf;     // -> thread-local cache slice, sized = max_readlength
 };
 
-// Same-slot T0 prefetch for the next inner-j step. The two CP_OCC blocks
-// the next backwardExt(smem, _) hits are at (smem.k >> CP_SHIFT) and
-// ((smem.k + smem.s) >> CP_SHIFT) — i.e. sp and ep. Matches the call
-// pattern in ls_advance_forward_step's tail prefetch.
+// Same-slot T0 prefetch for the next inner-j step. The bwtSeed walk is
+// forward-only: bsd_advance_step swaps k<->l and calls backwardExt on the
+// swapped interval, so the next occ read lands in cp_occ at (smem.l >> CP_SHIFT)
+// and ((smem.l + smem.s) >> CP_SHIFT) — i.e. sp and ep of the swapped interval,
+// NOT smem.k. Prefetching smem.k (the un-swapped field) targets the wrong lines,
+// so every continuation-step prefetch was a no-op and each step paid full cp_occ
+// latency. smem.s is unchanged by the k<->l swap.
 void FMI_search::bsd_prefetch_cp_occ(const BwtSeedSlot *s)
 {
 #ifdef ENABLE_PREFETCH
-    _mm_prefetch((const char *)(&cp_occ[(s->smem.k) >> CP_SHIFT]), _MM_HINT_T0);
-    _mm_prefetch((const char *)(&cp_occ[(s->smem.k + s->smem.s) >> CP_SHIFT]), _MM_HINT_T0);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.l) >> CP_SHIFT]), _MM_HINT_T0);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.l + s->smem.s) >> CP_SHIFT]), _MM_HINT_T0);
 #else
     (void)s;
 #endif
 }
 
-// Cross-slot T1 (L2) prefetch — same two-line target as T0 but at L2
-// hint, used in the driver's (s + N/2) % N lookahead to cover DRAM-class
-// latency when cp_occ spills out of L3.
+// Cross-slot T1 (L2) prefetch — same two-line target as T0 (the swapped
+// interval at smem.l; see bsd_prefetch_cp_occ) but at L2 hint, used in the
+// driver's (s + N/2) % N lookahead to cover DRAM-class latency when cp_occ
+// spills out of L3.
 void FMI_search::bsd_prefetch_cp_occ_t1(const BwtSeedSlot *s)
 {
 #ifdef ENABLE_PREFETCH
-    _mm_prefetch((const char *)(&cp_occ[(s->smem.k) >> CP_SHIFT]), _MM_HINT_T1);
-    _mm_prefetch((const char *)(&cp_occ[(s->smem.k + s->smem.s) >> CP_SHIFT]), _MM_HINT_T1);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.l) >> CP_SHIFT]), _MM_HINT_T1);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.l + s->smem.s) >> CP_SHIFT]), _MM_HINT_T1);
 #else
     (void)s;
 #endif


### PR DESCRIPTION
## Summary

The third seeding round (`bwtSeedStrategy`) prefetched the wrong `cp_occ` cache lines on every continuation step, so the prefetch was effectively a no-op and each forward-extension step paid the full `cp_occ` load latency.

## The bug

The third round is forward-only. `bsd_advance_step` implements forward extension as a backward extension on the reverse complement: it swaps the interval's `k` and `l`, calls `backwardExt` on the swapped interval, and swaps back. `backwardExt` therefore reads `cp_occ` at the *swapped* sp/ep — i.e. at `smem.l` and `smem.l + smem.s`, **not** at `smem.k`.

`bsd_prefetch_cp_occ` (and its T1 lookahead variant) prefetched `smem.k`, the un-swapped field — the wrong lines. Every continuation-step prefetch missed, and the walk ran exposed to `cp_occ` latency.

## The fix

Prefetch the lines `backwardExt(swapped)` actually reads: `smem.l` and `smem.l + smem.s` (`smem.s` is unchanged by the `k`/`l` swap). One-line change in each of the two prefetch helpers, plus corrected comments.

## Correctness

Byte-identical by construction — a prefetch hint cannot change a computed value. Verified md5-identical SAM and unchanged record counts on a 200k-read single-end set. No result-affecting code changes, so the `bwa-bsw-bench` SW-kernel gate does not apply.

## Performance

Graviton4 (`c8g`, `-t1`, 200k reads, 2×150 SE), within-binary A/B via a temporary toggle so only the prefetch address differs:

| metric | before (prefetch `smem.k`) | after (prefetch `smem.l`) |
|---|---|---|
| third-round stage | 34.6 ns / FM step | **28.8 ns / FM step (−16%)** |
| end-to-end user CPU | — | **~−1%** (the round is ~5% of single-thread runtime) |

The fix is width-independent: a wrong-address prefetch is not recovered by keeping more lockstep walks in flight, which is why an earlier sweep of `BWTSEED_LOCKSTEP_N` over this round read flat. FM-step counts are identical before and after (same walks, same work); only the per-step latency changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BWT-seed processing so backward-extension steps access the correct occurrence data.
  * Fixed same-slot and cross-slot lookahead behavior, improving processing accuracy and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->