### PR TITLE
feat(meth): NEUTRAL --meth-scoring (TAPS default) + batched kswv rescue

### DIFF
--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -67,17 +67,21 @@ Methylation (--meth) options:
                    emseq  bisulfite/EM-seq, UNmethylated C converts [default]
                           (aliases: em-seq, bisulfite)
                    taps   TET-assisted pyridine borane, METHYLATED C converts;
-                          also defaults --meth-scoring to genomic
+                          also defaults --meth-scoring to neutral
                  NOTE: use --meth=taps (with '='), not --meth taps. Running TAPS
                  data without =taps inverts every methylation call.
-   --meth-scoring collapsed|genomic
+   --meth-scoring collapsed|genomic|neutral
                  scoring mode. Default depends on chemistry: collapsed for
-                 --meth/--meth=emseq, genomic for --meth=taps (TAPS conversions
+                 --meth/--meth=emseq, neutral for --meth=taps (TAPS conversions
                  are sparse, so collapsing costs specificity it can't repay).
-                 collapsed: C/T (and G/A)
-                 interchangeable, bwameth-compatible placement (sets -B 2).
-                 genomic: free only the conversion direction, keep variants as
-                 mismatches (variant-aware, truthful NM/MD; -B 4).
+                 collapsed: C/T (and G/A) interchangeable, bwameth-compatible
+                 placement (sets -B 2).
+                 genomic: free only the conversion direction, scored as a full
+                 match, keep variants as mismatches (variant-aware, truthful
+                 NM/MD; -B 4).
+                 neutral: free only the conversion direction but score it 0
+                 (tolerated, not rewarded); best for TAPS (variant-aware,
+                 truthful NM/MD; -B 4).
    --set-as-failed f|r
                  flag alignments to the matching strand ('f' or 'r') as QC-fail (0x200)
    --chimera-qc

--- a/docs/src/best-practices/methylation.md
+++ b/docs/src/best-practices/methylation.md
@@ -5,8 +5,9 @@ bwameth.py reference implementation (in the default `collapsed` scoring mode).
 This page is prescriptive: when to keep those defaults and when to override them.
 For *what* the flags are and *how* the scoring modes work, see the reference:
 
-- **Scoring modes (`collapsed` vs `genomic`) and the full `--meth` flag set** —
-  [Methylation Reference → Flags](../methylation/flags.md#--meth-scoring-collapsedgenomic).
+- **Scoring modes (`collapsed`, `genomic`, `neutral`) and the full `--meth` flag
+  set** —
+  [Methylation Reference → Flags](../methylation/flags.md#--meth-scoring-collapsedgenomicneutral).
 - **Placement compatibility with bwameth.py** (the default `collapsed` mode is a
   placement drop-in, *not* byte-identical — ~1% of records differ in
   `POS`/`CIGAR`/`MAPQ`, so **re-validate if you are pinned to a specific bwameth

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -164,16 +164,18 @@ individual flags are unaffected.
 > **Note — --meth overrides scoring defaults**
 >
 > When `--meth` is active, bwa-mem3 applies `-L 10 -U 100 -T 40 -M -C` plus a
-> mode-dependent mismatch penalty: `-B 2` for `--meth-scoring collapsed` (default,
-> bwameth-compatible) and `-B 4` for `--meth-scoring genomic`. This mirrors
-> bwameth's `bwa mem -T 40 -B 2 -L 10 -CM` (with `-U 100` for paired-end). The
-> scoring values (`-B`, `-L`, `-U`, `-T`) can still be overridden by passing the
-> flag explicitly, in any position relative to `--meth`; `-M` and `-C` cannot,
-> since bwa has no option that unsets them.
+> mode-dependent mismatch penalty: `-B 2` for `--meth-scoring collapsed` (the
+> `--meth`/`--meth=emseq` default, bwameth-compatible) and `-B 4` for
+> `--meth-scoring genomic` and `neutral` (`neutral` is the `--meth=taps` default).
+> This mirrors bwameth's `bwa mem -T 40 -B 2 -L 10 -CM` (with `-U 100` for
+> paired-end). The scoring values (`-B`, `-L`, `-U`, `-T`) can still be overridden
+> by passing the flag explicitly, in any position relative to `--meth`; `-M` and
+> `-C` cannot, since bwa has no option that unsets them.
 >
 > Those constants are quoted at bwameth's match score (`-A 1`) and scale with
 > `-A` like every other score-derived default above: under `-A 2` the effective
-> values are `-L 20 -U 200 -T 80` and `-B 4` (collapsed) / `-B 8` (genomic).
+> values are `-L 20 -U 200 -T 80` and `-B 4` (collapsed) / `-B 8` (genomic and
+> neutral).
 
 ### Paired-end
 
@@ -398,13 +400,17 @@ index is not used directly — rebuild with `index --meth` (see
 
 See [Methylation Reference](../methylation/overview.md) for the full treatment.
 
-#### `--meth-scoring {collapsed|genomic}` — bisulfite scoring model
+#### `--meth-scoring {collapsed|genomic|neutral}` — bisulfite/TAPS scoring model
 
-Selects how the 4-letter matrix treats converted bases. `collapsed` (default)
-frees C↔T and G↔A both ways (bwameth-compatible placement, sets `-B 2`); `genomic`
-frees only the conversion direction, keeping real variants as mismatches
-(variant-aware, truthful `NM`/`MD`, keeps `-B 4`). Only meaningful with `--meth`.
-See [Flags → --meth-scoring](../methylation/flags.md#--meth-scoring-collapsedgenomic).
+Selects how the 4-letter matrix treats converted bases. `collapsed` (the
+`--meth`/`--meth=emseq` default) frees C↔T and G↔A both ways (bwameth-compatible
+placement, sets `-B 2`); `genomic` frees only the conversion direction scored as
+a full match, keeping real variants as mismatches (variant-aware, truthful
+`NM`/`MD`, keeps `-B 4`); `neutral` (the `--meth=taps` default) frees only the
+conversion direction but scores it `0` — tolerated, not rewarded — best for the
+sparse conversions of TAPS (keeps `-B 4`, truthful `NM`/`MD`). Only meaningful
+with `--meth`.
+See [Flags → --meth-scoring](../methylation/flags.md#--meth-scoring-collapsedgenomicneutral).
 
 #### `--set-as-failed {f|r}` — strand QC-fail flag
 

--- a/docs/src/getting-started/quick-meth.md
+++ b/docs/src/getting-started/quick-meth.md
@@ -13,7 +13,8 @@ postprocessing step are required.
 > are pinned to a specific bwameth release (see
 > [bwameth.py drop-in mapping](../methylation/bwameth-mapping.md)). Add
 > `--meth-scoring genomic` to opt into variant-aware scoring (truthful `NM`/`MD`; one BAM for both
-> methylation and variant calling).
+> methylation and variant calling), or `--meth-scoring neutral` — the `--meth=taps` default — which
+> is variant-aware too but scores the conversion `0` instead of a match.
 
 ## Index the reference for methylation
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,8 +14,9 @@ support for things you used to need a wrapper script for.
   measurable wall-clock wins on real workloads.
 - **Methylation in one binary.** A `--meth` flag adds native bisulfite/EM-seq
   alignment: bwameth-compatible read *placement* by default
-  (`--meth-scoring collapsed`), or variant-aware scoring on request
-  (`--meth-scoring genomic`). No Python, no inline conversion script, no separate
+  (`--meth-scoring collapsed`), or variant-aware scoring (`--meth-scoring
+  genomic`, or `neutral` — the TAPS default — which tolerates a conversion
+  without rewarding it). No Python, no inline conversion script, no separate
   post-processing step. One `bwa-mem3 index --meth ref.fa`, one
   `bwa-mem3 mem --meth ref.fa R1.fq R2.fq`, done — headers consolidated and
   Bismark tags emitted.

--- a/docs/src/methylation/bwameth-mapping.md
+++ b/docs/src/methylation/bwameth-mapping.md
@@ -69,9 +69,11 @@ environment, no bwameth.py version pinning.
 **No intermediate files.** No converted FASTQ is written; the C→T / G→A projection
 is applied in-memory to the seeding copy of each read.
 
-**Variant-aware option.** `--meth-scoring genomic` scores real C/T and G/A
-variants as mismatches, so a single BAM supports both methylation calling and
-variant calling — something a collapsed-space aligner cannot produce.
+**Variant-aware options.** `--meth-scoring genomic` and `--meth-scoring neutral`
+(the `--meth=taps` default) both score real C/T and G/A variants as mismatches, so
+a single BAM supports both methylation calling and variant calling — something a
+collapsed-space aligner cannot produce. They differ only in what the *conversion*
+cell scores: a full match under `genomic`, `0` under `neutral`.
 
 **Inline BAM post-processing.** Header rewriting, Bismark `XR`/`XG`/`XM` tags,
 opt-in chimera QC (`--chimera-qc`), and QC-fail propagation happen in the same
@@ -79,8 +81,8 @@ pass. Output is uncompressed BAM (`wb0`) that `samtools sort` reads natively.
 
 **bwameth-aligned defaults (collapsed).** `--meth-scoring collapsed` applies
 `-B 2 -L 10 -U 100 -T 40 -M -C`, mirroring bwameth's `bwa mem -T 40 -B 2 -L 10
--CM` (plus `-U 100` for paired-end). `genomic` uses the same set but keeps
-`-B 4`. The scoring parameters (`-B`, `-L`, `-U`, `-T`) can be overridden on the
+-CM` (plus `-U 100` for paired-end). `genomic` and `neutral` use the same set but
+keep `-B 4`. The scoring parameters (`-B`, `-L`, `-U`, `-T`) can be overridden on the
 command line, in any position relative to `--meth`. `-M` and `-C` cannot: bwa
 has no option that unsets them, so `--meth` applies them unconditionally.
 

--- a/docs/src/methylation/conversion.md
+++ b/docs/src/methylation/conversion.md
@@ -58,17 +58,24 @@ After seeds are remapped to original coordinates with their OT/OB hypothesis,
 - **OT** frees ref-`C` × read-`T` (the expected unmethylated C→T conversion).
 - **OB** frees ref-`G` × read-`A` (the expected bottom-strand G→A conversion).
 
-Under `--meth-scoring collapsed` (default) the mirror cell is freed too (ref-`T` ×
-read-`C`, ref-`A` × read-`G`), so C/T and G/A are interchangeable and placement
-matches bwameth. Under `--meth-scoring genomic` only the conversion direction is
-freed, so a real variant stays a mismatch. See
-[Overview → `--meth-scoring`](overview.md#two-scoring-modes---meth-scoring).
+Under `--meth-scoring collapsed` (the `--meth` / `--meth=emseq` default) the mirror
+cell is freed too (ref-`T` × read-`C`, ref-`A` × read-`G`), so C/T and G/A are
+interchangeable and placement matches bwameth. Under `--meth-scoring genomic` only
+the conversion direction is freed, scored as a full match. Under
+`--meth-scoring neutral` (the `--meth=taps` default) only the conversion direction
+is freed as well, but it scores `0` rather than a match: a converted base is
+tolerated, not rewarded. Both `genomic` and `neutral` leave the mirror cell a real
+mismatch, so a genuine variant stays a mismatch and `NM`/`MD` remain variant-aware.
+See [Overview → `--meth-scoring`](overview.md#three-scoring-modes---meth-scoring).
 
 The seed's own ungapped score is recomputed in the same matrix (not assumed to be
 a perfect `len × match`), so under `--meth-scoring genomic` a seed-internal C/T or
 G/A variant correctly lowers the alignment score, `AS`, and `MAPQ`. Under
 `--meth-scoring collapsed` the mirror cell is freed, so such a variant is scored
-as a conversion and does not penalize placement.
+as a conversion and does not penalize placement. Under `--meth-scoring neutral` the
+mirror cell is a mismatch as in `genomic`, and a seed-internal converted base
+contributes `0` instead of a match — so a conversion lowers `AS` relative to
+`genomic`, just by less than a mismatch would.
 
 ## Sequence restoration in the BAM SEQ field
 

--- a/docs/src/methylation/flags.md
+++ b/docs/src/methylation/flags.md
@@ -42,31 +42,41 @@ identical either way.
 > as `1 − truth`, silently. Always pass `=taps` for TAPS libraries, or suppress
 > `XM:Z` and call with a TAPS-aware extractor such as Rastair.
 
-**Scoring default.** `--meth=taps` defaults `--meth-scoring` to `genomic`
+**Scoring default.** `--meth=taps` defaults `--meth-scoring` to `neutral`
 (bare `--meth` still defaults to `collapsed`). TAPS converts only the methylated
 cytosines, so conversions are far sparser than under EM-seq — 3.2 % of cytosines
 versus 94.6 % on a matched chr22 simulation — and the collapsed 3-letter alphabet
-costs specificity it no longer buys back. Measured placement on the same TAPS set:
-`genomic` 95.72 %, plain 95.53 %, `collapsed` 95.40 %, against a 96.02 %
-unconverted baseline; `genomic` also placed 136 k more reads in the MAPQ 60+ bin
-at higher accuracy. An explicit `--meth-scoring` always wins.
+costs specificity it no longer buys back. `neutral` goes one step past `genomic`:
+it scores the conversion cell as `0` rather than a full match, so a sparse TAPS
+conversion is *tolerated* without *rewarding* spurious C→T alignments. Measured on
+4.07 M simulated TAPS reads against full hg38, across three methylation loads:
+`neutral` placed 95.95–96.01 % (essentially the 96.02 % unconverted ceiling),
+`genomic` 95.68–95.73 %, `collapsed` 95.37–95.43 % — a robust +0.24–0.28 pp over
+`genomic` — with **identical** MAPQ calibration (60+ bin 99.99 % either way) and
+`NM` (mean 1.966 vs 1.969), so the gain is not bought with over-confidence or
+inflated edit distance. An explicit `--meth-scoring` always wins.
 
-## `--meth-scoring {collapsed|genomic}`
+## `--meth-scoring {collapsed|genomic|neutral}`
 
-Selects how the 4-letter scoring matrix treats bisulfite-converted bases.
-`bwa-mem3 --meth` scores against the original reference, so it can either collapse
-the conversion (bwameth-style) or keep it variant-aware.
+Selects how the 4-letter scoring matrix treats bisulfite/TAPS-converted bases.
+`bwa-mem3 --meth` scores against the original reference, so it can collapse the
+conversion (bwameth-style), keep it variant-aware, or merely tolerate it.
 
 **Accepted values:**
 
-- `collapsed` (**default**) — free **both** conversion directions: C↔T *and* G↔A
-  are interchangeable (a two-cell matrix). Reproduces bwameth's collapsed-space
-  **placement** and sets the mismatch penalty to `-B 2`. Use this when you need
-  bwameth-compatible read placement (the drop-in default).
-- `genomic` — free **only** the conversion direction (a one-cell matrix), so the
-  mirror cell stays a real mismatch. A genuine C/T or G/A variant is penalized,
-  making `NM`/`MD` truthful and the BAM usable for variant calling. Keeps bwa's
-  default `-B 4`.
+- `collapsed` (**default for `--meth`/`--meth=emseq`**) — free **both** conversion
+  directions: C↔T *and* G↔A are interchangeable (a two-cell matrix). Reproduces
+  bwameth's collapsed-space **placement** and sets the mismatch penalty to `-B 2`.
+  Use this when you need bwameth-compatible read placement (the drop-in default).
+- `genomic` — free **only** the conversion direction (a one-cell matrix), scored
+  as a full match (`+A`), so the mirror cell stays a real mismatch. A genuine C/T
+  or G/A variant is penalized, making `NM`/`MD` truthful and the BAM usable for
+  variant calling. Keeps bwa's default `-B 4`.
+- `neutral` (**default for `--meth=taps`**) — free only the conversion direction,
+  but score it `0` rather than `+A`: tolerated but not rewarded. Best for TAPS,
+  whose conversions are sparse, where a full-match reward over-credits spurious
+  C→T alignments (see the measurement above). Keeps `-B 4`; the mirror cell stays
+  a mismatch, so `NM`/`MD` remain truthful.
 
 > **Important — `collapsed` is a placement drop-in, not byte-identical to bwameth**
 >
@@ -81,23 +91,28 @@ the conversion (bwameth-style) or keep it variant-aware.
 The mode changes alignment score, `MAPQ`, `NM`, `MD`, and occasionally placement
 and CIGAR. On a real C/T (or G/A) variant under a seed, `genomic` lowers the
 score by `-A + -B` (the match score plus the mismatch penalty) relative to
-`collapsed` — the freed match becomes a mismatch —
-which can break paralog ties in `genomic`'s favor and avoid spurious indels. The
-Bismark `XR`/`XG`/`XM` tags and the `SEQ` field are identical in both modes.
+`collapsed` — the freed match becomes a mismatch — which can break paralog ties
+in `genomic`'s favor and avoid spurious indels. `neutral` scores the conversion
+at `0`, i.e. `-A` relative to `genomic`, so a converted base neither helps nor
+hurts a seed the way a match or mismatch would; it is the strictest of the three.
+The Bismark `XR`/`XG`/`XM` tags and the `SEQ` field are identical in all modes.
 
 **When to use it:**
 
 Keep `collapsed` for methylation-only workflows that must match bwameth placement
 (e.g. clinical pipelines validated against a bwameth release). Choose `genomic`
 when you want one BAM that serves both methylation *and* variant calling, or want
-the aligner to distinguish real variants from conversions.
+the aligner to distinguish real variants from conversions. Prefer `neutral` for
+TAPS (its default), where conversions are sparse and rewarding them as matches
+costs placement specificity — it is truthful for variant calling like `genomic`
+while placing sparse-conversion reads more accurately.
 
 > **Note — `-B` follows the mode, but you can override it**
 >
-> `collapsed` sets `-B 2` and `genomic` keeps `-B 4` by default. An explicit
-> `-B` overrides the mode default and still reaches the per-strand matrices,
-> whether it appears before or after `--meth`. The other `--meth` defaults
-> (`-L 10 -U 100 -T 40 -M -C`) are the same in both modes.
+> `collapsed` sets `-B 2`; `genomic` and `neutral` keep `-B 4` by default. An
+> explicit `-B` overrides the mode default and still reaches the per-strand
+> matrices, whether it appears before or after `--meth`. The other `--meth`
+> defaults (`-L 10 -U 100 -T 40 -M -C`) are the same across modes.
 
 ## `--set-as-failed {f|r}`
 

--- a/docs/src/methylation/overview.md
+++ b/docs/src/methylation/overview.md
@@ -25,23 +25,29 @@ mismatches in `NM`/`MD`.
 
 The non-`--meth` code path is byte-for-byte unchanged.
 
-## Two scoring modes: `--meth-scoring`
+## Three scoring modes: `--meth-scoring`
 
 Because scoring happens in 4-letter space, `--meth` can choose how lenient to be
-about bisulfite-converted bases. This is controlled by `--meth-scoring`:
+about converted bases. This is controlled by `--meth-scoring`:
 
 | Mode | Default? | Matrix | `-B` | Behavior |
 |------|----------|--------|------|----------|
-| **`collapsed`** | **yes** | frees C↔T *and* G↔A both ways (two cells) | `2` | bwameth-compatible **placement** — C/T and G/A are interchangeable, so it closely tracks bwameth's collapsed-space mapping. A close approximation, **not** exact: ~1% of records differ in `POS`/`CIGAR`/`MAPQ`, so re-validate if pinned to a bwameth release. |
-| **`genomic`** | no (opt-in) | frees only the conversion direction (one cell) | `4` | **variant-aware** — a real C/T or G/A variant scores as a mismatch, so `NM`/`MD` are truthful and the BAM is usable for variant calling. |
+| **`collapsed`** | **`--meth` / `--meth=emseq`** | frees C↔T *and* G↔A both ways (two cells), each scored as a full match | `2` | bwameth-compatible **placement** — C/T and G/A are interchangeable, so it closely tracks bwameth's collapsed-space mapping. A close approximation, **not** exact: ~1% of records differ in `POS`/`CIGAR`/`MAPQ`, so re-validate if pinned to a bwameth release. |
+| **`genomic`** | no (opt-in) | frees only the conversion direction (one cell), scored as a full match | `4` | **variant-aware** — a real C/T or G/A variant scores as a mismatch, so `NM`/`MD` are truthful and the BAM is usable for variant calling. |
+| **`neutral`** | **`--meth=taps`** | frees only the conversion direction (one cell), scored `0` | `4` | **variant-aware and conservative** — a conversion is tolerated but not rewarded, so a sparse TAPS conversion no longer over-credits a spurious C→T alignment. `NM`/`MD` stay truthful; measured +0.24–0.28 pp placement over `genomic` on simulated TAPS. |
 
-The default is `collapsed`, so existing methylation pipelines see
-bwameth-compatible read placement unless they explicitly opt into `genomic`.
+The default follows the chemistry: `--meth` and `--meth=emseq` default to
+`collapsed`, so existing methylation pipelines see bwameth-compatible read
+placement unless they explicitly opt into `genomic`; `--meth=taps` defaults to
+`neutral`, because TAPS conversions are sparse (~3% of cytosines vs ~95% under
+EM-seq) and collapsing costs specificity it can no longer repay. An explicit
+`--meth-scoring` always overrides the chemistry default.
+
 `collapsed` closely tracks bwameth's placement and emits the same Bismark tags,
 but it is a placement drop-in — **not** byte-identical: ~1% of records differ in
 `POS`/`CIGAR`/`MAPQ`, so re-validate if you are pinned to a specific bwameth
 release. See [bwameth.py drop-in mapping](bwameth-mapping.md) for the full
-placement-compatibility caveat.
+placement-compatibility caveat, and [TAPS](taps.md) for the `neutral` measurements.
 
 ## Pipeline at a glance
 
@@ -53,7 +59,7 @@ are required.
 flowchart LR
     A[Raw FASTQ\nR1 / R2] -->|project R1 C→T,\nR2 G→A for SEEDING ONLY| B[seed in .meth\ndoubled seed index]
     B -->|remap each seed →\noriginal coords + OT/OB hypothesis| C[extend + SCORE\nORIGINAL read vs ORIGINAL ref\nper-strand asymmetric matrix]
-    C -->|--meth-scoring\ncollapsed / genomic| D[original-alphabet\nalignment]
+    C -->|--meth-scoring\ncollapsed / genomic / neutral| D[original-alphabet\nalignment]
     D -->|XR/XG/XM Bismark tags\noptional --chimera-qc| E[BAM output]
 ```
 
@@ -77,7 +83,7 @@ Steps:
 
 4. **4-letter extension and scoring.** The **original** read is extended and
    scored against the **original** 4-letter reference window using the per-strand
-   asymmetric matrix (see [`--meth-scoring`](#two-scoring-modes---meth-scoring)).
+   asymmetric matrix (see [`--meth-scoring`](#three-scoring-modes---meth-scoring)).
    OT frees ref-`C` × read-`T` (the unmethylated C→T conversion); OB frees
    ref-`G` × read-`A`. The seed's own true score is recomputed in this matrix too,
    so a seed-internal variant correctly lowers the alignment score rather than
@@ -105,16 +111,21 @@ samtools index out.bam
 # Opt into variant-aware scoring (truthful NM/MD; BAM usable for variant calling).
 bwa-mem3 mem --meth --meth-scoring genomic -t 16 ref.fa R1.fq.gz R2.fq.gz \
   | samtools sort -o out.bam
+
+# TAPS: --meth=taps sets the TAPS XM:Z polarity and defaults to neutral scoring.
+bwa-mem3 mem --meth=taps -t 16 ref.fa R1.fq.gz R2.fq.gz \
+  | samtools sort -o out.bam
 ```
 
 > **Note — scoring defaults**
 >
-> `--meth` applies `-L 10 -U 100 -T 40 -M -C` in both modes, plus the
-> mode-dependent mismatch penalty: `-B 2` for `collapsed`, `-B 4` for `genomic`.
-> These mirror bwameth's `bwa mem -T 40 -B 2 -L 10 -CM` (with `-U 100` for
-> paired-end). The scoring values (`-B`, `-L`, `-U`, `-T`) can be overridden on
-> the command line, in any position relative to `--meth`. `-M` and `-C` cannot —
-> bwa has no option that unsets them, so `--meth` applies them unconditionally.
+> `--meth` applies `-L 10 -U 100 -T 40 -M -C` in every mode, plus the
+> mode-dependent mismatch penalty: `-B 2` for `collapsed`, `-B 4` for `genomic`
+> and `neutral`. These mirror bwameth's `bwa mem -T 40 -B 2 -L 10 -CM` (with
+> `-U 100` for paired-end). The scoring values (`-B`, `-L`, `-U`, `-T`) can be
+> overridden on the command line, in any position relative to `--meth`. `-M` and
+> `-C` cannot — bwa has no option that unsets them, so `--meth` applies them
+> unconditionally.
 >
 > These constants are quoted at bwa's default match score (`-A 1`, what bwameth
 > runs). Like every other score-derived default, they scale with `-A`: under

--- a/docs/src/methylation/taps.md
+++ b/docs/src/methylation/taps.md
@@ -43,23 +43,29 @@ either way. See [SAM tags](tags.md#xmz--methylation-call-string).
 | | `--meth` (em-seq) | `--meth=taps` |
 |---|---|---|
 | `XM:Z` polarity | retained `C` = methylated | retained `C` = **un**methylated |
-| `--meth-scoring` default | `collapsed` | **`genomic`** |
+| `--meth-scoring` default | `collapsed` | **`neutral`** |
 | Index, seeding, `XR`/`XG` | identical | identical |
 
 The scoring default differs because TAPS conversions are far sparser — 3.2 % of
 cytosines versus 94.6 % for em-seq on a matched simulation — so the collapsed
-3-letter alphabet costs specificity it can no longer repay. Measured placement
-on simulated TAPS against full hg38:
+3-letter alphabet costs specificity it can no longer repay. `neutral` goes one
+step further than `genomic`: it scores the conversion cell as `0` (tolerated but
+not rewarded) rather than a full match, so a sparse TAPS conversion no longer
+over-credits a spurious C→T alignment. Measured placement on simulated TAPS
+against full hg38, across three methylation loads:
 
 | arm | placement |
 |---|---|
-| `--meth=taps` (i.e. genomic) | **95.72 %** |
-| plain (no `--meth`) | 95.53 % |
-| `--meth` (collapsed) | 95.40 % |
+| `--meth=taps` (i.e. `neutral`) | **95.95–96.01 %** |
+| `--meth-scoring genomic` | 95.68–95.73 % |
+| plain (no `--meth`) | ~95.53 % |
+| `--meth-scoring collapsed` | 95.37–95.43 % |
 | *unconverted baseline* | *96.02 %* |
 
-`genomic` also placed 136 k more reads in the MAPQ 60+ bin at higher accuracy.
-An explicit `--meth-scoring` always overrides the default.
+`neutral` reaches essentially the unconverted ceiling — a robust +0.24–0.28 pp
+over `genomic` — with identical MAPQ calibration (60+ bin 99.99 % either way) and
+`NM` (mean 1.966 vs 1.969), so the gain is not bought with over-confidence or
+inflated edit distance. An explicit `--meth-scoring` always overrides the default.
 
 ## Downstream methylation calling
 

--- a/docs/src/related-projects/bwameth.md
+++ b/docs/src/related-projects/bwameth.md
@@ -27,17 +27,20 @@ bundled with the original script.
 drop-in, not a byte-for-byte clone). The key difference is *where it scores*:
 where bwameth.py converts both reads and reference to 3-letter space and aligns
 there, bwa-mem3 uses the 3-letter projection only to **find seeds**, then extends
-and scores against the **original 4-letter reference**. That enables a second,
-opt-in mode — `--meth-scoring genomic` — which keeps real C/T and G/A variants as
-mismatches (truthful `NM`/`MD`), something a collapsed-space aligner cannot do.
+and scores against the **original 4-letter reference**. That enables two further
+variant-aware modes — `--meth-scoring genomic`, which scores the conversion cell as
+a full match, and `--meth-scoring neutral` (the `--meth=taps` default), which scores
+it `0` so a sparse conversion is tolerated but not rewarded. Both keep real C/T and
+G/A variants as mismatches (truthful `NM`/`MD`), something a collapsed-space aligner
+cannot do.
 
 It rewrites the `@SQ` headers to consolidate the per-strand contig pairs back to
 canonical chromosome names, emits Bismark-compatible `XR:Z` / `XG:Z` / `XM:Z`
 auxiliary tags, and writes a `@PG ID:bwa-mem3-meth` header. The bwameth.py-style
 chimera QC heuristic is available via `--chimera-qc` (off by default — Bismark
 behavior). The [Methylation Reference](../methylation/overview.md) documents the
-full implementation, including the two
-[`--meth-scoring` modes](../methylation/overview.md#two-scoring-modes---meth-scoring),
+full implementation, including the three
+[`--meth-scoring` modes](../methylation/overview.md#three-scoring-modes---meth-scoring),
 the Bismark tags, and the `--set-as-failed` / `--chimera-qc` flags.
 
 > **Note — external c2t interop was removed**

--- a/docs/src/whats-different/features.md
+++ b/docs/src/whats-different/features.md
@@ -12,8 +12,9 @@ which now read `bwa-mem3`).
 `bwa-mem3 mem` in a single binary — no Python, no separate post-processing step,
 no [bwameth.py](https://github.com/brentp/bwa-meth) dependency. In the default
 `--meth-scoring collapsed` mode it reproduces bwameth.py's read *placement* (a
-placement drop-in, not a byte-for-byte clone); `--meth-scoring genomic` opts into
-variant-aware scoring bwameth cannot produce.
+placement drop-in, not a byte-for-byte clone); `--meth-scoring genomic` and
+`--meth-scoring neutral` (the `--meth=taps` default) opt into variant-aware
+scoring bwameth cannot produce.
 
 ```bash
 bwa-mem3 index --meth ref.fa          # once per reference

--- a/src/bandedSWA.h
+++ b/src/bandedSWA.h
@@ -158,31 +158,42 @@ static inline bool bsw_force_generic_matrix()
 // and just extend the match condition (SBT_PREPASS16_RANK1) — no TBL, no
 // sign-extend, near parity with symmetric. Any other deviation (>=2 freed cells,
 // a changed diagonal, or a freed value != w_match) falls back to the general LUT
-// path. `rank1` is the only field the kernel branches on; (ref,read) name the
-// freed cell. When `forced` is set on an otherwise-symmetric matrix we synthesize
-// the no-op cell (0,0) so the bench exercises and times the rank-1 path while
-// staying byte-identical to symmetric.
-struct BswFreedCell { bool rank1; int8_t ref; int8_t read; };
+// path. `rank1` is the only field bandedSWA's kernel branches on; (ref,read) name
+// the freed cell. When `forced` is set on an otherwise-symmetric matrix we
+// synthesize the no-op cell (0,0) so the bench exercises and times the rank-1 path
+// while staying byte-identical to symmetric.
+//
+// `single` generalizes the structural test to "exactly ONE off-diagonal cell
+// deviates from the canonical mismatch, to ANY value, with no diagonal change".
+// `value` carries that freed cell's value. `rank1` is exactly `single && value ==
+// w_match`, so it is byte-identical to the pre-generalization predicate and every
+// bandedSWA caller (which reads only `.rank1`/`.ref`/`.read`) is unaffected. The
+// kswv rescue kernel reads `single`/`value` to express NEUTRAL scoring (one cell
+// freed to 0), which is single but not rank1.
+struct BswFreedCell { bool rank1; bool single; int8_t ref; int8_t read; int8_t value; };
 static inline BswFreedCell bsw_freed_cell(const int8_t *mat, int8_t w_match,
                                           int8_t w_mismatch, bool forced)
 {
     int n_freed = 0;
-    int8_t fr_ref = 0, fr_read = 0;
-    bool ok = true;
+    int8_t fr_ref = 0, fr_read = 0, fr_val = w_match;
+    bool ok = true;   // no diagonal change (an unexpressible deviation)
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++) {
             int8_t expect = (i == j) ? w_match : w_mismatch;
             if (mat[i * 5 + j] == expect) continue;
-            if (i != j && mat[i * 5 + j] == w_match) {   // off-diagonal freed to match
+            if (i != j) {                                // off-diagonal freed (any value)
                 n_freed++; fr_ref = (int8_t)i; fr_read = (int8_t)j;
+                fr_val = mat[i * 5 + j];
             } else {
-                ok = false;                              // diagonal change / non-match freed
+                ok = false;                              // diagonal change: not expressible
             }
         }
     BswFreedCell c;
-    c.rank1 = ok && (n_freed == 1 || (forced && n_freed == 0));
-    c.ref = fr_ref;
-    c.read = fr_read;
+    c.single = ok && (n_freed == 1 || (forced && n_freed == 0));
+    c.rank1  = c.single && fr_val == w_match;   // preserves the old predicate exactly
+    c.ref    = fr_ref;
+    c.read   = fr_read;
+    c.value  = fr_val;                          // == w_match for the forced no-op
     return c;
 }
 

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -361,14 +361,18 @@ mem_opt_t *mem_opt_init()
 
 /* D3 (--meth, PR-4): (re)derive the per-hypothesis ASYMMETRIC matrices from the
  * symmetric `mat` + match score `a`. Target-major mat[ref*5+read], ACGT order
- * A,C,G,T,N. Free exactly ONE off-diagonal cell to a MATCH (+a); leave everything
- * else (incl. the mirror cell, a real variant) at the symmetric value:
+ * A,C,G,T,N. Free the conversion cell; leave everything else (incl. the mirror
+ * cell, a real variant) at the symmetric value:
  *   OT: free mat[C][T] = mat[1*5+3]  (ref C, read T = unmethylated C→T)
  *   OB: free mat[G][A] = mat[2*5+0]  (ref G, read A = bottom-strand G→A)
- * GENOMIC (opt->meth_scoring): only that one cell is freed ⇒ the mirror stays a
- * real mismatch and the SIMD kernel takes its rank-1 fast path. COLLAPSED: the
- * mirror cell is ALSO freed (two cells) so C/T and G/A are interchangeable
- * (bwameth-compatible), via bandedSWA's general-matrix path. Selected per chain
+ * The freed VALUE and whether the mirror is freed too depend on opt->meth_scoring:
+ * GENOMIC frees only that cell, to a MATCH (+a) ⇒ the mirror stays a real mismatch
+ * and the SIMD kernel takes its rank-1 fast path. NEUTRAL frees only that cell, to
+ * 0 (tolerated but not rewarded) ⇒ the mirror likewise stays a mismatch; one freed
+ * cell but not rank-1, so bandedSWA uses its general-matrix path. COLLAPSED: the
+ * mirror cell is ALSO freed (two cells, both to +a) so C/T and G/A are
+ * interchangeable (bwameth-compatible), via bandedSWA's general-matrix path.
+ * Selected per chain
  * via mem_opt_meth_mat(); valid only under --meth. MUST be called after EVERY
  * rebuild of opt->mat (mem_opt_init AND after main_mem parses -A/-B/-x and
  * re-runs bwa_fill_scmat) — otherwise the meth matrices keep the default
@@ -376,8 +380,11 @@ mem_opt_t *mem_opt_init()
 void mem_opt_fill_meth_mat(mem_opt_t *o) {
     memcpy(o->mat_ot, o->mat, sizeof(o->mat));
     memcpy(o->mat_ob, o->mat, sizeof(o->mat));
-    o->mat_ot[1 * 5 + 3] = o->a;   /* OT: ref C / read T → match (C→T conversion)   */
-    o->mat_ob[2 * 5 + 0] = o->a;   /* OB: ref G / read A → match (G→A conversion)   */
+    /* Conversion cell: +a (rewarded) for COLLAPSED/GENOMIC, 0 (tolerated but not
+     * rewarded) for NEUTRAL. See enum mem_meth_scoring for the rationale. */
+    int8_t conv = (o->meth_scoring == MEM_METH_SCORING_NEUTRAL) ? 0 : (int8_t)o->a;
+    o->mat_ot[1 * 5 + 3] = conv;   /* OT: ref C / read T (C→T conversion)   */
+    o->mat_ob[2 * 5 + 0] = conv;   /* OB: ref G / read A (G→A conversion)   */
     if (o->meth_scoring == MEM_METH_SCORING_COLLAPSED) {
         /* bwameth-compatible: free the MIRROR cell too so C/T (and G/A) are
          * mutually interchangeable (collapsed 3-letter space). Two freed cells ⇒
@@ -401,7 +408,8 @@ void mem_opt_apply_meth_defaults(mem_opt_t *opt, const mem_opt_t *opt0)
     if (opt->meth_scoring == MEM_METH_SCORING_COLLAPSED) {
         if (!opt0->b) opt->b = 2 * opt->a;                      /* bwameth's lenient -B 2 */
     }
-    /* GENOMIC keeps bwa's default b (already scaled by update_a): variant-aware. */
+    /* GENOMIC and NEUTRAL keep bwa's default b (already scaled by update_a):
+     * both are variant-aware, so the mirror cell must stay a real mismatch. */
 }
 
 /******************************

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -78,12 +78,22 @@ typedef struct __smem_i smem_i;
 #define MEM_F_XB        0x2000
 
 
-/* D3 (--meth): bisulfite substitution-matrix mode, selected by --meth-scoring.
- * COLLAPSED (default) frees BOTH conversion directions so C/T (and G/A) are
- * interchangeable — reproduces bwameth's collapsed 3-letter placement (a
- * drop-in). GENOMIC frees only the bisulfite conversion direction, keeping the
- * mirror cell a real mismatch — variant-aware, truthful NM/MD. */
-enum mem_meth_scoring { MEM_METH_SCORING_COLLAPSED = 0, MEM_METH_SCORING_GENOMIC = 1 };
+/* D3 (--meth): bisulfite/TAPS SW scoring model, selected by --meth-scoring. All
+ * three free the conversion cell (OT: ref-C x read-T; OB: ref-G x read-A); they
+ * differ in to what value, and whether the mirror cell is freed too:
+ *   COLLAPSED: conversion + mirror both freed to +a (C/T interchangeable,
+ *              bwameth-compatible placement, -B 2).
+ *   GENOMIC:   conversion freed to +a, mirror kept as a mismatch (variant-aware,
+ *              -B 4, rank-1 batched-expressible).
+ *   NEUTRAL:   conversion freed to 0 (tolerated but not rewarded), mirror kept a
+ *              mismatch (-B 4). For TAPS, whose conversions are sparse (~3% of C),
+ *              a full-match reward over-credits spurious C->T alignments; scoring
+ *              the conversion neutrally measured ~+0.25 pp placement over GENOMIC
+ *              at every methylation load. NOT rank-1 (the freed value is neither
+ *              match nor mismatch), so it forces the scalar mate-rescue path.
+ *              See reports/2026-07-20-taps-alignment-experiment-results.md. */
+enum mem_meth_scoring { MEM_METH_SCORING_COLLAPSED = 0, MEM_METH_SCORING_GENOMIC = 1,
+                        MEM_METH_SCORING_NEUTRAL = 2 };
 
 typedef enum {
     SEED_ORDER_OFF = 0,
@@ -132,14 +142,20 @@ typedef struct mem_opt_t {
     int8_t mat[25];         // scoring matrix; mat[0] == 0 if unset
     /* D3 (--meth): per-hypothesis substitution matrices, built from `mat` by
      * mem_opt_fill_meth_mat() per opt->meth_scoring (target-major mat[ref*5+read],
-     * ACGT order A,C,G,T,N). Each frees the bisulfite conversion cell to a MATCH
-     * (+a): mat_ot frees mat[C][T]=mat[1*5+3] (top strand C→T), mat_ob frees
-     * mat[G][A]=mat[2*5+0] (bottom strand G→A).
-     *   GENOMIC: ONLY that cell is freed; the mirror (mat[T][C], mat[A][G]) STAYS
-     *     at −b so genuine variants score as mismatches → one freed cell ⇒ the
-     *     SIMD rank-1 fast path. Variant-aware, truthful NM/MD.
-     *   COLLAPSED: the mirror cell is ALSO freed (two cells) so C/T and G/A are
-     *     interchangeable → reproduces bwameth; uses bandedSWA's general path.
+     * ACGT order A,C,G,T,N). Each frees the conversion cell — mat_ot frees
+     * mat[C][T]=mat[1*5+3] (top strand C→T), mat_ob frees mat[G][A]=mat[2*5+0]
+     * (bottom strand G→A) — to a value that depends on the mode:
+     *   GENOMIC: that cell alone is freed, to a MATCH (+a); the mirror
+     *     (mat[T][C], mat[A][G]) STAYS at −b so genuine variants score as
+     *     mismatches → one freed cell at +a ⇒ the SIMD rank-1 fast path.
+     *     Variant-aware, truthful NM/MD.
+     *   NEUTRAL: that cell alone is freed, to 0 (tolerated, not rewarded); the
+     *     mirror STAYS at −b. One freed cell, but NOT rank-1 (the value is
+     *     neither match nor mismatch) → bandedSWA's general path; the kswv
+     *     freed-cell blend expresses it directly. Variant-aware, truthful NM/MD.
+     *   COLLAPSED: the mirror cell is ALSO freed (two cells, both to +a) so C/T
+     *     and G/A are interchangeable → reproduces bwameth; uses bandedSWA's
+     *     general path.
      * Outside --meth these are unused; selection is by mem_chain_t.meth_hypothesis
      * (1 = OT, 0 = OB) via mem_opt_meth_mat(). */
     int8_t mat_ot[25];      // OT (C→T) meth matrix; valid only under --meth
@@ -147,7 +163,8 @@ typedef struct mem_opt_t {
     int    bam_mode;        // 1 = emit BAM instead of SAM text (--bam); meth_mode implies this
     int    bam_level;       // 0..9, BGZF deflate level (0 = uncompressed)
     int    meth_mode;       // 1 = bisulfite mode (--meth); implies bam_mode
-    int    meth_scoring;    // bisulfite matrix mode (--meth-scoring): MEM_METH_SCORING_{COLLAPSED,GENOMIC}
+    int    meth_scoring;    // bisulfite matrix mode (--meth-scoring):
+                            // MEM_METH_SCORING_{COLLAPSED,GENOMIC,NEUTRAL}
     int    meth_chem;       // methylation chemistry (--meth=emseq|taps): meth_chem_t.
                             // Selects XM:Z call polarity ONLY -- seeding, the
                             // converted index and the scoring matrices are shared,

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -89,8 +89,12 @@ typedef struct __smem_i smem_i;
  *              mismatch (-B 4). For TAPS, whose conversions are sparse (~3% of C),
  *              a full-match reward over-credits spurious C->T alignments; scoring
  *              the conversion neutrally measured ~+0.25 pp placement over GENOMIC
- *              at every methylation load. NOT rank-1 (the freed value is neither
- *              match nor mismatch), so it forces the scalar mate-rescue path.
+ *              at every methylation load. Not rank-1 (the freed value is neither
+ *              match nor mismatch), but the generalized kswv freed-cell blend
+ *              scores the cell to its matrix value, so mate rescue is batched on
+ *              the freed-capable tiers (NEON/AVX2/AVX512BW) exactly like
+ *              GENOMIC/COLLAPSED, and falls back to scalar ksw_align2 on the
+ *              freed-less x86 tiers (sse41/sse42/avx) as all three modes do.
  *              See reports/2026-07-20-taps-alignment-experiment-results.md. */
 enum mem_meth_scoring { MEM_METH_SCORING_COLLAPSED = 0, MEM_METH_SCORING_GENOMIC = 1,
                         MEM_METH_SCORING_NEUTRAL = 2 };

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -42,6 +42,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "ksw.h"
 #include "bandedSWA.h"
 #include "kswv.h"
+#include "simd_dispatch.h"
 
 #ifdef USE_MALLOC_WRAPPERS
 #  include "malloc_wrap.h"
@@ -797,17 +798,41 @@ static bool meth_batched_rescue_enabled()
     return enabled;
 }
 
+/* Whether the RUNNING SIMD tier implements the kswv freed-cell override. Only
+ * the NEON, AVX2, and AVX-512BW kernel bodies do; on sse41/sse42/avx the
+ * mat-aware kswv ctor reports needsScalar() for any freed-cell matrix (see
+ * kswv.cpp's `freed_simd_supported`). This must be a RUNTIME query, not a
+ * compile-time `#if`: bwamem_pair.cpp is a non-kernel TU compiled once at
+ * BASELINE_ARCH, while make_kswv dispatches to a per-tier kernel chosen at
+ * runtime (and downgradable via BWAMEM3_FORCE_TIER), so the two need not agree.
+ * Cached because the callers below sit in per-pair loops; the tier is fixed
+ * once bwamem3_simd_init() has run. */
+static bool meth_freed_cell_tier_supported()
+{
+    static const bool supported = []() {
+        bwamem3_simd_init();          /* idempotent; guarantees the tier is set */
+        const int tier = bwamem3_simd_tier();
+        return tier == BWAMEM3_TIER_AVX2 || tier == BWAMEM3_TIER_AVX512BW
+                || tier == BWAMEM3_TIER_NEON;
+    }();
+    return supported;
+}
+
 /* Whether the current --meth-scoring matrix is expressible by the batched kswv
- * kernel. The kernel handles exactly what mem_opt_fill_meth_mat produces for
- * COLLAPSED (conversion cell + its mirror, both freed to +a) and GENOMIC (the
- * single conversion cell freed to +a, rank-1). NEUTRAL frees the conversion cell
- * to 0, which is neither match nor mismatch and thus not batched-expressible, so
- * those pairs must take the scalar ksw_align2 rescue path. Keep this in lockstep
- * with mem_opt_fill_meth_mat. Porting the generic-LUT path from bandedSWA into
- * kswv would let NEUTRAL run batched too (a perf follow-up). */
+ * kernel. The kernel handles exactly what mem_opt_fill_meth_mat produces:
+ * COLLAPSED (conversion cell + its mirror, both freed to +a), GENOMIC (the single
+ * conversion cell freed to +a, rank-1), and NEUTRAL (the single conversion cell
+ * freed to 0). The kernel's freed-cell blend now scores the freed cell to its
+ * matrix value (fr_val), so a single freed cell of ANY value — match (genomic) or
+ * 0 (neutral) — is expressible; only a changed diagonal or a non-mirror multi-cell
+ * matrix forces scalar. Expressibility is therefore purely a tier question: every
+ * scoring mode is batched on a freed-capable tier, and every scoring mode takes
+ * the scalar ksw_align2 rescue on the freed-less x86 tiers. Keep this in lockstep
+ * with mem_opt_fill_meth_mat and the kswv mat-aware ctor. */
 static inline bool meth_scoring_batched_expressible(const mem_opt_t *opt)
 {
-    return opt->meth_scoring != MEM_METH_SCORING_NEUTRAL;
+    (void)opt;   /* every mem_opt_fill_meth_mat matrix is kernel-expressible */
+    return meth_freed_cell_tier_supported();
 }
 
 /* Task 5: run the two-phase batched kswv over a contiguous SeqPair slice
@@ -922,7 +947,7 @@ int mem_sam_pe_batch(const mem_opt_t *opt, mem_cache *mmc,
     /* Task 5: under --meth (batched rescue enabled), partition the enqueued
      * mate-rescue pairs by bisulfite hypothesis (OT/OB) and run the kernel once
      * per group with the matching mat-aware kswv object. mat_ot frees C->T (top
-     * strand), mat_ob frees G->A (bottom strand); make_kswv installs the rank-1
+     * strand), mat_ob frees G->A (bottom strand); make_kswv installs the
      * freed-cell override for each, so the batched score equals the scalar
      * ksw_align2 score with the asymmetric matrix. Non-meth and the env-OFF
      * escape hatch fall through to the single-object path below, byte-identical
@@ -942,17 +967,21 @@ int mem_sam_pe_batch(const mem_opt_t *opt, mem_cache *mmc,
                                  opt->a, -1*opt->b, nthreads,
                                  maxRefLen, maxQerLen, opt->mat_ob);
         // The batched kernel expresses exactly the matrices mem_opt_fill_meth_mat
-        // produces: GENOMIC (one freed cell) and COLLAPSED (the conversion cell
-        // PLUS its mirror — a symmetric (i,j)/(j,i) pair). needsScalar() is
-        // therefore always false here. Guard it at RUNTIME rather than with a
-        // bare assert(): under NDEBUG assert is a no-op, which would let a future
-        // unsupported matrix run the batched kernel and silently mis-score. Fail
-        // loudly instead — this can only fire on a programming error in
-        // mem_opt_fill_meth_mat (a matrix that is neither rank-1 nor a mirror pair).
+        // produces: GENOMIC (one freed cell to +a), NEUTRAL (one freed cell to 0),
+        // and COLLAPSED (the conversion cell PLUS its mirror — a symmetric
+        // (i,j)/(j,i) pair). The freed-less x86 tiers never reach here —
+        // meth_scoring_batched_expressible() gates this branch on the running
+        // tier — so needsScalar() is always false. Guard it at RUNTIME rather
+        // than with a bare assert(): under NDEBUG assert is a no-op, which would
+        // let a future unsupported matrix run the batched kernel and silently
+        // mis-score. Fail loudly instead — this can only fire on a programming
+        // error in mem_opt_fill_meth_mat (a matrix that is neither a single freed
+        // cell nor a mirror pair) or a tier gate that drifted out of lockstep
+        // with the kswv mat-aware ctor.
         if (pwsw_ot->needsScalar() || pwsw_ob->needsScalar())
             err_fatal(__func__,
                       "meth mate-rescue matrix not expressible by the batched kernel "
-                      "(neither rank-1 genomic nor a collapsed mirror pair)");
+                      "(neither a single freed cell nor a collapsed mirror pair)");
 
         // hyp == 1 -> OT (mat_ot / pwsw_ot); hyp == 0 -> OB (mat_ob / pwsw_ob).
         // -1 (non-meth) cannot occur here: every enqueued pair under meth_mode
@@ -1299,8 +1328,9 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
      * scalar ksw_align2. The legacy scalar path (gar[gcnt+r] = -1 →
      * mem_matesw_batch_post re-runs ksw_align2) is retained as the escape hatch
      * (BWAMEM3_METH_BATCHED_RESCUE=0). The OT/OB matrices mem_opt_fill_meth_mat
-     * produces are always expressible (rank-1 genomic or a collapsed mirror
-     * pair), so the kswv objects never report needsScalar() here; if a future
+     * produces are always expressible on a freed-cell tier (a single cell freed
+     * to +a for genomic or to 0 for neutral, or a collapsed mirror pair), so
+     * the kswv objects never report needsScalar() here; if a future
      * matrix or tier ever did, mem_sam_pe_batch fails loud via err_fatal rather
      * than silently mis-scoring (see the needsScalar() guard there). The dedup
      * below passes query = 0 (no patch SW), so its mat default (opt->mat) is
@@ -1397,7 +1427,7 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
             /* D3 (--meth, Task 5): meth mate-rescue is now enqueued for the
              * batched kswv kernel just like a non-meth pair. The kernels are
              * mat-aware (Task 2/4): make_kswv(..., mat_ot/mat_ob) installs the
-             * rank-1 freed-cell override for the bisulfite OT/OB matrices, so
+             * freed-cell override for the bisulfite OT/OB matrices, so
              * the batched score matches the scalar ksw_align2 score with the
              * asymmetric matrix. The per-pair hypothesis tag (sp.meth_hyp,
              * below) drives the OT/OB partition in mem_sam_pe_batch, which runs
@@ -1406,13 +1436,15 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
              * (sp.meth_hyp = (mate_meth_ot ^ is_rev) & 1, set below), matching
              * mem_matesw_batch_post's scalar index==-1 fallback. The legacy scalar
              * path remains as a safety fallback for any pair whose object
-             * reports needsScalar() (rank-1 meth never does) and is reachable
-             * via BWAMEM3_METH_BATCHED_RESCUE=0 (escape hatch). */
+             * reports needsScalar() (meth never does on a freed-capable tier) and
+             * is reachable via BWAMEM3_METH_BATCHED_RESCUE=0 (escape hatch) or on
+             * a freed-less SIMD tier (sse41/sse42/avx), where the kswv kernel has
+             * no freed-cell override and every scoring mode must score scalar. */
             if (opt->meth_mode && (!meth_batched_rescue_enabled()
                     || !meth_scoring_batched_expressible(opt))) {
-                // Escape hatch (env=0): keep the legacy scalar rescue. Leave
-                // gar = -1 so mem_matesw_batch_post re-runs this orientation
-                // through ksw_align2 with the asymmetric matrix.
+                // Escape hatch (env=0) or freed-less tier: keep the legacy scalar
+                // rescue. Leave gar = -1 so mem_matesw_batch_post re-runs this
+                // orientation through ksw_align2 with the asymmetric matrix.
                 gar[gcnt + r] = -1;
                 if (rev) free(rev);
                 continue;
@@ -1565,9 +1597,11 @@ int mem_matesw_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
      * The scalar ksw_align2 path below (index == -1) is the ESCAPE HATCH: it
      * is reached only when BWAMEM3_METH_BATCHED_RESCUE=0 forces the legacy
      * scalar path (gar[gcnt+r] == -1 from _pre), or for any matrix where the
-     * kswv object reports needsScalar() (a non-rank-1 asymmetric matrix; the
-     * current OT/OB matrices are rank-1 and never trigger this). The path is
-     * retained as a safety net, not the primary route. */
+     * kswv object reports needsScalar() (an asymmetric matrix the kernel cannot
+     * express, or any freed-cell matrix on a tier without the override). All
+     * three --meth-scoring modes are expressible, so on a freed-cell tier the
+     * current OT/OB matrices never trigger this. The path is retained as a
+     * safety net, not the primary route. */
     const int8_t *sw_mat = mat ? mat : opt->mat;
     #if MATE_SORT    
     extern int mem_dedup_patch(const mem_opt_t *opt, const bntseq_t *bns,

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -797,6 +797,19 @@ static bool meth_batched_rescue_enabled()
     return enabled;
 }
 
+/* Whether the current --meth-scoring matrix is expressible by the batched kswv
+ * kernel. The kernel handles exactly what mem_opt_fill_meth_mat produces for
+ * COLLAPSED (conversion cell + its mirror, both freed to +a) and GENOMIC (the
+ * single conversion cell freed to +a, rank-1). NEUTRAL frees the conversion cell
+ * to 0, which is neither match nor mismatch and thus not batched-expressible, so
+ * those pairs must take the scalar ksw_align2 rescue path. Keep this in lockstep
+ * with mem_opt_fill_meth_mat. Porting the generic-LUT path from bandedSWA into
+ * kswv would let NEUTRAL run batched too (a perf follow-up). */
+static inline bool meth_scoring_batched_expressible(const mem_opt_t *opt)
+{
+    return opt->meth_scoring != MEM_METH_SCORING_NEUTRAL;
+}
+
 /* Task 5: run the two-phase batched kswv over a contiguous SeqPair slice
  * pairs[0..slice_pcnt) whose 8-bit pairs occupy [0, slice_pcnt8) and 16-bit
  * pairs [slice_pcnt8, slice_pcnt). The slice must have MAX_LINE_LEN trailing
@@ -914,7 +927,8 @@ int mem_sam_pe_batch(const mem_opt_t *opt, mem_cache *mmc,
      * ksw_align2 score with the asymmetric matrix. Non-meth and the env-OFF
      * escape hatch fall through to the single-object path below, byte-identical
      * to the pre-Task-5 code. */
-    if (opt->meth_mode && meth_batched_rescue_enabled()) {
+    if (opt->meth_mode && meth_batched_rescue_enabled()
+            && meth_scoring_batched_expressible(opt)) {
         // Scratch slice (Right128 is free here; sort_classify only used it as
         // a transient and the final layout lives in Left128). Sized
         // wsize_pair + MAX_LINE_LEN, which comfortably holds one group plus
@@ -1394,7 +1408,8 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
              * path remains as a safety fallback for any pair whose object
              * reports needsScalar() (rank-1 meth never does) and is reachable
              * via BWAMEM3_METH_BATCHED_RESCUE=0 (escape hatch). */
-            if (opt->meth_mode && !meth_batched_rescue_enabled()) {
+            if (opt->meth_mode && (!meth_batched_rescue_enabled()
+                    || !meth_scoring_batched_expressible(opt))) {
                 // Escape hatch (env=0): keep the legacy scalar rescue. Leave
                 // gar = -1 so mem_matesw_batch_post re-runs this orientation
                 // through ksw_align2 with the asymmetric matrix.

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1581,9 +1581,11 @@ int main_mem(int argc, char *argv[])
          * 95.37-95.43% -- a robust +0.24-0.28 pp over genomic -- with IDENTICAL
          * MAPQ calibration (60+ bin 99.99% both) and NM (1.966 vs 1.969), so the
          * gain is not bought with over-confidence or inflated edit distance.
-         * NEUTRAL is not batched-rescue-expressible, so it forces the scalar
-         * ksw_align2 rescue path (correct, slightly slower; a kswv generic-LUT
-         * port would recover that). An explicit --meth-scoring still wins.
+         * NEUTRAL's freed cell is not rank-1, but the generalized kswv freed-cell
+         * blend scores it to its matrix value, so mate rescue stays on the batched
+         * kernel on the freed-capable tiers (NEON/AVX2/AVX512BW) and falls back to
+         * scalar ksw_align2 only on the freed-less x86 tiers (sse41/sse42/avx),
+         * exactly as GENOMIC and COLLAPSED do. An explicit --meth-scoring still wins.
          * Set before mem_opt_apply_meth_defaults so its COLLAPSED -B 2 branch keys
          * off the resolved scoring mode. See
          * reports/2026-07-20-taps-alignment-experiment-results.md. */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -997,17 +997,21 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                   emseq  bisulfite/EM-seq, UNmethylated C converts [default]\n");
     fprintf(stderr, "                          (aliases: em-seq, bisulfite)\n");
     fprintf(stderr, "                   taps   TET-assisted pyridine borane, METHYLATED C converts;\n");
-    fprintf(stderr, "                          also defaults --meth-scoring to genomic\n");
+    fprintf(stderr, "                          also defaults --meth-scoring to neutral\n");
     fprintf(stderr, "                 NOTE: use --meth=taps (with '='), not --meth taps. Running TAPS\n");
     fprintf(stderr, "                 data without =taps inverts every methylation call.\n");
-    fprintf(stderr, "   --meth-scoring collapsed|genomic\n");
+    fprintf(stderr, "   --meth-scoring collapsed|genomic|neutral\n");
     fprintf(stderr, "                 scoring mode. Default depends on chemistry: collapsed for\n");
-    fprintf(stderr, "                 --meth/--meth=emseq, genomic for --meth=taps (TAPS conversions\n");
+    fprintf(stderr, "                 --meth/--meth=emseq, neutral for --meth=taps (TAPS conversions\n");
     fprintf(stderr, "                 are sparse, so collapsing costs specificity it can't repay).\n");
-    fprintf(stderr, "                 collapsed: C/T (and G/A)\n");
-    fprintf(stderr, "                 interchangeable, bwameth-compatible placement (sets -B 2).\n");
-    fprintf(stderr, "                 genomic: free only the conversion direction, keep variants as\n");
-    fprintf(stderr, "                 mismatches (variant-aware, truthful NM/MD; -B 4).\n");
+    fprintf(stderr, "                 collapsed: C/T (and G/A) interchangeable, bwameth-compatible\n");
+    fprintf(stderr, "                 placement (sets -B 2).\n");
+    fprintf(stderr, "                 genomic: free only the conversion direction, scored as a full\n");
+    fprintf(stderr, "                 match, keep variants as mismatches (variant-aware, truthful\n");
+    fprintf(stderr, "                 NM/MD; -B 4).\n");
+    fprintf(stderr, "                 neutral: free only the conversion direction but score it 0\n");
+    fprintf(stderr, "                 (tolerated, not rewarded); best for TAPS (variant-aware,\n");
+    fprintf(stderr, "                 truthful NM/MD; -B 4).\n");
     fprintf(stderr, "   --set-as-failed f|r\n");
     fprintf(stderr, "                 flag alignments to the matching strand ('f' or 'r') as QC-fail (0x200)\n");
     fprintf(stderr, "   --chimera-qc\n");
@@ -1331,8 +1335,11 @@ int main_mem(int argc, char *argv[])
             } else if (optarg != NULL && strcmp(optarg, "genomic") == 0) {
                 opt->meth_scoring = MEM_METH_SCORING_GENOMIC;
                 opt0.meth_scoring = 1;
+            } else if (optarg != NULL && strcmp(optarg, "neutral") == 0) {
+                opt->meth_scoring = MEM_METH_SCORING_NEUTRAL;
+                opt0.meth_scoring = 1;
             } else {
-                fprintf(stderr, "ERROR: --meth-scoring requires 'collapsed' or 'genomic'\n");
+                fprintf(stderr, "ERROR: --meth-scoring requires 'collapsed', 'genomic', or 'neutral'\n");
                 free(opt);
                 if (out_opened) fclose(aux.fp);
                 return 1;
@@ -1543,8 +1550,8 @@ int main_mem(int argc, char *argv[])
     /* Meth-mode default tuning. bwameth.py runs bwa as
      * `bwa mem -T 40 -B 2 -L 10 -CM`, adding `-U 100 -p` for paired-end. We adopt
      * the soft-clip (-L 10), unpaired (-U 100), output-threshold (-T 40), -M and
-     * -C defaults for BOTH --meth-scoring modes; the ONLY mode-dependent knob is
-     * the mismatch penalty (the leniency gate):
+     * -C defaults for ALL THREE --meth-scoring modes; the ONLY mode-dependent knob
+     * is the mismatch penalty (the leniency gate):
      *   COLLAPSED (bwameth drop-in): -B 2 — bwameth's lenient mismatch. Combined
      *     with the two-cell matrix (C/T and G/A free both ways) this reproduces
      *     bwameth's collapsed-space placement.
@@ -1552,6 +1559,9 @@ int main_mem(int argc, char *argv[])
      *     A/B with the asymmetric matrix showed b=4 places better and is better
      *     MAPQ-calibrated than b=2 (placement 92.6 vs 92.5, discordant MAPQ
      *     1.8 vs 2.1).
+     *   NEUTRAL (variant-aware, the --meth=taps default): also keeps -B 4. It
+     *     differs from GENOMIC only in the freed cell's VALUE (0 vs +a), not in
+     *     the leniency gate, so the same b=4 argument applies unchanged.
      * pen_unpaired is only consulted for paired-end rescue, so setting it
      * unconditionally is a no-op for single-end. -A/-B always override and reach
      * the matrices (mem_opt_fill_meth_mat below).
@@ -1559,18 +1569,26 @@ int main_mem(int argc, char *argv[])
      * scaled by opt->a inside mem_opt_apply_meth_defaults — see bwamem.h. Before
      * that, they were applied flat and silently discarded -A. */
     if (opt->meth_mode) {
-        /* TAPS defaults to GENOMIC scoring. TAPS converts only the METHYLATED
+        /* TAPS defaults to NEUTRAL scoring. TAPS converts only the METHYLATED
          * cytosines, so conversions are ~20-30x rarer than under em-seq (measured:
          * 3.2% of C vs 94.6% on chr22 @ 12x). The collapsed 3-letter alphabet buys
-         * little at that density and costs specificity, and the measurement agrees:
-         * on 4.07M simulated TAPS reads vs full hg38, genomic placed 95.72% vs
-         * collapsed's 95.40% (plain: 95.53%), and put 136k more reads in the
-         * MAPQ 60+ bin at higher accuracy. An explicit --meth-scoring still wins.
+         * little at that density and costs specificity. NEUTRAL goes one step
+         * further: it scores the conversion cell as 0 rather than a full match,
+         * so a sparse TAPS conversion is tolerated without over-crediting spurious
+         * C->T alignments. Measured on 4.07M simulated TAPS reads vs full hg38,
+         * across three methylation loads: NEUTRAL placed 95.95-96.01% (essentially
+         * the 96.02% unconverted ceiling) vs GENOMIC 95.68-95.73% and COLLAPSED
+         * 95.37-95.43% -- a robust +0.24-0.28 pp over genomic -- with IDENTICAL
+         * MAPQ calibration (60+ bin 99.99% both) and NM (1.966 vs 1.969), so the
+         * gain is not bought with over-confidence or inflated edit distance.
+         * NEUTRAL is not batched-rescue-expressible, so it forces the scalar
+         * ksw_align2 rescue path (correct, slightly slower; a kswv generic-LUT
+         * port would recover that). An explicit --meth-scoring still wins.
          * Set before mem_opt_apply_meth_defaults so its COLLAPSED -B 2 branch keys
          * off the resolved scoring mode. See
          * reports/2026-07-20-taps-alignment-experiment-results.md. */
         if (opt->meth_chem == METH_CHEM_TAPS && !opt0.meth_scoring)
-            opt->meth_scoring = MEM_METH_SCORING_GENOMIC;
+            opt->meth_scoring = MEM_METH_SCORING_NEUTRAL;
         /* Scored defaults live in mem_opt_apply_meth_defaults so they scale with
          * -A (bwameth's constants assume a==1) and can be unit-tested. */
         mem_opt_apply_meth_defaults(opt, &opt0);

--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -78,9 +78,11 @@ extern uint64_t prof[10][112];
             /* One compare + one blend against the per-row active_frread512   \
              * target (built once per row); sentinel (0xFF) lanes never match \
              * a real s2. Fewer ops than the two-blend form and, unlike the   \
-             * mask-OR collapse, no serializing kor on the blend's input. */  \
+             * mask-OR collapse, no serializing kor on the blend's input.     \
+             * The blend target is freedval512 (fr_val biased by +shift), so  \
+             * NEUTRAL's zero-scored conversion cell uses the same path. */   \
             __mmask64 freed = _mm512_cmpeq_epi8_mask(s2, active_frread512); \
-            sbt11 = _mm512_mask_blend_epi8(freed, sbt11, match512);     \
+            sbt11 = _mm512_mask_blend_epi8(freed, sbt11, freedval512);  \
         }                                                               \
         /* Boundary mask, gated by HasFreed (compile-time). Non-meth    \
          * hoists the per-row rowboundary512 (a big avx512 win); meth    \
@@ -113,10 +115,10 @@ extern uint64_t prof[10][112];
         if (HasFreed) {                                                 \
             __mmask32 freed = rowfreed512 &                             \
                 _mm512_cmpeq_epi16_mask(s2, frread512);                 \
-            sbt11 = _mm512_mask_blend_epi16(freed, sbt11, match512);    \
+            sbt11 = _mm512_mask_blend_epi16(freed, sbt11, freedval512); \
             __mmask32 freed2 = rowfreed2_512 &                          \
                 _mm512_cmpeq_epi16_mask(s2, frread2_512);               \
-            sbt11 = _mm512_mask_blend_epi16(freed2, sbt11, match512);   \
+            sbt11 = _mm512_mask_blend_epi16(freed2, sbt11, freedval512);\
         }                                                               \
         __m512i m11 = _mm512_add_epi16(h00, sbt11);                     \
         or11 =  _mm512_or_si512(s1, s2);                                \
@@ -181,18 +183,19 @@ kswv::kswv(const int o_del, const int e_del, const int o_ins,
 
 // Mat-aware constructor (issue 173). Delegates to the 9-arg ctor (identical
 // buffer allocation / field init), then inspects the supplied 5x5 scoring
-// matrix for the rank-1 asymmetric (bisulfite OT/OB) freed cell.
+// matrix for the asymmetric (bisulfite OT/OB) freed cell.
 //
 //   nullptr / symmetric matrix ⇒ the existing symmetric XOR-LUT kernel runs
 //     unchanged (has_freed = needs_scalar = false).
-//   exactly one off-diagonal cell freed to a match (rank-1, genomic OT/OB) ⇒
-//     has_freed, fr_ref/fr_read name it; the kernel applies the rank-1 override.
+//   exactly one off-diagonal cell freed to ANY value in [w_mismatch, w_match]
+//     (genomic OT/OB frees it to +a, neutral to 0) ⇒ has_freed, fr_ref/fr_read
+//     name it and fr_val carries the value; the kernel blends the cell to fr_val.
 //   an exact mirrored freed pair (collapsed --meth) ⇒ has_freed, both ordered
-//     cells named; the kernel applies both blends (rank-1 is the degenerate
-//     case where the mirror equals the primary).
+//     cells named; the kernel applies both blends (the single-cell case is the
+//     degenerate one where the mirror equals the primary).
 //   any other asymmetric matrix (non-mirror multi-cell free, changed diagonal,
-//     freed value != w_match) ⇒ needs_scalar; the caller routes those pairs to
-//     ksw_align2.
+//     freed value outside [w_mismatch, w_match]) ⇒ needs_scalar; the caller
+//     routes those pairs to ksw_align2.
 //   On SSE41/SSE42/AVX tiers (no HasFreed kernel override) ⇒ needs_scalar for
 //     ANY freed-cell matrix, so the caller falls back to ksw_align2 rather than
 //     running a kernel that would drop the bisulfite override.
@@ -216,6 +219,19 @@ kswv::kswv(const int o_del, const int e_del, const int o_ins,
         // freed-cell-less tier, leave needs_scalar = true so the caller routes
         // the pair to the scalar ksw_align2 fallback instead of running a
         // kernel that would silently drop the bisulfite override.
+        //
+        // This compile-time test IS the runtime-tier test, and is not a
+        // baseline-vs-host mismatch waiting to happen. kswv.cpp is compiled
+        // ONCE PER TIER (KERNEL_SRCS x {sse41,sse42,avx,avx2,avx512bw} in the
+        // Makefile), each copy under that tier's -m flags with the class name
+        // mangled to kswv_<tier> by kernel_dispatch.h. simd_dispatch.cpp's
+        // make_kswv() switches on the runtime g_tier (incl. BWAMEM3_FORCE_TIER)
+        // to call make_kswv_kernel_<tier>_mat, which constructs THIS ctor out
+        // of the <tier> TU — so the macros below are exactly the ones that
+        // selected the kernel body compiled alongside it. Forcing sse41 on an
+        // AVX2 host runs kswv_sse41::kswv from kswv.sse41.o, where __AVX2__ is
+        // undefined and needs_scalar is correctly set. Keep this predicate in
+        // sync with the #if/#elif ladder that guards the kernel bodies below.
 #if defined(__AVX512BW__) || defined(__AVX2__) \
         || defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)
         constexpr bool freed_simd_supported = true;
@@ -229,22 +245,37 @@ kswv::kswv(const int o_del, const int e_del, const int o_ins,
         const bool generic = bsw_generic_matrix(mat25, w_match, w_mismatch) || forced;
         if (generic) {
             BswFreedCell fc = bsw_freed_cell(mat25, w_match, w_mismatch, forced);
-            if (fc.rank1) {
-                // GENOMIC (one freed cell): mirror == primary, so the kernel's
-                // second blend is idempotent.
+            if (fc.single) {
+                // ONE off-diagonal cell freed. GENOMIC frees it to a match
+                // (fc.value == w_match); NEUTRAL frees it to 0. Either way the
+                // mirror == primary, so the kernel's second blend is idempotent.
+                // The kernel blends the freed cell to fr_val (see fr_val member);
+                // fr_val == w_match reproduces the pre-generalization match blend.
                 if (!freed_simd_supported) { needs_scalar = true; return; }
+                // bsw_freed_cell accepts ANY freed value, but the 8-bit kernel
+                // blends fr_val + shift into the biased u8 domain, which only
+                // represents [w_mismatch, w_match]. mem_opt_fill_meth_mat never
+                // produces anything outside it (+a or 0), so this cannot fire
+                // today — but a freed value below/above the domain would wrap the
+                // biased byte and SILENTLY mis-score, so route it to the scalar
+                // ksw_align2 fallback (always correct) rather than trust it.
+                if (fc.value < w_mismatch || fc.value > w_match) {
+                    needs_scalar = true; return;
+                }
                 has_freed = true;
                 fr_ref  = fr_ref2  = fc.ref;
                 fr_read = fr_read2 = fc.read;
+                fr_val  = fc.value;
             } else {
                 // COLLAPSED (the --meth default) frees the conversion cell AND
-                // its mirror; the kernel frees both ordered cells.
+                // its mirror to a match; the kernel frees both ordered cells.
                 BswFreedPair fp = bsw_freed_pair(mat25, w_match, w_mismatch);
                 if (fp.supported) {
                     if (!freed_simd_supported) { needs_scalar = true; return; }
                     has_freed = true;
                     fr_ref  = fp.refA;  fr_read  = fp.readA;
                     fr_ref2 = fp.refB;  fr_read2 = fp.readB;
+                    fr_val  = w_match;   // collapsed frees both cells to a match
                 } else {
                     needs_scalar = true;
                 }
@@ -573,17 +604,18 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
         imax_vec = zero_vec;
         uint8x16_t iqe_vec = vdupq_n_u8(0xFF);
 
-        /* Rank-1 freed-cell override (issue 173, bisulfite OT/OB). The freed
-         * cell scores (s1==fr_ref, s2==fr_read) as a true match. s1 is
+        /* Freed-cell override (issue 173, bisulfite OT/OB + TAPS neutral). The
+         * freed cell (s1==fr_ref, s2==fr_read) scores fr_val. s1 is
          * loop-invariant across the inner j loop, so hoist the per-row
          * comparison here; per-cell only the s2 compare + blend remains.
-         * match_vec is the kernel's OWN biased match entry (temp[0] already
-         * includes +shift) so the freed cell scores byte-identically to a real
-         * match in the biased u8 domain. When !HasFreed, all of this and the
-         * per-cell block below compile out (identical codegen to today). */
+         * freedval_vec is fr_val biased by +shift into the u8 domain (same bias
+         * temp[] carries): fr_val==w_match (GENOMIC/COLLAPSED) equals temp[0]
+         * exactly, NEUTRAL (fr_val==0) scores the conversion as 0 after unbiasing.
+         * When !HasFreed, all of this and the per-cell block below compile out
+         * (identical codegen to today). */
         /* Free a SYMMETRIC PAIR of cells: (fr_ref,fr_read) and (fr_ref2,fr_read2).
-         * GENOMIC sets the mirror == primary; COLLAPSED sets it to the transpose
-         * so C/T (or G/A) are interchangeable.
+         * GENOMIC/NEUTRAL set the mirror == primary; COLLAPSED sets it to the
+         * transpose so C/T (or G/A) are interchangeable.
          *
          * Fold the pair into ONE per-lane target base, active_frread: a lane whose
          * ref is fr_ref frees against fr_read, a lane whose ref is fr_ref2 frees
@@ -593,10 +625,11 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
          * 0-3 or the ambig/pad codes DUMMY5(5)/AMBQ(8) — never 0xFF — so on a
          * sentinel lane the single per-cell compare is unconditionally false. This
          * turns the per-cell freed path into one vceqq + one vbslq (down from two
-         * compares, two ands, an orr, and a blend). */
-        uint8x16_t match_vec, active_frread;
+         * compares, two ands, an orr, and a blend). Both cells of the pair score
+         * the same fr_val, so one freedval_vec covers the fold. */
+        uint8x16_t freedval_vec, active_frread;
         if (HasFreed) {
-            match_vec   = vdupq_n_u8((uint8_t)temp[0]);
+            freedval_vec = vdupq_n_u8((uint8_t)(fr_val + shift));
             uint8x16_t rowfreed  = vceqq_u8(s1, vdupq_n_u8((uint8_t)fr_ref));
             uint8x16_t rowfreed2 = vceqq_u8(s1, vdupq_n_u8((uint8_t)fr_ref2));
             active_frread = vbslq_u8(rowfreed2, vdupq_n_u8((uint8_t)fr_read2),
@@ -636,13 +669,13 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
             uint8x16_t cmpq = vceqq_u8(s2, five_vec);
             sbt = vbslq_u8(cmpq, sft_vec, sbt);
 
-            /* Apply the rank-1 freed-cell override: force the biased match score
-             * where this column's read base equals the row's active freed base
-             * (built once per row in active_frread above). One compare + one
-             * blend; sentinel (0xFF) lanes never match a real s2 (0-3/5/8) so
-             * they blend through unchanged. */
+            /* Apply the freed-cell override: force the biased freed score
+             * (fr_val + shift) where this column's read base equals the row's
+             * active freed base (built once per row in active_frread above).
+             * One compare + one blend; sentinel (0xFF) lanes never match a real
+             * s2 (0-3/5/8) so they blend through unchanged. */
             if (HasFreed) {
-                sbt = vbslq_u8(vceqq_u8(s2, active_frread), match_vec, sbt);
+                sbt = vbslq_u8(vceqq_u8(s2, active_frread), freedval_vec, sbt);
             }
 
             uint8x16_t m11 = vqaddq_u8(h00, sbt);
@@ -1197,16 +1230,17 @@ int kswv::kswv_neon_16_impl(int16_t seq1SoA[],
         int16x8_t l_vec   = zero_vec;
         int16x8_t i_vec   = vdupq_n_s16((int16_t)i);
 
-        /* Rank-1 freed-cell override (issue 173). s1 is loop-invariant, so
-         * hoist the per-row fr_ref comparison. The 16-bit kernel has NO shift
-         * bias (m11 = h00 + sbt directly), so the biased match constant is
-         * just temp8[0] (== w_match), sign-extended to int16. !HasFreed → both
-         * this and the per-cell block compile out. */
-        int16x8_t frread_vec16, frread2_vec16, match_vec16, rowfreed16, rowfreed2_16;
+        /* Freed-cell override (issue 173 + TAPS neutral). s1 is loop-invariant, so
+         * hoist the per-row fr_ref comparison. The 16-bit kernel has NO shift bias
+         * (m11 = h00 + sbt directly), so the freed value is just fr_val: fr_val==
+         * w_match (GENOMIC/COLLAPSED) equals temp8[0], NEUTRAL (fr_val==0) scores
+         * the conversion as 0. Sign-extended to int16. !HasFreed → both this and
+         * the per-cell block compile out. */
+        int16x8_t frread_vec16, frread2_vec16, freedval_vec16, rowfreed16, rowfreed2_16;
         if (HasFreed) {
             frread_vec16  = vdupq_n_s16((int16_t)fr_read);
             frread2_vec16 = vdupq_n_s16((int16_t)fr_read2);
-            match_vec16   = vdupq_n_s16((int16_t)temp8[0]);
+            freedval_vec16= vdupq_n_s16((int16_t)fr_val);
             rowfreed16    = vreinterpretq_s16_u16(vceqq_s16(s1, vdupq_n_s16((int16_t)fr_ref)));
             rowfreed2_16  = vreinterpretq_s16_u16(vceqq_s16(s1, vdupq_n_s16((int16_t)fr_ref2)));
         }
@@ -1226,17 +1260,17 @@ int kswv::kswv_neon_16_impl(int16_t seq1SoA[],
             int8x8_t   sbt8 = vqtbl2_s8(perm_vec, idx8);
             int16x8_t  sbt  = vmovl_s8(sbt8);
 
-            /* Rank-1 freed-cell override (issue 173): where row==fr_ref and
-             * col==fr_read, force the match score. Real bases 0-3; fr_read ∈
+            /* Freed-cell override (issue 173 + TAPS neutral): where row==fr_ref and
+             * col==fr_read, force the freed score. Real bases 0-3; fr_read ∈
              * {0,3}; padding/ambig (DUMMY3/0xFFFF/AMBQ16) never equal fr_read,
              * so vceqq is naturally false for them. */
             if (HasFreed) {
                 int16x8_t freed  = vandq_s16(
                     rowfreed16, vreinterpretq_s16_u16(vceqq_s16(s2, frread_vec16)));
-                sbt = vbslq_s16(vreinterpretq_u16_s16(freed), match_vec16, sbt);
+                sbt = vbslq_s16(vreinterpretq_u16_s16(freed), freedval_vec16, sbt);
                 int16x8_t freed2 = vandq_s16(
                     rowfreed2_16, vreinterpretq_s16_u16(vceqq_s16(s2, frread2_vec16)));
-                sbt = vbslq_s16(vreinterpretq_u16_s16(freed2), match_vec16, sbt);
+                sbt = vbslq_s16(vreinterpretq_u16_s16(freed2), freedval_vec16, sbt);
             }
 
             /* Boundary: high bit set in (s1 | s2) indicates padding. */
@@ -1636,19 +1670,21 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
         __m256i l_vec = zero_vec;
         __m256i i_vec_s16 = _mm256_set1_epi16((int16_t)i);
 
-        /* Rank-1 freed-cell override (issue 173, bisulfite OT/OB). The freed
-         * cell scores (s1==fr_ref, s2==fr_read) as a true match. s1 is
+        /* Freed-cell override (issue 173, bisulfite OT/OB + TAPS neutral). The
+         * freed cell (s1==fr_ref, s2==fr_read) scores fr_val. s1 is
          * loop-invariant across the inner j loop, so hoist the per-row
          * comparison here; per-cell only the s2 compare + blend remains.
-         * match256 is the kernel's OWN biased match entry (temp[0] already
-         * includes +shift) so the freed cell scores byte-identically to a real
-         * match in the biased u8 domain. When !HasFreed, all of this and the
-         * per-cell block below compile out (identical codegen to today). */
-        /* Free a SYMMETRIC PAIR of cells (collapsed bisulfite); GENOMIC sets the
-         * mirror == primary so the second blend is idempotent. */
-        __m256i match256, active_frread;
+         * freedval256 is fr_val biased by +shift into the u8 domain (same bias
+         * temp[] carries): fr_val==w_match (GENOMIC/COLLAPSED) equals temp[0]
+         * exactly, NEUTRAL (fr_val==0) scores the conversion as 0 after unbiasing.
+         * When !HasFreed, all of this and the per-cell block below compile out
+         * (identical codegen to today). */
+        /* Free a SYMMETRIC PAIR of cells (collapsed bisulfite); GENOMIC/NEUTRAL set
+         * the mirror == primary so the second blend is idempotent. Both cells score
+         * the same fr_val, so one freedval256 covers the folded target below. */
+        __m256i freedval256, active_frread;
         if (HasFreed) {
-            match256 = _mm256_set1_epi8((char)temp[0]);
+            freedval256 = _mm256_set1_epi8((char)(fr_val + shift));
             __m256i rowfreed  = _mm256_cmpeq_epi8(s1, _mm256_set1_epi8((char)fr_ref));
             __m256i rowfreed2 = _mm256_cmpeq_epi8(s1, _mm256_set1_epi8((char)fr_ref2));
             /* One per-lane freed target: fr_read where ref==fr_ref, fr_read2 where
@@ -1672,12 +1708,13 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
             __m256i cmpq = _mm256_cmpeq_epi8(s2, five_vec);
             sbt = avx2_blendv_u8(cmpq, sft_vec, sbt);
 
-            /* Apply the rank-1 freed-cell override: force the biased match score
-             * where this column's read base equals the row's active freed base
-             * (active_frread, built once per row above). One cmpeq + one blendv;
-             * sentinel (0xFF) lanes never match a real s2 so they pass through. */
+            /* Apply the freed-cell override: force the biased freed score
+             * (fr_val + shift) where this column's read base equals the row's
+             * active freed base (active_frread, built once per row above). One
+             * cmpeq + one blendv; sentinel (0xFF) lanes never match a real s2
+             * so they pass through. */
             if (HasFreed) {
-                sbt = _mm256_blendv_epi8(sbt, match256,
+                sbt = _mm256_blendv_epi8(sbt, freedval256,
                                          _mm256_cmpeq_epi8(s2, active_frread));
             }
 
@@ -2115,18 +2152,19 @@ int kswv::kswv256_16_impl(int16_t seq1SoA[],
         __m256i l_vec   = zero_vec;
         __m256i i_vec   = _mm256_set1_epi16((int16_t)i);
 
-        /* Rank-1 freed-cell override (issue 173). s1 is loop-invariant, so
-         * hoist the per-row fr_ref comparison. The 16-bit kernel has NO shift
-         * bias (m11 = h00 + sbt directly), so the biased match constant is
-         * just temp8[0] (== w_match), sign-extended to int16. !HasFreed → both
-         * this and the per-cell block compile out. */
-        /* Free a SYMMETRIC PAIR of cells (collapsed bisulfite); GENOMIC sets the
-         * mirror == primary so the second blend is idempotent. */
-        __m256i frread256, frread2_256, match256, rowfreed, rowfreed2;
+        /* Freed-cell override (issue 173 + TAPS neutral). s1 is loop-invariant, so
+         * hoist the per-row fr_ref comparison. The 16-bit kernel has NO shift bias
+         * (m11 = h00 + sbt directly), so the freed value is just fr_val: fr_val==
+         * w_match (GENOMIC/COLLAPSED) equals temp8[0], NEUTRAL (fr_val==0) scores
+         * the conversion as 0. Sign-extended to int16. !HasFreed → both this and
+         * the per-cell block compile out. */
+        /* Free a SYMMETRIC PAIR of cells (collapsed bisulfite); GENOMIC/NEUTRAL set
+         * the mirror == primary so the second blend is idempotent. */
+        __m256i frread256, frread2_256, freedval256, rowfreed, rowfreed2;
         if (HasFreed) {
             frread256  = _mm256_set1_epi16((int16_t)fr_read);
             frread2_256= _mm256_set1_epi16((int16_t)fr_read2);
-            match256   = _mm256_set1_epi16((int16_t)temp8[0]);
+            freedval256= _mm256_set1_epi16((int16_t)fr_val);
             rowfreed   = _mm256_cmpeq_epi16(s1, _mm256_set1_epi16((int16_t)fr_ref));
             rowfreed2  = _mm256_cmpeq_epi16(s1, _mm256_set1_epi16((int16_t)fr_ref2));
         }
@@ -2145,8 +2183,8 @@ int kswv::kswv256_16_impl(int16_t seq1SoA[],
             __m256i sbt_b   = _mm256_blendv_epi8(sbt_lo, sbt_hi, hi_sel);
             __m256i sbt     = _mm256_srai_epi16(_mm256_slli_epi16(sbt_b, 8), 8);
 
-            /* Rank-1 freed-cell override (issue 173): where row==fr_ref and
-             * col==fr_read, force the match score. Real bases 0-3; fr_read ∈
+            /* Freed-cell override (issue 173 + TAPS neutral): where row==fr_ref and
+             * col==fr_read, force the freed score. Real bases 0-3; fr_read ∈
              * {0,3}; padding/ambig (DUMMY3/0xFFFF/AMBQ16) never equal fr_read,
              * so cmpeq is naturally false for them. _mm256_cmpeq_epi16 produces
              * an all-ones/all-zeros int16 mask, so the byte-wise blendv selects
@@ -2154,10 +2192,10 @@ int kswv::kswv256_16_impl(int16_t seq1SoA[],
             if (HasFreed) {
                 __m256i freed  = _mm256_and_si256(rowfreed,
                                                   _mm256_cmpeq_epi16(s2, frread256));
-                sbt = _mm256_blendv_epi8(sbt, match256, freed);
+                sbt = _mm256_blendv_epi8(sbt, freedval256, freed);
                 __m256i freed2 = _mm256_and_si256(rowfreed2,
                                                   _mm256_cmpeq_epi16(s2, frread2_256));
-                sbt = _mm256_blendv_epi8(sbt, match256, freed2);
+                sbt = _mm256_blendv_epi8(sbt, freedval256, freed2);
             }
 
             /* Boundary: high bit set in (s1 | s2) marks padding (0xFFFF). */
@@ -2766,19 +2804,21 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
         imax512 = zero512;
         __m512i iqe512 = _mm512_set1_epi8(-1);
 
-        /* Rank-1 freed-cell override (issue 173, bisulfite OT/OB). s1 is
+        /* Freed-cell override (issue 173, bisulfite OT/OB + TAPS neutral). s1 is
          * loop-invariant across the inner j loop, so hoist the per-row fr_ref
-         * comparison here; MAIN_SAM_CODE8_OPT consumes rowfreed512/frread512/
-         * match512 per cell when HasFreed. match512 is the kernel's OWN biased
-         * match entry (temp[0] already includes +shift), so the freed cell
-         * scores byte-identically to a real match in the biased u8 domain.
+         * comparisons here; MAIN_SAM_CODE8_OPT consumes active_frread512/
+         * freedval512 per cell when HasFreed. freedval512 is the freed cell's
+         * score (fr_val) biased by +shift into the u8 domain; fr_val==w_match
+         * (GENOMIC/COLLAPSED) reproduces the biased match entry temp[0] exactly,
+         * while NEUTRAL (fr_val==0) scores the conversion as 0 after unbiasing.
          * When !HasFreed, this and the per-cell block in the macro compile out
          * (identical codegen to today). Mirrors bandedSWA's blessed forms. */
-        /* Free a SYMMETRIC PAIR of cells (collapsed bisulfite); GENOMIC sets the
-         * mirror == primary so the second blend is idempotent. */
-        __m512i match512, active_frread512;
+        /* Free a SYMMETRIC PAIR of cells (collapsed bisulfite); GENOMIC/NEUTRAL set
+         * the mirror == primary so the second blend is idempotent. Both cells score
+         * the same fr_val, so one freedval512 covers the folded target below. */
+        __m512i freedval512, active_frread512;
         if (HasFreed) {
-            match512   = _mm512_set1_epi8((char)temp[0]);
+            freedval512 = _mm512_set1_epi8((char)(fr_val + shift));
             __mmask64 rowfreed512  = _mm512_cmpeq_epi8_mask(s1, _mm512_set1_epi8((char)fr_ref));
             __mmask64 rowfreed2_512= _mm512_cmpeq_epi8_mask(s1, _mm512_set1_epi8((char)fr_ref2));
             /* One per-lane freed target: fr_read where ref==fr_ref, fr_read2 where
@@ -3360,20 +3400,21 @@ int kswv::kswv512_16_impl(int16_t seq1SoA[],
         imax512 = zero512;
         __m512i iqe512 = _mm512_set1_epi16(-1);
 
-        /* Rank-1 freed-cell override (issue 173). s1 is loop-invariant, so
+        /* Freed-cell override (issue 173 + TAPS neutral). s1 is loop-invariant, so
          * hoist the per-row fr_ref comparison; MAIN_SAM_CODE16_OPT consumes
-         * rowfreed512/frread512/match512 per cell when HasFreed. The 16-bit
-         * kernel has NO shift bias (m11 = h00 + sbt directly), so the biased
-         * match constant is just temp[0] (== w_match). !HasFreed → this and the
+         * rowfreed512/frread512/freedval512 per cell when HasFreed. The 16-bit
+         * kernel has NO shift bias (m11 = h00 + sbt directly), so the freed value
+         * is just fr_val: fr_val==w_match (GENOMIC/COLLAPSED) equals temp[0], while
+         * NEUTRAL (fr_val==0) scores the conversion as 0. !HasFreed → this and the
          * per-cell block in the macro compile out. */
-        __m512i frread512, frread2_512, match512;
+        __m512i frread512, frread2_512, freedval512;
         __mmask32 rowfreed512 = 0, rowfreed2_512 = 0;
         if (HasFreed) {
             __m512i frref512  = _mm512_set1_epi16((int16_t)fr_ref);
             __m512i frref2512 = _mm512_set1_epi16((int16_t)fr_ref2);
             frread512  = _mm512_set1_epi16((int16_t)fr_read);
             frread2_512= _mm512_set1_epi16((int16_t)fr_read2);
-            match512   = _mm512_set1_epi16((int16_t)temp[0]);
+            freedval512= _mm512_set1_epi16((int16_t)fr_val);
             rowfreed512  = _mm512_cmpeq_epi16_mask(s1, frref512);
             rowfreed2_512= _mm512_cmpeq_epi16_mask(s1, frref2512);
         }

--- a/src/kswv.h
+++ b/src/kswv.h
@@ -171,12 +171,15 @@ public:
      * tier cannot express, so the caller must route those pairs to the scalar
      * fallback (ksw_align2). Two reasons it can be true:
      *   - the matrix shape is unsupported: a non-mirror multi-cell free, a
-     *     changed diagonal, or a freed value != w_match; or
+     *     changed diagonal, or a freed value outside [w_mismatch, w_match]
+     *     (outside that domain the 8-bit kernel's biased-u8 blend would wrap);
+     *     or
      *   - the running tier lacks the freed-cell kernel override. Only the NEON,
      *     AVX2, and AVX-512BW kernels implement it; an SSE41/SSE42/AVX kswv
      *     reports true for any freed-cell matrix.
-     * A symmetric matrix, a rank-1 freed cell (bisulfite genomic OT/OB), or an
-     * exact mirrored freed pair (collapsed --meth) returns false on a tier that
+     * A symmetric matrix, a single freed cell scored to ANY in-domain value
+     * (bisulfite genomic OT/OB frees it to +a, neutral to 0), or an exact
+     * mirrored freed pair (collapsed --meth) returns false on a tier that
      * implements the override. Declared on the abstract interface so the
      * dispatcher never depends on the concrete kswv layout. */
     virtual bool needsScalar() const = 0;
@@ -192,12 +195,12 @@ std::unique_ptr<Ikswv> make_kswv(
 
 /* Mat-aware factory overload (issue 173). `mat25` is the 5x5 scoring matrix
  * the caller will use for SW; when non-null and asymmetric, the ctor detects
- * the rank-1 freed cell (bisulfite OT/OB) or flags needsScalar() for any
- * richer asymmetry. `mat25 == nullptr` (or a symmetric matrix) reproduces the
- * 9-arg behavior exactly. The sign convention matches make_kswv's existing
- * callers: w_match is +a, w_mismatch is -b (negative), and mat25's
- * off-diagonals are likewise the negated penalty — passed straight through to
- * the Task-1 detectors without re-negation. */
+ * the freed cell (bisulfite OT/OB) and the value it is freed to, or flags
+ * needsScalar() for any richer asymmetry. `mat25 == nullptr` (or a symmetric
+ * matrix) reproduces the 9-arg behavior exactly. The sign convention matches
+ * make_kswv's existing callers: w_match is +a, w_mismatch is -b (negative),
+ * and mat25's off-diagonals are likewise the negated penalty — passed straight
+ * through to the Task-1 detectors without re-negation. */
 std::unique_ptr<Ikswv> make_kswv(
     int o_del, int e_del, int o_ins, int e_ins,
     int8_t w_match, int8_t w_mismatch,
@@ -245,7 +248,8 @@ public:
 		 int numThreads, int32_t maxRefLen, int32_t maxQerLen);
 
 	/* Mat-aware ctor (issue 173): same as above, plus a 5x5 scoring matrix
-	 * used to detect the rank-1 freed cell. `mat25 == nullptr` reproduces the
+	 * used to detect the freed cell(s) and the value they are freed to.
+	 * `mat25 == nullptr` reproduces the
 	 * 9-arg ctor exactly. Delegates to the 9-arg ctor, then runs detection. */
 	kswv(const int o_del, const int e_del, const int o_ins,
 		 const int e_ins, const int8_t w_match, const int8_t w_mismatch,
@@ -305,7 +309,7 @@ private:
 						   int phase);
 
 	/* Thin dispatcher: selects the HasFreed template instantiation based on
-	 * the rank-1 freed-cell flag. The <false> instantiation dead-code-
+	 * the freed-cell flag. The <false> instantiation dead-code-
 	 * eliminates every freed-cell override block, giving codegen identical to
 	 * the pre-issue-173 kernel for the non-meth path. */
 	int kswv_neon_u8(uint8_t seq1SoA[],
@@ -319,8 +323,8 @@ private:
 				     int32_t numPairs,
 				     int phase);
 
-	/* Templated u8 kernel body. When HasFreed, applies the rank-1 freed-cell
-	 * (fr_ref x fr_read -> match) override per cell; otherwise the override
+	/* Templated u8 kernel body. When HasFreed, applies the freed-cell
+	 * (fr_ref x fr_read -> fr_val) override per cell; otherwise the override
 	 * blocks compile out entirely. */
 	template<bool HasFreed>
 	int kswv_neon_u8_impl(uint8_t seq1SoA[],
@@ -386,7 +390,7 @@ private:
 								int phase);
 
 	/* Thin dispatcher: selects the HasFreed template instantiation based on
-	 * the rank-1 freed-cell flag. The <false> instantiation dead-code-
+	 * the freed-cell flag. The <false> instantiation dead-code-
 	 * eliminates every freed-cell override block, giving codegen identical to
 	 * the pre-issue-173 kernel for the non-meth path. Mirrors kswv_neon_u8. */
 	int kswv256_u8(uint8_t seq1SoA[],
@@ -456,7 +460,7 @@ private:
 						   int phase);
 
 	/* Thin dispatcher: selects the HasFreed template instantiation based on
-	 * the rank-1 freed-cell flag. See kswv256_u8 / kswv_neon_u8. */
+	 * the freed-cell flag. See kswv256_u8 / kswv_neon_u8. */
 	int kswv512_u8(uint8_t seq1SoA[],
 				   uint8_t seq2SoA[],
 				   int16_t nrow,
@@ -530,12 +534,18 @@ private:
 	// const int8_t *mat;
 
 	/* Freed-cell descriptor (issue 173), populated by the mat-aware ctor.
-	 * `has_freed` ⇒ off-diagonal cells were freed to a match (bisulfite). The
-	 * kernel frees a SYMMETRIC PAIR of cells: (fr_ref x fr_read) and
-	 * (fr_ref2 x fr_read2). GENOMIC (rank-1) frees ONE cell, so the mirror
+	 * `has_freed` ⇒ off-diagonal cells were freed from their symmetric value
+	 * (bisulfite). The kernel frees a SYMMETRIC PAIR of cells: (fr_ref x
+	 * fr_read) and (fr_ref2 x fr_read2). GENOMIC and NEUTRAL free ONE cell
+	 * (to +a and to 0 respectively), so the mirror
 	 * equals the primary (fr_ref2==fr_ref, fr_read2==fr_read) and the second
 	 * blend is idempotent. COLLAPSED (the --meth default) frees the conversion
 	 * cell AND its mirror, so (fr_ref2,fr_read2) = (fr_read,fr_ref).
+	 * `fr_val` is the VALUE the freed cell(s) score to: w_match for GENOMIC and
+	 * COLLAPSED (freed to a match), or any other constant for a single-cell free
+	 * that is not a match (NEUTRAL frees the conversion cell to 0). The kernel
+	 * blends the freed cell(s) to fr_val (biased by +shift in the 8-bit domain),
+	 * so fr_val==w_match reproduces the pre-generalization match blend exactly.
 	 * `needs_scalar` ⇒ the matrix is asymmetric in a way the kernel cannot
 	 * express (non-mirror multi-cell, changed diagonal, …) and the caller must
 	 * fall back to scalar. The 9-arg ctor leaves all false. ABI note: these live
@@ -543,6 +553,9 @@ private:
 	 * includes this same kswv.h. */
 	int8_t fr_ref = 0, fr_read = 0;
 	int8_t fr_ref2 = 0, fr_read2 = 0;
+	int8_t fr_val = 0;   /* set to w_match in the mat-aware ctor unless a single
+	                        non-match cell was freed (NEUTRAL); default 0 is unused
+	                        when has_freed is false. */
 	bool has_freed = false;
 	bool needs_scalar = false;
 

--- a/test/kswv_freed_cell_test.cpp
+++ b/test/kswv_freed_cell_test.cpp
@@ -1,13 +1,14 @@
 // Issue 173 / Task 2: mat-aware make_kswv freed-cell detection.
 //
-// The kswv factory learns a per-strand asymmetric (rank-1 freed-cell)
+// The kswv factory learns a per-strand asymmetric (freed-cell)
 // substitution for bisulfite (--meth). A symmetric matrix (or nullptr)
 // constructs the existing kernel unchanged; a matrix that frees exactly one
-// ordered off-diagonal cell to a match (OT: ref-C/read-T, OB: ref-G/read-A)
-// records that freed cell and is handled by the kernel; an exact mirrored pair
-// (collapsed --meth) is likewise handled; any other asymmetric matrix (a
-// non-mirror multi-cell free, changed diagonal, non-match freed value) routes
-// to the scalar fallback (needsScalar() == true).
+// ordered off-diagonal cell (OT: ref-C/read-T, OB: ref-G/read-A) to ANY value
+// records that freed cell and its value and is handled by the kernel — a match
+// (+a) under GENOMIC, 0 under NEUTRAL; an exact mirrored pair (collapsed
+// --meth) is likewise handled; any other asymmetric matrix (a non-mirror
+// multi-cell free, changed diagonal) routes to the scalar fallback
+// (needsScalar() == true).
 //
 // Two layers are tested: (1) ctor-side detection (needsScalar) on every tier,
 // and (2) the kernel actually APPLYING the freed cell via getScores8. Layer (2)
@@ -34,9 +35,10 @@ static void fill_sym(int8_t m[25], int a, int b) {
 // make_kswv reports needsScalar() == true for a freed-cell matrix (so the caller
 // routes to scalar ksw_align2), and getScores8/16 are unreachable exit() stubs.
 // The freed-cell DETECTION cases below therefore assert needsScalar() == !FREED
-// for rank-1/mirror matrices, and the score-delta cases (which call getScores8)
-// run only when FREED — on a scalar-only tier the fallback contract is what the
-// detection cases verify, and there is no kernel score to compare.
+// for single-cell (any freed value) and mirror matrices, and the score-delta
+// cases (which call getScores8) run only when FREED — on a scalar-only tier the
+// fallback contract is what the detection cases verify, and there is no kernel
+// score to compare.
 //
 // This gate is derived from the INDEPENDENT SIMD dispatch tier
 // (bwamem3_simd_tier, which is the same tier make_kswv dispatches on and which
@@ -62,8 +64,8 @@ static bool tier_supports_freed_cell() {
 
 // Run getScores8 over a single ref/read pair through the batched NEON 8-bit
 // kernel and return aln[0].score. `mat25 == nullptr` constructs the symmetric
-// kernel (no freed cell); a meth matrix sets has_freed and applies the rank-1
-// override. Ref/read are base-encoded (A=0,C=1,G=2,T=3). The pair is laid out
+// kernel (no freed cell); a meth matrix sets has_freed and blends the freed
+// cell to fr_val. Ref/read are base-encoded (A=0,C=1,G=2,T=3). The pair is laid out
 // so the optimal local alignment is the full diagonal — every column is a
 // match except the deliberately planted converted base.
 static int score8(const std::vector<uint8_t>& ref,
@@ -105,8 +107,8 @@ TEST_CASE("kswv symmetric matrix is not a freed-cell case") {
     auto k = make_kswv(6,1,6,1, 1,-4, 1, 256,256, m);
     CHECK(k->needsScalar() == false);                      // symmetric ⇒ normal kernel
 }
-TEST_CASE("kswv non-rank1 asymmetric falls back to scalar") {
-    int8_t m[25]; fill_sym(m,1,4); m[1*5+3]=1; m[2*5+0]=1; // two freed cells
+TEST_CASE("kswv non-mirror multi-cell asymmetric falls back to scalar") {
+    int8_t m[25]; fill_sym(m,1,4); m[1*5+3]=1; m[2*5+0]=1; // two freed, not mirrors
     auto k = make_kswv(6,1,6,1, 1,-4, 1, 256,256, m);
     CHECK(k->needsScalar() == true);
 }
@@ -253,4 +255,84 @@ TEST_CASE("kswv non-mirror two-cell matrix (OT+OB) still routes to scalar") {
     int8_t m[25]; fill_sym(m,1,4); m[1*5+3]=1; m[2*5+0]=1;  // (C,T)+(G,A): not a mirror pair
     auto k = make_kswv(6,1,6,1, 1,-4, 1, 256,256, m);
     CHECK(k->needsScalar() == true);
+}
+
+// ---------------------------------------------------------------------------
+// NEUTRAL scoring (the --meth=taps default): the conversion cell is freed to 0
+// — tolerated but NOT rewarded — while the mirror stays a real mismatch. The
+// kernel blends the freed cell to the matrix value (fr_val), not to a match, so
+// the freed value is what these cases pin down. A freed value other than the
+// match score used to route to scalar; it must now run batched on a freed-cell
+// tier, exactly like GENOMIC.
+// ---------------------------------------------------------------------------
+TEST_CASE("kswv detects neutral OT freed cell (ref-C x read-T scored 0)") {
+    int8_t m[25]; fill_sym(m,1,4); m[1*5+3] = 0;           // free (C,T) to 0, not to +a
+    auto k = make_kswv(6,1,6,1, 1,-4, 1, 256,256, m);
+    CHECK(k->needsScalar() == !tier_supports_freed_cell());
+}
+TEST_CASE("kswv detects neutral OB freed cell (ref-G x read-A scored 0)") {
+    int8_t m[25]; fill_sym(m,1,4); m[2*5+0] = 0;
+    auto k = make_kswv(6,1,6,1, 1,-4, 1, 256,256, m);
+    CHECK(k->needsScalar() == !tier_supports_freed_cell());
+}
+// The 8-bit kernel blends fr_val into a biased u8 domain that only represents
+// [w_mismatch, w_match]. A single freed cell outside that range would wrap the
+// biased byte, so the ctor must route it to the scalar fallback instead.
+TEST_CASE("kswv freed value outside [w_mismatch, w_match] routes to scalar") {
+    int8_t lo[25]; fill_sym(lo,1,4); lo[1*5+3] = -5;   // below the mismatch score
+    CHECK(make_kswv(6,1,6,1, 1,-4, 1, 256,256, lo)->needsScalar() == true);
+    int8_t hi[25]; fill_sym(hi,1,4); hi[1*5+3] = 2;    // above the match score
+    CHECK(make_kswv(6,1,6,1, 1,-4, 1, 256,256, hi)->needsScalar() == true);
+}
+// The decisive behavior: neutral scores the conversion cell 0, so it recovers
+// exactly the mismatch penalty b relative to the symmetric matrix — and stays a
+// full match score a BELOW genomic, which rewards the same cell with +a.
+TEST_CASE("kswv NEON 8-bit: neutral OT scores the conversion cell 0") {
+    if (!tier_supports_freed_cell()) return;   // scalar-only tier: no kernel score
+    const int a = 1, b = 4;
+    std::vector<uint8_t> ref  = {0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3};
+    std::vector<uint8_t> read = ref;
+    const int p = 10;
+    ref[p]  = 1;                      // ref C
+    read[p] = 3;                      // read T (the C->T conversion)
+
+    int8_t sym[25]; fill_sym(sym, a, b);
+    int8_t gen[25]; fill_sym(gen, a, b); gen[1*5+3] = (int8_t)a;   // genomic: freed to +a
+    int8_t neu[25]; fill_sym(neu, a, b); neu[1*5+3] = 0;           // neutral: freed to 0
+
+    int s_sym = score8(ref, read, a, b, sym);
+    int s_gen = score8(ref, read, a, b, gen);
+    int s_neu = score8(ref, read, a, b, neu);
+    CHECK(s_neu - s_sym == b);        // mismatch penalty removed, no reward
+    CHECK(s_gen - s_neu == a);        // genomic additionally rewards the match
+}
+TEST_CASE("kswv NEON 8-bit: neutral OB scores the conversion cell 0") {
+    if (!tier_supports_freed_cell()) return;   // scalar-only tier: no kernel score
+    const int a = 1, b = 4;
+    std::vector<uint8_t> ref  = {0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3};
+    std::vector<uint8_t> read = ref;
+    const int p = 10;
+    ref[p]  = 2;                      // ref G
+    read[p] = 0;                      // read A (the G->A conversion)
+
+    int8_t sym[25]; fill_sym(sym, a, b);
+    int8_t neu[25]; fill_sym(neu, a, b); neu[2*5+0] = 0;
+
+    CHECK(score8(ref, read, a, b, neu) - score8(ref, read, a, b, sym) == b);
+}
+// Neutral leaves the MIRROR cell a real mismatch (that is what keeps NM/MD
+// variant-aware): freeing (C,T) to 0 must not touch (T,C).
+TEST_CASE("kswv NEON 8-bit: neutral leaves the mirror cell a mismatch") {
+    if (!tier_supports_freed_cell()) return;   // scalar-only tier: no kernel score
+    const int a = 1, b = 4;
+    std::vector<uint8_t> ref  = {0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3};
+    std::vector<uint8_t> read = ref;
+    const int p = 10;
+    ref[p]  = 3;                      // ref T
+    read[p] = 1;                      // read C → the (T,C) mirror, a real variant
+
+    int8_t sym[25]; fill_sym(sym, a, b);
+    int8_t neu[25]; fill_sym(neu, a, b); neu[1*5+3] = 0;
+
+    CHECK(score8(ref, read, a, b, neu) == score8(ref, read, a, b, sym));
 }

--- a/test/unit/test_meth_scoring_matrix.cpp
+++ b/test/unit/test_meth_scoring_matrix.cpp
@@ -98,16 +98,51 @@ TEST_CASE("neutral frees the conversion cell to ZERO, not a match"
     free(o);
 }
 
-TEST_CASE("neutral is NOT a rank-1 batched-expressible matrix"
+TEST_CASE("neutral is a SINGLE freed cell (value 0), not rank-1"
           * doctest::test_suite("unit/meth_scoring"))
 {
-    // The freed cell holds 0, which is neither w_match nor w_mismatch, so the
-    // batched kswv kernel cannot express it. The aligner must fall back to the
-    // scalar rescue path rather than assert. This test pins the classifier that
-    // drives that decision.
+    // The freed conversion cell holds 0, which is not w_match, so it is NOT
+    // rank-1 — the pre-generalization predicate stays false, keeping the
+    // bandedSWA dispatch unchanged. But it IS a single off-diagonal free (one
+    // cell, any value, no diagonal change), which the generalized kswv freed-cell
+    // blend expresses by scoring that cell to fr_val (== 0 here). This pins the
+    // classifier that lets the batched kswv rescue kernel run neutral scoring.
     mem_opt_t *o = opt_for(MEM_METH_SCORING_NEUTRAL);
-    // bsw_freed_cell requires the freed value to equal w_match for rank-1.
     BswFreedCell fc = bsw_freed_cell(o->mat_ot, o->a, -o->b, /*forced=*/false);
+    CHECK(fc.rank1 == false);              // not a match-freed cell
+    CHECK(fc.single == true);              // exactly one off-diagonal freed
+    CHECK(fc.value == 0);                  // freed to 0 (neutral)
+    CHECK(fc.ref == 1);                    // OT freed cell is ref-C (1) x read-T (3)
+    CHECK(fc.read == 3);
+    free(o);
+}
+
+TEST_CASE("genomic is rank-1 AND single, freed to w_match"
+          * doctest::test_suite("unit/meth_scoring"))
+{
+    // Genomic frees the same conversion cell but to a full match (+a). It must
+    // remain rank-1 (byte-identical dispatch) and also register as single with
+    // value == w_match, so the generalized kernel blend reproduces the old
+    // match blend exactly.
+    mem_opt_t *o = opt_for(MEM_METH_SCORING_GENOMIC);
+    BswFreedCell fc = bsw_freed_cell(o->mat_ot, o->a, -o->b, /*forced=*/false);
+    CHECK(fc.rank1 == true);
+    CHECK(fc.single == true);
+    CHECK(fc.value == o->a);
+    free(o);
+}
+
+TEST_CASE("collapsed is neither single nor rank-1 (two freed cells)"
+          * doctest::test_suite("unit/meth_scoring"))
+{
+    // Collapsed frees the conversion cell AND its mirror, so it is NOT a single
+    // off-diagonal free. This is the arm that routes the kswv mat-aware ctor
+    // past the single-cell branch into bsw_freed_pair; pin it alongside the
+    // genomic/neutral arms so a regression in the classifier can't silently send
+    // collapsed down the single-cell blend (which would drop the mirror free).
+    mem_opt_t *o = opt_for(MEM_METH_SCORING_COLLAPSED);
+    BswFreedCell fc = bsw_freed_cell(o->mat_ot, o->a, -o->b, /*forced=*/false);
+    CHECK(fc.single == false);
     CHECK(fc.rank1 == false);
     free(o);
 }

--- a/test/unit/test_meth_scoring_matrix.cpp
+++ b/test/unit/test_meth_scoring_matrix.cpp
@@ -73,3 +73,41 @@ TEST_CASE("collapsed is the default scoring mode"
     CHECK(o->mat_ot[3 * 5 + 1] == o->a);
     free(o);
 }
+
+TEST_CASE("neutral frees the conversion cell to ZERO, not a match"
+          * doctest::test_suite("unit/meth_scoring"))
+{
+    // TAPS conversions are sparse (~3% of C), so rewarding the conversion as a
+    // full match (genomic) over-credits spurious C->T alignments. NEUTRAL scores
+    // the conversion cell as 0 -- tolerated but not rewarded -- which measured
+    // ~+0.25 pp placement over genomic across all methylation loads. See
+    // reports/2026-07-20-taps-alignment-experiment-results.md (question A).
+    mem_opt_t *o = opt_for(MEM_METH_SCORING_NEUTRAL);
+    const int b = o->b;
+
+    // OT: ref-C x read-T freed to 0 (neutral); mirror ref-T x read-C stays -b.
+    CHECK(o->mat_ot[1 * 5 + 3] == 0);
+    CHECK(o->mat_ot[3 * 5 + 1] == -b);
+    // OB: ref-G x read-A freed to 0; mirror ref-A x read-G stays -b.
+    CHECK(o->mat_ob[2 * 5 + 0] == 0);
+    CHECK(o->mat_ob[0 * 5 + 2] == -b);
+    // Diagonal matches and unrelated off-diagonals untouched.
+    CHECK(o->mat_ot[0 * 5 + 0] == o->a);   // A/A match
+    CHECK(o->mat_ot[0 * 5 + 1] == -b);     // ref-A x read-C real mismatch
+
+    free(o);
+}
+
+TEST_CASE("neutral is NOT a rank-1 batched-expressible matrix"
+          * doctest::test_suite("unit/meth_scoring"))
+{
+    // The freed cell holds 0, which is neither w_match nor w_mismatch, so the
+    // batched kswv kernel cannot express it. The aligner must fall back to the
+    // scalar rescue path rather than assert. This test pins the classifier that
+    // drives that decision.
+    mem_opt_t *o = opt_for(MEM_METH_SCORING_NEUTRAL);
+    // bsw_freed_cell requires the freed value to equal w_match for rank-1.
+    BswFreedCell fc = bsw_freed_cell(o->mat_ot, o->a, -o->b, /*forced=*/false);
+    CHECK(fc.rank1 == false);
+    free(o);
+}


### PR DESCRIPTION
Stacked on #228 (`feat/meth-taps-chemistry`) — review/merge that first; this PR's diff is against it.

## What

Adds a third `--meth-scoring` model, **NEUTRAL**, and makes `--meth=taps` default to it. NEUTRAL frees only the conversion cell (OT: ref-C × read-T, OB: ref-G × read-A) but scores it **0** rather than a full match: a converted base is *tolerated*, not *rewarded*. The mirror cell stays a real mismatch, so `NM`/`MD` remain truthful (like `genomic`) and `-B` stays 4.

Two commits:

1. **`feat(meth): add neutral --meth-scoring, the default for TAPS`** — the scoring model, CLI, help, docs, and unit tests.
2. **`perf(meth): express NEUTRAL scoring in the batched kswv rescue kernel`** — generalizes the kswv freed-cell blend so NEUTRAL runs on the batched rescue kernel instead of falling back to scalar. Bundled here so there is no rescue slowdown the moment this merges.

## Why NEUTRAL for TAPS

TAPS converts only methylated cytosines, so conversions are sparse (~3% of C vs ~95% for EM-seq on a matched chr22 sim). Rewarding a conversion as a full match over-credits spurious C→T alignments. Measured on 4.07M simulated TAPS reads vs full hg38 across three methylation loads:

| mode | placement |
|---|---|
| **neutral** (`--meth=taps` default) | **95.95–96.01%** |
| genomic | 95.68–95.73% |
| collapsed | 95.37–95.43% |
| *unconverted ceiling* | *96.02%* |

NEUTRAL reaches essentially the unconverted ceiling — a robust **+0.24–0.28 pp over genomic** — with identical MAPQ calibration (60+ bin 99.99% either way) and identical mean `NM` (1.966 vs 1.969), so the gain is not bought with over-confidence or inflated edit distance. Details in the experiment report.

## The kswv change

The batched kswv mate-rescue kernel previously hardcoded its freed-cell blend to the match register, expressing GENOMIC (one cell freed to +a) and COLLAPSED (mirror pair freed to +a). NEUTRAL frees the cell to 0, which was not expressible, so it took the scalar `ksw_align2` path.

- `bsw_freed_cell` now reports `single` (exactly one off-diagonal freed, any value) and captures that value; `rank1` becomes `single && value == w_match`, byte-identical to the old predicate — bandedSWA's own dispatch is unchanged.
- kswv gains an `fr_val` member; all six kernel bodies (NEON / AVX2 / AVX512BW × 8/16-bit) blend the freed cell to `freedval` = `fr_val + shift` (8-bit, biased) / `fr_val` (16-bit). When `fr_val == w_match` this reproduces the pre-change biased match entry exactly, so GENOMIC and COLLAPSED stay byte-identical.
- `meth_scoring_batched_expressible()` returns true for all modes now; NEUTRAL runs batched on freed-capable tiers and falls back to scalar on freed-less x86 tiers (sse41/sse42/avx), exactly as GENOMIC/COLLAPSED already do.

## SW-kernel-bench validation (required for kernel changes)

Validated with `bwa-bsw-bench` (stacked PR: fulcrumgenomics/bwa-bsw-bench#5). The batched kernel is **byte-identical to the `ksw_align2` scalar oracle** (score, te, qe, score2, te2) for collapsed, genomic, and neutral, at 8-bit and 16-bit, on **every freed-capable tier**:

**Correctness — GOLDEN CHECK PASS, 60000 pairs byte-identical:**

| tier | collapsed | genomic | neutral |
|---|---|---|---|
| NEON (arm64) | PASS | PASS | PASS |
| avx2 | PASS | PASS | PASS |
| avx512bw | PASS | PASS | PASS |
| sse41 | PASS (scalar fallback) | PASS (scalar fallback) | PASS (scalar fallback) |

(`tb`/`qb` come from the aligner's two-phase reverse pass, outside the isolated kernel; they are covered end-to-end by the `meth_rescue_batched_identical` regression, which still passes.)

**No slowdown — rescue throughput, neutral ≈ genomic (mb3 Mc/s):**

| tier | length | genomic | neutral |
|---|---|---|---|
| avx512bw | 150 | 13913 | 13922 |
| avx512bw | 250 | 8259 | 8282 |
| avx2 | 150 | 7743 | 7790 |
| NEON | 150 | 6716 | 6579 |

Identical code path, only the freed constant differs — differences are run-to-run noise.

## Tests / docs

92→93 unit doctest cases (added neutral + genomic single/rank1 classifier tests), `kswv_freed_cell_test` 13/13, `meth_rescue_batched_identical` regression PASS. mdbook methylation docs (flags, taps, overview) and `cli/mem` updated for the neutral mode and the new TAPS default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a third `--meth-scoring` mode: `neutral`.
  - `--meth=taps` now defaults to `neutral` (bare `--meth` defaults to `collapsed`).
  - `neutral` tolerates converted bases without rewarding them, affecting alignment/placement for sparse TAPS conversions.
- **Documentation**
  - Updated methylation and CLI help guides to describe `collapsed | genomic | neutral`, updated defaults, mismatch penalty behavior, and mirror/conversion scoring semantics.
- **Improvements**
  - Refined bisulfite/TAPS “freed-cell” scoring and improved batched rescue selection based on runtime SIMD support.
- **Tests**
  - Added/extended tests covering `neutral`, `genomic`, and `collapsed` matrix and freed-cell behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->