### PR TITLE
perf(kswv): skip the ref-boundary vbsl on all-real rows in 8-bit mate rescue (+7.5%)

### DIFF
--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -623,8 +623,12 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
             m11 = vbslq_u8(rowboundary, zero_vec, m11);
             m11 = vqsubq_u8(m11, sft_vec);
 
-            h11 = vmaxq_u8(m11, e11);
-            h11 = vmaxq_u8(h11, f11);
+            /* hme = max(m11, e11); reused verbatim for `me` (gap-D) below, where
+             * the original code recomputed the identical max(m11,e11) -- e11 is
+             * not modified between the two, so this is byte-identical and drops
+             * one vmaxq per cell. */
+            uint8x16_t hme = vmaxq_u8(m11, e11);
+            h11 = vmaxq_u8(hme, f11);
 
             /* Update imax tracking */
             uint8x16_t cmp0 = vcgtq_u8(h11, imax_vec);
@@ -636,7 +640,7 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
              * dominated by its own extension arg (O>=0, saturating u8). me must
              * read the OLD e11, so compute it before the e-update overwrites e11. */
             uint8x16_t mf = vmaxq_u8(m11, f11);
-            uint8x16_t me = vmaxq_u8(m11, e11);
+            uint8x16_t me = hme;   /* == vmaxq_u8(m11, e11), reused (e11 unchanged) */
             uint8x16_t gapE = vqsubq_u8(mf, oe_ins_vec);
             e11 = vqsubq_u8(e11, e_ins_vec);
             e11 = vmaxq_u8(gapE, e11);

--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -549,6 +549,17 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
     vst1q_u8(H0, zero_vec);
     vst1q_u8(H1, zero_vec);
 
+    /* Rows below the group's SHORTEST ref window have no padding lane, so the
+     * per-row boundary mask (rowboundary, below) is all-zero there and the vbsl
+     * that applies it is a no-op. Below minLen1 we skip it entirely. For a
+     * uniform-length group (the common case: production ref windows cluster
+     * tightly) minLen1 == nrow, so the vbsl never runs -- recovering the whole
+     * boundary-mask cost -- while mixed-length groups still apply it on exactly
+     * the rows where some lane has started padding. Dummy tail lanes have
+     * len1==0, pinning minLen1 to 0 for a partial final group (no skip, safe). */
+    int minLen1 = p[0].len1;
+    for (int l = 1; l < SIMD_WIDTH8; l++) if (p[l].len1 < minLen1) minLen1 = p[l].len1;
+
     int i, limit = nrow;
     for (i = 0; i < nrow; i++)
     {
@@ -590,6 +601,12 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
          * the per-cell blend remains. The byte-identity golden gate is the safety
          * net: if any s2 lane ever carried bit 7, the check would fail instantly. */
         uint8x16_t rowboundary = vtstq_u8(s1, vdupq_n_u8(0x80));
+        /* Apply the mask only once some lane has begun padding (i >= minLen1);
+         * below that every lane still holds a real base, so rowboundary is
+         * all-zero and the blend is a no-op. Loop-invariant across j, so the
+         * compiler unswitches the inner loop into a masked and an unmasked
+         * copy -- no per-cell branch. */
+        const bool apply_bound = (i >= minLen1);
 
         uint8x16_t l_vec = zero_vec;
         for (j = 0; j < ncol; j++)
@@ -620,7 +637,10 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
             }
 
             uint8x16_t m11 = vqaddq_u8(h00, sbt);
-            m11 = vbslq_u8(rowboundary, zero_vec, m11);
+            /* Zero m11 on ref-boundary/padding rows via the hoisted per-row mask
+             * (see rowboundary above). Skipped entirely below minLen1, where no
+             * lane pads and the mask is provably all-zero. */
+            if (apply_bound) m11 = vbslq_u8(rowboundary, zero_vec, m11);
             m11 = vqsubq_u8(m11, sft_vec);
 
             /* hme = max(m11, e11); reused verbatim for `me` (gap-D) below, where


### PR DESCRIPTION
## Summary

Removes the remaining per-cell boundary work from the NEON 8-bit mate-rescue inner loop (`kswv_neon_u8_impl`) — the larger of the two vectorized SW kernels (~31% of `mem` CPU; 100% 8-bit for Illumina rescue). Net **+7.5%** on Graviton4 at the production rescue shape, byte-identical.

> **Rebased onto post-#253 `main`.** This PR originally carried the row-boundary hoist as its first commit; that hoist landed independently as #253 (which also covers the AVX-512 and AVX2 tiers), so it has been dropped here. The headline moved from `+10.6%` (vs pre-#253 `main`) to **`+7.5%`** (vs post-#253 `main`) — the same measurement, re-anchored to the new baseline. Nothing about the remaining change was altered.

Two commits:

### 1. Reuse the duplicate `max(m11,e11)` (neutral)

The loop computed `h11`'s first `max(m11,e11)` and later recomputed the identical value for the gap-D `me` term. `e11` is unchanged between the two, so reuse it and drop one `vmaxq` per cell. Neutral on its own; it sets up commit 2, where the two uses straddle the skipped mask.

### 2. Skip the retained `vbsl` on all-real rows (+7.5%)

After #253's hoist, a per-cell `vbsl` applying the per-row `rowboundary` mask remains. It is a **no-op on every row below the group's shortest ref window** (`minLen1`), where no lane has started padding and the mask is provably all-zero. Gate it on `i >= minLen1` — loop-invariant across `j`, so the compiler unswitches the inner loop into masked/unmasked copies (no per-cell branch). For uniform-length groups (the common case; production ref windows cluster tightly at ~1044) `minLen1 == nrow` and the `vbsl` never runs. Dummy tail lanes carry `len1 == 0`, pinning `minLen1 = 0` for a partial final group, so the skip is disabled exactly where it would be unsafe.

## Correctness

Byte-identical, validated against exactly the case that makes the boundary mask load-bearing. The **naive full removal** of the mask (also ~+10% over pre-#253 `main`) is **unsafe** — it corrupts **41% of pairs** when a SIMD group has mixed ref-window lengths, because a `0xFF` padding row leaks into the `te`/`gmax` tracking. This PR keeps the zeroing on exactly the padding rows, so it is safe.

Validated with `bwa-bsw-bench`'s **mixed-length rescue gate** (`--rescue-mixlen`, varying both ref-window and read length within SIMD groups, incl. `--n-pct 10`). Re-run after the rebase, with goldens emitted from a worktree at post-#253 `origin/main` and checked against this branch — six gates, 60000 pairs each:

```
extend                                    GOLDEN CHECK PASS
rescue, uniform                           GOLDEN CHECK PASS
rescue, --rescue-mixlen 40                GOLDEN CHECK PASS
rescue, --rescue-mixlen 40 --n-pct 10     GOLDEN CHECK PASS
rescue, --force-width 8 uniform           GOLDEN CHECK PASS
rescue, --force-width 8 --rescue-mixlen   GOLDEN CHECK PASS
```

In-repo `kswv_nrow_zero_test` and `kswv_freed_cell_test` also pass.

**Depends on** the `--rescue-mixlen` gate — fulcrumgenomics/bwa-bsw-bench#6. The previous uniform-length rescue workload could not exercise the padding path and would false-PASS a broken boundary change.

## Performance (Graviton4 c8g, production rescue shape 150×1044, reps=5, 3 samples)

| build | kswv 8-bit Mc/s | Δ vs post-#253 `main` | scoreOK% |
|---|---|---|---|
| post-#253 `main` equivalent (hoist only) | 4934.1 | — | 100.0% |
| **+ skip vbsl (this PR)** | **5301.9** | **+7.5%** | 100.0% |

For reference against the pre-#253 baseline that the original measurement used: `origin/main` 4793.3 → hoist 4934.1 (+2.9%, now shipped as #253) → this PR 5301.9 (+10.6% cumulative). The `hoist only` row above is functionally identical to what #253 shipped on NEON, so the +7.5% is a direct measurement of this PR against the current baseline and does not need re-running.

This safely matches the unsafe full-removal ceiling (~+10.4% cumulative, 41%-corrupt).

**Host caveat:** the gain is Graviton4-specific. On Apple Silicon (arm64 laptop) the same change measures neutral — 3 rep-sets × 7 reps at 150×1044 gave 8520/8523/8550 Mc/s for this branch vs 8543/8573 for `main`, within noise. That matches the pattern seen repeatedly in this kernel family (Apple's wider issue absorbs per-cell work that Graviton4 does not), and is why all throughput numbers here are taken on c8g. Correctness is host-independent and gated on both.

## Scope

- NEON 8-bit path only (`kswv_neon_u8_impl<false>`). x86 tiers and the 16-bit path untouched (16-bit rescue is effectively dead for Illumina — all reads ≤151 bp route to 8-bit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved processing efficiency for mate-rescue alignment calculations.
  * Reduced redundant computations during SIMD-accelerated processing.

* **Bug Fixes**
  * Corrected row-boundary masking behavior in SIMD processing, improving accuracy for edge/tail regions of alignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
