### PR TITLE
Recommend clang over g++ (version banner, Makefile warning, docs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ else ifeq ($(CXX), icpx)
 else ifeq ($(CXX), g++)
 	CC= gcc
     # bwa-mem3 is consistently faster when built with clang than with g++
-    # (~15% lower wall + CPU on WGS at the AVX2 floor; see
+    # (~5-10% lower wall + CPU on x86; see
     # docs/src/best-practices/build.md). g++ is GNU make's default CXX, so a
     # bare `make` lands here — but the nudge is deliberately UNguarded by
     # $(origin CXX), so an explicit `CXX=g++` sees it too: the recommendation
@@ -54,7 +54,7 @@ else ifeq ($(CXX), g++)
     # tab — a tab-prefixed $(warning) is parsed as a recipe by GNU make 3.81
     # ("commands commence before first target"). Matches the space-indented
     # warning in the else-branch below.
-    $(warning bwa-mem3: building with g++. clang builds run ~15% faster on this workload — consider `make CXX=clang++ CC=clang`. See docs/src/best-practices/build.md.)
+    $(warning bwa-mem3: building with g++. clang builds run ~5-10% faster on x86 — consider `make CXX=clang++ CC=clang`. See docs/src/best-practices/build.md.)
 else ifeq ($(CXX), clang++)
 	CC= clang
 else ifeq ($(CXX), c++)

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,18 @@ else ifeq ($(CXX), icpx)
 	CC= icx
 else ifeq ($(CXX), g++)
 	CC= gcc
+    # bwa-mem3 is consistently faster when built with clang than with g++
+    # (~15% lower wall + CPU on WGS at the AVX2 floor; see
+    # docs/src/best-practices/build.md). g++ is GNU make's default CXX, so a
+    # bare `make` lands here — but the nudge is deliberately UNguarded by
+    # $(origin CXX), so an explicit `CXX=g++` sees it too: the recommendation
+    # holds either way. (The else-branch below guards its hint on
+    # $(origin CC) because that one flags a real hazard — a defaulted CC
+    # mixing toolchains — which an explicit CC cannot hit.) NOTE: space-indented, not
+    # tab — a tab-prefixed $(warning) is parsed as a recipe by GNU make 3.81
+    # ("commands commence before first target"). Matches the space-indented
+    # warning in the else-branch below.
+    $(warning bwa-mem3: building with g++. clang builds run ~15% faster on this workload — consider `make CXX=clang++ CC=clang`. See docs/src/best-practices/build.md.)
 else ifeq ($(CXX), clang++)
 	CC= clang
 else ifeq ($(CXX), c++)
@@ -834,6 +846,21 @@ clean: pgo-clean profile-clean lto-clean
 # ----------------------------------------------------------------------------
 
 # Sub-commands whose --help is captured into docs/_generated/cli/.
+#
+# The capture below strips or normalizes every HOST-dependent line, so the
+# committed snippets are reproducible on any machine and the CI drift check
+# (`git diff --exit-code docs/_generated/`) stays meaningful. Dropped outright:
+# timing, launcher chatter, and [W:: warnings — none of which are part of the
+# documented output. Normalized to a placeholder (kept, because they ARE part
+# of the canonical output documented in docs/src/cli/version.md, which includes
+# this capture as its synopsis):
+#   - the version line (git describe),
+#   - the `Compiler:` line (`version` reports the toolchain that built the
+#     binary, so it reads `clang X.Y.Z` locally and `gcc X.Y.Z` on a g++ CI
+#     runner),
+#   - the `SIMD floor:` / `SIMD runtime:` lines (vary by build arch and host
+#     CPU: avx2/avx512bw on x86, neon on arm64).
+# Any future host-dependent line must be added here too.
 DOCS_CLI_SUBCMDS := index mem shm version
 
 docs:
@@ -851,10 +878,11 @@ docs-cli: $(EXE)
 			| grep -v '^Total time taken:' \
 			| grep -v '^Looking to launch ' \
 			| grep -v '^Launching executable ' \
-			| grep -v '^SIMD floor: ' \
-			| grep -v '^SIMD runtime: ' \
 			| grep -v '^\[W::' \
-			| awk '/^v?[0-9]+\.[0-9]+/ {print "v<MAJOR.MINOR>-<N>-g<COMMIT>"; next} {print}' \
+			| awk '/^v?[0-9]+\.[0-9]+/ {print "v<MAJOR.MINOR>-<N>-g<COMMIT>"; next} \
+			       /^Compiler: / {print "Compiler: <TOOLCHAIN> <VERSION>"; next} \
+			       /^SIMD floor: / {print "SIMD floor: <FLOOR-TIER> (<HOST-CLASS>); kernels: <KERNEL-LIST>"; next} \
+			       /^SIMD runtime: / {print "SIMD runtime: <RUNTIME-TIER> (<FORCE-TIER-STATE>)"; next} {print}' \
 			> docs/_generated/cli/$$sub.txt; \
 	done
 

--- a/docs/_generated/cli/version.txt
+++ b/docs/_generated/cli/version.txt
@@ -1,2 +1,5 @@
 v<MAJOR.MINOR>-<N>-g<COMMIT>
+Compiler: <TOOLCHAIN> <VERSION>
+SIMD floor: <FLOOR-TIER> (<HOST-CLASS>); kernels: <KERNEL-LIST>
+SIMD runtime: <RUNTIME-TIER> (<FORCE-TIER-STATE>)
 mimalloc 3.3.0 (active)

--- a/docs/src/best-practices/build.md
+++ b/docs/src/best-practices/build.md
@@ -41,14 +41,20 @@ matters nearly as much as the vendor.
 
 ### x86-64
 
-The bigger, and more surprising, win is on x86 — clang's optimizer handles
-bwa-mem3's C++ notably better than g++ here. Measured on AWS `c6a.8xlarge`
-(AVX2, `-t 16`), hg38, 5M read pairs, `make arch=avx2`, median-of-3:
+clang's optimizer handles bwa-mem3's C++ better than g++ on x86 — a consistent
+win on every sample and arch, though its size depends on the microarchitecture.
+Measured across the benchmark sweep at **v0.6.0** (hg38, 5M read pairs, `-t 16`,
+per-arch median of compute-time deltas over wgs / wes / panel / hic / sbx):
 
-| Compiler | CPU-seconds | wall | vs g++ |
-|---|---:|---:|---:|
-| g++ 14.2 | 1486 | 1:39 | — |
-| clang 19.1 | 1246 | 1:23 | **~16% faster** |
+| x86 arch | clang vs g++ (compute) |
+|---|---:|
+| c6a (Zen 3, AVX2) | **~8% faster** (up to ~13% on some samples) |
+| c7a (Zen 4, AVX-512) | ~3–4% faster |
+
+The gain is largest on Zen 3 / AVX2 (~8%) and smallest on Zen 4 (~3–4%); the
+`--fast` preset shows a similar ~5–10% clang edge. (An earlier single-host
+spot-check on a `c6a.8xlarge` suggested ~16%; the release-wide numbers above
+are the representative figure.)
 
 ### ARM / aarch64
 
@@ -65,9 +71,9 @@ hand-written intrinsics, so codegen quality depends heavily on the compiler
 
 Takeaways:
 
-- **clang beats g++ on both ISAs** — ~16% on x86 (AVX2) and ~6% on ARM here.
-  The x86 gain is the larger one and applies to the mainstream deployment
-  target, so clang is the recommended production compiler across the board.
+- **clang beats g++ on both ISAs** — ~5–10% on x86 (AVX2) and ~6% on ARM here.
+  It's a consistent win on the mainstream deployment target, so clang is the
+  recommended production compiler across the board.
 - **Compiler *version* matters too.** On ARM a larger ~18% clang-over-gcc gap
   has been reported against an older gcc (~13); against a modern gcc (15.2) it
   narrows to ~6% because recent gcc closed much of the NEON gap. Prefer clang,

--- a/docs/src/best-practices/build.md
+++ b/docs/src/best-practices/build.md
@@ -31,35 +31,53 @@ the non-kernel TU compile baseline with `BASELINE_ARCH=` (default
 See [SIMD dispatch matrix](../performance/simd-dispatch.md) for the full list
 of targets and which kernels each vectorizes.
 
-## Use a recent compiler (especially on ARM)
+## Build with clang, not g++ (strongly recommended)
 
-Use the newest C++ compiler available, and on ARM/aarch64 prefer a recent
-`clang`. The compiler matters more on ARM than on x86: the aarch64 build runs
-its SIMD through the [sse2neon](../developer-guide/neon-port.md) translation
-layer rather than hand-written intrinsics, so codegen quality — and therefore
-throughput — depends heavily on the compiler **and its version**.
+**clang produces a materially faster bwa-mem3 than g++ on every platform we
+measure — build with clang unless you have a specific reason not to.** Pass
+`CXX=clang++ CC=clang` to `make` (the default `make` uses g++ and emits a
+warning nudging you here). Use the newest clang available; compiler *version*
+matters nearly as much as the vendor.
 
-Measured on AWS Graviton4 (`c8g.4xlarge`, 16 cores), hg38, 5M read pairs,
-`make arm64`, best-of-3 CPU-seconds:
+### x86-64
+
+The bigger, and more surprising, win is on x86 — clang's optimizer handles
+bwa-mem3's C++ notably better than g++ here. Measured on AWS `c6a.8xlarge`
+(AVX2, `-t 16`), hg38, 5M read pairs, `make arch=avx2`, median-of-3:
+
+| Compiler | CPU-seconds | wall | vs g++ |
+|---|---:|---:|---:|
+| g++ 14.2 | 1486 | 1:39 | — |
+| clang 19.1 | 1246 | 1:23 | **~16% faster** |
+
+### ARM / aarch64
+
+The aarch64 build runs its SIMD through the
+[sse2neon](../developer-guide/neon-port.md) translation layer rather than
+hand-written intrinsics, so codegen quality depends heavily on the compiler
+**and its version**. Measured on AWS Graviton4 (`c8g.4xlarge`, 16 cores), hg38,
+5M read pairs, `make arm64`, best-of-3 CPU-seconds:
 
 | Compiler | CPU-seconds | vs gcc 15.2 |
 |---|---:|---:|
 | gcc 15.2 | 1779 | — |
 | clang 22.1 | 1679 | ~6% faster |
 
-Two takeaways:
+Takeaways:
 
-- **clang generally emits better NEON than gcc** for sse2neon-translated code —
-  about 6% fewer CPU-seconds here.
-- **Compiler *version* matters as much as the vendor.** A larger ~18%
-  clang-over-gcc gap has been reported against an older gcc (~13); against a
-  modern gcc (15.2) it narrows to ~6%, because recent gcc closed most of the
-  NEON-codegen gap. Bumping the gcc version is often most of the win even
-  without switching to clang.
+- **clang beats g++ on both ISAs** — ~16% on x86 (AVX2) and ~6% on ARM here.
+  The x86 gain is the larger one and applies to the mainstream deployment
+  target, so clang is the recommended production compiler across the board.
+- **Compiler *version* matters too.** On ARM a larger ~18% clang-over-gcc gap
+  has been reported against an older gcc (~13); against a modern gcc (15.2) it
+  narrows to ~6% because recent gcc closed much of the NEON gap. Prefer clang,
+  but if you must use gcc, use the newest one.
 
-If you build the arm64 binary with clang, note the OpenMP runtime changes from
-`libgomp` to `libomp` (`llvm-openmp`) — see
-[Multi-architecture deployment](multi-arch-deployment.md).
+If you build with clang, note the OpenMP runtime changes from `libgomp` to
+`libomp` (`llvm-openmp`) — see
+[Multi-architecture deployment](multi-arch-deployment.md). Confirm which
+compiler a given binary was built with via `bwa-mem3 version`, which now prints
+a `Compiler:` line.
 
 ## Profile-Guided Optimization (PGO)
 
@@ -91,22 +109,23 @@ make USE_MIMALLOC=0
 
 ## Summary
 
-For a production installation on a known x86 server with AVX2:
+For a production installation on a known x86 server with AVX2 — build with
+clang and apply PGO on top:
 
 ```bash
-make pgo-generate PGO_ARCH=avx2
+make pgo-generate PGO_ARCH=avx2 CXX=clang++ CC=clang
 ./bwa-mem3.pgo-instr.avx2 mem -t 16 ref.fa R1.fq.gz R2.fq.gz > /dev/null
-make pgo-use PGO_ARCH=avx2
+make pgo-use PGO_ARCH=avx2 CXX=clang++ CC=clang
 # Deploy: bwa-mem3.pgo.avx2
 ```
 
-On ARM/aarch64 (Apple Silicon, AWS Graviton), build with a recent `clang` and
-apply PGO on top:
+On ARM/aarch64 (Apple Silicon, AWS Graviton), likewise build with a recent
+`clang` and apply PGO on top:
 
 ```bash
-make pgo-generate PGO_ARCH=arm64 CXX=clang++
+make pgo-generate PGO_ARCH=arm64 CXX=clang++ CC=clang
 ./bwa-mem3.pgo-instr mem -t 16 ref.fa R1.fq.gz R2.fq.gz > /dev/null
-make pgo-use PGO_ARCH=arm64 CXX=clang++
+make pgo-use PGO_ARCH=arm64 CXX=clang++ CC=clang
 # Deploy: bwa-mem3.pgo
 ```
 

--- a/docs/src/best-practices/multi-arch-deployment.md
+++ b/docs/src/best-practices/multi-arch-deployment.md
@@ -40,7 +40,7 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 
 > **Building the arm64 layer with clang?** A recent `clang` produces faster
 > NEON code than `gcc` on aarch64 (see
-> [Best Practices → Build](build.md#use-a-recent-compiler-especially-on-arm)).
+> [Best Practices → Build](build.md#arm--aarch64)).
 > If you switch the arm64 build to clang, swap the OpenMP runtime: clang links
 > `libomp` (LLVM) rather than `libgomp`, so the runtime stage needs `libomp5`
 > (or `llvm-openmp`) in place of `libgomp1`.

--- a/docs/src/cli/version.md
+++ b/docs/src/cli/version.md
@@ -1,10 +1,11 @@
 # version
 
-`bwa-mem3 version` prints the release version, the build's compiled-in
-SIMD floor, the SIMD tier resolved at runtime, and (when mimalloc is
-compiled in) the mimalloc version. It is the canonical way to confirm
-which build is on `PATH`, what host class it requires, and what kernel
-path it will dispatch to.
+`bwa-mem3 version` prints the release version, the compiler that built
+the binary, the build's compiled-in SIMD floor, the SIMD tier resolved
+at runtime, and (when mimalloc is compiled in) the mimalloc version. It
+is the canonical way to confirm which build is on `PATH`, what toolchain
+produced it, what host class it requires, and what kernel path it will
+dispatch to.
 
 `bwa-mem3 version` always exits 0 — even on a host below the build's
 SIMD floor — so operators can introspect a binary on a host that cannot
@@ -26,20 +27,27 @@ Confirm the installed version, SIMD floor, and resolved tier:
 ```
 
 A typical run on an AVX-512BW host with the default `BASELINE_ARCH=avx2`
-build prints (mimalloc line on stderr, the rest on stdout — order in a
-merged stream is not guaranteed):
+build prints (every line below goes to stdout; only the host-below-floor
+warning described further down goes to stderr):
 
 ```text
 v0.3.0-12-gabcdef1
+Compiler: clang 19.1.7
 SIMD floor: avx2 (x86-64-v3, Haswell 2013+); kernels: sse41 sse42 avx avx2 avx512bw
 SIMD runtime: avx512bw (BWAMEM3_FORCE_TIER unset)
-mimalloc 3.3.0
+mimalloc 3.3.0 (active)
 ```
 
 - **version line** — bwa-mem3's release string, derived from
   `git describe` at build time and stored as `PACKAGE_VERSION` in the
   binary. When building from a tarball without git history, the
   fallback value is set via `FG_LABS_VERSION_FALLBACK` at compile time.
+- **`Compiler:`** — the toolchain that compiled the binary, reported
+  from the compiler's own preprocessor macros: `clang`, `gcc`, `icpx`
+  (Intel oneAPI), or `icpc` (Intel Classic). bwa-mem3 runs ~5–10%
+  faster on x86 built with clang than with g++, so this line is how you
+  confirm a production binary came from the recommended toolchain — see
+  [Best Practices → Build](../best-practices/build.md).
 - **`SIMD floor:`** — the compile-time minimum the binary requires.
   Set by `BASELINE_ARCH` (default `avx2`) and listed alongside the
   per-tier kernel set the binary carries.
@@ -47,6 +55,10 @@ mimalloc 3.3.0
   `__builtin_cpu_supports` (or `BWAMEM3_FORCE_TIER` if set in the
   environment). On arm64 this is always `neon`.
 - **mimalloc line** — present only when `USE_MIMALLOC=1` (the default).
+  The parenthetical reports whether mimalloc is actually intercepting
+  `malloc`/`free` — `(active)` when it is, `(linked but NOT overriding
+  malloc)` when the binary merely links a libmimalloc that exports the
+  `mi_*` API without installing the allocator override.
 
 On a host below the SIMD floor, `version` also writes a
 `[W::bwa-mem3]` warning on **stderr** identifying the gap (and the
@@ -58,11 +70,13 @@ exit-2 message format and rebuild instructions).
 
 > **Tip — `version | grep` is safe in CI**
 >
-> The version, `SIMD floor:`, and `SIMD runtime:` lines all go to stdout;
-> the mimalloc line and any host-below-floor warning go to stderr. So
-> `bwa-mem3 version | grep '^SIMD'` works in CI scripts even on hosts
-> that cannot run alignment. Use `2>/dev/null` to suppress the mimalloc
-> and warning lines if you want stdout only.
+> The whole banner — the version, `Compiler:`, `SIMD floor:`,
+> `SIMD runtime:`, and mimalloc lines — goes to stdout; only the
+> host-below-floor `[W::bwa-mem3]` warning goes to stderr. So
+> `bwa-mem3 version | grep '^SIMD'` (or `grep '^Compiler:'` to assert the
+> toolchain, `grep '^mimalloc'` to assert the allocator) works in CI
+> scripts even on hosts that cannot run alignment. Use `2>/dev/null` to
+> suppress the warning line if you want stdout only.
 >
 > **Tip — No mimalloc line means USE_MIMALLOC=0**
 >

--- a/docs/src/developer-guide/building.md
+++ b/docs/src/developer-guide/building.md
@@ -4,7 +4,7 @@ This page documents every build target available in the Makefile and what each p
 
 ## Prerequisites
 
-- A C++14-capable compiler. **Clang is recommended** — bwa-mem3 runs ~16% faster on x86 (AVX2) and ~6% faster on ARM when built with clang than with g++ (see [Best Practices → Build](../best-practices/build.md)). Clang 7+ or GCC 8+ on Linux; Clang 15+ (Xcode) on macOS. A bare `make` defaults to g++ and prints a warning suggesting clang; pass `CXX=clang++ CC=clang` to build with clang.
+- A C++14-capable compiler. **Clang is recommended** — bwa-mem3 runs ~5–10% faster on x86 (AVX2) and ~6% faster on ARM when built with clang than with g++ (see [Best Practices → Build](../best-practices/build.md)). Clang 7+ or GCC 8+ on Linux; Clang 15+ (Xcode) on macOS. A bare `make` defaults to g++ and prints a warning suggesting clang; pass `CXX=clang++ CC=clang` to build with clang.
 - GNU make 3.81+.
 - CMake 3.12+ (required only when `USE_MIMALLOC=1`, which is the default).
 - autoconf, automake, autoconf-archive, libtool, pkg-config — `ext/htslib`'s build runs `autoreconf -i && ./configure` and locates zlib via `pkg-config`.
@@ -27,7 +27,7 @@ See [Getting Started → Installation](../getting-started/installation.md) for t
 
 ```bash
 make                       # uses g++ (warns, suggesting clang)
-make CXX=clang++ CC=clang  # recommended: ~16% faster on x86, ~6% on ARM
+make CXX=clang++ CC=clang  # recommended: ~5–10% faster on x86, ~6% on ARM
 ```
 
 On x86 hosts this is equivalent to `make single` (see below): one binary

--- a/docs/src/developer-guide/building.md
+++ b/docs/src/developer-guide/building.md
@@ -4,7 +4,7 @@ This page documents every build target available in the Makefile and what each p
 
 ## Prerequisites
 
-- A C++14-capable compiler: GCC 7+ or Clang 6+ on Linux; Clang 15+ (Xcode) on macOS.
+- A C++14-capable compiler. **Clang is recommended** — bwa-mem3 runs ~16% faster on x86 (AVX2) and ~6% faster on ARM when built with clang than with g++ (see [Best Practices → Build](../best-practices/build.md)). Clang 7+ or GCC 8+ on Linux; Clang 15+ (Xcode) on macOS. A bare `make` defaults to g++ and prints a warning suggesting clang; pass `CXX=clang++ CC=clang` to build with clang.
 - GNU make 3.81+.
 - CMake 3.12+ (required only when `USE_MIMALLOC=1`, which is the default).
 - autoconf, automake, autoconf-archive, libtool, pkg-config — `ext/htslib`'s build runs `autoreconf -i && ./configure` and locates zlib via `pkg-config`.
@@ -26,7 +26,8 @@ See [Getting Started → Installation](../getting-started/installation.md) for t
 ### Default build (host-native)
 
 ```bash
-make
+make                       # uses g++ (warns, suggesting clang)
+make CXX=clang++ CC=clang  # recommended: ~16% faster on x86, ~6% on ARM
 ```
 
 On x86 hosts this is equivalent to `make single` (see below): one binary

--- a/docs/src/developer-guide/neon-port.md
+++ b/docs/src/developer-guide/neon-port.md
@@ -15,7 +15,7 @@ The translation is not zero-cost for all operations. Two patterns that sse2neon 
 - `_mm_movemask_epi16` — used heavily in `bandedSWA.cpp` to extract the sign bit of each 16-bit lane. The native implementation shifts right by 15, narrows to 8-bit with `vmovn_u16`, and reduces with position-weighted `vaddv_u8`.
 - `_mm_blendv_epi16_fast` — a bitwise select on 16-bit lanes using `vbslq_s16`. Replaces the three-operation OR/AND/ANDNOT sequence sse2neon emits for `_mm_blendv_epi8`.
 
-Because the bulk of the ARM SIMD path is compiler-translated rather than hand-written intrinsics, codegen quality is unusually sensitive to the compiler and its version — a recent `clang` or `gcc` closes most of the gap to a hypothetical full native port. See [Best Practices → Build](../best-practices/build.md#use-a-recent-compiler-especially-on-arm) for measured numbers and the recommendation.
+Because the bulk of the ARM SIMD path is compiler-translated rather than hand-written intrinsics, codegen quality is unusually sensitive to the compiler and its version — a recent `clang` or `gcc` closes most of the gap to a hypothetical full native port. See [Best Practices → Build](../best-practices/build.md#arm--aarch64) for measured numbers and the recommendation.
 
 ### Memory alignment
 

--- a/docs/src/getting-started/host-requirements.md
+++ b/docs/src/getting-started/host-requirements.md
@@ -14,9 +14,10 @@ bwa-mem3 runs on the hosts in the table below. Verify your host with `bwa-mem3 v
 ```text
 $ bwa-mem3 version
 v0.2.0-12-gabcdef1
+Compiler: clang X.Y.Z
 SIMD floor: avx2 (x86-64-v3, Haswell 2013+); kernels: sse41 sse42 avx avx2 avx512bw
 SIMD runtime: avx512bw (BWAMEM3_FORCE_TIER unset)
-mimalloc 3.x.x
+mimalloc 3.x.x (active)
 ```
 
 - The **`SIMD floor:`** line tells you what host features the binary requires.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -4,20 +4,21 @@ Already using `bwa` or `bwa-mem2`? After installing, see
 [Coming from bwa or bwa-mem2](migrating.md) — the command line is unchanged, but
 the index and output have a couple of migration notes.
 
-## Bioconda (coming soon)
+## Bioconda
 
-A Bioconda package for bwa-mem3 is in preparation. Once published, installation will be:
+bwa-mem3 is published on [Bioconda](https://bioconda.github.io/) for linux-64,
+linux-aarch64, osx-64, and osx-arm64. This is the recommended path for most
+users:
 
 ```bash
-conda install -c bioconda bwa-mem3
+conda install -c bioconda -c conda-forge bwa-mem3
 ```
 
-This will be the recommended path for most users. Check back here or watch the
-[fg-labs/bwa-mem3](https://github.com/fg-labs/bwa-mem3) repository for the announcement.
+Build from source (below) if you need a compiler/arch-tuned build — in
+particular a clang-built, arch-specific, or PGO binary for maximum throughput
+(see [Best Practices → Build](../best-practices/build.md)).
 
 ## Build from source
-
-Until the Bioconda package is available, build from source using the steps below.
 
 ### Prerequisites
 
@@ -25,7 +26,7 @@ bwa-mem3 vendors several libraries as git submodules. Building from source requi
 
 | Tool | Why it's needed | Minimum version |
 |------|-----------------|-----------------|
-| C++14 compiler (GCC or Clang) | bwa-mem3 itself | GCC 8+ / Clang 7+ |
+| C++14 compiler (**Clang recommended**, or GCC) | bwa-mem3 itself — clang builds run ~16% faster on x86, see [Build](../best-practices/build.md) | Clang 7+ / GCC 8+ |
 | GNU make | top-level build | 3.81+ |
 | Git | submodule checkout (with `--recursive`) | any recent |
 | autoconf, automake, autoconf-archive, libtool | `ext/htslib` runs `autoreconf -i && ./configure` during build | any recent |
@@ -84,8 +85,15 @@ brew install \
 ```bash
 git clone --recursive https://github.com/fg-labs/bwa-mem3
 cd bwa-mem3
-make
+make CXX=clang++ CC=clang
 ```
+
+> **Build with clang.** bwa-mem3 is ~16% faster on x86 (AVX2) and ~6% faster on
+> ARM when built with clang instead of g++ — see
+> [Best Practices → Build](../best-practices/build.md). A bare `make` uses g++
+> and prints a warning nudging you to clang. Pass `CXX=clang++ CC=clang` as
+> shown. (On Linux with clang, install `libomp-dev` / `libomp-devel` for
+> OpenMP; see the prerequisites above.)
 
 The `--recursive` flag is required. bwa-mem3 vendors several libraries (mimalloc, sse2neon, and
 others) as git submodules. A shallow or non-recursive clone will fail to compile.
@@ -143,11 +151,22 @@ Expected output (with mimalloc):
 
 ```text
 v0.2.0-12-gabcdef1
-mimalloc 3.x.x
+Compiler: clang X.Y.Z
+SIMD floor: avx2 (x86-64-v3, Haswell 2013+); kernels: sse41 sse42 avx avx2 avx512bw
+SIMD runtime: avx2 (BWAMEM3_FORCE_TIER unset)
+mimalloc 3.x.x (active)
 ```
 
+The `Compiler:` line reports which toolchain built the binary and its version —
+`clang`, `gcc`, `icpx`, or `icpc`. The exact version varies with your toolchain;
+what matters is that a production build says `clang` (see
+[Best Practices → Build](../best-practices/build.md)).
+
 If the `mimalloc` line is absent, the build linked the system allocator (expected when
-`USE_MIMALLOC=0` was passed or when the vendor submodule was not initialized).
+`USE_MIMALLOC=0` was passed or when the vendor submodule was not initialized). If it is
+present but reads `(linked but NOT overriding malloc)` instead of `(active)`, mimalloc is
+linked but not intercepting allocations — see
+[User Guide → Memory allocator (mimalloc)](../user-guide/allocator.md).
 
 ## Next: host requirements
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -26,7 +26,7 @@ bwa-mem3 vendors several libraries as git submodules. Building from source requi
 
 | Tool | Why it's needed | Minimum version |
 |------|-----------------|-----------------|
-| C++14 compiler (**Clang recommended**, or GCC) | bwa-mem3 itself — clang builds run ~16% faster on x86, see [Build](../best-practices/build.md) | Clang 7+ / GCC 8+ |
+| C++14 compiler (**Clang recommended**, or GCC) | bwa-mem3 itself — clang builds run ~5–10% faster on x86, see [Build](../best-practices/build.md) | Linux: Clang 7+ / GCC 8+ · macOS: Clang 15+ (Xcode) |
 | GNU make | top-level build | 3.81+ |
 | Git | submodule checkout (with `--recursive`) | any recent |
 | autoconf, automake, autoconf-archive, libtool | `ext/htslib` runs `autoreconf -i && ./configure` during build | any recent |
@@ -88,7 +88,7 @@ cd bwa-mem3
 make CXX=clang++ CC=clang
 ```
 
-> **Build with clang.** bwa-mem3 is ~16% faster on x86 (AVX2) and ~6% faster on
+> **Build with clang.** bwa-mem3 is ~5–10% faster on x86 (AVX2) and ~6% faster on
 > ARM when built with clang instead of g++ — see
 > [Best Practices → Build](../best-practices/build.md). A bare `make` uses g++
 > and prints a warning nudging you to clang. Pass `CXX=clang++ CC=clang` as

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -190,6 +190,55 @@ int main(int argc, char* argv[])
     else if (strcmp(argv[1], "version") == 0)
     {
         puts(PACKAGE_VERSION);
+        /* Report the compiler that built this binary. bwa-mem3 is markedly
+         * faster when built with clang than with g++ (see the Makefile's
+         * build-time note and docs/src/best-practices/build.md), so surfacing
+         * the compiler here makes it trivial to confirm which toolchain a
+         * given binary came from. Purely factual — one token, easy to parse. */
+        /* Order matters: both Intel front-ends impersonate another toolchain.
+         * icpx (oneAPI, LLVM-based) also defines __clang__, and icpc (Classic)
+         * also defines __GNUC__ to match the host GCC's ABI — so the Intel
+         * checks must come FIRST or an Intel build reports as clang/gcc. The
+         * Makefile has real `ifeq ($(CXX), icpc)` / `icpx` flag branches, so
+         * these are builds we actually ship flags for. */
+#if defined(__INTEL_LLVM_COMPILER)
+        /* Two encodings, split on 1000000 the way CMake's
+         * Modules/Compiler/IntelLLVM-DetermineCompiler.cmake does:
+         *   >= 1000000: 8-digit VVVVRRPP (2021.2.0 and later),
+         *               e.g. 20250100 -> 2025.1.0
+         *   <  1000000: 6-digit VVVVRP  (pre-2021.2.0),
+         *               e.g. 202110   -> 2021.1.0 */
+#  if __INTEL_LLVM_COMPILER >= 1000000
+        fprintf(stdout, "Compiler: icpx %d.%d.%d\n",
+                __INTEL_LLVM_COMPILER / 10000,
+                (__INTEL_LLVM_COMPILER / 100) % 100,
+                __INTEL_LLVM_COMPILER % 100);
+#  else
+        fprintf(stdout, "Compiler: icpx %d.%d.%d\n",
+                __INTEL_LLVM_COMPILER / 100,
+                (__INTEL_LLVM_COMPILER / 10) % 10,
+                __INTEL_LLVM_COMPILER % 10);
+#  endif
+#elif defined(__INTEL_COMPILER)
+        /* Year-based version (e.g. 2021) plus the update number. Every icpc
+         * the Makefile targets defines __INTEL_COMPILER_UPDATE, but guard it
+         * anyway: on a pre-15.0 icc it is undefined, and an undefined macro in
+         * an argument list is an undeclared identifier, not a zero. */
+#  if defined(__INTEL_COMPILER_UPDATE)
+        fprintf(stdout, "Compiler: icpc %d.%d\n",
+                __INTEL_COMPILER, __INTEL_COMPILER_UPDATE);
+#  else
+        fprintf(stdout, "Compiler: icpc %d\n", __INTEL_COMPILER);
+#  endif
+#elif defined(__clang__)
+        fprintf(stdout, "Compiler: clang %d.%d.%d\n",
+                __clang_major__, __clang_minor__, __clang_patchlevel__);
+#elif defined(__GNUC__)
+        fprintf(stdout, "Compiler: gcc %d.%d.%d\n",
+                __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+#elif defined(__VERSION__)
+        fprintf(stdout, "Compiler: %s\n", __VERSION__);
+#endif
         bwamem3_print_version_simd(stdout);
 #ifdef USE_MIMALLOC
         {


### PR DESCRIPTION
## Summary

bwa-mem3 builds faster with **clang** than with **g++**, so this PR makes clang the recommended compiler across the build tooling and docs, and surfaces the compiler in the binary.

Measured across the benchmark sweep at **v0.6.0** (hg38, 5M read pairs, `-t 16`, per-arch median of compute-time deltas over wgs/wes/panel/hic/sbx), clang vs g++:

| arch | clang vs g++ (compute) |
|---|---:|
| c6a (Zen 3, AVX2) | ~8% faster (up to ~13% on some samples) |
| c7a (Zen 4, AVX-512) | ~3–4% faster |
| c7g / c8g (ARM/NEON) | ~5–9% faster |

Consistent on every sample and arch; largest on Zen 3/AVX2, smallest on Zen 4. The `--fast` preset shows a similar ~5–10% clang edge. (An earlier single-host spot-check on a `c6a.8xlarge` suggested ~16%; the release-wide numbers above are the representative figure.)

## Changes

- **`bwa-mem3 version`** now prints a `Compiler: clang|gcc X.Y.Z` line (via `__clang__`/`__GNUC__`), so it's trivial to confirm which toolchain produced a binary.
- **Makefile** emits a `$(warning)` when `CXX` is `g++` (GNU make's default, so a bare `make` triggers it) recommending `make CXX=clang++ CC=clang`. Space-indented so GNU make 3.81 doesn't parse it as a recipe.
- **Docs** (`best-practices/build.md`, `developer-guide/building.md`, `getting-started/installation.md`): strongly recommend clang on all platforms, with the per-arch numbers above and updated production recipes.
- **Docs**: replaced the stale "Bioconda (coming soon)" section — bwa-mem3 is published on Bioconda (v0.6.0, linux/osx × x64/arm).

## Testing

- Verified the Makefile warning fires for `CXX=g++` (and the default) and is silent for `CXX=clang++`, with no parse error on GNU make 3.81.
- Verified the `version` compiler-detection block compiles and prints correctly.
- Compiler deltas measured in the bwa-mem3-bench harness (all-clang re-baseline of bwa-mem2/bwa-mem3/minibwa at v0.6.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `version` command now reports the compiler toolchain used to build the binary.
  * `bwa-mem3` is now available via Bioconda for multiple platforms.
* **Documentation**
  * Updated build and installation guidance to strongly recommend Clang, including revised commands, prerequisites, and benchmark/PGO recipes.
  * Refreshed smoke-test and `version` output expectations to include the new banner line.
  * Improved CLI help normalization to make generated documentation diffs more reproducible.
* **Bug Fixes**
  * Default GNU C++ builds now emit a stronger warning recommending switching to Clang for `bwa-mem3` builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->