### PR TITLE
perf(index): parallel pread of the FM-index for faster startup

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -33,12 +33,163 @@ Authors: Sanchit Misra <sanchit.misra@intel.com>; Vasimuddin Md <vasimuddin.md@i
 #include <inttypes.h>
 #include <climits>
 #include <cstring>
+#include <vector>
+#include <cstdarg>
+#include <pthread.h>
+#include <unistd.h>       /* pread, _exit */
 #include <sys/mman.h>     /* munmap */
+#if defined(__linux__)
+#include <fcntl.h>        /* posix_fadvise */
+#endif
 #include "bwa_madvise.h"
 #include "bwa_shm.h"
+#include "utils.h"        /* ATTRIBUTE, err_fread_noeof */
 #include "FMI_search.h"
 #include "profiling.h"
 #include "libsais_build.h"
+
+/*
+ * Parallel index load.
+ *
+ * The bwa-mem3 FM-index (cp_occ + compressed SA samples, ~10 GB on hg38) is
+ * otherwise slurped by a single-threaded fread whose warm-cache cost is one
+ * core's page-fault + memcpy bandwidth out of the page cache (~0.8 s on hg38).
+ * Splitting each big array across a few workers is memory-bandwidth bound and
+ * cuts that ~4x. pread (not read) lets every worker share one fd without
+ * touching the shared file offset, so no locking is needed.
+ *
+ * The destination stays the _mm_malloc'd + MADV_HUGEPAGE buffer, so the
+ * transparent-hugepage coverage the hot Occ-lookup loop relies on is preserved
+ * -- unlike an mmap/shm alias of the file, which lands on non-THP pages and
+ * slows alignment enough to erase the load saving.
+ */
+
+/* Declared in FMI_search.h; see there for the contract. Uses a floor division
+ * so the chunk size never dips below FMI_PREAD_MIN_CHUNK: at `nbytes` a whole
+ * multiple of the floor, `nbytes / min_chunk + 1` would hand out one chunk more
+ * than the array can cover at that size (8 MB read across 2 workers = 4 MB
+ * chunks). Only reachable for small arrays -- a caller asking for more workers
+ * than a test-sized reference can feed, or a large BWA3_LOAD_THREADS. */
+int fmi_pread_worker_count(size_t nbytes, int nthreads)
+{
+    if (nthreads < 1) nthreads = 1;
+    size_t max_threads = nbytes / FMI_PREAD_MIN_CHUNK;
+    if (max_threads < 1) max_threads = 1;
+    if ((size_t)nthreads > max_threads) nthreads = (int)max_threads;
+    return nthreads;
+}
+
+namespace {
+
+struct PreadChunk { int fd; char *dst; size_t nbytes; off_t off; };
+
+/* Bail out of a failed chunk read.
+ *
+ * _exit, not exit: this runs on a worker thread while its siblings are still
+ * inside pread(). exit() would run atexit handlers and static destructors
+ * (mimalloc teardown, htslib) against live threads, and two workers reaching it
+ * at once -- what a truncated index produces, since every chunk past the real
+ * EOF fails together -- is undefined. stderr is unbuffered, but flush anyway so
+ * the diagnostic survives if a caller made it buffered.
+ *
+ * noreturn keeps the caller's `if (r < 0) { ... }` terminating the way the
+ * inline exit() it replaced did; format(printf) keeps -Wformat checking the
+ * call sites, matching utils.h's err_fatal family. */
+void pread_chunk_fail(const char *fmt, ...)
+    ATTRIBUTE((noreturn)) ATTRIBUTE((format(printf, 1, 2)));
+
+void pread_chunk_fail(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fflush(stderr);
+    _exit(EXIT_FAILURE);
+}
+
+void *pread_chunk_worker(void *arg)
+{
+    PreadChunk *c = static_cast<PreadChunk *>(arg);
+    size_t done = 0;
+    while (done < c->nbytes) {
+        ssize_t r = pread(c->fd, c->dst + done, c->nbytes - done, c->off + (off_t)done);
+        if (r < 0) {
+            if (errno == EINTR) continue;
+            pread_chunk_fail("ERROR: pread failed during index load: %s\n", strerror(errno));
+        }
+        if (r == 0) {  // index file shorter than the header says it should be
+            // Counts are for THIS worker's chunk, not the whole array: a
+            // truncated index trips every chunk past the real EOF, so several
+            // of these can interleave, each describing a different slice.
+            pread_chunk_fail("ERROR: unexpected EOF during index load "
+                             "(chunk at offset %lld: %zu of %zu bytes)\n",
+                             (long long)c->off, done, c->nbytes);
+        }
+        done += (size_t)r;
+    }
+    return NULL;
+}
+
+// Read `nbytes` at file offset `off` into `dst` using up to `nthreads` workers.
+void parallel_pread(int fd, void *dst, size_t nbytes, off_t off, int nthreads)
+{
+    if (nbytes == 0) return;
+    nthreads = fmi_pread_worker_count(nbytes, nthreads);
+
+    std::vector<PreadChunk> chunks((size_t)nthreads);
+    std::vector<pthread_t>  tids((size_t)nthreads);
+    std::vector<bool>       spawned((size_t)nthreads, false);
+    size_t base = nbytes / (size_t)nthreads, rem = nbytes % (size_t)nthreads, cum = 0;
+    for (int i = 0; i < nthreads; i++) {
+        size_t len = base + ((size_t)i < rem ? 1 : 0);
+        chunks[i] = PreadChunk{ fd, (char *)dst + cum, len, off + (off_t)cum };
+        cum += len;
+    }
+    // Main thread takes chunk 0; spawn workers for the rest. If a spawn fails
+    // (e.g. thread limit), fall back to reading that chunk inline so the load
+    // still completes correctly, just less parallel.
+    for (int i = 1; i < nthreads; i++) {
+        if (pthread_create(&tids[i], NULL, pread_chunk_worker, &chunks[i]) == 0)
+            spawned[i] = true;
+        else
+            pread_chunk_worker(&chunks[i]);
+    }
+    pread_chunk_worker(&chunks[0]);
+    for (int i = 1; i < nthreads; i++)
+        if (spawned[i]) pthread_join(tids[i], NULL);
+}
+
+// Worker count for the index load: the caller's -t, capped (bandwidth bound
+// past ~8), with an explicit BWA3_LOAD_THREADS override for tuning.
+int index_load_threads(int n_threads)
+{
+    int t = n_threads > 0 ? n_threads : 1;
+    if (t > 8) t = 8;
+    const char *e = getenv("BWA3_LOAD_THREADS");
+    if (e != NULL) { int v = atoi(e); if (v > 0) t = v; }
+    return t;
+}
+
+}  // namespace
+
+/* Declared in FMI_search.h; see there for the contract. ftello reports the
+ * stream's logical position (buffered bytes included), so it is the right
+ * offset to hand pread; the fseeko afterwards drops the now-stale buffer and
+ * re-anchors the stream past the array we just read behind its back. */
+void fmi_pread_from_stream(FILE *fp, void *dst, size_t nbytes, int nthreads)
+{
+    off_t off = ftello(fp);
+    if (off < 0) {
+        fprintf(stderr, "ERROR: ftello failed during index load: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+    parallel_pread(fileno(fp), dst, nbytes, off, nthreads);
+    if (fseeko(fp, off + (off_t)nbytes, SEEK_SET) != 0) {
+        fprintf(stderr, "ERROR: fseeko failed during index load: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+}
 
 /* Build "<prefix><suffix>" into `out` (sized `outsz`); aborts on overflow.
  * Replaces the prior strcpy_s/strcat_s pattern for assembling FMI sidecar
@@ -228,7 +379,7 @@ int FMI_search::build_index(bool emit_unpacked_ref) {
     return libsais_build_fm_index(prefix, pac_len, opts);
 }
 
-void FMI_search::load_index(bool load_pac)
+void FMI_search::load_index(bool load_pac, int n_threads)
 {
     /* Try the staged shm segment first. On hit, both the FMI internals
      * (cp_occ / sa_*) and the BNS+PAC are attached as views into the
@@ -252,6 +403,9 @@ void FMI_search::load_index(bool load_pac)
     // attempted size and how much we'd already committed before failing.
     int64_t index_alloc = 0;
 
+    // Worker count for the big-array reads below (read once, out of any loop).
+    const int load_nt = index_load_threads(n_threads);
+
     char *ref_file_name = file_name;
     //beCalls = 0;
     char cp_file_name[PATH_MAX];
@@ -270,6 +424,12 @@ void FMI_search::load_index(bool load_pac)
         fprintf(stderr, "* Index file found. Loading index from %s\n", cp_file_name);
     }
 
+#if defined(__linux__)
+    // Kick readahead for the whole index so the parallel preads below hit warm
+    // pages on a cold cache (no-op benefit when already cached).
+    posix_fadvise(fileno(cpstream), 0, 0, POSIX_FADV_WILLNEED);
+#endif
+
     err_fread_noeof(&reference_seq_len, sizeof(int64_t), 1, cpstream);
     assert(reference_seq_len > 0);
     assert(reference_seq_len <= 0x7fffffffffL);
@@ -287,7 +447,7 @@ void FMI_search::load_index(bool load_pac)
     assert_not_null(cp_occ, cp_occ_bytes, index_alloc);
     bwamem_madv_hugepage(cp_occ, cp_occ_bytes);
 
-    err_fread_noeof(cp_occ, sizeof(CP_OCC), cp_occ_size, cpstream);
+    fmi_pread_from_stream(cpstream, cp_occ, (size_t)cp_occ_bytes, load_nt);
     int64_t ii = 0;
     for(ii = 0; ii < 5; ii++)// update read count structure
     {
@@ -307,8 +467,8 @@ void FMI_search::load_index(bool load_pac)
     assert_not_null(sa_ls_word, sa_ls_bytes, index_alloc);
     bwamem_madv_hugepage(sa_ms_byte, sa_ms_bytes);
     bwamem_madv_hugepage(sa_ls_word, sa_ls_bytes);
-    err_fread_noeof(sa_ms_byte, sizeof(int8_t), reference_seq_len_, cpstream);
-    err_fread_noeof(sa_ls_word, sizeof(uint32_t), reference_seq_len_, cpstream);
+    fmi_pread_from_stream(cpstream, sa_ms_byte, (size_t)sa_ms_bytes, load_nt);
+    fmi_pread_from_stream(cpstream, sa_ls_word, (size_t)sa_ls_bytes, load_nt);
 
     #else
 
@@ -322,8 +482,8 @@ void FMI_search::load_index(bool load_pac)
     assert_not_null(sa_ls_word, sa_ls_bytes, index_alloc);
     bwamem_madv_hugepage(sa_ms_byte, sa_ms_bytes);
     bwamem_madv_hugepage(sa_ls_word, sa_ls_bytes);
-    err_fread_noeof(sa_ms_byte, sizeof(int8_t), reference_seq_len, cpstream);
-    err_fread_noeof(sa_ls_word, sizeof(uint32_t), reference_seq_len, cpstream);
+    fmi_pread_from_stream(cpstream, sa_ms_byte, (size_t)sa_ms_bytes, load_nt);
+    fmi_pread_from_stream(cpstream, sa_ls_word, (size_t)sa_ls_bytes, load_nt);
 
     #endif
 

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -104,6 +104,35 @@ typedef struct smem_struct
 #define BWTSEED_LOCKSTEP_N 8
 #endif
 
+/* Smallest slice of an index array a parallel-load worker is given. The load is
+ * memory-bandwidth bound, so below this the per-thread create/join overhead is
+ * a larger share of the work than the bandwidth it unlocks. */
+#define FMI_PREAD_MIN_CHUNK (8UL << 20)
+
+/* Number of workers to split an `nbytes` index-array read across, given the
+ * caller's requested `nthreads`.
+ *
+ * Never returns more than `nthreads` when `nthreads` is positive, and never so
+ * many that a chunk would fall below FMI_PREAD_MIN_CHUNK -- except for the
+ * unavoidable single-worker case where `nbytes` is itself below the floor. A
+ * non-positive `nthreads` clamps UP to 1: the result is always >= 1, since the
+ * caller divides `nbytes` by it. Small references and a large BWA3_LOAD_THREADS
+ * are what push against the floor; on a GB-scale index the load's own 8-worker
+ * cap binds first.
+ *
+ * Exposed (rather than kept file-local with the pread machinery) so the chunk
+ * arithmetic is unit-testable without a real index on disk. */
+int fmi_pread_worker_count(size_t nbytes, int nthreads);
+
+/* Read the next `nbytes` of `fp` into `dst` using up to `nthreads` pread
+ * workers, then leave the stream positioned exactly past them so a following
+ * sequential read (the trailing sentinel index) still lands correctly.
+ *
+ * Aborts the process on a read error or short file. Exposed alongside the
+ * worker count so the chunk-splitting and the stream postcondition are
+ * unit-testable against a synthetic file. */
+void fmi_pread_from_stream(FILE *fp, void *dst, size_t nbytes, int nthreads);
+
 class FMI_search: public indexEle
 {
     public:
@@ -137,7 +166,9 @@ class FMI_search: public indexEle
      * --meth uses this for the SEED index: seeding needs the FM-index + bns
      * (for the seed->original remap) but never the seed pac — extension/scoring
      * runs against the ORIGINAL pac (meth_orig_pac). Saves ~1.6 GB on hg38. */
-    void load_index(bool load_pac = true);
+    /* n_threads: worker count for the big-array disk reads (capped internally,
+     * overridable via BWA3_LOAD_THREADS). Default 1 preserves prior behavior. */
+    void load_index(bool load_pac = true, int n_threads = 1);
 
     /* Attach to a packed bwa-mem3 index segment from bwa_shm_attach. Sets
      * scalars and the cp_occ / sa_ms_byte / sa_ls_word pointers; the

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1685,7 +1685,7 @@ int main_mem(int argc, char *argv[])
     /* D3 --meth: load the SEED index's FM + bns but NOT its pac. The seed pac is
      * never read in --meth (extension/scoring/mate-rescue use meth_orig_pac);
      * skipping it saves ~1.6 GB on hg38. Outside --meth, load the pac as before. */
-    aux.fmi->load_index(/*load_pac=*/!opt->meth_mode);
+    aux.fmi->load_index(/*load_pac=*/!opt->meth_mode, /*n_threads=*/opt->n_threads);
     aux.shm_base = aux.fmi->shm_attached_base();
     tprof[FMI][0] += __rdtsc() - tim;
 

--- a/test/unit/test_fmi_pread_from_stream.cpp
+++ b/test/unit/test_fmi_pread_from_stream.cpp
@@ -1,0 +1,167 @@
+// test/unit/test_fmi_pread_from_stream.cpp
+//
+// Byte-exactness and stream-postcondition tests for the parallel index read.
+//
+// FMI_search::load_index reads each big index array by handing the stream's
+// current offset to a pool of pread workers, then re-anchoring the FILE* past
+// the array (src/FMI_search.cpp, fmi_pread_from_stream). Two things have to
+// hold for the loaded index to be correct, and neither is visible in the
+// aligner's output until an alignment silently goes wrong:
+//
+//   1. The concatenated chunks reproduce the file's bytes exactly, at every
+//      worker count -- a chunk-offset or chunk-length slip corrupts the array
+//      across an interior boundary while both ends still look right.
+//   2. The stream lands exactly past the array, because the trailing
+//      sentinel_index is still read sequentially with err_fread_noeof().
+//
+// The reads run against a synthetic temp file so no index build is needed.
+
+#include "doctest/doctest.h"
+#include "../../src/FMI_search.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <unistd.h>   /* getpid -- per-process temp path */
+#include <vector>
+
+namespace {
+
+// Deterministic byte pattern with a long period, so a chunk read at the wrong
+// offset -- or a chunk of the wrong length -- cannot coincidentally match.
+uint8_t pattern_byte(size_t i)
+{
+    return (uint8_t)((i * 1103515245u + 12345u) >> 16);
+}
+
+// Index of the first byte of `buf` that departs from the pattern starting at
+// file offset `file_off`, or `len` if every byte matches. Returning the offset
+// rather than asserting per byte keeps the suite's assertion count sane while
+// still naming the chunk boundary a failure landed on.
+size_t first_pattern_mismatch(const uint8_t *buf, size_t len, size_t file_off)
+{
+    for (size_t i = 0; i < len; ++i) {
+        if (buf[i] != pattern_byte(file_off + i)) return i;
+    }
+    return len;
+}
+
+// A temp file holding `nbytes` of pattern_byte(), removed on destruction.
+class PatternFile {
+  public:
+    explicit PatternFile(size_t nbytes) : path_(make_path())
+    {
+        FILE *fp = fopen(path_.c_str(), "wb");
+        REQUIRE(fp != NULL);
+        std::vector<uint8_t> buf(nbytes);
+        for (size_t i = 0; i < nbytes; ++i) buf[i] = pattern_byte(i);
+        if (nbytes > 0) REQUIRE(fwrite(buf.data(), 1, nbytes, fp) == nbytes);
+        REQUIRE(fclose(fp) == 0);
+    }
+
+    ~PatternFile() { remove(path_.c_str()); }
+
+    const char *path() const { return path_.c_str(); }
+
+  private:
+    static std::string make_path()
+    {
+        const char *dir = getenv("TMPDIR");
+        std::string p = std::string(dir != NULL ? dir : "/tmp");
+        if (!p.empty() && p[p.size() - 1] != '/') p += '/';
+        // Distinct per process so concurrent test runs don't collide.
+        char suffix[64];
+        snprintf(suffix, sizeof(suffix), "bwa3_pread_test_%ld", (long)getpid());
+        return p + suffix;
+    }
+
+    std::string path_;
+};
+
+}  // namespace
+
+TEST_CASE("fmi_pread_from_stream: chunked read reproduces the file bytes") {
+    // Spans several FMI_PREAD_MIN_CHUNK floors so worker counts above 1 are
+    // actually honored, plus a ragged tail so the remainder distribution
+    // (base + 1 for the first `rem` chunks) is exercised rather than an even
+    // split that would hide an off-by-one in the chunk arithmetic.
+    const size_t nbytes = 5 * FMI_PREAD_MIN_CHUNK + 4097;
+    PatternFile file(nbytes);
+
+    const int worker_counts[] = {1, 2, 3, 5, 8, 64};
+    for (size_t k = 0; k < sizeof(worker_counts) / sizeof(worker_counts[0]); ++k) {
+        const int nthreads = worker_counts[k];
+        CAPTURE(nthreads);
+
+        FILE *fp = fopen(file.path(), "rb");
+        REQUIRE(fp != NULL);
+
+        std::vector<uint8_t> dst(nbytes, 0);
+        fmi_pread_from_stream(fp, dst.data(), nbytes, nthreads);
+
+        CHECK(first_pattern_mismatch(dst.data(), nbytes, 0) == nbytes);
+
+        REQUIRE(fclose(fp) == 0);
+    }
+}
+
+TEST_CASE("fmi_pread_from_stream: resumes from and restores the stream position") {
+    // Mirrors load_index's actual shape: a sequential header read, then the
+    // parallel array read, then a sequential trailer read. If the FILE* is not
+    // re-anchored exactly past the array, the trailer comes back wrong -- this
+    // is what keeps sentinel_index correct.
+    const size_t header  = sizeof(int64_t);
+    const size_t array   = 2 * FMI_PREAD_MIN_CHUNK + 123;
+    const size_t trailer = sizeof(int64_t);
+    PatternFile file(header + array + trailer);
+
+    const int worker_counts[] = {1, 2, 4};
+    for (size_t k = 0; k < sizeof(worker_counts) / sizeof(worker_counts[0]); ++k) {
+        const int nthreads = worker_counts[k];
+        CAPTURE(nthreads);
+
+        FILE *fp = fopen(file.path(), "rb");
+        REQUIRE(fp != NULL);
+
+        uint8_t head[sizeof(int64_t)];
+        REQUIRE(fread(head, 1, header, fp) == header);
+        CHECK(first_pattern_mismatch(head, header, 0) == header);
+
+        std::vector<uint8_t> dst(array, 0);
+        fmi_pread_from_stream(fp, dst.data(), array, nthreads);
+        CHECK(first_pattern_mismatch(dst.data(), array, header) == array);
+
+        // The stream must sit exactly at header + array, both by report...
+        CHECK((size_t)ftello(fp) == header + array);
+        // ...and by what the next sequential read actually returns.
+        uint8_t tail[sizeof(int64_t)];
+        REQUIRE(fread(tail, 1, trailer, fp) == trailer);
+        CHECK(first_pattern_mismatch(tail, trailer, header + array) == trailer);
+
+        REQUIRE(fclose(fp) == 0);
+    }
+}
+
+TEST_CASE("fmi_pread_from_stream: zero-length read is a no-op") {
+    // cp_occ/sa_* are never empty in a real index, but parallel_pread's
+    // nbytes == 0 short-circuit must leave the stream untouched rather than
+    // divide by a zero worker count.
+    PatternFile file(FMI_PREAD_MIN_CHUNK);
+
+    FILE *fp = fopen(file.path(), "rb");
+    REQUIRE(fp != NULL);
+
+    uint8_t head[4];
+    REQUIRE(fread(head, 1, sizeof(head), fp) == sizeof(head));
+
+    fmi_pread_from_stream(fp, NULL, 0, 4);
+    CHECK((size_t)ftello(fp) == sizeof(head));
+
+    uint8_t next[4];
+    REQUIRE(fread(next, 1, sizeof(next), fp) == sizeof(next));
+    CHECK(first_pattern_mismatch(next, sizeof(next), sizeof(head)) == sizeof(next));
+
+    REQUIRE(fclose(fp) == 0);
+}

--- a/test/unit/test_fmi_pread_worker_count.cpp
+++ b/test/unit/test_fmi_pread_worker_count.cpp
@@ -1,0 +1,108 @@
+// test/unit/test_fmi_pread_worker_count.cpp
+//
+// Regression test for the parallel index load's chunk-size floor.
+//
+// FMI_search::load_index splits each big index array (cp_occ, the compressed SA
+// samples) across pread workers. The split is only worth its create/join cost
+// while every worker still gets a bandwidth-sized slice, so the worker count is
+// capped such that no chunk falls below FMI_PREAD_MIN_CHUNK.
+//
+// The original cap computed `nbytes / min_chunk + 1`, which hands out one
+// worker more than the array can cover at that size: an array exactly one
+// min_chunk long was split across two workers, giving each half the floor.
+// Reachable whenever a caller requests more workers than the array can feed --
+// a test-sized reference, or a large BWA3_LOAD_THREADS override -- since on a
+// GB-scale index the load's own 8-worker cap binds long before this one.
+
+#include "doctest/doctest.h"
+#include "../../src/FMI_search.h"
+
+#include <cstddef>
+
+namespace {
+
+// Largest chunk any worker receives when `nbytes` is split `nthreads` ways the
+// way parallel_pread does it (base size plus one byte for the first `rem`).
+size_t max_chunk_bytes(size_t nbytes, int nthreads)
+{
+    const size_t n = (size_t)nthreads;
+    return nbytes / n + (nbytes % n != 0 ? 1 : 0);
+}
+
+// Smallest chunk any worker receives under the same split.
+size_t min_chunk_bytes(size_t nbytes, int nthreads)
+{
+    return nbytes / (size_t)nthreads;
+}
+
+}  // namespace
+
+TEST_CASE("fmi_pread_worker_count: never splits below the chunk floor") {
+    const size_t floor_bytes = FMI_PREAD_MIN_CHUNK;
+
+    // The regression: an array exactly at the floor must stay single-worker,
+    // however many workers the caller asks for. Pre-fix this returned 2.
+    CHECK(fmi_pread_worker_count(floor_bytes, 8) == 1);
+    CHECK(fmi_pread_worker_count(floor_bytes, 2) == 1);
+
+    // Just under two floors is still one worker's worth of work.
+    CHECK(fmi_pread_worker_count(2 * floor_bytes - 1, 8) == 1);
+
+    // Two full floors can support two workers, not three.
+    CHECK(fmi_pread_worker_count(2 * floor_bytes, 8) == 2);
+    CHECK(fmi_pread_worker_count(3 * floor_bytes - 1, 8) == 2);
+}
+
+TEST_CASE("fmi_pread_worker_count: honors the caller's request when it fits") {
+    const size_t floor_bytes = FMI_PREAD_MIN_CHUNK;
+
+    // Plenty of bytes to go around: the caller's count is returned as-is.
+    CHECK(fmi_pread_worker_count(64 * floor_bytes, 8) == 8);
+    CHECK(fmi_pread_worker_count(64 * floor_bytes, 1) == 1);
+
+    // hg38-scale cp_occ (~6 GB) against the load's own 8-worker cap.
+    CHECK(fmi_pread_worker_count(6UL << 30, 8) == 8);
+}
+
+TEST_CASE("fmi_pread_worker_count: degenerate inputs yield one worker") {
+    // Sub-floor arrays cannot honor the floor at any count; one worker is the
+    // only correct answer (the caller short-circuits nbytes == 0 before this,
+    // but the arithmetic must not divide by zero or return 0 regardless).
+    CHECK(fmi_pread_worker_count(0, 8) == 1);
+    CHECK(fmi_pread_worker_count(1, 8) == 1);
+    CHECK(fmi_pread_worker_count(FMI_PREAD_MIN_CHUNK - 1, 8) == 1);
+
+    // Non-positive requests clamp up, never to 0 (a 0 return would make
+    // parallel_pread divide by zero when sizing its chunks).
+    CHECK(fmi_pread_worker_count(64 * FMI_PREAD_MIN_CHUNK, 0) == 1);
+    CHECK(fmi_pread_worker_count(64 * FMI_PREAD_MIN_CHUNK, -4) == 1);
+}
+
+TEST_CASE("fmi_pread_worker_count: the resulting split respects the floor") {
+    // The property the count exists to guarantee, checked against the same
+    // chunk arithmetic parallel_pread uses: every worker gets at least
+    // FMI_PREAD_MIN_CHUNK, unless the whole array is smaller than that.
+    const size_t floor_bytes = FMI_PREAD_MIN_CHUNK;
+    const size_t sizes[] = {
+        1, floor_bytes - 1, floor_bytes, floor_bytes + 1,
+        2 * floor_bytes - 1, 2 * floor_bytes, 5 * floor_bytes + 12345,
+        1UL << 30, 6UL << 30,
+    };
+
+    for (size_t i = 0; i < sizeof(sizes) / sizeof(sizes[0]); ++i) {
+        const size_t nbytes = sizes[i];
+        for (int requested = 1; requested <= 16; ++requested) {
+            const int n = fmi_pread_worker_count(nbytes, requested);
+            REQUIRE(n >= 1);
+            CHECK(n <= requested);
+            // Chunks stay balanced: at most one byte between largest and
+            // smallest, so no worker is left holding the whole array.
+            CHECK(max_chunk_bytes(nbytes, n) - min_chunk_bytes(nbytes, n) <= 1);
+            if (nbytes >= floor_bytes) {
+                CHECK(min_chunk_bytes(nbytes, n) >= floor_bytes);
+            } else {
+                CHECK(n == 1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Load the FM-index (`cp_occ` + the compressed SA samples, ~10 GB on hg38) with a small pool of `pread` workers into the existing `_mm_malloc`'d + `MADV_HUGEPAGE` buffers, instead of the single-threaded `fread`.

## Why

The warm-cache index load is one core's page-fault + memcpy bandwidth out of the page cache — measured at **0.79 s on hg38** (via `tprof[FMI]`, the "Index read time" line already printed by `display_stats`). It's a fixed serial cost paid on every invocation, so it hurts most exactly where parallel efficiency matters: short and small jobs, and the benchmark harness's many runs.

Splitting each big array across workers is memory-bandwidth bound and collapses that load (Graviton4 `c8g.8xlarge`, warm cache):

| load threads | index load | speedup |
|---:|---:|---:|
| 1 (= prior `fread`) | 0.80 s | — |
| 4 | 0.33 s | 2.4× |
| 8 | 0.25 s | 3.2× |
| 16 | **0.18 s** | **4.4×** |

End-to-end SE `-t16` on 2M WGS reads: wall **11.88 s → 11.30 s (−4.9%)**, `align_real` unchanged (9.64 s). Noise on multi-hour WGS, but free.

## Why not mmap / shm

`bwa-mem3 shm` already zeroes the index load, and a file `mmap` would too — but both alias the index onto pages that don't get transparent hugepages (tmpfs `shmem_enabled` is commonly `never`), while the disk path deliberately `MADV_HUGEPAGE`s the anon buffer for dTLB coverage in the hot Occ-lookup loop. Measured: one clean shm-attached run was **+17% on `main_mem`** — trading 0.79 s of load for ~1.9 s of slower alignment. Keeping the anon+THP destination and just filling it faster sidesteps that entirely; it's the only startup lever here that doesn't regress alignment.

## Design notes

- `pread` (not `read`) so every worker shares one fd without touching the file offset — no locking.
- Worker count follows `-t`, capped at 8 (bandwidth bound past that), overridable via `BWA3_LOAD_THREADS` for tuning. `load_index`'s new `n_threads` param defaults to 1, so any other caller keeps prior behavior.
- Chunks are ≥ 8 MB (fewer threads on small arrays); a failed `pthread_create` falls back to reading that chunk inline.
- `posix_fadvise(WILLNEED)` primes readahead for the **cold-cache** first run (Linux only; guarded, so macOS still builds).
- The destination buffers, `MADV_HUGEPAGE` hints, and all small header/sentinel reads are unchanged — only the three big-array `fread`s become parallel `pread`s.

## Validation

- **Byte-identical** to the prior `fread` across `BWA3_LOAD_THREADS` = 1/4/8/16, SE and PE, on both single-chunk and multi-chunk (195 MB index) arrays. Baseline built from `origin/main` by reverting just this change; record-body md5 matches on every combination.
- Builds clean on Linux (Graviton4/gcc) and macOS/arm64 (the `posix_fadvise` guard).
- Not a SW-kernel change, so the `bwa-bsw-bench` gate does not apply.

## Follow-ups (not in this PR)

- The `.pac` slurp (~0.1 s) could use the same loader; left out to keep this focused.
- x86/NUMA: parallel first-touch lands pages on the touching thread's node; a 2-socket host may prefer interleaving. Non-issue on single-socket arm64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Accelerated large FM-index loading by using parallel chunked file reads on Linux.
  * Added configurable thread count control for index loading (defaults to single-thread).
  * Improved index file readahead to reduce wait time during load.
* **Compatibility**
  * Preserved existing shared-memory fast path behavior.
  * Kept file stream position consistent after chunked reads.
  * Added robustness for interrupted reads, short reads/EOF, and zero-length reads.
* **Tests**
  * Added unit tests covering parallel stream reading correctness, stream re-anchoring, and worker-count/chunk-splitting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->