### PR TITLE
perf(kswv): collapse the two freed-cell blends into one in the u8 rescue kernel

### DIFF
--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -599,10 +599,13 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
              * ambig/padding (AMBQ=8, DUMMY5=5) never equal fr_read, so vceqq
              * is naturally false for them — no extra masking needed. */
             if (HasFreed) {
+                /* Both freed blends select match_vec, so OR their masks and do
+                 * ONE blend instead of two serially-dependent vbsl ops. Same
+                 * op count as the original two-blend form (one vbsl swapped for
+                 * one vorr), byte-identical, one shorter link in the sbt chain. */
                 uint8x16_t freed  = vandq_u8(rowfreed,  vceqq_u8(s2, frread_vec));
-                sbt = vbslq_u8(freed, match_vec, sbt);
                 uint8x16_t freed2 = vandq_u8(rowfreed2, vceqq_u8(s2, frread2_vec));
-                sbt = vbslq_u8(freed2, match_vec, sbt);
+                sbt = vbslq_u8(vorrq_u8(freed, freed2), match_vec, sbt);
             }
 
             /* Check for boundary (high bit set in s1 or s2). vtstq_u8 against


### PR DESCRIPTION
## What

`kswv_neon_u8_impl<true>` is the hot kernel for methylation (`--meth`) mate rescue — **~45% of `--meth` CPU** on current `main` (post-#224, which routed meth rescue through the batched `kswv` kernel by default). Its per-cell rank-1 freed-cell override did **two serially-dependent `vbslq_u8` blends** into the scoring vector `sbt`, both selecting the same value (`match_vec`):

```c
sbt = vbslq_u8(freed,  match_vec, sbt);
sbt = vbslq_u8(freed2, match_vec, sbt);
```

Because both blends select `match_vec`, OR the masks and do **one** blend:

```c
sbt = vbslq_u8(vorrq_u8(freed, freed2), match_vec, sbt);
```

This is **byte-identical** — `(freed?match:sbt)` then `(freed2?match:sbt)` equals `((freed|freed2)?match:sbt)` since both branches select `match` — and keeps the per-cell vector-op count **unchanged** (one `vbsl` swapped for one `vorr`), removing one link from the `sbt` dependency chain. `<false>` codegen and x86 tiers are untouched (NEON-only edit).

## Why op-count-neutral

The kernel is **vector-ALU-throughput-bound**, not latency-bound on `sbt`. An aggressive variant that also folded in the ambiguous-query blend — shortening the chain by two links but adding one net vector op — **regressed −5%**. Removing one chain link at constant op count gained **+2.1%**. Rule for this kernel family: a NEON micro-opt here only helps if it does not raise the per-cell op count.

## Validation (bwa-bsw-bench, rescue mode)

Graviton4 (`c8g.4xlarge`, aarch64, tier `neon/8b`), `--mode rescue --meth-scoring collapsed --lengths 150 --slack 894 --n 20000`.

**Byte-identity golden gate** (baseline goldens vs this kernel):

| Mode | Result |
|---|---|
| collapsed (emseq) | GOLDEN CHECK PASS |
| collapsed `--n-pct 10` (N handling) | GOLDEN CHECK PASS |
| genomic (TAPS) | GOLDEN CHECK PASS |
| neutral (Neutral TAPS) | GOLDEN CHECK PASS |

All meth chemistries route through this same `kswv_neon_u8_impl<true>` kernel, so the one change covers emseq and TAPS.

**Throughput** (`mb3 Mc/s`, collapsed, `--reps 30`, rock-stable across 3–4 runs):

| Build | mb3 Mc/s | Δ |
|---|---|---|
| baseline (`main`, unmodified) | 3804.8 / 3804.4 / 3803.5 | — |
| this PR | 3885.2 / 3885.0 / 3885.3 / 3884.2 | **+2.1%** |

GCUPS is within-host only (every run stamps host/arch/tier).
