### PR TITLE
perf(kswv): collapse the two freed-cell blends into one in the AVX2 rescue kernels

### DIFF
--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -1634,12 +1634,16 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
              * never equal fr_read, so cmpeq is naturally false for them — no
              * extra masking needed. Mirrors bandedSWA SBT_PREPASS8_RANK1. */
             if (HasFreed) {
+                /* Both freed blends select match256, so OR their masks and do
+                 * ONE blend instead of two serially-dependent blendv ops. Same
+                 * op count (one blendv swapped for one or), byte-identical, one
+                 * shorter link in the sbt chain. */
                 __m256i freed  = _mm256_and_si256(rowfreed,
                                                   _mm256_cmpeq_epi8(s2, frread256));
-                sbt = _mm256_blendv_epi8(sbt, match256, freed);
                 __m256i freed2 = _mm256_and_si256(rowfreed2,
                                                   _mm256_cmpeq_epi8(s2, frread2_256));
-                sbt = _mm256_blendv_epi8(sbt, match256, freed2);
+                sbt = _mm256_blendv_epi8(sbt, match256,
+                                         _mm256_or_si256(freed, freed2));
             }
 
             /* High bit of (s1 | s2) indicates boundary (padding 0xFF).
@@ -2110,12 +2114,15 @@ int kswv::kswv256_16_impl(int16_t seq1SoA[],
              * an all-ones/all-zeros int16 mask, so the byte-wise blendv selects
              * whole int16 lanes correctly. */
             if (HasFreed) {
+                /* Both freed blends select match256, so OR their masks and do
+                 * ONE blend instead of two serially-dependent blendv ops (same
+                 * op count, byte-identical, one shorter link in the sbt chain). */
                 __m256i freed  = _mm256_and_si256(rowfreed,
                                                   _mm256_cmpeq_epi16(s2, frread256));
-                sbt = _mm256_blendv_epi8(sbt, match256, freed);
                 __m256i freed2 = _mm256_and_si256(rowfreed2,
                                                   _mm256_cmpeq_epi16(s2, frread2_256));
-                sbt = _mm256_blendv_epi8(sbt, match256, freed2);
+                sbt = _mm256_blendv_epi8(sbt, match256,
+                                         _mm256_or_si256(freed, freed2));
             }
 
             /* Boundary: high bit set in (s1 | s2) marks padding (0xFFFF). */


### PR DESCRIPTION
## What

Stacked on #249. That PR collapsed the two freed-cell blends into one in the **NEON** `kswv` u8 rescue kernel. This PR applies the same byte-identical transformation to the **AVX2** u8 and u16 kernels, where it also wins. The **AVX-512BW** kernels are deliberately left unchanged — the same collapse was measured to *regress* there (see below).

The freed-cell override exists on exactly three SIMD tiers — NEON, AVX2, AVX-512BW (`kswv.cpp:207-218`); SSE41/SSE42/AVX have no SIMD freed path and fall back to scalar `ksw_align2`.

Each AVX2 site did two serially-dependent blends into the score vector `sbt`, both selecting `match256`:

```c
sbt = _mm256_blendv_epi8(sbt, match256, freed);
sbt = _mm256_blendv_epi8(sbt, match256, freed2);
```

Because both select `match256`, OR the masks and do one blend:

```c
sbt = _mm256_blendv_epi8(sbt, match256, _mm256_or_si256(freed, freed2));
```

Op-count-neutral (one `blendv` swapped for one `or`), one shorter link in the `sbt` chain. Byte-identity holds for the same reason as #249: `(freed?match:sbt)` then `(freed2?match:sbt)` equals `((freed|freed2)?match:sbt)`.

## Why AVX-512 is excluded

On AVX2/NEON the mask combine is a vector `or` that is genuinely op-count-neutral. On AVX-512 the combine is a `kor`, but folding `freed | freed2` forces *both* masks to be ready before the single `vpblendmb` can issue — whereas the two-blend form lets the first blend start on `freed` alone and overlaps `freed2`'s computation. That serialization costs more than the saved blend, so AVX-512 regressed and is left byte-for-byte unchanged. The tiers are independent kernel objects (`kswv.avx2.o` vs `kswv.avx512bw.o`), so this does not affect the AVX2 win.

## Validation (bwa-bsw-bench, rescue mode)

c7i.4xlarge (Sapphire Rapids), `--mode rescue --lengths 150 --slack 894 --n 20000`, tiers forced via `BWAMEM3_FORCE_TIER`. `mb3 Mc/s` is the bwa-mem3 `kswv<true>` kernel column.

**Byte-identity golden gate** (baseline goldens vs this build), all PASS:

| Tier | collapsed | collapsed --n-pct 10 | genomic | neutral |
|---|---|---|---|---|
| avx2 | PASS | PASS | PASS | PASS |
| avx512bw | PASS | PASS | PASS | PASS |

**Throughput** (`mb3 Mc/s`, collapsed, `--reps 30`, 3 runs each):

| Tier | Baseline | This PR | Δ |
|---|---|---|---|
| **avx2** | 6235.8 / 6187.0 / 6196.8 | 6347.7 / 6355.4 / 6348.2 | **+2.3%** |
| avx512bw (unchanged) | 10615.8 / 10524.9 / 10620.0 | — (collapse regressed −5.7%, reverted) | — |

GCUPS is within-host only.
