### PR TITLE
perf(kswv): hoist the u8 boundary test per-row (NEON both paths, AVX-512 non-meth +12.6%)

### DIFF
--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -69,7 +69,7 @@ extern uint64_t prof[10][112];
 
 #define MAIN_SAM_CODE8_OPT(s1, s2, h00, h11, e11, f11, f21, max512, sft512) \
     {                                                                   \
-        __m512i sbt11, xor11, or11;                                     \
+        __m512i sbt11, xor11;                                           \
         xor11 = _mm512_xor_si512(s1, s2);                               \
         sbt11 = _mm512_shuffle_epi8(permSft512, xor11);                 \
         __mmask64 cmpq = _mm512_cmpeq_epu8_mask(s2, five512);           \
@@ -82,8 +82,13 @@ extern uint64_t prof[10][112];
                 _mm512_cmpeq_epi8_mask(s2, frread2_512);                \
             sbt11 = _mm512_mask_blend_epi8(freed2, sbt11, match512);    \
         }                                                               \
-        or11 =  _mm512_or_si512(s1, s2);                                \
-        __mmask64 cmp = _mm512_movepi8_mask(or11);                      \
+        /* Boundary mask, gated by HasFreed (compile-time). Non-meth    \
+         * hoists the per-row rowboundary512 (a big avx512 win); meth    \
+         * keeps the per-cell s1|s2 form — hoisting there pins a third   \
+         * live k-reg against the two freed masks and slightly regressed.*/ \
+        __mmask64 cmp = HasFreed                                        \
+            ? _mm512_movepi8_mask(_mm512_or_si512(s1, s2))              \
+            : rowboundary512;                                           \
         __m512i m11 = _mm512_adds_epu8(h00, sbt11);                     \
         m11 = _mm512_mask_blend_epi8(cmp, m11, zero512);                \
         m11 = _mm512_subs_epu8(m11, sft512);                            \
@@ -577,6 +582,15 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
             rowfreed2   = vceqq_u8(s1, vdupq_n_u8((uint8_t)fr_ref2));
         }
 
+        /* Boundary detection hoisted per-row. The per-cell test zeroed m11 where
+         * bit 7 was set in s1 OR s2. In the u8 kernel s2 only ever holds real
+         * bases (0-3) or ambig/padding (DUMMY5=5, AMBQ=8) — never the high bit —
+         * so high_bit(s1|s2) == high_bit(s1), and s1 is loop-invariant across the
+         * inner j loop. Hoist the vorr+vtst pair to a single per-row vtst; only
+         * the per-cell blend remains. The byte-identity golden gate is the safety
+         * net: if any s2 lane ever carried bit 7, the check would fail instantly. */
+        uint8x16_t rowboundary = vtstq_u8(s1, vdupq_n_u8(0x80));
+
         uint8x16_t l_vec = zero_vec;
         for (j = 0; j < ncol; j++)
         {
@@ -605,14 +619,8 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
                 sbt = vbslq_u8(freed2, match_vec, sbt);
             }
 
-            /* Check for boundary (high bit set in s1 or s2). vtstq_u8 against
-             * 0x80 sets 0xFF where bit 7 is set, 0x00 otherwise — one op vs the
-             * prior vshr+vceq pair, and this runs per cell in the inner loop. */
-            uint8x16_t or_val = vorrq_u8(s1, s2);
-            uint8x16_t is_boundary = vtstq_u8(or_val, vdupq_n_u8(0x80));
-
             uint8x16_t m11 = vqaddq_u8(h00, sbt);
-            m11 = vbslq_u8(is_boundary, zero_vec, m11);
+            m11 = vbslq_u8(rowboundary, zero_vec, m11);
             m11 = vqsubq_u8(m11, sft_vec);
 
             h11 = vmaxq_u8(m11, e11);
@@ -1641,7 +1649,10 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
 
             /* High bit of (s1 | s2) indicates boundary (padding 0xFF).
              * Sign compare against zero gives 0xFF wherever high bit is
-             * set in the u8 byte. */
+             * set in the u8 byte. NB: the boundary hoist that helps NEON and
+             * AVX-512 non-meth regresses here — AVX2's 16-register file spills
+             * once the mask is loop-invariant (however computed), so this tier
+             * keeps the per-cell s1|s2 form. */
             __m256i or_val      = _mm256_or_si256(s1, s2);
             __m256i is_boundary = _mm256_cmpgt_epi8(zero_vec, or_val);
 
@@ -2741,6 +2752,13 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
             rowfreed512  = _mm512_cmpeq_epi8_mask(s1, frref512);
             rowfreed2_512= _mm512_cmpeq_epi8_mask(s1, _mm512_set1_epi8((char)fr_ref2));
         }
+
+        /* Boundary detection hoisted per-row: in u8, s2 only holds 0-3/5/8 (never
+         * the high bit), so high_bit(s1|s2) == high_bit(s1). Consumed by
+         * MAIN_SAM_CODE8_OPT only in the non-meth (!HasFreed) instantiation; the
+         * meth path keeps the per-cell form, so this is DCE'd there. The golden
+         * gate fails instantly if any s2 lane ever carried bit 7. */
+        __mmask64 rowboundary512 = _mm512_movepi8_mask(s1);
 
         __m512i l512 = zero512;
         for (j=0; j<ncol; j++)


### PR DESCRIPTION
## What

The `kswv` mate-rescue u8 inner loop zeroes `m11` at padding/sentinel cells via a per-cell boundary mask `is_boundary = high_bit(s1 | s2)`. In the **u8** kernel `s2` only ever holds real bases (`0-3`) or ambig/padding (`DUMMY5=5`/`AMBQ=8`) and **never** carries bit 7, so `high_bit(s1|s2) == high_bit(s1)`. Since `s1` is loop-invariant across the inner `j` loop, the per-cell `or`+`high_bit` pair (2 ops/cell) hoists to a single per-row mask over a hotspot the re-profile put at ~19% of the `kswv<true>` kernel. It lives in the shared core, so it touches **both** `kswv<true>` (meth) and `kswv<false>` (non-meth mate rescue).

The **byte-identity golden gate is the safety proof**: if any `s2` lane ever carried bit 7 the hoisted result would diverge and the check would fail instantly.

## The win is strongly tier-dependent

The same op-reduction helps NEON, splits on AVX-512, and regresses AVX2 — the canonical "measure per-tier, never extrapolate." The shipped config keeps only the wins:

| Tier | meth collapsed | non-meth | shipped form |
|---|---|---|---|
| **NEON** (Graviton4) | **+2.1%** | **+2.9%** | unconditional per-row hoist |
| **AVX2** (c7i) | 0% | 0% | **baseline kept** (hoist regresses) |
| **AVX-512BW** (c7i) | 0% | **+12.6%** | hoist **gated to non-meth** (`HasFreed`) |

- **AVX2**: any loop-invariant boundary mask (forced hoist *or* gcc-LICM'd rematerialize both measured) spills AVX2's 16-register file — ~−0.7% meth / −2.6% non-meth. The only way to keep the mask loop-varying is the redundant `s1|s2` OR, i.e. the baseline. Left untouched.
- **AVX-512**: hoisting the *meth* path pins a third live k-register against the two freed-cell masks and slightly regresses (−0.8%); gating the hoist to the non-meth instantiation keeps the +12.6% and restores meth to 0%.

u16 kernels untouched — their `s2` padding can be `0xFFFF`, so the sentinel argument does not hold.

## Numbers are kernel throughput, not end-to-end

**All percentages are isolated-kernel throughput (`mb3 Mc/s`) from `bwa-bsw-bench`** (`--mode rescue --lengths 150 --slack 894 --n 20000 --reps 30`, 3 runs/config), same methodology as the merged kernel PRs (#147/#149/#160/#252). No end-to-end `bwa-mem3 mem` wall-clock A/B was run for this change; the kernel is ~45% of `--meth` CPU, so whole-program impact is smaller (Amdahl estimate ~+0.9% end-to-end `--meth` on NEON). Not a user-facing speedup claim.

## Correctness

Byte-identity **PASS** on all three tiers × 5 modes (non-meth, collapsed, collapsed+N%, genomic, neutral). NEON validated on Graviton4 + Apple-Silicon laptop; AVX2/AVX-512BW on a c7i.4xlarge (Sapphire Rapids). u8 only (the 8-bit tier the bench throughput-validates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved processing efficiency for 8-bit SIMD operations by reducing repeated boundary checks during cell processing.
  * Optimized AVX-512BW, AVX2, and ARM/NEON execution paths while preserving existing behavior.
* **Bug Fixes**
  * Improved handling of padding and boundary cells in supported 8-bit processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->