### PR TITLE
perf(bandedSWA): fewer ops in the AVX2/AVX-512 extend cores (x86-only; +4-6% AVX-512)

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -503,8 +503,10 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
          * the signed substitution score into its +bonus and -penalty parts:  \
          * adds_epu8 (no wrap past 255) then subs_epu8 (floors at 0). Mirrors  \
          * the validated NEON smithWaterman128_8 recurrence. */                \
+        /* sbt_neg = max(0,-sbt) = sbt_pos - sbt (exactly one of pos/neg nonzero); \
+         * one op, byte-identical for sbt in [-127,127] (golden gate guards -128). */ \
         __m256i sbt_pos = _mm256_max_epi8(sbt11, zero256);              \
-        __m256i sbt_neg = _mm256_max_epi8(_mm256_sub_epi8(zero256, sbt11), zero256); \
+        __m256i sbt_neg = _mm256_sub_epi8(sbt_pos, sbt11);              \
         __m256i m11 = _mm256_subs_epu8(_mm256_adds_epu8(h00, sbt_pos), sbt_neg); \
         __m256i cmp11 = _mm256_cmpeq_epi8(h00, zero256);                \
         m11 = _mm256_andnot_si256(cmp11, m11);  /* h00==0 -> local restart */ \
@@ -564,12 +566,13 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
         m11 = _mm256_andnot_si256(cmp11, m11);                 \
         h11 = _mm256_max_epi16(m11, e11);                               \
         h11 = _mm256_max_epi16(h11, f11);                               \
-        __m256i temp256 = _mm256_sub_epi16(h11, oe_ins256);             \
-        __m256i val256  = _mm256_max_epi16(temp256, zero256);           \
+        /* max(x - open, 0) == subs_epu16(x, open): scores are non-negative and \
+         * < 32768, so unsigned-saturating sub matches the signed sub + zero  \
+         * floor (brings the u16 core to parity with the u8 core's subs_epu8). */ \
+        __m256i val256 = _mm256_subs_epu16(h11, oe_ins256);            \
         e11 = _mm256_sub_epi16(e11, e_ins256);                          \
         e11 = _mm256_max_epi16(val256, e11);                            \
-        temp256 = _mm256_sub_epi16(h11, oe_del256);                     \
-        val256  = _mm256_max_epi16(temp256, zero256);                   \
+        val256 = _mm256_subs_epu16(h11, oe_del256);                    \
         f21 = _mm256_sub_epi16(f11, e_del256);                          \
         f21 = _mm256_max_epi16(val256, f21);                            \
     }
@@ -2438,8 +2441,10 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
          * substitution score into +bonus and -penalty parts: adds_epu8 (no   \
          * wrap past 255) then subs_epu8 (floors at 0). Mirrors the validated  \
          * NEON smithWaterman128_8 recurrence. */                              \
+        /* sbt_neg = max(0,-sbt) = sbt_pos - sbt (exactly one of pos/neg nonzero); \
+         * one op, byte-identical for sbt in [-127,127] (golden gate guards -128). */ \
         __m512i sbt_pos = _mm512_max_epi8(sbt11, zero512);              \
-        __m512i sbt_neg = _mm512_max_epi8(_mm512_sub_epi8(zero512, sbt11), zero512); \
+        __m512i sbt_neg = _mm512_sub_epi8(sbt_pos, sbt11);              \
         __m512i m11 = _mm512_subs_epu8(_mm512_adds_epu8(h00, sbt_pos), sbt_neg); \
         __mmask64 cmp11 = _mm512_cmpeq_epi8_mask(h00, zero512);         \
         m11 = _mm512_mask_blend_epi8(cmp11, m11, zero512);  /* h00==0 -> local restart */ \
@@ -2512,12 +2517,13 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         m11 = _mm512_mask_blend_epi16(cmp11, m11, zero512);             \
         h11 = _mm512_max_epi16(m11, e11);                               \
         h11 = _mm512_max_epi16(h11, f11);                               \
-        __m512i temp512 = _mm512_sub_epi16(h11, oe_ins512);             \
-        __m512i val512  = _mm512_max_epi16(temp512, zero512);           \
+        /* max(x - open, 0) == subs_epu16(x, open): scores are non-negative and \
+         * < 32768, so unsigned-saturating sub matches the signed sub + zero  \
+         * floor (brings the u16 core to parity with the u8 core's subs_epu8). */ \
+        __m512i val512 = _mm512_subs_epu16(h11, oe_ins512);            \
         e11 = _mm512_sub_epi16(e11, e_ins512);                          \
         e11 = _mm512_max_epi16(val512, e11);                            \
-        temp512 = _mm512_sub_epi16(h11, oe_del512);                     \
-        val512  = _mm512_max_epi16(temp512, zero512);                   \
+        val512 = _mm512_subs_epu16(h11, oe_del512);                    \
         f21 = _mm512_sub_epi16(f11, e_del512);                          \
         f21 = _mm512_max_epi16(val512, f21);                            \
     }
@@ -4387,7 +4393,7 @@ _mm_blendv_epi16(__m128i x, __m128i y, __m128i mask)
         temp128 = _mm_sub_epi16(me128, oe_del128);                     \
         val128  = _mm_max_epi16(temp128, zero128);                      \
         f21 = _mm_sub_epi16(f11, e_del128);                             \
-        f21 = _mm_max_epi16(val128, f21);                               \
+        f21 = _mm_max_epi16(val128, f21);                              \
     }
 
 


### PR DESCRIPTION
## What

Two byte-identical op-count reductions in the x86 banded-**extension** cell-update cores (`MAIN_CODE8_CORE` / `MAIN_CODE16_CORE`), which run for **every seed extension** — meth and non-meth (unlike `kswv`, which is rescue-only):

1. **u16 gap-open floor fusion (−2 ops/cell):** `max(sub_epi16(x, open), 0)` == `subs_epu16(x, open)` since scores are non-negative and < 32768. Two floors per cell. The **u8 core already used `subs_epu8`** here — the u16 core was just never brought to parity.
2. **u8 substitution split (−1 op/cell):** `sbt_neg = max(0,-sbt) = sbt_pos - sbt` (exactly one of pos/neg is nonzero). Byte-identical for `sbt ∈ [-127,127]` (the LUT never emits −128; the golden gate guards it).

## Per-tier result — x86-only, by design

| Tier | u16 (hot tier) | u8 | shipped |
|---|---|---|---|
| **NEON** (Graviton4) | −1.0% | flat | **reverted** (unchanged) |
| **AVX2** (c7i) | **+3.5%** | **+1.9%** | kept |
| **AVX-512BW** (c7i) | **+6.2%** | **+4.1%** | kept |

Byte-identity **PASS** on all three tiers × (non-meth, collapsed, N-handling).

**Why NEON is reverted, not shipped:** `perf stat` on the baseline Graviton4 u16 extend core shows **3.85 IPC at ~0.01% L1 miss** — it's already near the wide Neoverse-V2 core's execution ceiling and is **latency/ILP-bound, not SIMD-op-throughput-bound**. The batched kernel fills idle SIMD slots with independent-pair ILP, so cutting off-critical-path ops can't shorten the binding recurrence (measured −1% on u16). On x86 the cores **are** op-throughput-bound, so the identical cut wins. The cores are separate per-tier macros, so NEON is left exactly as `main` — zero regression.

> Note: the hot extend tier at realistic lengths (150–250 bp) is the **u16** kernel, not u8 — the adapter routes each pair independently. And the Apple-Silicon laptop mis-predicted Graviton4 badly here (laptop showed +7.9% NEON; Graviton4 showed −1%), so all NEON numbers above are from Graviton4.

## Scope

Isolated-kernel throughput (`bwa-bsw-bench` `mb3 Mc/s`), not end-to-end `mem` wall clock. Extension is ~60% of `mem` CPU, so a real x86 end-to-end gain is plausible but unmeasured.

## Validation

Byte-identity golden gate + per-tier throughput on Graviton4 (NEON) and a c7i.4xlarge (AVX2 + AVX-512BW). u8 tier at len 150, u16 tier at len 250.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment scoring accuracy across supported SIMD instruction sets.
  * Corrected gap and substitution score calculations, including saturation behavior for edge-case values.
  * No changes to the user-facing interface or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->