### PR TITLE
refactor(bsw): derive extension gaps from M again (bwa-mem2 compatibility)

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -345,18 +345,21 @@ int BandedPairWiseSW::scalarBandedSWA(int qlen, const uint8_t *query,
             h1 = h;             // save H(i,j) to h1 for the next column
             mj = m > h? mj : j; // record the position where max score is achieved
             m = m > h? m : h;   // m is stored at eh[mj+1]
-            // gap-from-H (standard Gotoh): gap-open is subtracted from the cell
-            // max H(i,j)=h, not the diagonal-only M. This matches ksw2/minimap2
-            // and is the convention the int8 delta recurrence requires. The final
-            // reported CIGAR/score still come from ksw_global2 (gap-from-M), so
-            // alignment output is unchanged; this only governs the extension
-            // boundary scorer. See FINDINGS-delta-recurrence.md (task #16).
-            t = h - oe_del;
+            // gap-from-M (bwa/bwa-mem2 convention): gap-open is subtracted from
+            // the diagonal-only M, not the cell max H. This is deliberate --
+            // "separating H and M to disallow a cigar like 100M3I3D20M" -- and it
+            // is what upstream ksw_extend2 and bwa-mem2's bandedSWA do, so it is
+            // required for bwa-mem2 output compatibility. (ksw2/minimap2 use
+            // gap-from-H; the mate-rescue kernels in ksw.cpp/kswv.cpp keep
+            // gap-from-H because that is what bwa's own ksw_u8/ksw_i16 do. The two
+            // conventions are intentionally NOT unified.) See PR #141 and its
+            // revert for the int8-delta-recurrence history.
+            t = M - oe_del;
             t = t > 0? t : 0;
             e -= e_del;
             e = e > t? e : t;   // computed E(i+1,j)
             p->e = e;           // save E(i+1,j) for the next row
-            t = h - oe_ins;
+            t = M - oe_ins;
             t = t > 0? t : 0;
             f -= e_ins;
             f = f > t? f : t;   // computed F(i,j+1)
@@ -513,10 +516,10 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
         h11 = _mm256_max_epu8(m11, e11);                                \
         h11 = _mm256_max_epu8(h11, f11);                                \
         /* gap-open from H (standard Gotoh), unsigned-saturating */      \
-        __m256i temp256 = _mm256_subs_epu8(h11, oe_ins256);            \
+        __m256i temp256 = _mm256_subs_epu8(m11, oe_ins256);            \
         e11 = _mm256_subs_epu8(e11, e_ins256);                          \
         e11 = _mm256_max_epu8(temp256, e11);                            \
-        temp256 = _mm256_subs_epu8(h11, oe_del256);                    \
+        temp256 = _mm256_subs_epu8(m11, oe_del256);                    \
         f21 = _mm256_subs_epu8(f11, e_del256);                          \
         f21 = _mm256_max_epu8(temp256, f21);                            \
     }
@@ -569,10 +572,10 @@ void BandedPairWiseSW::scalarBandedSWAWrapper(SeqPair *seqPairArray,
         /* max(x - open, 0) == subs_epu16(x, open): scores are non-negative and \
          * < 32768, so unsigned-saturating sub matches the signed sub + zero  \
          * floor (brings the u16 core to parity with the u8 core's subs_epu8). */ \
-        __m256i val256 = _mm256_subs_epu16(h11, oe_ins256);            \
+        __m256i val256 = _mm256_subs_epu16(m11, oe_ins256);            \
         e11 = _mm256_sub_epi16(e11, e_ins256);                          \
         e11 = _mm256_max_epi16(val256, e11);                            \
-        val256 = _mm256_subs_epu16(h11, oe_del256);                    \
+        val256 = _mm256_subs_epu16(m11, oe_del256);                    \
         f21 = _mm256_sub_epi16(f11, e_del256);                          \
         f21 = _mm256_max_epi16(val256, f21);                            \
     }
@@ -2451,10 +2454,10 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         h11 = _mm512_max_epu8(m11, e11);                                \
         h11 = _mm512_max_epu8(h11, f11);                                \
         /* gap-open from H (standard Gotoh), unsigned-saturating */      \
-        __m512i temp512 = _mm512_subs_epu8(h11, oe_ins512);            \
+        __m512i temp512 = _mm512_subs_epu8(m11, oe_ins512);            \
         e11 = _mm512_subs_epu8(e11, e_ins512);                          \
         e11 = _mm512_max_epu8(temp512, e11);                            \
-        temp512 = _mm512_subs_epu8(h11, oe_del512);                    \
+        temp512 = _mm512_subs_epu8(m11, oe_del512);                    \
         f21 = _mm512_subs_epu8(f11, e_del512);                          \
         f21 = _mm512_max_epu8(temp512, f21);                            \
     }
@@ -2520,10 +2523,10 @@ void BandedPairWiseSW::smithWaterman256_16(uint16_t seq1SoA[],
         /* max(x - open, 0) == subs_epu16(x, open): scores are non-negative and \
          * < 32768, so unsigned-saturating sub matches the signed sub + zero  \
          * floor (brings the u16 core to parity with the u8 core's subs_epu8). */ \
-        __m512i val512 = _mm512_subs_epu16(h11, oe_ins512);            \
+        __m512i val512 = _mm512_subs_epu16(m11, oe_ins512);            \
         e11 = _mm512_sub_epi16(e11, e_ins512);                          \
         e11 = _mm512_max_epi16(val512, e11);                            \
-        val512 = _mm512_subs_epu16(h11, oe_del512);                    \
+        val512 = _mm512_subs_epu16(m11, oe_del512);                    \
         f21 = _mm512_sub_epi16(f11, e_del512);                          \
         f21 = _mm512_max_epi16(val512, f21);                            \
     }
@@ -4382,15 +4385,13 @@ _mm_blendv_epi16(__m128i x, __m128i y, __m128i mask)
         m11 = _mm_blendv_epi16(m11, zero128, cmp11);                    \
         h11 = _mm_max_epi16(m11, e11);                                  \
         h11 = _mm_max_epi16(h11, f11);                                  \
-        /* Reassociate gap recurrences off h11 (variant B, signed; keep   \
-         * the existing max(.,0) floor). me reads OLD e11. */              \
-        __m128i mf128 = _mm_max_epi16(m11, f11);                        \
-        __m128i me128 = _mm_max_epi16(m11, e11);                        \
-        __m128i temp128 = _mm_sub_epi16(mf128, oe_ins128);             \
+        /* Gaps open from m11 (bwa-mem2 convention), not h11: m11 does not \
+         * depend on the carried f, so this recurrence is naturally short. */ \
+        __m128i temp128 = _mm_sub_epi16(m11, oe_ins128);                \
         __m128i val128  = _mm_max_epi16(temp128, zero128);              \
         e11 = _mm_sub_epi16(e11, e_ins128);                             \
         e11 = _mm_max_epi16(val128, e11);                               \
-        temp128 = _mm_sub_epi16(me128, oe_del128);                     \
+        temp128 = _mm_sub_epi16(m11, oe_del128);                        \
         val128  = _mm_max_epi16(temp128, zero128);                      \
         f21 = _mm_sub_epi16(f11, e_del128);                             \
         f21 = _mm_max_epi16(val128, f21);                              \
@@ -5250,14 +5251,12 @@ void BandedPairWiseSW::smithWaterman128_16(uint16_t seq1SoA[],
         m11 = _mm_blendv_epi8(m11, zero128, cmp11);  /* h00==0 -> local restart */ \
         h11 = _mm_max_epu8(m11, e11);                                   \
         h11 = _mm_max_epu8(h11, f11);                                   \
-        /* Reassociate gap recurrences off h11 (variant A, saturating u8). \
-         * me reads OLD e11 — compute before the e-update. */               \
-        __m128i mf128 = _mm_max_epu8(m11, f11);                         \
-        __m128i me128 = _mm_max_epu8(m11, e11);                         \
-        __m128i temp128 = _mm_subs_epu8(mf128, oe_ins128);             \
+        /* Gaps open from m11 (bwa-mem2 convention), not h11: m11 does not \
+         * depend on the carried f, so this recurrence is naturally short. */ \
+        __m128i temp128 = _mm_subs_epu8(m11, oe_ins128);                \
         e11 = _mm_subs_epu8(e11, e_ins128);                            \
         e11 = _mm_max_epu8(temp128, e11);                               \
-        temp128 = _mm_subs_epu8(me128, oe_del128);                     \
+        temp128 = _mm_subs_epu8(m11, oe_del128);                        \
         f21 = _mm_subs_epu8(f11, e_del128);                            \
         f21 = _mm_max_epu8(temp128, f21);                               \
     }


### PR DESCRIPTION
refactor(bsw): derive extension gaps from M again (bwa-mem2 compatibility)

Reverts the semantic half of #141. `BandedPairWiseSW`'s banded Smith-Waterman opens gaps from the diagonal-only `M` again, as upstream `ksw_extend2` and bwa-mem2's `bandedSWA` do, instead of from the cell max `H`.

## Why now

#141's sole stated driver was unblocking an int8 Suzuki–Kasahara difference recurrence: under gap-from-M the `E−H` delta is unbounded (`[−361, 0]`, ~24k int8 overflows per sweep), under gap-from-H it is `[−11, 0]` and the recurrence closes. That was a reasonable bet on the evidence available in June.

**The bet did not pay off.** The delta recurrence was built in July and rejected twice, independently:

- `reports/2026-07-22-m2e-throughput-delta-too-slow.md` — the reconstruction-based delta is **2.8–3.2× slower** than the absolute 8-bit kernel and ~2× slower than the 16-bit tier it was meant to replace. *"This defeats the project premise as currently implemented."*
- `reports/2026-07-22-m2f-step2-neon-growth-edge-obstacle.md` — the true difference-only SK kernel is byte-identical to the oracle but **11% slower on the 16-bit tier (its addressable slice)** and 6% slower on 8-bit, measured on real dumped SBX pair shapes. *"NO-GO confirmed on production data."*

With the delta recurrence dead, gap-from-H has no remaining benefit, and it carries three costs.

## This is a compatibility choice, not a bug fix

To be explicit: gap-from-**H** is standard Gotoh and what ksw2/minimap2 do. Gap-from-**M** is a bwa idiosyncrasy, deliberate upstream — *"separating H and M to disallow a cigar like `100M3I3D20M`"*. This PR chooses **bwa-mem2 output compatibility** over the textbook convention. That is the right trade for a drop-in replacement, but it is a trade, not a correctness fix.

`IPNP-BIPN/bwa-mem4` made the same call for the same reason (`990df3a`, *"fix(sw): open gaps from M, not H"*), reporting SE output byte-identical to bwa-mem2 over 400k HG002 reads afterwards.

## Cost 1 — output divergence from bwa-mem2

Measured against a real bwa-mem2 v2.2.1 baseline BAM (`s3://fg-bwa-mem3-bench/baseline/bwa-mem2-v2.2.1/wgs-5M/c6a/rep-1/aligned.bam`, c6a = AVX2 = scalar mate-rescue path), 5M HG00096 WGS pairs, hg38, `-t 16` on both sides so batch boundaries and therefore `mem_pestat` match:

| | primaries differing | XS | AS |
|---|---:|---:|---:|
| `origin/main` | 1,501 (0.01504%) | 1,167 | 44 |
| this PR | **1,487 (0.01490%)** | **1,154** | **43** |

−14 records, essentially all `XS` (the runner-up score). FLAG/RNAME/POS/MAPQ/CIGAR counts are unchanged, as expected for a change that only moves the extension boundary scorer.

The mechanism is the one bwa-mem4 documented: gap-from-H is upward-only on `gscore`, and `gscore` is not purely internal — it is consumed at `mem_chain2aln`'s `gscore <= score - pen_clip3` test, which selects between the local and extend-to-end branches. An inflated `gscore` flips that test.

**Note the rate is data-dependent.** 14/9.98M here on HG00096; bwa-mem4 saw far more on HG002 inside satellite repeats. This PR's measurement under-represents the effect on satellite-rich data, exactly as #141's original chr17/idt-cfdna validation did.

## Cost 2 — #141's latency, and #166's tax to undo it

`m11` is computed before `h11` and does not depend on the carried `f`, so gap-from-M's loop-carried chain is naturally 2 ops (`f → sub → max`). Gap-from-H makes it 4 (`f → h11 → sub → max`) at the same op count. #166 then spent **+2 ops/cell** (`mf = max(m,f)`, `me = max(m,e)`) to reassociate it back to 2 on NEON.

This PR **deletes that reassociation** — gap-from-M gets the short chain for free at the original op count. Both 128-bit cores lose `mf128`/`me128` entirely.

It also retires `perf/banded-gap-reassoc`, the unmerged x86 half of #166, which regressed ~7% on AVX-512 because x86 is execution-port-throughput-bound and could not afford the +2 ops.

## What changed

16 assertion-guarded replacements in `src/bandedSWA.cpp`, verified against upstream bwa-mem2 (`bandedSWA.cpp:338,342 / 1898,1902 / 3399,3403 / 4188,4191`):

| tier | sites |
|---|---|
| AVX2 256, 8-bit + 16-bit | `subs_epu8/16(h11, oe_*)` → `(m11, oe_*)` |
| AVX-512, 8-bit + 16-bit | `subs_epu8/16(h11, oe_*)` → `(m11, oe_*)` |
| SSE2-NEON 128, 8-bit + 16-bit | `mf128`/`me128` dropped; `(m11, oe_*)` |
| scalar | `t = h - oe_*` → `t = M - oe_*` |

The row-init sites (`h0_* - oe_ins`) are untouched — they are gap-from-`h0` in bwa-mem2 too.

**`ksw.cpp` and `kswv.cpp` are deliberately NOT touched.** bwa's own `ksw_u8`/`ksw_i16` open gaps from H, so mate rescue must stay gap-from-H. The extension/rescue asymmetry is intentional and is now documented in the replacement comment so it is not "unified" by a future cleanup.

## Validation (`bwa-bsw-bench`, arm64/NEON)

Baseline = clean `228a61b`; candidate = this branch. Goldens regenerated fresh for this run (n=20000, lengths 100,150,250).

```
### EXTEND golden  -> GOLDEN CHECK FAIL: 1/60000 pairs differ   (tier=neon/16b)
### RESCUE golden  -> GOLDEN CHECK PASS: 60000 pairs byte-identical (tier=neon/16b)
```

- The **extend FAIL is expected and is the point of the PR** — a deliberate, reviewed semantics change. 1 pair in 60,000 differ, consistent with the 14/9.98M aligner-level rate.
- The **rescue PASS is the load-bearing control**: it proves mate rescue was not touched and the gap-from-H convention still holds there.

Throughput — clean back-to-back run, quiet machine, `--reps 15`, arm64/NEON:

| qlen | tier | baseline `mb3 Mc/s` | this PR | Δ |
|---|---|---:|---:|---:|
| 100 | neon/8b  | 5539.9 | 5671.1 | **+2.4%** |
| 150 | neon/16b | 3647.4 | 3693.5 | **+1.3%** |
| 250 | neon/16b | 3444.0 | 3509.0 | **+1.9%** |

Small but uniformly positive, consistent with removing 2 ops/cell from both 128-bit cores. The `ksw2 Mc/s` control column (identical code in both runs) agrees to within 1-3% (1663.7/2033.0/2367.2 vs 1661.3/2006.7/2293.5), which is what makes the comparison trustworthy.

**Caveat:** at qlen 250 the control itself moved ~3%, so a ~2% signal is near this host's noise floor. The result is credible because the direction is uniform across all three lengths and the mechanism (fewer ops) is known — not because any single number is decisive. x86 is unmeasured here; the expectation is that AVX2/AVX-512 benefit at least as much, since #166's x86 counterpart regressed ~7% on AVX-512 precisely because it could not afford the +2 ops.

## Follow-ups

- Re-validate on satellite-rich data (HG002) before release, not just HG00096 — this is where the effect concentrates.
- Parity baselines (chr22, holodeck) regenerate.
- `perf/banded-gap-reassoc` can be closed.
- The divergence catalog / `expected-divergences.yaml` budgets should be updated; see `reports/2026-07-22-runner-up-score2-mapq-parity-vs-bwa-mem2-and-mem4.md` §5.4 for the full three-cause attribution this PR is the first part of.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sequence alignment scoring consistency across scalar and SIMD processing modes.
  * Updated gap handling to produce results compatible with bwa-mem2 output.
  * Aligned scoring behavior across supported processor instruction sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->