### PR TITLE
perf(sort): move the pdqsort/total-order dedup sort behind --fast

### DIFF
--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -27,6 +27,9 @@ Options:
                   -s 2). Opt-in; explicit
                   flags override where applicable; --smem-dedup,
                   --skip-contained-ext and --adaptive-band are always enabled.
+                  Also switches the alignment-region dedup sort to a strict
+                  total order (faster, but resolves equal-end-position ties
+                  differently from bwa-mem2, which the default reproduces).
                   NOT byte-identical to the default (divergence confined to the
                   low-confidence tail).
 Scoring options:

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -369,6 +369,20 @@ mate-concordant chain the cap would otherwise drop — and is included for both 
 `--fast` (see
 [Settings profiles → `--extend-mate-concordant`](../best-practices/settings-profiles.md#mate-concordant-chain-retention---extend-mate-concordant)).
 
+`--fast` also flips one lever that has **no flag of its own**: the sort that orders alignment
+regions by reference end position before the order-sensitive dedup/patch pass. The default
+build uses bwa-mem2's comparator — a partial order on the end position alone — under the same
+unstable introsort bwa-mem2 uses, which reproduces upstream's dedup outcome exactly. `--fast`
+switches to a strict total order (end position, then start, score and query start) under
+pdqsort, which is measurably faster and can resolve equal-end-position ties
+differently. The two orderings only diverge when the strict order's deterministic result differs
+from the permutation the unstable sort happens to leave; because bwa-mem2's output is defined by
+that permutation, a strict total order and exact bwa-mem2 parity cannot both hold in general. The
+effect is confined to reads carrying several regions that end
+at the same reference base, and it surfaces as different `XS`/MAPQ and occasionally a different
+primary or supplementary record. Runs report the lever as `alnreg-sort=fast` on the audit line
+below.
+
 Under `--meth` it additionally sets `-s 2` (light Pass-2 re-seeding) and lowers the chain cap to `10`.
 Earlier releases used `-s 0` (no re-seed), which inflated
 MAPQ on bisulfite reads; `-s 2` recovers the MAPQ/placement at nearly the same speed

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -333,6 +333,7 @@ mem_opt_t *mem_opt_init()
     o->est_insert_high = 0;          // runtime state; set from data (mem_pestat) or -I during the run
     o->seed_emit_order = SEED_ORDER_OFF;  // byte-identical default
     o->smem_dedup  = 0;   // off by default -> byte-identical to baseline; opt-in via --smem-dedup
+    o->alnreg_sort_fast = 0;  // off by default -> bwa-mem2's dedup sort (see mem_sort_dedup_patch); set by --fast
     o->skip_contained_ext = 0;   // off by default; opt-in via --skip-contained-ext (byte-identical)
     o->band_start  = 0;   // off by default (adaptive chain-geometry band); opt-in via --adaptive-band
     o->split_width = 10;
@@ -416,16 +417,30 @@ void mem_opt_apply_meth_defaults(mem_opt_t *opt, const mem_opt_t *opt0)
  * De-overlap single-end hits *
  ******************************/
 
-/* mem_ars2: primary sort by reference END position (`re`). Used by
- * mem_sort_dedup_patch as the first ordering before its order-sensitive
- * dedup/patch loop. The tie-break keys (rb, score-desc, qb) make the
- * order deterministic at equal `re`; without them, the dedup outcome
- * depended on whichever ordering the underlying sort algorithm happened
- * to produce (klib introsort is unstable, pdqsort is unstable
- * differently, radix is stable) — different orderings produced
- * different surviving alnreg sets, propagating to `sub_n` and MAPQ.
- * With the full key, every sort algorithm produces the same surviving
- * set and the SAM is bit-equal regardless of which sort runs. */
+/* The two comparators below are the two halves of the same trade-off, and
+ * mem_sort_dedup_patch picks between them on opt->alnreg_sort_fast. Its first
+ * sort feeds an ORDER-SENSITIVE dedup loop, so the comparator decides which of
+ * several equal-`re` regions survives, propagating to `sub_n` and MAPQ:
+ *
+ *   mem_ars2_m2 (default) -- bwa-mem2's ORIGINAL comparator, a PARTIAL order on
+ *     `re` alone, run under klib's unstable introsort. The surviving set depends
+ *     on the *permutation* introsort produces, which is precisely what
+ *     bwa-mem2's output is defined by. Kept so the default build reproduces
+ *     upstream's dedup outcome exactly.
+ *
+ *   mem_ars2 (--fast) -- a STRICT TOTAL order: `re`, then the tie-break keys
+ *     (rb, score-desc, qb). Every sort algorithm then produces the same
+ *     surviving set, so the SAM is bit-equal regardless of which sort runs
+ *     (klib introsort is unstable, pdqsort is unstable differently, radix is
+ *     stable). Paired with pdqsort here.
+ *
+ * The two properties are mutually exclusive: any strict total order necessarily
+ * picks different winners among equal-`re` records than the permutation
+ * introsort happens to leave, so robustness-to-sort-choice and bwa-mem2 parity
+ * cannot both hold. Covered by test/unit/test_alnreg_sort_dedup.cpp. */
+#define alnreg_slt2_m2(a, b) ((a).re < (b).re)
+KSORT_INIT(mem_ars2_m2, mem_alnreg_t, alnreg_slt2_m2)
+
 #define alnreg_slt2(a, b) \
     ((a).re < (b).re || ((a).re == (b).re && \
      ((a).rb < (b).rb || ((a).rb == (b).rb && \
@@ -591,7 +606,11 @@ int mem_sort_dedup_patch(const mem_opt_t *opt, const bntseq_t *bns,
     if (mat == NULL) mat = opt->mat;
     int m, i, j;
     if (n <= 1) return n;
-    pdqsort_mem_ars2(n, a); // sort by the END position, not START!
+    /* Default: bwa-mem2's re-only comparator + klib introsort, reproducing
+     * upstream's dedup outcome. --fast: strict total order + pdqsort, which is
+     * ~35-55% faster for n>=9 but resolves equal-`re` ties differently. */
+    if (opt->alnreg_sort_fast) pdqsort_mem_ars2(n, a);       // sort by the END position, not START!
+    else                       ks_introsort(mem_ars2_m2, n, a);
 
     for (i = 0; i < n; ++i) a[i].n_comp = 1;
     for (i = 1; i < n; ++i)
@@ -635,7 +654,8 @@ int mem_sort_dedup_patch(const mem_opt_t *opt, const bntseq_t *bns,
             else ++m;
         }
     n = m;
-    pdqsort_mem_ars(n, a);
+    if (opt->alnreg_sort_fast) pdqsort_mem_ars(n, a);
+    else                       ks_introsort(mem_ars, n, a);
     /* The historical post-sort exact-duplicate passes (mark then exclude regions
      * sharing (score, rb, qb)) have been removed: they are provably dead. Any two
      * regions with equal (rb, qb) have the shorter fully contained in the longer,

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -178,6 +178,7 @@ typedef struct mem_opt_t {
     int    meth_chimera_qc; // 1 to enable bwameth.py-style longest-M <44% chimera heuristic (default off; not in Bismark)
     int    supp_rep_hard_cap; // supp alnregs whose chain's seeds share >=this many genome hits are forced to MAPQ=0; 0 disables
     int    smem_dedup;        // 1 = dedup fully-identical SMEMs before SA expansion (--smem-dedup); 0 = off (default, byte-identical to baseline)
+    int    alnreg_sort_fast;  // 1 = strict-total-order comparator + pdqsort at the mem_sort_dedup_patch sort sites (set by --fast); 0 = bwa-mem2's re-only comparator + ks_introsort (default, bwa-mem2-compatible)
     int    skip_contained_ext; // 1 = skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed (--skip-contained-ext); 0 = off. Byte-identical to baseline: the skip set is a subset of the post-extension containment purge (PE18).
     int    band_start;       // >0 = adaptive chain-geometry banding active (start band; set to ADAPTIVE_BAND_START by --adaptive-band); 0 = off (byte-identical). Long-read speed lever; no-op on the 8-bit short-read tier.
 } mem_opt_t;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -952,6 +952,9 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                  -s 2). Opt-in; explicit\n");
     fprintf(stderr, "                  flags override where applicable; --smem-dedup,\n");
     fprintf(stderr, "                  --skip-contained-ext and --adaptive-band are always enabled.\n");
+    fprintf(stderr, "                  Also switches the alignment-region dedup sort to a strict\n");
+    fprintf(stderr, "                  total order (faster, but resolves equal-end-position ties\n");
+    fprintf(stderr, "                  differently from bwa-mem2, which the default reproduces).\n");
     fprintf(stderr, "                  NOT byte-identical to the default (divergence confined to the\n");
     fprintf(stderr, "                  low-confidence tail).\n");
     fprintf(stderr, "Scoring options:\n");
@@ -1487,11 +1490,15 @@ int main_mem(int argc, char *argv[])
     /* --fast: one-flag shorthand for the characterized speed levers
      *   -m 10  -y 0  --min-ext-len 30  --smem-dedup  --skip-contained-ext
      *   --max-extend-chains 20  --adaptive-band  --extend-mate-concordant
-     *   (under --meth: --max-extend-chains 10 and also adds -s 2).
+     *   (under --meth: --max-extend-chains 10 and also adds -s 2),
+     *   plus the strict-total-order + pdqsort dedup sort (alnreg_sort_fast),
+     *   which has no flag of its own -- see the alnreg_sort_fast assignment
+     *   below and the comparator commentary in src/bwamem.cpp.
      * Mirrors the -x preset: each lever is applied only when the user did not
      * set it explicitly (opt0), so explicit flags win where applicable. The
-     * exceptions are --smem-dedup and --skip-contained-ext, which are plain
-     * on/off booleans forced on unconditionally (no opt-out flag exists).
+     * exceptions are --smem-dedup, --skip-contained-ext and the dedup sort,
+     * which are plain on/off booleans forced on unconditionally (no opt-out
+     * flag exists; the dedup sort has no flag at all).
      * --skip-contained-ext is byte-identical on non-meth SE/PE and no-ops under
      * --meth via its own internal gate (see bwamem.cpp), so forcing it on here is
      * safe for --fast --meth too.
@@ -1514,6 +1521,9 @@ int main_mem(int argc, char *argv[])
          * floor (verified --fast) while keeping ~-20% aligner CPU. */
         if (!opt0.max_extend_chains) opt->max_extend_chains = opt->meth_mode ? 10 : 20;
         opt->smem_dedup = 1;                             /* --smem-dedup (plain on/off) */
+        opt->alnreg_sort_fast = 1;                       /* strict-total-order + pdqsort dedup sort
+                                                          * (~35-55% faster for n>=9; diverges from
+                                                          * bwa-mem2 on equal-`re` ties) */
         opt->skip_contained_ext = 1;                     /* --skip-contained-ext (plain on/off;
                                                           * meth-gated internally) */
         opt->band_start = ADAPTIVE_BAND_START;           /* --adaptive-band: no-op on short reads
@@ -1679,14 +1689,20 @@ int main_mem(int argc, char *argv[])
     if (opt->seed_emit_order != SEED_ORDER_OFF)
         fprintf(stderr, "[M::%s] seed order: %s\n", __func__, seed_order_to_str(opt->seed_emit_order));
     if (fast) {
+        /* `alnreg-sort=fast` is deliberately spelled WITHOUT a leading `--`: unlike
+         * every other item on this line it is not a flag the user can pass, only a
+         * lever --fast turns on. That is also why it must be here: with no flag to
+         * grep for, this line is the only record a run leaves of a lever that
+         * changes output (see the comparator commentary in src/bwamem.cpp). It is
+         * not meth-gated, so it appears on both branches. */
         if (opt->meth_mode)
             /* --skip-contained-ext is set but no-ops under --meth (internal gate), so it is
              * intentionally omitted from the meth audit line to reflect the effective levers.
              * --adaptive-band is set unconditionally and applies under --meth, so it stays. */
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --max-extend-chains %d --adaptive-band -s %d --extend-mate-concordant\n",
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --max-extend-chains %d --adaptive-band -s %d --extend-mate-concordant alnreg-sort=fast\n",
                     __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains, opt->split_width);
         else
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d --adaptive-band --extend-mate-concordant\n",
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d --adaptive-band --extend-mate-concordant alnreg-sort=fast\n",
                     __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains);
     }
 

--- a/test/fast_preset_test.sh
+++ b/test/fast_preset_test.sh
@@ -52,11 +52,12 @@ line="$(fast_line --fast)"
    && "$line" == *"--skip-contained-ext"* \
    && "$line" == *"--max-extend-chains 20"* \
    && "$line" == *"--adaptive-band"* \
-   && "$line" == *"--extend-mate-concordant"* ]] \
+   && "$line" == *"--extend-mate-concordant"* \
+   && "$line" == *"alnreg-sort=fast"* ]] \
     || { echo "FAIL: --fast bundle wrong: '$line'" >&2; exit 1; }
 [[ "$line" != *"-s "* ]] \
     || { echo "FAIL: non-meth --fast must not set -s: '$line'" >&2; exit 1; }
-echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 20 --adaptive-band --extend-mate-concordant (no -s)"
+echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 20 --adaptive-band --extend-mate-concordant alnreg-sort=fast (no -s)"
 
 # 2. Override precedence: an explicit flag wins *only* for its own field; the
 #    rest of the preset (including the unconditional --smem-dedup) must survive.
@@ -65,21 +66,24 @@ line="$(fast_line --fast -m 30)"
    && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
    && "$line" == *"--skip-contained-ext"* \
    && "$line" == *"--max-extend-chains 20"* \
-   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* ]] \
+   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* \
+   && "$line" == *"alnreg-sort=fast"* ]] \
     || { echo "FAIL: explicit -m 30 should only override -m: '$line'" >&2; exit 1; }
 line="$(fast_line --fast -y 5)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 5"* \
    && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
    && "$line" == *"--skip-contained-ext"* \
    && "$line" == *"--max-extend-chains 20"* \
-   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* ]] \
+   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* \
+   && "$line" == *"alnreg-sort=fast"* ]] \
     || { echo "FAIL: explicit -y 5 should only override -y: '$line'" >&2; exit 1; }
 line="$(fast_line --fast --min-ext-len 45)"
 [[ "$line" == *"-m 10"* && "$line" == *"-y 0"* \
    && "$line" == *"--min-ext-len 45"* && "$line" == *"--smem-dedup"* \
    && "$line" == *"--skip-contained-ext"* \
    && "$line" == *"--max-extend-chains 20"* \
-   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* ]] \
+   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* \
+   && "$line" == *"alnreg-sort=fast"* ]] \
     || { echo "FAIL: explicit --min-ext-len 45 should only override min-ext-len: '$line'" >&2; exit 1; }
 # --max-extend-chains is overridable under --fast (respects an explicit value).
 line="$(fast_line --fast --max-extend-chains 8)"
@@ -87,9 +91,10 @@ line="$(fast_line --fast --max-extend-chains 8)"
    && "$line" == *"--min-ext-len 30"* && "$line" == *"--smem-dedup"* \
    && "$line" == *"--skip-contained-ext"* \
    && "$line" == *"--max-extend-chains 8"* \
-   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* ]] \
+   && "$line" == *"--adaptive-band"* && "$line" == *"--extend-mate-concordant"* \
+   && "$line" == *"alnreg-sort=fast"* ]] \
     || { echo "FAIL: explicit --max-extend-chains 8 should only override that lever: '$line'" >&2; exit 1; }
-echo "OK:   explicit -m/-y/--min-ext-len/--max-extend-chains override only their field; rest of preset (--adaptive-band, --extend-mate-concordant, ...) survives"
+echo "OK:   explicit -m/-y/--min-ext-len/--max-extend-chains override only their field; rest of preset (--adaptive-band, --extend-mate-concordant, alnreg-sort=fast, ...) survives"
 
 # 3. Default contract: no --fast => no audit line at all.
 "$bin" mem "$ref" "$reads" >/dev/null 2>"$err" || { echo "FAIL: plain mem nonzero" >&2; exit 1; }
@@ -112,7 +117,10 @@ if "$bin" index --meth "$mdir/ref.fa" >/dev/null 2>&1; then
         || { echo "FAIL: --max-extend-chains applies under --meth (cap 10); must be in audit line: '$line'" >&2; exit 1; }
     [[ "$line" == *"--extend-mate-concordant"* ]] \
         || { echo "FAIL: --fast --meth must enable --extend-mate-concordant: '$line'" >&2; exit 1; }
-    echo "OK:   --fast --meth additionally sets -s 2 and --extend-mate-concordant (skip-contained-ext omitted meth-gated, --max-extend-chains raised to 10)"
+    # The dedup-sort lever is not meth-gated; it must be reported under --meth too.
+    [[ "$line" == *"alnreg-sort=fast"* ]] \
+        || { echo "FAIL: --fast --meth must enable alnreg-sort=fast: '$line'" >&2; exit 1; }
+    echo "OK:   --fast --meth additionally sets -s 2, --extend-mate-concordant and alnreg-sort=fast (skip-contained-ext omitted meth-gated, --max-extend-chains raised to 10)"
     # Explicit -s wins even under --meth (src/fastmap.cpp: -s 2 is gated on !opt0.split_width).
     "$bin" mem --meth --fast -s 7 -t 1 "$mdir/ref.fa" "$reads" >/dev/null 2>"$err" \
         || { echo "FAIL: mem --meth --fast -s 7 nonzero" >&2; cat "$err" >&2; exit 1; }

--- a/test/unit/test_alnreg_sort_dedup.cpp
+++ b/test/unit/test_alnreg_sort_dedup.cpp
@@ -1,0 +1,254 @@
+// test/unit/test_alnreg_sort_dedup.cpp — mem_sort_dedup_patch's two sort modes.
+//
+// mem_sort_dedup_patch opens with a sort by reference END position whose result
+// feeds an ORDER-SENSITIVE dedup loop, so the choice of comparator decides which
+// of several equal-`re` regions survives:
+//
+//   opt->alnreg_sort_fast == 0 (default, set by mem_opt_init)
+//       bwa-mem2's comparator -- a PARTIAL order on `re` alone -- plus klib's
+//       unstable ks_introsort. Equal-`re` records keep whatever permutation
+//       introsort leaves them in, which is exactly what bwa-mem2's output is
+//       defined by. Consequence: the survivor depends on the input permutation.
+//
+//   opt->alnreg_sort_fast == 1 (set by --fast)
+//       a STRICT TOTAL order (re, rb, score desc, qb) plus pdqsort. Equal-`re`
+//       records are fully ordered, so the survivor is permutation-independent --
+//       and necessarily differs from bwa-mem2's on some ties.
+//
+// The two properties are mutually exclusive, which is why the lever exists. The
+// cases below pin both halves: divergence on a tie, agreement when there is no
+// tie to resolve, and the permutation (in)dependence that distinguishes them.
+//
+// Every expectation here is derived from the comparators themselves, not
+// recorded from a run:
+//   * ks_introsort's n == 2 fast path is a single compare-swap, and the re-only
+//     comparator reports `false` for equal `re`, so a 2-element equal-`re` input
+//     is returned in its original order.
+//   * The strict total order breaks an equal-`re` tie on `rb` ascending.
+//   * In the dedup loop's redundancy branch, `p->score < q->score` is false when
+//     the scores are equal, so the EARLIER record (q) is dropped -- i.e. the
+//     region the first sort placed LAST survives.
+//
+// Fixtures are built in-memory; no test data files are read.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <set>
+#include <vector>
+
+#include "doctest/doctest.h"
+#include "bwamem.h"
+
+// Defined in src/bwamem.cpp. `mat` defaults to NULL there via a declaration in
+// src/bwamem_pair.cpp; spell it out here so this TU introduces no new default.
+extern int mem_sort_dedup_patch(const mem_opt_t *opt, const bntseq_t *bns,
+                                const uint8_t *pac, uint8_t *query, int n,
+                                mem_alnreg_t *a, const int8_t *mat);
+
+namespace {
+
+// Region end shared by every tie fixture; the exact value is irrelevant, only
+// that the tied regions agree on it.
+const int64_t TIE_RE = 1150;
+
+// Build the subset of mem_alnreg_t fields mem_sort_dedup_patch reads: the
+// [rb,re) / [qb,qe) spans, rid and score. Everything else is zeroed.
+mem_alnreg_t reg(int64_t rb, int64_t re, int qb, int qe, int score, int rid = 0) {
+    mem_alnreg_t a;
+    memset(&a, 0, sizeof(a));
+    a.rb = rb; a.re = re;
+    a.qb = qb; a.qe = qe;
+    a.rid = rid;
+    a.score = a.truesc = score;
+    a.meth_hypothesis = a.meth_strand_hyp = -1;
+    return a;
+}
+
+// A tie member: [TIE_RE - len, TIE_RE) on the reference, [150 - len, 150) on the
+// query. Every pair of these is mutually redundant under mask_level_redun = 0.95
+// (the reference overlap is the shorter region's full length and the query
+// overlap equals the shorter query span), so the dedup loop always takes its
+// redundancy branch and mem_patch_reg -- which would dereference the NULL bns we
+// pass -- is never reached.
+mem_alnreg_t tie_reg(int len, int score) {
+    return reg(TIE_RE - len, TIE_RE, 150 - len, 150, score);
+}
+
+// Run mem_sort_dedup_patch over a copy of `in` with the given sort mode and
+// return the surviving regions.
+std::vector<mem_alnreg_t> dedup(const std::vector<mem_alnreg_t> &in, int sort_fast) {
+    mem_opt_t *opt = mem_opt_init();
+    opt->alnreg_sort_fast = sort_fast;
+    std::vector<mem_alnreg_t> a(in);
+    int n = mem_sort_dedup_patch(opt, NULL, NULL, NULL,
+                                 static_cast<int>(a.size()), a.data(), NULL);
+    free(opt);
+    REQUIRE(n >= 0);
+    REQUIRE(n <= static_cast<int>(a.size()));
+    a.resize(static_cast<size_t>(n));
+    return a;
+}
+
+// The `rb` of every survivor, in output order.
+std::vector<int64_t> rbs(const std::vector<mem_alnreg_t> &a) {
+    std::vector<int64_t> v;
+    for (size_t i = 0; i < a.size(); ++i) v.push_back(a[i].rb);
+    return v;
+}
+
+// The closing sort's key: score descending, then rb ascending, then qb ascending
+// (alnreg_slt in src/bwamem.cpp). mem_mark_primary_se / mem_pair rely on it, so
+// it must hold in BOTH modes.
+bool ordered_by_score(const std::vector<mem_alnreg_t> &a) {
+    for (size_t i = 1; i < a.size(); ++i) {
+        const mem_alnreg_t &p = a[i - 1], &q = a[i];
+        bool ok = p.score > q.score ||
+                  (p.score == q.score &&
+                   (p.rb < q.rb || (p.rb == q.rb && p.qb <= q.qb)));
+        if (!ok) return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Default contract
+// ---------------------------------------------------------------------------
+
+TEST_CASE("mem_opt_init defaults to the bwa-mem2-compatible dedup sort"
+          * doctest::test_suite("unit/alnreg_sort_dedup")) {
+    mem_opt_t *opt = mem_opt_init();
+    CHECK(opt->alnreg_sort_fast == 0);
+    free(opt);
+}
+
+TEST_CASE("n <= 1 short-circuits identically in both modes"
+          * doctest::test_suite("unit/alnreg_sort_dedup")) {
+    for (int fast = 0; fast <= 1; ++fast) {
+        CAPTURE(fast);
+        CHECK(dedup(std::vector<mem_alnreg_t>(), fast).empty());
+
+        std::vector<mem_alnreg_t> one(1, tie_reg(150, 150));
+        std::vector<mem_alnreg_t> out = dedup(one, fast);
+        REQUIRE(out.size() == 1u);
+        CHECK(out[0].rb == one[0].rb);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Equal-`re` tie: the modes pick different survivors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("equal-`re` tie: default keeps bwa-mem2's input-order outcome, --fast does not"
+          * doctest::test_suite("unit/alnreg_sort_dedup")) {
+    // Two mutually redundant regions ending at TIE_RE with equal scores. `wide`
+    // starts earlier (smaller rb), `narrow` later (larger rb).
+    mem_alnreg_t wide   = tie_reg(150, 150);  // rb = 1000
+    mem_alnreg_t narrow = tie_reg(148, 150);  // rb = 1002
+    REQUIRE(wide.rb < narrow.rb);
+    REQUIRE(wide.re == narrow.re);
+    REQUIRE(wide.score == narrow.score);
+
+    SUBCASE("input already in strict-total-order (narrow last): modes agree") {
+        std::vector<mem_alnreg_t> in;
+        in.push_back(wide); in.push_back(narrow);
+        // Default: equal `re` => no swap => narrow stays last => narrow survives.
+        // Fast: rb ascending puts narrow last => narrow survives. Same answer.
+        CHECK(rbs(dedup(in, 0)) == std::vector<int64_t>(1, narrow.rb));
+        CHECK(rbs(dedup(in, 1)) == std::vector<int64_t>(1, narrow.rb));
+    }
+
+    SUBCASE("input reversed (narrow first): the modes diverge") {
+        std::vector<mem_alnreg_t> in;
+        in.push_back(narrow); in.push_back(wide);
+        // Default preserves the given order, so `wide` is last and survives --
+        // this is the bwa-mem2 outcome the PR restores.
+        CHECK(rbs(dedup(in, 0)) == std::vector<int64_t>(1, wide.rb));
+        // Fast re-sorts on the total order, so `narrow` is last and survives.
+        CHECK(rbs(dedup(in, 1)) == std::vector<int64_t>(1, narrow.rb));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Permutation (in)dependence over a larger tie cluster
+// ---------------------------------------------------------------------------
+
+TEST_CASE("tie cluster: --fast is permutation-independent, the default is not"
+          * doctest::test_suite("unit/alnreg_sort_dedup")) {
+    // Six equal-`re`, equal-score, mutually redundant regions. All but one are
+    // dropped, so each permutation yields exactly one survivor.
+    std::vector<mem_alnreg_t> base;
+    for (int len = 145; len <= 150; ++len) base.push_back(tie_reg(len, 150));
+    const int64_t max_rb = TIE_RE - 145;  // the largest rb in the cluster
+
+    std::vector<mem_alnreg_t> perm(base);
+    std::sort(perm.begin(), perm.end(),
+              [](const mem_alnreg_t &x, const mem_alnreg_t &y) { return x.rb < y.rb; });
+
+    std::set<int64_t> default_survivors, fast_survivors;
+    do {
+        std::vector<mem_alnreg_t> slow_out = dedup(perm, 0);
+        std::vector<mem_alnreg_t> fast_out = dedup(perm, 1);
+        REQUIRE(slow_out.size() == 1u);
+        REQUIRE(fast_out.size() == 1u);
+        default_survivors.insert(slow_out[0].rb);
+        fast_survivors.insert(fast_out[0].rb);
+    } while (std::next_permutation(
+                 perm.begin(), perm.end(),
+                 [](const mem_alnreg_t &x, const mem_alnreg_t &y) { return x.rb < y.rb; }));
+
+    // The strict total order puts the largest `rb` last among equal `re`, and the
+    // redundancy branch keeps the last region, for every one of the 720 inputs.
+    CHECK(fast_survivors == std::set<int64_t>{max_rb});
+    // The re-only comparator leaves ties to the sort's permutation, so the
+    // survivor moves with the input -- the property bwa-mem2's output depends on.
+    CHECK(default_survivors.size() > 1u);
+}
+
+// ---------------------------------------------------------------------------
+// No ties to resolve: the modes must agree
+// ---------------------------------------------------------------------------
+
+TEST_CASE("well-separated regions survive intact and identically in both modes"
+          * doctest::test_suite("unit/alnreg_sort_dedup")) {
+    // Spaced far beyond max_chain_gap (10000), so the dedup loop's window check
+    // skips every pair and nothing is merged or dropped. What remains is the
+    // closing by-score sort, which downstream primary selection depends on.
+    std::vector<mem_alnreg_t> in;
+    in.push_back(reg(5000000, 5000150, 0, 150, 120));
+    in.push_back(reg(1000000, 1000150, 0, 150, 150));
+    in.push_back(reg(3000000, 3000150, 0, 150, 90));
+    in.push_back(reg(7000000, 7000150, 0, 150, 150));
+
+    std::vector<mem_alnreg_t> slow_out = dedup(in, 0);
+    std::vector<mem_alnreg_t> fast_out = dedup(in, 1);
+
+    REQUIRE(slow_out.size() == in.size());
+    REQUIRE(fast_out.size() == in.size());
+    CHECK(ordered_by_score(slow_out));
+    CHECK(ordered_by_score(fast_out));
+    // Score desc, then rb asc: 150@1000000, 150@7000000, 120@5000000, 90@3000000.
+    std::vector<int64_t> want;
+    want.push_back(1000000); want.push_back(7000000);
+    want.push_back(5000000); want.push_back(3000000);
+    CHECK(rbs(slow_out) == want);
+    CHECK(rbs(fast_out) == want);
+}
+
+TEST_CASE("distinct-score redundant regions: the best scoring one wins in both modes"
+          * doctest::test_suite("unit/alnreg_sort_dedup")) {
+    // Same tie cluster geometry, but the scores are distinct, so the redundancy
+    // branch decides on score rather than on position -- no tie for the two
+    // comparators to disagree about.
+    std::vector<mem_alnreg_t> in;
+    in.push_back(tie_reg(150, 130));
+    in.push_back(tie_reg(148, 170));  // the unique best score
+    in.push_back(tie_reg(146, 110));
+    const int64_t best_rb = TIE_RE - 148;
+
+    CHECK(rbs(dedup(in, 0)) == std::vector<int64_t>(1, best_rb));
+    CHECK(rbs(dedup(in, 1)) == std::vector<int64_t>(1, best_rb));
+}


### PR DESCRIPTION
perf(sort): move the pdqsort/total-order dedup sort behind --fast

Makes the **default** build reproduce bwa-mem2's `mem_sort_dedup_patch` outcome again, and moves PR #123's faster-but-divergent sort behind `--fast`.

## What #123 actually traded

#123 bundled two coupled changes. The driver was the **pdqsort drop-in**; the tie-break stabilization existed to make that swap *safe* — quoting the commit, *"making the order-sensitive dedup-patch loop outcome bit-deterministic regardless of sort algorithm."*

That prerequisite is exactly what broke bwa-mem2 parity. `mem_sort_dedup_patch`'s merge loop is order-sensitive, and bwa-mem2's comparator (`alnreg_slt2 = (a).re < (b).re`) is only a **partial** order — ties are resolved by whatever permutation klib's unstable introsort happens to produce, and *that permutation is what bwa-mem2's output is defined by*. Any strict total order necessarily picks different winners among equal-`re` records. Robustness-to-sort-choice and bwa-mem2 parity cannot both hold.

`IPNP-BIPN/bwa-mem4` hit the same wall from the other side: it had to hand-port klib's introsort (`ks_introsort_by`, `crates/bwa-chain/src/lib.rs:690` — median-of-3, `2*ceil(log2 n)` depth budget, comb-sort bailout) and call it with bwa-mem2's original comparators, because Rust has no klib. **bwa-mem3 needs no port**: it still carries klib's `ksort.h` with the algorithm unmodified (its only diff vs upstream is the on-stack partition buffer from #78 and a C++17 `register` fix — neither changes the permutation).

## The change

- New `opt->alnreg_sort_fast`, default **0**.
- **Default (0)**: `alnreg_slt2_m2` (bwa-mem2's `re`-only comparator) + `ks_introsort` — upstream's exact dedup outcome.
- **`--fast` (1)**: the strict total order + pdqsort, i.e. today's `main` behaviour, unchanged.

`alnreg_slt` (sort2) is already character-identical to bwa-mem2's, so that site only needed the algorithm restored, not a new comparator. #123's scaffolding made this cheap, as it predicted: *"revert is one-line/site."*

## Correctness

Local (arm64, 5M HG00096 WGS pairs, hg38, `-t 16`): this PR's default path is **byte-identical** to a hand-reverted #123 build (`c6ba471f475cc94a3ceab42ed734a791` both), i.e. provably the same as the revert measured against the bwa-mem2 golden:

| vs bwa-mem2 v2.2.1 golden | `origin/main` | this PR (default) |
|---|---:|---:|
| differing primaries | 1,501 (0.01504%) | **508 (0.00509%)** |
| `XS` | 1,167 | **141** (−88%) |
| MAPQ | 702 | **137** (−80%) |
| extra supplementary alignments | +239 | **+4** (−98%) |

This also resolves **`FG-SUPP-ADDITIONS` / #127** ("Pinning them to a specific upstream-divergence PR is tracked as follow-up"): the extra split alignments are #123.

## A/B on EC2 (c6a.4xlarge, AVX2, clang-20)

Same host, same 5M pairs, both binaries built from the same tree with the patch applied/withheld under explicit assertions. 4 configs; identity is md5 of the SAM stream excluding `@PG`; timing is 3 reps, output discarded.

| config | md5 | median wall | vs baseline |
|---|---|---:|---|
| base, default | `21a9bcfb…` | 100.78 s | — |
| **cand, default** | `99724189…` | **105.43 s** | **+4.6%** |
| base, `--fast` | `50eecca9…` | 49.09 s | — |
| **cand, `--fast`** | **`50eecca9…`** | 48.96 s | −0.3% (noise) |

Two things this establishes:

1. **`--fast` is byte-identical between baseline and this PR** — the flag restores current behaviour exactly, so nobody using `--fast` sees any change at all.
2. **The default path costs +4.6% wall clock.** Reps were tight (±0.3 s across all 12), so this is a real number, not noise. That is the honest price of the parity gain above.

## The trade, stated plainly

Default builds get bwa-mem2's dedup outcome (−66% divergent primaries, −98% extra supplementaries) for **+4.6% wall clock**. `--fast` users keep today's speed and today's output, bit-for-bit.

What the default gives up is *not* run-to-run determinism — `ks_introsort` is deterministic, so reproducibility is unaffected. It gives up **freedom to change the sort implementation later without changing output**. Since `ksort.h` has already been modified once (#78), that invariant should be pinned by a test rather than left implicit.

No accuracy claim is made in either direction: nobody has F1 data comparing the total order against introsort's permutation at this site. The framing is "match the reference implementation," not "more correct." (Contrast `mem_chain_flt`, where #123 *measured* that tie-breaking produced strictly worse alignments on ≥9 smoke-1M reads and correctly declined — this PR leaves that site alone.)

## Follow-up that could make this moot

A **tie-detection fast path** would get pdqsort's speed *with* byte-identity:

```c
memcpy(tmp, a, n * sizeof(*a));
pdqsort_mem_ars2(n, tmp);
if (no adjacent equal `re` in tmp) memcpy(a, tmp, n * sizeof(*a));  // == introsort's output
else                              ks_introsort(mem_ars2_m2, n, a);   // exact, on the ORIGINAL order
```

When all `re` are distinct the ordering is *unique*, so any correct comparison sort agrees. The fallback must run on the **original** array — `ks_introsort` is input-order-dependent. Worth building only if the tie rate is low (measure first), and it should be gated on `n >= 9`, since `ks_introsort` is *faster* than pdqsort at n 2–8 (127.4 vs 119.0 Mc/s) which is 38% of calls. If it works, the `--fast` special-case here can be deleted entirely.

## Notes

- Part 2 of the three-cause attribution in `reports/2026-07-22-runner-up-score2-mapq-parity-vs-bwa-mem2-and-mem4.md` §5.4. Part 1 is #256 (gap-from-M). Part 3 (PR #174's non-meth divergence) is still unexplained.
- Changing the default output warrants a version bump, changelog entry, and a tightening of the `expected-divergences.yaml` budgets.
- Building bwa-mem3 on Amazon Linux 2023 needed five things beyond the documented recipe: `cmake`, `patch`, a source-built libdeflate, `clang20`, and `autoconf/automake/libtool`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional fast alignment-region sorting mode (`alnreg-sort=fast`) via a new runtime setting.
  * The `--fast` preset now enables this mode and records `alnreg-sort=fast` in the resolved audit line.

* **Documentation**
  * Updated `mem --fast` documentation to explain how tie handling may differ from bwa-mem2 behavior.

* **Tests**
  * Added unit coverage to verify dedup/survivor behavior under default vs fast sorting.

* **Compatibility**
  * Default sorting preserves bwa-mem2-compatible deduplication.
  * Fast sorting can change equal-`re` tie resolution, which may affect ordering and MAPQ/XS and occasionally primary/supplementary records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->