### PR TITLE
fix(meth): reject mate rescues whose SW alignment runs past the read

### DIFF
--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -278,7 +278,7 @@ int mem_matesw(const mem_opt_t *opt, const bntseq_t *bns,
                              opt->o_ins, opt->e_ins, xtra, 0);
 
             memset(&b, 0, sizeof(mem_alnreg_t));
-            if (aln.score >= opt->min_seed_len && aln.qb >= 0) { // something goes wrong if aln.qb < 0
+            if (aln.score >= opt->min_seed_len && aln.qb >= 0 && aln.qe < l_ms) { // something goes wrong if aln.qb < 0, or if aln.qe runs past the read
                 b.rid = a->rid;
                 b.is_alt = a->is_alt;
                 /* D3 (--meth): record the rescued mate's genome-strand hypothesis
@@ -1737,7 +1737,7 @@ int mem_matesw_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
                 aln = *(*myaln + index);
 
             memset(&b, 0, sizeof(mem_alnreg_t));
-            if (aln.score >= opt->min_seed_len && aln.qb >= 0) { // something goes wrong if aln.qb < 0
+            if (aln.score >= opt->min_seed_len && aln.qb >= 0 && aln.qe < l_ms) { // something goes wrong if aln.qb < 0, or if aln.qe runs past the read
                 b.rid = a->rid;
                 b.is_alt = a->is_alt;
                 /* D3 (--meth): rescued mate hypothesis = the mate's own read#


### PR DESCRIPTION
## Problem

A `--meth` run can abort outright, killing the whole job over a single read:

```
[E::bam_set1] CIGAR and query sequence are of different length
[mem_aln2sam] meth BAM conversion failed for read "NB551597:382:HF2LFBGYW:1:21106:9354:4513"
```

`mem_aln2sam` reaches `err_fatal`, which `_exit`s the process, so one malformed record discards the entire alignment run. This reproduces on released 0.7.0 and is **not** `--fast`-specific: plain `--meth` hits it too, so it affects the default meth path.

## Root cause

`mem_matesw` derives the rescued region's query bounds from the rescue Smith-Waterman result:

```c
b.qb = is_rev? l_ms - (aln.qe + 1) : aln.qb;
b.qe = is_rev? l_ms - aln.qb : aln.qe + 1;
```

The existing sanity guard rejects `aln.qb < 0` — the comment already says *"something goes wrong if aln.qb < 0"* — but there is no guard on the symmetric end. When the rescue SW returns `aln.qe >= l_ms`, the derived `b.qb` goes **negative**.

`mem_reg2aln` then packs that negative value straight into the CIGAR as a soft-clip length, without validation:

```c
clip5 = is_rev? l_query - qe : qb;
a.cigar[0] = clip5<<4 | 3;
```

so the clip reads back as a huge unsigned length and the CIGAR claims far more query bases than the read has. htslib's `bam_set1` correctly rejects it.

Observed on a 36bp low-complexity read (`GCATAGTGGTGGTGGTGGTAGTGGTGGTGGAAAACG`) rescued with `qb = -34`:

```
l_seq=36  cigar=268435422S 57M 34D 2M 11S   (268435422 decodes from (-34 << 4) | 3)
```

The arithmetic is self-consistent — `-34 + 57 + 2 + 11 = 36` — which is why it survives until htslib validates it.

## Fix

Extend the existing guard to also require `aln.qe < l_ms`, at both rescue sites (the scalar `ksw_align2` path and the batched `kswv` path). A malformed rescue is dropped rather than emitted. Mate rescue is opportunistic, so this loses nothing but a bogus alignment.

## Verification

- Reproducer: 1000 read pairs from `twist-emseq`, aborts in seconds before the fix, clean after (541 records).
- `--meth` and `--fast --meth` both clean on the reproducer and on a full 1M-pair panel.
- Non-meth output is **byte-identical** before and after, for both the default path and `--fast` (md5 of alignment records on a 100k-pair panel).
- Full unit suite passes (110 cases).

Disabling mate rescue (`-m 0`) also avoids the crash, which localises the producer to `mem_matesw`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mate-pair alignment validation to reject results that extend beyond read boundaries.
  * Increased consistency between standard and batched mate-rescue processing, helping prevent invalid rescued alignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->