### PR TITLE
fix(index): cap each pread() at 1GiB so large indexes load on macOS

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -79,6 +79,12 @@ int fmi_pread_worker_count(size_t nbytes, int nthreads)
     return nthreads;
 }
 
+size_t fmi_pread_request_size(size_t remaining)
+{
+    const size_t PREAD_MAX_ONCE = (size_t)1 << 30;   /* 1GiB, well under INT_MAX */
+    return remaining > PREAD_MAX_ONCE ? PREAD_MAX_ONCE : remaining;
+}
+
 namespace {
 
 struct PreadChunk { int fd; char *dst; size_t nbytes; off_t off; };
@@ -112,8 +118,15 @@ void *pread_chunk_worker(void *arg)
 {
     PreadChunk *c = static_cast<PreadChunk *>(arg);
     size_t done = 0;
+    /* macOS pread() rejects any count > INT_MAX with EINVAL, so a chunk larger
+     * than 2GiB fails outright -- with the 8-worker cap that is every index over
+     * ~17.2GB (the hg38 --meth FM-index is 20.9GB). Request a bounded slice per
+     * call; the loop already accumulates partial reads. Linux has no such limit,
+     * which is why this only ever bit local macOS runs. */
     while (done < c->nbytes) {
-        ssize_t r = pread(c->fd, c->dst + done, c->nbytes - done, c->off + (off_t)done);
+        ssize_t r = pread(c->fd, c->dst + done,
+                          fmi_pread_request_size(c->nbytes - done),
+                          c->off + (off_t)done);
         if (r < 0) {
             if (errno == EINTR) continue;
             pread_chunk_fail("ERROR: pread failed during index load: %s\n", strerror(errno));

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -124,6 +124,15 @@ typedef struct smem_struct
  * arithmetic is unit-testable without a real index on disk. */
 int fmi_pread_worker_count(size_t nbytes, int nthreads);
 
+/* Bytes to request from a single pread() call, given how many remain in this
+ * worker's chunk. macOS fails a pread() whose count exceeds INT_MAX with EINVAL,
+ * so a chunk larger than 2GiB can never be read in one call -- and with the
+ * 8-worker load cap that is every index over ~17.2GB.
+ *
+ * Exposed (rather than kept file-local with the pread machinery) so the clamp
+ * is unit-testable without materialising a multi-GB file. */
+size_t fmi_pread_request_size(size_t remaining);
+
 /* Read the next `nbytes` of `fp` into `dst` using up to `nthreads` pread
  * workers, then leave the stream positioned exactly past them so a following
  * sequential read (the trailing sentinel index) still lands correctly.

--- a/test/unit/test_fmi_pread_request_size.cpp
+++ b/test/unit/test_fmi_pread_request_size.cpp
@@ -1,0 +1,66 @@
+// test/unit/test_fmi_pread_request_size.cpp
+//
+// Per-call size clamp for the parallel index read.
+//
+// parallel_pread splits an index array into index_load_threads() chunks (capped
+// at 8) and each worker loops pread() until its chunk is consumed. Handing the
+// whole remaining chunk to a single pread() is fine on Linux but fails on macOS,
+// where a count greater than INT_MAX returns EINVAL. With the 8-worker cap that
+// makes every index over ~17.2GB unloadable: the hg38 --meth FM-index is 20.9GB,
+// so an 8-way split asks for 2.61GB per call and the load aborts with
+//
+//     ERROR: pread failed during index load: Invalid argument
+//
+// The failure is silent on Linux and total on macOS, so the invariant worth
+// pinning is simply that the requested count is always a legal pread() count.
+
+#include "doctest/doctest.h"
+#include "../../src/FMI_search.h"
+
+#include <cstddef>
+#include <climits>
+
+TEST_CASE("fmi_pread_request_size never asks pread() for more than INT_MAX")
+{
+    const size_t int_max = (size_t)INT_MAX;
+
+    // The chunk sizes an 8-way split produces for real indexes, plus the
+    // boundary itself. Every one must be a legal pread() count.
+    const size_t sizes[] = {
+        0,
+        1,
+        (size_t)1 << 20,                 // 1MiB
+        int_max - 1,
+        int_max,
+        int_max + 1,                     // first illegal count on macOS
+        2614094383u,                     // 20.9GB --meth index / 8 workers
+        (size_t)20912755063u,            // the whole --meth index in one chunk
+    };
+    for (size_t n : sizes)
+        CHECK(fmi_pread_request_size(n) <= int_max);
+}
+
+TEST_CASE("fmi_pread_request_size makes progress and never over-reads")
+{
+    // Must never return more than remains, or the worker would read past its
+    // chunk and corrupt the neighbouring array.
+    CHECK(fmi_pread_request_size(0) == 0);
+    CHECK(fmi_pread_request_size(1) == 1);
+    CHECK(fmi_pread_request_size(4096) == 4096);
+
+    // Must always make progress on a huge chunk, otherwise the worker loop
+    // spins forever instead of aborting or completing.
+    CHECK(fmi_pread_request_size((size_t)20912755063u) > 0);
+
+    // A chunk larger than the clamp is consumed in a finite number of calls.
+    size_t remaining = 2614094383u, calls = 0;
+    while (remaining > 0) {
+        size_t want = fmi_pread_request_size(remaining);
+        REQUIRE(want > 0);
+        REQUIRE(want <= remaining);
+        remaining -= want;
+        if (++calls > 64) break;         // guard against a non-progressing clamp
+    }
+    CHECK(remaining == 0);
+    CHECK(calls <= 64);
+}


### PR DESCRIPTION
## Problem

Loading any index larger than about 17.2GB fails on macOS:

```
ERROR: pread failed during index load: Invalid argument
```

The hg38 `--meth` FM-index is 20.9GB, so `--meth` is unusable on macOS at default settings. Linux imposes no such limit, which is why CI and the cloud fleet never saw this.

## Root cause

`parallel_pread` splits an index array into `index_load_threads()` chunks — capped at 8 — and each worker hands its whole remaining chunk to a single `pread()`:

```c
ssize_t r = pread(c->fd, c->dst + done, c->nbytes - done, c->off + (off_t)done);
```

macOS rejects a `pread()` whose count exceeds `INT_MAX` with `EINVAL`. With the 8-worker cap, that makes every index over 8 × 2GiB fail outright. For the 20.9GB meth index each chunk is 2.61GB, so the load aborts immediately.

`BWA3_LOAD_THREADS=16` happens to work around it only because it drops the per-chunk size back under 2GiB.

## Fix

Request a bounded slice per call (1GiB) instead of the whole chunk. The worker loop already accumulates partial reads, so nothing else changes.

The clamp is extracted as `fmi_pread_request_size()` and exposed in the header, following the existing precedent of `fmi_pread_worker_count()` — which is exposed for exactly this reason, so the chunk arithmetic is unit-testable without a real index on disk.

## Tests

New `test/unit/test_fmi_pread_request_size.cpp` pins the invariant that was violated:

- the requested count is never greater than `INT_MAX`, across the chunk sizes an 8-way split produces for real indexes (including 2.61GB — the 20.9GB meth index split 8 ways — and the `INT_MAX` boundary itself)
- the clamp never returns more than remains, so a worker cannot read past its chunk into the neighbouring array
- the clamp always makes progress, and a 2.61GB chunk is consumed in a finite number of calls

Materialising a multi-GB fixture just to exercise the clamp would be far too heavy for CI, hence testing the pure function.

## Verification

- `--meth` now loads and aligns at default settings on macOS (no `BWA3_LOAD_THREADS` override).
- Non-meth `default` and `--fast` panel output are **byte-identical** before and after.
- Full unit suite passes (112 cases, including the 2 new ones).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved large index reads on macOS by splitting oversized read requests into safe chunks.
  * Prevented read failures caused by platform limits on request sizes.

* **Tests**
  * Added coverage for request-size limits, boundary conditions, preventing over-reads, and ensuring read progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->