### PR TITLE
perf(sort): run pdqsort in the dedup sorts when the comparator sees no tie

### DIFF
--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -371,17 +371,24 @@ mate-concordant chain the cap would otherwise drop — and is included for both 
 
 `--fast` also flips one lever that has **no flag of its own**: the sort that orders alignment
 regions by reference end position before the order-sensitive dedup/patch pass. The default
-build uses bwa-mem2's comparator — a partial order on the end position alone — under the same
-unstable introsort bwa-mem2 uses, which reproduces upstream's dedup outcome exactly. `--fast`
-switches to a strict total order (end position, then start, score and query start) under
-pdqsort, which is measurably faster and can resolve equal-end-position ties
-differently. The two orderings only diverge when the strict order's deterministic result differs
-from the permutation the unstable sort happens to leave; because bwa-mem2's output is defined by
-that permutation, a strict total order and exact bwa-mem2 parity cannot both hold in general. The
+build uses bwa-mem2's comparator — a partial order on the end position alone — and reproduces the
+permutation bwa-mem2's unstable introsort leaves, and so its dedup outcome, exactly. `--fast`
+switches to a strict total order (end position, then start, score and query start) under pdqsort,
+which can resolve equal-end-position ties differently. The two orderings only diverge when the
+strict order's deterministic result differs from the permutation that unstable sort leaves;
+because bwa-mem2's output is defined by that permutation, a strict total order and exact
+bwa-mem2 parity cannot both hold in general. The
 effect is confined to reads carrying several regions that end
 at the same reference base, and it surfaces as different `XS`/MAPQ and occasionally a different
 primary or supplementary record. Runs report the lever as `alnreg-sort=fast` on the audit line
 below.
+
+The lever is no longer worth much speed. The default path only needs the unstable introsort when
+the comparator actually sees a tie — with no tie the ordering is unique, so pdqsort's result is
+what introsort would have produced — and ties occur on under 1% of calls. Detecting them costs a
+save-copy and a linear scan, which leaves the bwa-mem2-compatible default within ~0.7% of the
+strict-total-order path on 5M HG00096 WGS pairs (arm64/NEON, `-t 16`, 5 interleaved reps), at or
+below this benchmark's run-to-run spread.
 
 Under `--meth` it additionally sets `-s 2` (light Pass-2 re-seeding) and lowers the chain cap to `10`.
 Earlier releases used `-s 0` (no re-seed), which inflated

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -449,9 +449,100 @@ KSORT_INIT(mem_ars2_m2, mem_alnreg_t, alnreg_slt2_m2)
 KSORT_INIT(mem_ars2, mem_alnreg_t, alnreg_slt2)
 PDQSORT_INIT(mem_ars2, mem_alnreg_t, alnreg_slt2)
 
+PDQSORT_INIT(mem_ars2_m2, mem_alnreg_t, alnreg_slt2_m2)
+
 #define alnreg_slt(a, b) ((a).score > (b).score || ((a).score == (b).score && ((a).rb < (b).rb || ((a).rb == (b).rb && (a).qb < (b).qb))))
 KSORT_INIT(mem_ars, mem_alnreg_t, alnreg_slt)
 PDQSORT_INIT(mem_ars, mem_alnreg_t, alnreg_slt)
+
+/*----------------------------------------------------------------------------
+ * Tie-free fast path for the default (bwa-mem2-compatible) dedup sorts.
+ *
+ * Under alnreg_sort_fast == 0 the surviving alnreg set is defined by the
+ * *permutation* klib's unstable introsort happens to produce, so substituting a
+ * faster sort changes which regions survive -- but only when the comparator
+ * actually sees a tie. With no tied pair the sorted sequence is unique, so
+ * pdqsort's result is bit-for-bit what introsort would have produced and the
+ * substitution is free. Ties are therefore detected, not avoided.
+ *
+ * Ties are rare. Instrumented over 2.32M calls / 186M regions (533,334 HG00096
+ * WGS pairs, -t 16): the `re` sort ties on 0.98% of calls and the closing
+ * by-score sort on 0 of them -- two survivors cannot share (rb, qb), see the
+ * comment at the end of mem_sort_dedup_patch. So ~99% of calls get pdqsort and
+ * the rest pay pdqsort plus a restore plus introsort.
+ *
+ * Saving the input first is what makes the fallback exact: ks_introsort is
+ * input-order-dependent, so running it on the pdqsort-permuted array would give
+ * a different permutation -- and a different SAM -- than bwa-mem2.
+ *--------------------------------------------------------------------------*/
+
+/* Below ~9 elements pdqsort wins nothing: on the alnreg microbench
+ * (reports/2026-07-12-dedup-sort-benchmark-arm64.md, 2-8 bucket) klib's introsort
+ * leads on the `re` sort (127.4 vs 119.0 Mcell/s) and ties it on the by-score
+ * sort (130.8 vs 130.1). Short arrays are ~46% of calls, so the save-copy is not
+ * worth paying there for either. */
+#define DEDUP_SORT_PDQ_MIN 9
+
+/* Per-thread save buffer, grown geometrically and released at thread exit. Held
+ * as bytes so it can reuse the u8vec scratch holder; realloc returns storage
+ * suitably aligned for mem_alnreg_t. Returns NULL only if the allocation fails,
+ * in which case the caller takes the exact (introsort) path. */
+static inline mem_alnreg_t *alnreg_save_buf(int n)
+{
+    static thread_local u8vec_scratch_t save;
+    const size_t want = (size_t)n * sizeof(mem_alnreg_t);
+    if (save.v.m < want) {
+        size_t cap = save.v.m * 2;
+        if (cap < want) cap = want;
+        uint8_t *p = (uint8_t *)realloc(save.v.a, cap);
+        if (p == NULL) return NULL;   /* keep the existing buffer intact */
+        save.v.a = p;
+        save.v.m = cap;
+    }
+    return (mem_alnreg_t *)save.v.a;
+}
+
+/* Emit `static void fn(int n, mem_alnreg_t *a)` that sorts `a` exactly as
+ * ks_introsort(name, n, a) would, but via pdqsort_##name whenever `lt` sees no
+ * tie. `lt` must be the comparator KSORT_INIT and PDQSORT_INIT were given. */
+#define DEDUP_TIE_SORT_INIT(fn, name, lt)                                        \
+    static void fn(int n, mem_alnreg_t *a)                                       \
+    {                                                                            \
+        mem_alnreg_t *save;                                                      \
+        if (n < DEDUP_SORT_PDQ_MIN || (save = alnreg_save_buf(n)) == NULL) {     \
+            ks_introsort(name, n, a);                                            \
+            return;                                                              \
+        }                                                                        \
+        memcpy(save, a, (size_t)n * sizeof(*a));                                 \
+        pdqsort_##name(n, a);                                                    \
+        for (int i = 1; i < n; ++i) {                                            \
+            /* `a` is sorted, so !lt(a[i-1], a[i]) means the pair is tied. */    \
+            if (!lt(a[i - 1], a[i])) {                                           \
+                memcpy(a, save, (size_t)n * sizeof(*a));                         \
+                ks_introsort(name, n, a);                                        \
+                return;                                                          \
+            }                                                                    \
+        }                                                                        \
+    }
+
+DEDUP_TIE_SORT_INIT(dedup_sort_by_re,    mem_ars2_m2, alnreg_slt2_m2)
+DEDUP_TIE_SORT_INIT(dedup_sort_by_score, mem_ars,     alnreg_slt)
+
+/* Exposed for test/unit/test_alnreg_sort_dedup.cpp, which asserts each fast path
+ * against the introsort it claims to reproduce, array for array. Thin enough not
+ * to perturb the call sites above, which still call the static helpers. Each
+ * takes the region count `n` and the array `a`, sorted in place. */
+
+/* The `re` sort as mem_sort_dedup_patch runs it by default: pdqsort, or restore
+ * plus introsort on a tie. */
+void bwamem3_dedup_sort_by_re(int n, mem_alnreg_t *a)          { dedup_sort_by_re(n, a); }
+/* The `re` sort bwa-mem2 runs: klib introsort, unconditionally. The oracle the
+ * fast path above must match record for record. */
+void bwamem3_dedup_sort_by_re_exact(int n, mem_alnreg_t *a)    { ks_introsort(mem_ars2_m2, n, a); }
+/* The closing by-score sort as mem_sort_dedup_patch runs it by default. */
+void bwamem3_dedup_sort_by_score(int n, mem_alnreg_t *a)       { dedup_sort_by_score(n, a); }
+/* The closing by-score sort bwa-mem2 runs, i.e. the oracle for the above. */
+void bwamem3_dedup_sort_by_score_exact(int n, mem_alnreg_t *a) { ks_introsort(mem_ars, n, a); }
 
 #define alnreg_hlt(a, b)  ((a).score > (b).score || ((a).score == (b).score && ((a).is_alt < (b).is_alt || ((a).is_alt == (b).is_alt && (a).hash < (b).hash))))
 KSORT_INIT(mem_ars_hash, mem_alnreg_t, alnreg_hlt)
@@ -606,11 +697,13 @@ int mem_sort_dedup_patch(const mem_opt_t *opt, const bntseq_t *bns,
     if (mat == NULL) mat = opt->mat;
     int m, i, j;
     if (n <= 1) return n;
-    /* Default: bwa-mem2's re-only comparator + klib introsort, reproducing
-     * upstream's dedup outcome. --fast: strict total order + pdqsort, which is
-     * ~35-55% faster for n>=9 but resolves equal-`re` ties differently. */
+    /* Default: bwa-mem2's re-only comparator, ordered exactly as klib introsort
+     * would order it -- dedup_sort_by_re runs pdqsort and restores-and-introsorts
+     * only on a tie -- reproducing upstream's dedup outcome. --fast: strict total
+     * order + pdqsort unconditionally, which skips the save-copy and the tie scan
+     * but resolves equal-`re` ties differently. */
     if (opt->alnreg_sort_fast) pdqsort_mem_ars2(n, a);       // sort by the END position, not START!
-    else                       ks_introsort(mem_ars2_m2, n, a);
+    else                       dedup_sort_by_re(n, a);
 
     for (i = 0; i < n; ++i) a[i].n_comp = 1;
     for (i = 1; i < n; ++i)
@@ -655,7 +748,7 @@ int mem_sort_dedup_patch(const mem_opt_t *opt, const bntseq_t *bns,
         }
     n = m;
     if (opt->alnreg_sort_fast) pdqsort_mem_ars(n, a);
-    else                       ks_introsort(mem_ars, n, a);
+    else                       dedup_sort_by_score(n, a);
     /* The historical post-sort exact-duplicate passes (mark then exclude regions
      * sharing (score, rb, qb)) have been removed: they are provably dead. Any two
      * regions with equal (rb, qb) have the shorter fully contained in the longer,

--- a/test/unit/test_alnreg_sort_dedup.cpp
+++ b/test/unit/test_alnreg_sort_dedup.cpp
@@ -252,3 +252,141 @@ TEST_CASE("distinct-score redundant regions: the best scoring one wins in both m
     CHECK(rbs(dedup(in, 0)) == std::vector<int64_t>(1, best_rb));
     CHECK(rbs(dedup(in, 1)) == std::vector<int64_t>(1, best_rb));
 }
+
+// ---------------------------------------------------------------------------
+// The tie-free fast path must be invisible
+// ---------------------------------------------------------------------------
+//
+// In the default mode each of mem_sort_dedup_patch's two sorts runs pdqsort
+// whenever the sorted array has no tied adjacent pair -- the ordering is then
+// unique, so every correct comparison sort agrees -- and otherwise restores the
+// input and runs ks_introsort over it. Both regimes have to be indistinguishable
+// from running ks_introsort unconditionally. That is the whole correctness
+// claim, so it is asserted directly on the sorts rather than inferred from the
+// dedup output.
+
+// src/bwamem.cpp: each fast path and the exact introsort it must reproduce.
+extern void bwamem3_dedup_sort_by_re(int n, mem_alnreg_t *a);
+extern void bwamem3_dedup_sort_by_re_exact(int n, mem_alnreg_t *a);
+extern void bwamem3_dedup_sort_by_score(int n, mem_alnreg_t *a);
+extern void bwamem3_dedup_sort_by_score_exact(int n, mem_alnreg_t *a);
+
+namespace {
+
+// Deterministic 64-bit LCG. std::rand would make the fixtures platform-defined.
+struct Rng {
+    uint64_t s;  // LCG state; seeded per test so every fixture is reproducible.
+    explicit Rng(uint64_t seed) : s(seed) {}
+    // Advances the state and returns the high bits, whose period is the long one.
+    uint64_t next() { s = s * 6364136223846793005ULL + 1442695040888963407ULL; return s >> 11; }
+    // A draw from the inclusive range [lo, hi]; the modulo bias is irrelevant here.
+    int in(int lo, int hi) { return lo + static_cast<int>(next() % static_cast<uint64_t>(hi - lo + 1)); }
+};
+
+// `n` regions on one reference. re_pool > 0 draws the reference end from that
+// many slots, so equal-`re` ties (the fallback) are common; re_pool == 0 gives
+// every region a distinct end, so the `re` sort is tie-free (the fast path).
+// Scores are drawn from a small range so the closing sort sees ties too.
+std::vector<mem_alnreg_t> random_regs(Rng &rng, int n, int re_pool) {
+    std::vector<int64_t> ends;
+    for (int i = 0; i < n; ++i)
+        ends.push_back(1000 + 37 * (re_pool > 0 ? rng.in(0, re_pool - 1) : i));
+    for (int i = n - 1; i > 0; --i) std::swap(ends[i], ends[rng.in(0, i)]);  // shuffle
+
+    std::vector<mem_alnreg_t> v;
+    for (int i = 0; i < n; ++i) {
+        const int len = rng.in(20, 150);
+        const int qb = rng.in(0, 150 - len);
+        v.push_back(reg(ends[i] - len, ends[i], qb, qb + len, rng.in(1, 12)));
+    }
+    return v;
+}
+
+// Byte-identity over the whole record, not just the sort key: the fast path has
+// to reproduce introsort's *permutation*, so two arrays that merely compare equal
+// under the comparator are not good enough.
+bool same_records(const std::vector<mem_alnreg_t> &x, const std::vector<mem_alnreg_t> &y) {
+    if (x.size() != y.size()) return false;
+    for (size_t i = 0; i < x.size(); ++i)
+        if (memcmp(&x[i], &y[i], sizeof(mem_alnreg_t)) != 0) return false;
+    return true;
+}
+
+// Sort one fixture both ways and report whether they agree; `tied` reports
+// whether the sorted array actually contained a tie, so a test can prove it
+// exercised the fallback instead of passing vacuously.
+typedef void (*sort_fn)(int, mem_alnreg_t *);
+bool agrees(const std::vector<mem_alnreg_t> &in, sort_fn fast, sort_fn exact,
+            bool (*tied)(const mem_alnreg_t &, const mem_alnreg_t &), bool *saw_tie) {
+    std::vector<mem_alnreg_t> f(in), e(in);
+    fast(static_cast<int>(f.size()), f.data());
+    exact(static_cast<int>(e.size()), e.data());
+    for (size_t i = 1; i < e.size(); ++i)
+        if (tied(e[i - 1], e[i])) { *saw_tie = true; break; }
+    return same_records(f, e);
+}
+
+// The two `tied` predicates `agrees` takes: each says when its comparator ranks
+// the pair equally, i.e. when the fast path's tie scan would fire.
+
+// alnreg_slt2_m2 orders on `re` alone, so equal ends are a tie.
+bool tied_by_re(const mem_alnreg_t &x, const mem_alnreg_t &y) { return x.re == y.re; }
+// alnreg_slt breaks score ties on (rb, qb), so all three must match.
+bool tied_by_score(const mem_alnreg_t &x, const mem_alnreg_t &y) {
+    return x.score == y.score && x.rb == y.rb && x.qb == y.qb;
+}
+
+}  // namespace
+
+TEST_CASE("the `re` fast path is byte-identical to unconditional ks_introsort"
+          * doctest::test_suite("unit/alnreg_sort_dedup")) {
+    const int TRIALS = 150;
+
+    SUBCASE("tie-free arrays (the pdqsort path itself)") {
+        Rng rng(0x51ed0001ULL);
+        bool saw_tie = false;
+        for (int t = 0; t < TRIALS; ++t) {
+            // n spans both sides of the n >= 9 gate.
+            CHECK(agrees(random_regs(rng, 1 + t, 0), bwamem3_dedup_sort_by_re,
+                         bwamem3_dedup_sort_by_re_exact, tied_by_re, &saw_tie));
+        }
+        CHECK_FALSE(saw_tie);  // distinct ends by construction
+    }
+
+    SUBCASE("tie-heavy arrays (the restore-and-introsort fallback)") {
+        Rng rng(0x51ed0002ULL);
+        bool saw_tie = false;
+        for (int t = 0; t < TRIALS; ++t) {
+            CHECK(agrees(random_regs(rng, 1 + t, 3), bwamem3_dedup_sort_by_re,
+                         bwamem3_dedup_sort_by_re_exact, tied_by_re, &saw_tie));
+        }
+        CHECK(saw_tie);  // guards against a vacuous pass
+    }
+
+    SUBCASE("mixed arrays") {
+        Rng rng(0x51ed0003ULL);
+        bool saw_tie = false;
+        for (int t = 0; t < TRIALS; ++t) {
+            const int n = 1 + t;
+            CHECK(agrees(random_regs(rng, n, n / 2 + 1), bwamem3_dedup_sort_by_re,
+                         bwamem3_dedup_sort_by_re_exact, tied_by_re, &saw_tie));
+        }
+        CHECK(saw_tie);
+    }
+}
+
+TEST_CASE("the by-score fast path is byte-identical to unconditional ks_introsort"
+          * doctest::test_suite("unit/alnreg_sort_dedup")) {
+    // Real inputs never tie here -- two survivors cannot share (rb, qb) -- but
+    // the fast path must not depend on that, so feed it ties anyway. Duplicated
+    // regions give equal (score, rb, qb).
+    Rng rng(0x51ed0004ULL);
+    bool saw_tie = false;
+    for (int t = 0; t < 150; ++t) {
+        std::vector<mem_alnreg_t> in = random_regs(rng, 1 + t, 4);
+        for (size_t i = 1; i < in.size(); i += 3) in[i] = in[i - 1];  // force exact duplicates
+        CHECK(agrees(in, bwamem3_dedup_sort_by_score,
+                     bwamem3_dedup_sort_by_score_exact, tied_by_score, &saw_tie));
+    }
+    CHECK(saw_tie);
+}


### PR DESCRIPTION
Stacked on #257 (base `perf/alnreg-sort-under-fast`; GitHub will retarget to `main` when #257 merges). This is one commit on top of it.

## What #257 leaves on the table

#257 buys bwa-mem2 parity in `mem_sort_dedup_patch` by reverting its two sorts to klib's unstable `ks_introsort` under bwa-mem2's `re`-only comparator — the surviving alnreg set is defined by the *permutation* that sort leaves, so any faster substitute changes the output. That parity costs **+2.31% aligner CPU** vs the strict-total-order pdqsort path it replaced (5M HG00096 WGS pairs, arm64/NEON, `-t 16`, paired per rep against v0.7.0).

## The idea

The permutation only matters where the comparator actually ties. With no tied pair the sorted sequence is unique, so pdqsort's result is bit-for-bit what introsort would have produced, and the substitution is free. Ties are rare: instrumented over 2.32M calls / 186M regions (533,334 HG00096 WGS pairs, `-t 16`), the `re` sort ties on **0.98%** of calls and the closing by-score sort on **0** of them (two survivors cannot share `(rb, qb)` — the argument already at the end of `mem_sort_dedup_patch`, now confirmed over 186M regions).

So detect ties rather than avoid them: save the input, sort in place with pdqsort, scan for an adjacent tie, and on a hit restore the input and run introsort over it. The restore is load-bearing — `ks_introsort` is input-order-dependent, so running it on the pdqsort-permuted array would give a different permutation, and a different SAM, than bwa-mem2. Gated at `n >= 9`, below which introsort is the faster of the two (127.4 vs 119.0 Mcell/s on the alnreg microbench).

Only the **default** (`alnreg_sort_fast=0`) path changes. `--fast` still runs unconditional pdqsort — it has already given up byte-identity, so it keeps the genuinely fastest sort with no save-copy or tie-scan overhead.

## Output is unchanged

Byte-identical SAM over **10,030,562 records** on 5M HG00096 WGS pairs, in **both** default and `--fast` modes:

| mode | records | md5 (SAM excl `@PG`) |
|---|---:|---|
| default | 10,030,562 | `5832c2c105486f4da27f153992e88be3` (both #257 and this) |
| `--fast` | 10,016,933 | `af7598f56ad6c4e39fe06a8e557ddf9c` (both #257 and this) |

## Performance

Aligner CPU (summed `mem_process_seqs` CPU-s), 5 interleaved reps, arm order rotated per rep, paired per rep against v0.7.0:

| arm | what it is | vs v0.7.0 |
|---|---|---:|
| v0.7.0 `228a61b` — pdqsort, no parity | baseline | — |
| #257 — introsort, parity | | **+2.31%** (above in 5/5 reps) |
| this PR — tie-detection path, parity | | **+0.66%** (straddles zero) |

Roughly three quarters of #257's cost is recovered; the residual is inside this benchmark's run-to-run spread.

## Tests

New cases in `test/unit/test_alnreg_sort_dedup.cpp` assert each fast path against the `ks_introsort` it claims to reproduce, record for record, over tie-free / tie-heavy / mixed randomized arrays spanning both sides of the `n >= 9` gate. Each subcase also asserts whether it actually saw a tie, so it cannot pass vacuously. `src/bwamem.cpp` exports four thin shims for this (zero cost on the hot path). Mutation check: disabling the tie detector fails **283** of the new assertions.

`make test`: 118 unit cases / 2,934,836 assertions, plus integration and the standalone regressions — all pass.

Report: `reports/2026-07-23-dedup-sort-tie-free-fast-path.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated `--fast` alignment-region sorting to use a strict total order when multiple regions share the same reference end position.
- **Bug Fixes**
  - Improved dedup/sorting behavior to preserve the exact dedup-survivor set by falling back to an exact path only when tie conditions are detected.
- **Documentation**
  - Refined `mem --fast` documentation with clearer notes on when `XS`, `MAPQ`, and primary/supplementary alignments may differ, plus updated performance guidance.
- **Tests**
  - Added unit tests validating fast-path correctness against exact sorting, including tie-free and tie-heavy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->