### PR TITLE
fix(simd): map _MM_HINT_T0 to L1, not L3, on arm64

### DIFF
--- a/src/simd_compat.h
+++ b/src/simd_compat.h
@@ -74,9 +74,33 @@
     #define _mm_malloc(size, align) _mm_malloc_compat(size, (align) < CACHE_LINE_BYTES ? CACHE_LINE_BYTES : (align))
     #define _mm_free(ptr) _mm_free_compat(ptr)
 
-    /* Prefetch compatibility */
+    /* Prefetch compatibility.
+     *
+     * Do NOT pass the SSE hint enum straight through as GCC's locality argument:
+     * the two scales are different, and for _MM_HINT_T0 they actively disagree.
+     *
+     *   SSE hint:            NTA=0    T0=1 (L1)   T1=2 (L2)   T2=3 (L3)
+     *   __builtin_prefetch:  0=stream 1=L3        2=L2        3=L1
+     *
+     * Passing the enum through maps T0 -> locality 1 -> `prfm pldl3keep`, i.e. the
+     * one hint that means "bring this to L1" was the one that landed in L3. NTA and
+     * T1 happen to coincide on both scales, so only T0 was wrong -- which is the hint
+     * used by the FM-index walk, whose entire lockstep design exists to make those
+     * lines L1-resident by the time the dependent load issues.
+     *
+     * Measured before this fix on arm64 (objdump src/FMI_search.o): 47 pldl3keep,
+     * 12 pldl2keep, ZERO pldl1keep.
+     *
+     * Note sse2neon does provide a correct _mm_prefetch, but as a FORCE_INLINE
+     * *function*, so `#ifndef _mm_prefetch` does not see it and this macro shadowed
+     * it. Mapping explicitly here is correct whether or not sse2neon is in play.
+     *
+     * Prefetches are pure hints: this cannot change output bytes. */
     #ifndef _mm_prefetch
-    #define _mm_prefetch(addr, hint) __builtin_prefetch((const void*)(addr), 0, (hint))
+    #define BWA3_PF_LOCALITY(hint) \
+        ((hint) == 0 ? 0 : (hint) == 1 ? 3 : (hint) == 2 ? 2 : 1)
+    #define _mm_prefetch(addr, hint) \
+        __builtin_prefetch((const void*)(addr), 0, BWA3_PF_LOCALITY(hint))
     #endif
 
     /* Mask types for SSE compatibility (sse2neon should provide these) */


### PR DESCRIPTION
## What

On arm64 the SSE→NEON compatibility shim passed the `_mm_prefetch` hint enum straight through as GCC's `__builtin_prefetch` locality argument, but the two scales disagree. SSE `_MM_HINT_T0 = 1` means "bring to L1"; GCC locality `1` means L3. Only `T0` is wrong — `NTA` and `T1` happen to coincide on both scales — and `T0` is exactly the hint the FM-index walk uses. That lockstep walk exists specifically to make the checkpoint lines L1-resident by the time the dependent occ load issues, so the miscompiled hint was sending them to L3 instead.

The shim also shadowed sse2neon's own correct `_mm_prefetch`, which is a `FORCE_INLINE` function rather than a macro, so the `#ifndef _mm_prefetch` guard never saw it. This maps the hint explicitly, so the result is correct regardless of include order.

## Byte-identity

Prefetches are pure hints — no output bytes change. `bwa-bsw-bench` extend golden: **`GOLDEN CHECK PASS`, 60,000 pairs byte-identical**.

## Evidence

`objdump src/FMI_search.o` (arm64, clang-19):

| build | pldl1keep | pldl2keep | pldl3keep |
|---|---|---|---|
| before | 0 | 12 | 47 |
| after | 47 | 12 | 0 |

The 47 FM-index checkpoint prefetches move from L3 to L1, as intended. SW-kernel throughput is unchanged (`bwa-bsw-bench` extend, Mc/s within noise: 5667/3727/3533 vs 5681/3727/3522) — the SW microbench doesn't exercise the FM-index, which is where the win lands.

## Wall

Isolated interleaved A/B on Graviton4 (m8g.4xlarge, 16 threads, clang-19, index on tmpfs, 5M-read WGS pair), best-of-3, byte-identity gated each rep: **−2.38% median (91.70 → 89.52 s)**.

Affects every arm64 build — the Graviton fleet and Apple Silicon dev machines alike.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory prefetch behavior on ARM and Apple Silicon platforms.
  * Added explicit compatibility handling to ensure prefetch hints are interpreted correctly across supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->