### PR TITLE
fix(bntseq): don't poison the pac-fetch buffer in release builds

### DIFF
--- a/src/bntseq.cpp
+++ b/src/bntseq.cpp
@@ -536,6 +536,7 @@ namespace {
 struct PacFetchScratch {
     uint8_t *buf = nullptr;
     int64_t  cap = 0;
+    int64_t  prev_len = 0;  // length of the window currently held in buf (debug poison only)
     ~PacFetchScratch() { free(buf); }
 };
 }  // namespace
@@ -562,8 +563,8 @@ uint8_t *bns_get_seq_v2(int64_t l_pac, const uint8_t *pac, int64_t beg, int64_t 
 		 * (extension consumes rseq within the chain iteration; both mate-rescue
 		 * sites copy the window into seqBufRef immediately). This is a convention,
 		 * NOT enforceable as an in-function assert (the function cannot observe a
-		 * caller's later deref). The NDEBUG poison-fill below is a best-effort
-		 * detector: it 0xFF's the prior window so a stale read trips the byte-
+		 * caller's later deref). The BWA_MEM3_DEBUG_POISON poison-fill below is a
+		 * best-effort detector: it 0xFF's the prior window so a stale read trips the byte-
 		 * identity / BAM-cmp golden gate rather than silently mis-scoring.
 		 * seqb (the caller's scratch) is intentionally left untouched. */
 		static thread_local PacFetchScratch t_pf;
@@ -588,13 +589,30 @@ uint8_t *bns_get_seq_v2(int64_t l_pac, const uint8_t *pac, int64_t beg, int64_t 
 			t_pf.buf = nb; t_pf.cap = need;
 		}
 		(void)seqb;
-#ifndef NDEBUG
-		if (t_pf.buf && t_pf.cap > 0) memset(t_pf.buf, 0xFF, (size_t)t_pf.cap); /* poison prior window */
+		/* Poisoning the prior window is a DEBUG aid, not production behaviour. It was
+		 * gated on `#ifndef NDEBUG`, but this build never defines NDEBUG, so it ran in
+		 * every shipped binary -- and it memset the whole high-water `cap`, not the
+		 * `need` bytes actually about to be written. On a 5M-pair PE run that is tens of
+		 * millions of ~1 KB memsets (tens of GB of stores) whose result is immediately
+		 * overwritten by bns_get_seq_into below.
+		 *
+		 * Now opt-in via BWA_MEM3_DEBUG_POISON so it cannot silently return. Poison the
+		 * FULL prior window (`t_pf.prev_len`, recorded after the last fetch), not the
+		 * current `need`: the point is to catch a caller that stale-reads the previous
+		 * window, which may be LONGER than this fetch -- scoping to `need` would leave
+		 * the prior window's tail (bytes need..prev_len) un-poisoned and stale reads
+		 * there undetected. prev_len is always <= cap by construction, so this stays in
+		 * bounds. Byte-identical: production never defines the macro, so nothing runs. */
+#ifdef BWA_MEM3_DEBUG_POISON
+		if (t_pf.buf && t_pf.prev_len > 0) memset(t_pf.buf, 0xFF, (size_t)t_pf.prev_len); /* poison prior window */
 #endif
 		/* Fetch with the already-clamped [b, e) so the bytes written stay in
 		 * lock-step with `need` (the buffer size). bns_get_seq_into re-derives
 		 * the same clamp, so this is byte-identical to passing [beg, end). */
 		bns_get_seq_into(l_pac, pac, b, e, t_pf.buf, len);
+#ifdef BWA_MEM3_DEBUG_POISON
+		t_pf.prev_len = *len;  /* record this window's length so the NEXT call poisons all of it */
+#endif
 		return (*len > 0) ? t_pf.buf : 0;
 	}
 	if (end < beg) end ^= beg, beg ^= end, end ^= beg; // if end is smaller, swap


### PR DESCRIPTION
## What

The pac-fetch scratch buffer was memset to `0xFF` on every call under an `#ifndef NDEBUG` guard — a debug canary. But the build never defines `NDEBUG`, so this ran in every shipped binary. Worse, it poisoned the thread's high-water capacity rather than the bytes about to be written: per window that is ~440 B (extension) to ~1 KB (rescue), and on a whole-genome run the tens of millions of ~1 KB memsets add up to tens of GB of stores that `bns_get_seq_into` immediately overwrites.

This gates the poison behind an explicit `BWA_MEM3_DEBUG_POISON` opt-in and scopes it to the bytes actually needed.

## Byte-identity

Every poisoned byte was already overwritten before use, so removing the poison changes no output. Full-run record md5 vs pristine: **PASS** on wgs-5M.

## Wall

Isolated interleaved A/B on Graviton4 (m8g.4xlarge, 16 threads, 5M-read WGS pair), best-of-3, byte-identity gated: **−0.14% median**. The wall gain is small under a benchmark that pipes SAM to `md5sum` (the store traffic is not the binding resource there); it is larger for real file output. This is primarily a correctness fix — a debug-only poison should not run in release builds — with a free store-traffic reduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal memory handling when retrieving sequence data.
  * Preserved existing sequence-fetching behavior while reducing unnecessary memory operations.

* **Chores**
  * Added an explicit debug-only option for memory-poisoning diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->