### PR TITLE
perf(seed): correct the FM-index checkpoint prefetch targets

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -605,8 +605,12 @@ void FMI_search::getSMEMsOnePosOneThread(uint8_t *enc_qdb,
                     }
                     smem = newSmem;
 #ifdef ENABLE_PREFETCH
-                    _mm_prefetch((const char *)(&cp_occ[(smem.k) >> CP_SHIFT]), _MM_HINT_T0);
+                    /* Next iteration swaps k<->l then backwardExt reads
+                     * sp = smem.l, ep = smem.l + smem.s (see ls_advance_forward_step
+                     * for the full derivation). Prefetching smem.k targeted an
+                     * address never touched; ep was never prefetched. Pure hint. */
                     _mm_prefetch((const char *)(&cp_occ[(smem.l) >> CP_SHIFT]), _MM_HINT_T0);
+                    _mm_prefetch((const char *)(&cp_occ[(smem.l + smem.s) >> CP_SHIFT]), _MM_HINT_T0);
 #endif
                 }
                 else
@@ -798,14 +802,39 @@ void FMI_search::ls_prefetch_cp_occ(const BatchSlot *s)
  * above lands at "this slot's next step" granularity; T1 here lands at
  * "this slot's step ~N/2 from now". For N=8 that's 4 stepping-passes ahead,
  * giving DRAM-latency-class lookahead when the cp_occ working set spills
- * out of L2/L3. */
+ * out of L2/L3.
+ *
+ * Target the interval the lookahead slot will actually read next, which
+ * differs by phase:
+ *
+ *   PH_FWD: smem is live and the next forward step consumes it, so warm all
+ *           four of its checkpoint blocks (k, l, k+s, l+s).
+ *
+ *   PH_BWD: ls_advance_backward_step runs entirely out of prev[] and NEVER
+ *           rewrites smem, so smem here is the STALE leftover from the end of
+ *           the forward phase -- warming it prefetches lines the backward walk
+ *           will not touch. The next backward step instead calls backwardExt on
+ *           each live prev[p], reading cp_occ[prev[p].k] and cp_occ[prev[p].k +
+ *           prev[p].s]. Aim the lookahead at those. This keeps the N/2-ahead L2
+ *           memory-level parallelism (the part that was actually hiding DRAM
+ *           latency) but points it at blocks that are really read. Pure hint,
+ *           so output is unchanged. */
 void FMI_search::ls_prefetch_cp_occ_t1(const BatchSlot *s)
 {
 #ifdef ENABLE_PREFETCH
-    _mm_prefetch((const char *)(&cp_occ[(s->smem.k) >> CP_SHIFT]), _MM_HINT_T1);
-    _mm_prefetch((const char *)(&cp_occ[(s->smem.l) >> CP_SHIFT]), _MM_HINT_T1);
-    _mm_prefetch((const char *)(&cp_occ[(s->smem.k + s->smem.s) >> CP_SHIFT]), _MM_HINT_T1);
-    _mm_prefetch((const char *)(&cp_occ[(s->smem.l + s->smem.s) >> CP_SHIFT]), _MM_HINT_T1);
+    if (s->phase == PH_BWD) {
+        const int32_t np = s->numPrev;
+        for (int32_t p = 0; p < np; p++) {
+            const SMEM m = s->prev[p];
+            _mm_prefetch((const char *)(&cp_occ[(m.k) >> CP_SHIFT]), _MM_HINT_T1);
+            _mm_prefetch((const char *)(&cp_occ[(m.k + m.s) >> CP_SHIFT]), _MM_HINT_T1);
+        }
+    } else {
+        _mm_prefetch((const char *)(&cp_occ[(s->smem.k) >> CP_SHIFT]), _MM_HINT_T1);
+        _mm_prefetch((const char *)(&cp_occ[(s->smem.l) >> CP_SHIFT]), _MM_HINT_T1);
+        _mm_prefetch((const char *)(&cp_occ[(s->smem.k + s->smem.s) >> CP_SHIFT]), _MM_HINT_T1);
+        _mm_prefetch((const char *)(&cp_occ[(s->smem.l + s->smem.s) >> CP_SHIFT]), _MM_HINT_T1);
+    }
 #else
     (void)s;
 #endif
@@ -903,8 +932,16 @@ void FMI_search::ls_advance_forward_step(BatchSlot *s, const uint8_t *enc_qdb)
     s->smem = newSmem;
     s->j++;
 #ifdef ENABLE_PREFETCH
-    _mm_prefetch((const char *)(&cp_occ[(s->smem.k) >> CP_SHIFT]), _MM_HINT_T0);
+    /* The NEXT forward step swaps k<->l (see smem_ above) before calling
+     * backwardExt, which reads sp = smem.k and ep = smem.k + smem.s. After the
+     * swap that is OUR smem.l and smem.l + smem.s -- so those are the two lines
+     * to prefetch. The old code prefetched smem.k (an address the next step
+     * never touches) and smem.l, leaving the ep line to always miss cold.
+     * Same targets as bsd_prefetch_cp_occ(), which fixed this for round 3 in
+     * #242; the fix was simply never propagated here. Prefetch is a pure hint,
+     * so this cannot change output. */
     _mm_prefetch((const char *)(&cp_occ[(s->smem.l) >> CP_SHIFT]), _MM_HINT_T0);
+    _mm_prefetch((const char *)(&cp_occ[(s->smem.l + s->smem.s) >> CP_SHIFT]), _MM_HINT_T0);
 #endif
 }
 
@@ -1492,8 +1529,12 @@ int64_t FMI_search::bwtSeedStrategyAllPosOneThread(uint8_t *enc_qdb,
                         newSmem.n = j;
                         smem = newSmem;
 #ifdef ENABLE_PREFETCH
-                        _mm_prefetch((const char *)(&cp_occ[(smem.k) >> CP_SHIFT]), _MM_HINT_T0);
+                        /* Same correction as the lockstep path: the next step reads
+                         * sp = smem.l, ep = smem.l + smem.s after the k<->l swap.
+                         * This is the x86 default round-3 path (the lockstep variant
+                         * is arm64-gated), so it was missing the #242 fix entirely. */
                         _mm_prefetch((const char *)(&cp_occ[(smem.l) >> CP_SHIFT]), _MM_HINT_T0);
+                        _mm_prefetch((const char *)(&cp_occ[(smem.l + smem.s) >> CP_SHIFT]), _MM_HINT_T0);
 #endif
 
 


### PR DESCRIPTION
## What

Two prefetch-targeting corrections in the lockstep FM-index walk, both pure hints (byte-identical), together **−1.0% wall** on a 5M-read WGS pair at `-t16`.

**Forward extension.** The same-slot T0 prefetch aimed at `cp_occ[k]`, but after the `k↔l` swap the next `backwardExt` reads `sp = l` and `ep = l + s`. So the `k` prefetch targeted a checkpoint block the next step never touches, and the `ep` block was never prefetched at all — a guaranteed cold miss. This aims it at `[l, l+s]` (the two blocks actually read next) at three sites: `getSMEMsOnePosOneThread`, the lockstep forward step, and the scalar round-3 path.

**Cross-slot N/2-ahead lookahead.** `ls_advance_backward_step` runs entirely out of `prev[]` and never rewrites `smem`, so in `PH_BWD` the slot's `smem` is the stale leftover from the forward phase — the L2 lookahead was warming blocks the backward walk does not read. This makes the lookahead phase-aware: in `PH_BWD` it targets each live `prev[p].[k, k+s]` (the intervals the next backward step feeds to `backwardExt`), while `PH_FWD` (where `smem` is live) is unchanged. It keeps the memory-level parallelism the lookahead provides but points it at blocks that are really read.

## Byte-identity

Prefetches are pure hints — no output bytes change. Full-run record md5 vs pristine: **PASS** on wgs-5M, every A/B rep.

## Wall

Isolated interleaved A/B on Graviton4 (m8g.4xlarge, 16 threads, clang-19, index on tmpfs, 5M-read WGS pair), best-of-5, byte-identity gated each rep:

| | pristine | this branch | Δ |
|---|---|---|---|
| median | 91.92 s | **90.99 s** | **−1.01%** |
| best | 91.68 s | 90.78 s | −0.98% |

Every rep on this branch (90.78–91.14 s) beats every pristine rep (91.68–92.06 s) — no overlap. Note the retargeting matters, not just the presence of prefetches: simply *removing* the N/2 lookahead instead of retargeting it regressed +1.4%, because its outstanding-request pressure was doing real DRAM-latency-hiding — it only needed correct targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search performance by correcting memory prefetching during sequence extension and traversal.
  * Optimized both scalar and parallel search paths, including forward and backward processing, for more efficient execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->