### PR TITLE
fix(chain): keep sizeof(mem_chain_t) at 48 B to preserve bwa-mem2 chaining parity

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -68,6 +68,18 @@ extern uint64_t tprof[LIM_R][LIM_C];
 #define chain_cmp(a, b) (((b).pos < (a).pos) - ((a).pos < (b).pos))
 KBTREE_INIT(chn, mem_chain_t, chain_cmp)
 
+/* chain_cmp orders chains by .pos ONLY, so chains that share a .pos are a tie
+ * whose resolution is left to the kbtree's internal structure. klib derives the
+ * B-tree node fan-out from sizeof(mem_chain_t) (kbtree.h), so changing that size
+ * changes which chain kb_getp returns at a tie, which regroups seeds and silently
+ * moves default (non-meth) output. This guard fails the build if mem_chain_t ever
+ * grows again — repack new fields into the existing bitfield word (see bwamem.h),
+ * do not append. 48 B is upstream bwa-mem2's size; keeping it preserves bwa-mem2
+ * chaining parity. */
+static_assert(sizeof(mem_chain_t) == 48,
+              "sizeof(mem_chain_t) feeds klib kbtree node fan-out; changing it moves default "
+              "output at chain_cmp .pos ties. Repack fields into the bitfield word, don't append.");
+
 #define intv_lt1(a, b) ((((uint64_t)(a).m) <<32 | ((uint64_t)(a).n)) < (((uint64_t)(b).m) <<32 | ((uint64_t)(b).n)))  // trial
 KSORT_INIT(mem_intv1, SMEM, intv_lt1)  // debug
 

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -204,22 +204,32 @@ typedef struct abc {
 typedef struct {
     int32_t seqid, cseed;
     int32_t n, m, first, rid;
-    uint32_t w:29, kept:2, is_alt:1;
+    /* meth_hypothesis lives in this bitfield word — NOT as a trailing byte — so
+     * sizeof(mem_chain_t) is unchanged from upstream bwa-mem2 (48 B). This struct
+     * is the klib kbtree key type (KBTREE_INIT(chn, mem_chain_t, chain_cmp) in
+     * bwamem.cpp), and kbtree derives its B-tree node fan-out from sizeof(key_t)
+     * (ext .../kbtree.h: b->t = ((size-4-sizeof(void*))/(sizeof(void*)+sizeof(key_t))+1)>>1).
+     * Growing the struct changes the tree shape, which changes WHICH chain kb_getp
+     * returns as the merge neighbour when two chains tie on chain_cmp (== .pos),
+     * which regroups seeds into different chains and silently moves default output.
+     * Adding it as a trailing `int8_t` (padded to +8 B) did exactly that — it moved
+     * non-meth output away from bwa-mem2 (see the static_assert in bwamem.cpp).
+     * Values: 1 = OT (C→T, odd "f" seed contig), 0 = OB (G→A, even "r" seed
+     * contig), -1 = not a meth chain (non-meth runs leave this at -1). A signed
+     * 2-bit field represents {-2,-1,0,1}, covering all three values.
+     *
+     * For directional libraries (the --meth contract) each read is projected under
+     * a SINGLE hypothesis (R1→OT, R2→OB), so all of a read's seeds carry the same
+     * label and no cross-hypothesis merge can occur; test_and_merge is therefore
+     * NOT hypothesis-guarded. NOTE (--meth directional invariant): if non-
+     * directional / dual-hypothesis-per-read support is ever added, test_and_merge
+     * MUST gain a hypothesis guard (it is currently safe only because each read is
+     * single-hypothesis). */
+    uint32_t w:27, kept:2, is_alt:1;   /* unsigned: w/kept/is_alt are 0..N flags (kept reaches 3) */
+    int32_t  meth_hypothesis:2;        /* signed: needs -1; packs into the same 4-byte word (static_assert below) */
     float frac_rep;
     int64_t pos;
     mem_seed_t *seeds;
-    /* D3 (--meth, PR-3): per-chain bisulfite hypothesis label, carried from the
-     * seed→original remap so PR-4 can pick the asymmetric OT/OB matrix. Encoding
-     * matches the seed contig parity (seed_rid & 1): 1 = OT (C→T, odd "f" seed
-     * contig), 0 = OB (G→A, even "r" seed contig). -1 = not a meth chain
-     * (non-meth runs leave this at -1). For directional libraries (the --meth
-     * contract) each read is projected under a SINGLE hypothesis (R1→OT, R2→OB),
-     * so all of a read's seeds carry the same label and no cross-hypothesis merge
-     * can occur; test_and_merge is therefore NOT hypothesis-guarded.
-     * NOTE (--meth directional invariant): if non-directional / dual-hypothesis-
-     * per-read support is ever added, test_and_merge MUST gain a hypothesis guard
-     * (it is currently safe only because each read is single-hypothesis). */
-    int8_t meth_hypothesis;
 } mem_chain_t;
 
 typedef struct { size_t n, m, cc; mem_chain_t *a;  } mem_chain_v;


### PR DESCRIPTION
## What

PR #174 (`--meth`) added `int8_t meth_hypothesis` as a **trailing** field of `mem_chain_t`, growing it from 48 → 56 bytes. That silently moved **default, non-meth** output away from bwa-mem2. This repacks the field into the existing bitfield word so `sizeof(mem_chain_t)` returns to 48, restoring bwa-mem2 chaining parity, and adds a `static_assert` so it can't regress.

## Why a size change moves output

`mem_chain_t` is the klib **kbtree** key type (`KBTREE_INIT(chn, mem_chain_t, chain_cmp)`), and klib derives its B-tree node fan-out straight from `sizeof(key_t)` — `ext/.../kbtree.h`:

```c
b->t = ((size - 4 - sizeof(void*)) / (sizeof(void*) + sizeof(key_t)) + 1) >> 1;
```

`chain_cmp` orders chains by `.pos` **only**, so chains sharing a `.pos` are a **tie** whose resolution is left to the tree's shape. Change `sizeof(mem_chain_t)` → change the fan-out → change which chain `kb_getp` returns as the merge neighbour at a tie → the same seeds regroup into different chains → different chain weights → `mem_chain_flt` keeps a different set → the paired primary flips among co-optimal placements. Same score, moved POS.

This was root-caused decisively: adding a **never-read** `int8_t` field to the *pre-#174* struct (pure size padding, zero logic) reproduced #174's exact divergent output. A field that is never read can only change `sizeof` — so `sizeof` is the cause.

## The fix (no tradeoff)

Unlike the alnreg/gap tie changes elsewhere, #174 did **not** change the tie-breaking *policy* — it still uses bwa-mem2's unstable kbtree. So byte-identity is recoverable simply by keeping the struct size. `meth_hypothesis` only holds `-1/0/1`, so it fits the existing bitfield word:

```c
// was:  uint32_t w:29, kept:2, is_alt:1;  ...  int8_t meth_hypothesis;   // 48 -> 56 B
// now:  uint32_t w:27, kept:2, is_alt:1;   // unsigned: kept reaches 3
//       int32_t  meth_hypothesis:2;        // signed: needs -1; packs into the same 4-byte word
```

`meth_hypothesis` stays **signed** (needs `-1`); `w`/`kept`/`is_alt` stay **unsigned** (`kept` reaches 3). The two declarations pack into one 4-byte word — verified by the `static_assert(sizeof(mem_chain_t) == 48, ...)`, which also guards against any future field being appended.

## Verification

**Parity — origin/main, batch-1 prefix (533,334 HG00096 WGS pairs, `-t 16`), primaries vs a real bwa-mem2 v2.2.1 golden (1,066,668 records):**

| build | primaries diverging from bwa-mem2 |
|---|---:|
| origin/main (baseline) | **54** |
| origin/main + this fix | **0** |

All 54 changed records now match bwa-mem2 exactly; **0 regressions**. The target read `A00132:53:HFHJKDSXX:1:1528:21124:25989` goes `chr10:126948019` → `chr10:126948220` (= bwa-mem2).

**`--meth` unchanged** — the field still carries the hypothesis; only the storage location moved.

**Tests:** all 118 unit test cases (2,934,252 assertions) + integration pass.

## Notes

- `mem_alnreg_t` also grew in #174 but is **harmless**: it is a plain `ksort`/introsort array element, and introsort's comparison sequence is layout-independent. Only the kbtree **key** (`mem_chain_t`) is `sizeof`-sensitive.
- The `static_assert` makes the class of bug loud: any future field added to `mem_chain_t` fails the build until repacked, instead of silently moving output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal memory layout for seed-chain processing while preserving behavior.
  * Added safeguards to detect incompatible layout changes during compilation, helping maintain consistent results across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->