### PR TITLE
fix(bsw): compute the 8-bit band clamp in wide arithmetic

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -858,26 +858,24 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 //------------------------
             /* Banding calculation in pre-processing */
             uint8_t myband[SIMD_WIDTH8] __attribute__((aligned(64)));
-            uint8_t temp[SIMD_WIDTH8] __attribute__((aligned(64)));
             {
-                __m256i qlen256 = _mm256_load_si256((__m256i *) qlen);
-                __m256i sum256 = _mm256_add_epi8(qlen256, eb_ins256);
-                _mm256_store_si256((__m256i *) temp, sum256);               
-                for (int l=0; l<SIMD_WIDTH8; l++)
-                {
-                    double val = temp[l]/e_ins + 1.0;
-                    int max_ins = (int) val;
-                    max_ins = max_ins > 1? max_ins : 1;
-                    myband[l] = min_(bsize, max_ins);
-                }
-                sum256 = _mm256_add_epi8(qlen256, eb_del256);
-                _mm256_store_si256((__m256i *) temp, sum256);               
-                for (int l=0; l<SIMD_WIDTH8; l++) {
-                    double val = temp[l]/e_del + 1.0;
-                    int max_ins = (int) val;
-                    max_ins = max_ins > 1? max_ins : 1;
-                    myband[l] = min_(myband[l], max_ins);
-                    bsize = bsize < myband[l] ? myband[l] : bsize;
+                /* Per-lane band clamp in WIDE arithmetic, mirroring scalarBandedSWA's
+                 * "adjust $w if it is too large" block. See smithWatermanBatchWrapper8
+                 * (128-bit) for the full rationale: the previous 8-bit SIMD form wrapped
+                 * whenever qlen*max_sc + end_bonus - o was negative, silently disabling
+                 * the clamp and running a far wider band than the scalar reference.
+                 * Per-batch (SIMD_WIDTH8 lanes), not per-cell, so wide math is free. */
+                for (int l = 0; l < SIMD_WIDTH8; l++) {
+                    const int ql    = (int) qlen[l];
+                    const int reach = ql + eb;
+                    int max_ins = (int)((double)(reach - o_ins) / e_ins + 1.0);
+                    if (max_ins < 1) max_ins = 1;
+                    int max_del = (int)((double)(reach - o_del) / e_del + 1.0);
+                    if (max_del < 1) max_del = 1;
+                    int band = bsize;
+                    if (max_ins < band) band = max_ins;
+                    if (max_del < band) band = max_del;
+                    myband[l] = (uint8_t) band;
                 }
             }
             
@@ -2779,25 +2777,24 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
 //------------------------
             /* Banding calculation in pre-processing */
             uint8_t myband[SIMD_WIDTH8] __attribute__((aligned(64)));
-            uint8_t temp[SIMD_WIDTH8] __attribute__((aligned(64)));
             {
-                __m512i qlen512 = _mm512_load_si512((__m512i *) qlen);
-                __m512i sum512 = _mm512_add_epi8(qlen512, eb_ins512);
-                _mm512_store_si512((__m512i *) temp, sum512);               
-                for (int l=0; l<SIMD_WIDTH8; l++) {
-                    double val = temp[l]/e_ins + 1.0;
-                    int max_ins = val;
-                    max_ins = max_ins > 1? max_ins : 1;
-                    myband[l] = min_(bsize, max_ins);
-                }
-                sum512 = _mm512_add_epi8(qlen512, eb_del512);
-                _mm512_store_si512((__m512i *) temp, sum512);               
-                for (int l=0; l<SIMD_WIDTH8; l++) {
-                    double val = temp[l]/e_del + 1.0;
-                    int max_ins = val;
-                    max_ins = max_ins > 1? max_ins : 1;
-                    myband[l] = min_(myband[l], max_ins);
-                    bsize = bsize < myband[l] ? myband[l] : bsize;
+                /* Per-lane band clamp in WIDE arithmetic, mirroring scalarBandedSWA's
+                 * "adjust $w if it is too large" block. See smithWatermanBatchWrapper8
+                 * (128-bit) for the full rationale: the previous 8-bit SIMD form wrapped
+                 * whenever qlen*max_sc + end_bonus - o was negative, silently disabling
+                 * the clamp and running a far wider band than the scalar reference.
+                 * Per-batch (SIMD_WIDTH8 lanes), not per-cell, so wide math is free. */
+                for (int l = 0; l < SIMD_WIDTH8; l++) {
+                    const int ql    = (int) qlen[l];
+                    const int reach = ql + eb;
+                    int max_ins = (int)((double)(reach - o_ins) / e_ins + 1.0);
+                    if (max_ins < 1) max_ins = 1;
+                    int max_del = (int)((double)(reach - o_del) / e_del + 1.0);
+                    if (max_del < 1) max_del = 1;
+                    int band = bsize;
+                    if (max_ins < band) band = max_ins;
+                    if (max_del < band) band = max_del;
+                    myband[l] = (uint8_t) band;
                 }
             }
 
@@ -5488,25 +5485,41 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             }
 //------------------------
             uint8_t myband[SIMD_WIDTH8] __attribute__((aligned(64)));
-            uint8_t temp[SIMD_WIDTH8] __attribute__((aligned(64)));
             {
-                __m128i qlen128 = _mm_load_si128((__m128i *) qlen);
-                __m128i sum128 = _mm_add_epi8(qlen128, eb_ins128);
-                _mm_store_si128((__m128i *) temp, sum128);              
-                for (int l=0; l<SIMD_WIDTH8; l++) {
-                    double val = temp[l]/e_ins + 1.0;
-                    int max_ins = (int) val;
-                    max_ins = max_ins > 1? max_ins : 1;
-                    myband[l] = min_(bsize, max_ins);
-                }
-                sum128 = _mm_add_epi8(qlen128, eb_del128);
-                _mm_store_si128((__m128i *) temp, sum128);              
-                for (int l=0; l<SIMD_WIDTH8; l++) {
-                    double val = temp[l]/e_del + 1.0;
-                    int max_ins = (int) val;
-                    max_ins = max_ins > 1? max_ins : 1;
-                    myband[l] = min_(myband[l], max_ins);
-                    bsize = bsize < myband[l] ? myband[l] : bsize;
+                // Per-lane band clamp, mirroring scalarBandedSWA's "adjust $w if it is
+                // too large" exactly (see the max_ins / max_del block there):
+                //   max_ins = max(1, (qlen*max_sc + end_bonus - o_ins)/e_ins + 1)
+                //   max_del = max(1, (qlen*max_sc + end_bonus - o_del)/e_del + 1)
+                //   band    = min(w, max_ins, max_del)
+                // where max_sc is the largest entry of the scoring matrix. It bounds how
+                // far a gap can profitably run before the end bonus can no longer repay
+                // it, so a wider band cannot contain the optimum.
+                //
+                // WIDE (int) ARITHMETIC IS LOAD-BEARING. This was computed with
+                // _mm_add_epi8(qlen, end_bonus - o) stored into a uint8_t: whenever
+                // qlen + end_bonus - o was NEGATIVE the int8 add wrapped and the byte read
+                // back near 255, so the clamp evaluated to ~256 and silently vanished.
+                // The kernel then ran the FULL band w where the scalar ran a band of 1,
+                // explored cells scalar never visits, and returned different gscore/gtle
+                // (the query-end fields) -- for example qlen=10, end_bonus=5, -O16 gives
+                // 10 + 5 - 16 = -1 -> 255. Reachable at bwa's DEFAULT -O6 as soon as
+                // end_bonus is small and the query is short (1 + 0 - 6 < 0). qlen[l]
+                // already holds qlen*max_sc (see the qlen SoA fill), so reach is just
+                // qlen[l] + end_bonus; that scaled reach does not fit int8, and this
+                // loop is per-batch (16 lanes), not per-cell, so there is nothing to
+                // gain by vectorizing it.
+                // Regression: test/unit/test_bandedswa_band_clamp.cpp.
+                for (int l = 0; l < SIMD_WIDTH8; l++) {
+                    const int ql   = (int) qlen[l];
+                    const int reach = ql + eb;
+                    int max_ins = (int)((double)(reach - o_ins) / e_ins + 1.0);
+                    if (max_ins < 1) max_ins = 1;
+                    int max_del = (int)((double)(reach - o_del) / e_del + 1.0);
+                    if (max_del < 1) max_del = 1;
+                    int band = bsize;
+                    if (max_ins < band) band = max_ins;
+                    if (max_del < band) band = max_del;
+                    myband[l] = (uint8_t) band;
                 }
             }
 

--- a/test/unit/test_bandedswa_band_clamp.cpp
+++ b/test/unit/test_bandedswa_band_clamp.cpp
@@ -1,0 +1,178 @@
+// test/unit/test_bandedswa_band_clamp.cpp
+//
+// Regression test for the 8-bit banded-SW per-lane band clamp.
+//
+// scalarBandedSWA narrows the band before the DP loop ("adjust $w if it is too large"):
+//
+//   max_ins = max(1, (qlen*max_sc + end_bonus - o_ins)/e_ins + 1)
+//   max_del = max(1, (qlen*max_sc + end_bonus - o_del)/e_del + 1)
+//   w       = min(w, max_ins, max_del)
+//
+// where max_sc is the largest scoring-matrix entry. It bounds how far a gap can profitably
+// run before the end bonus can no longer repay it.
+//
+// The vector wrappers used to compute this with `_mm_add_epi8(qlen, end_bonus - o)` stored
+// into a `uint8_t`. Whenever `qlen*max_sc + end_bonus - o` is NEGATIVE the int8 add wraps,
+// the byte reads back near 255, the clamp evaluates to ~256 and effectively disappears -- so
+// the kernel ran the full band `w` where the scalar ran a band as narrow as 1. It then
+// explored cells the scalar never visits and returned different `gscore`/`gtle`. `score`,
+// `tle`, `qle` and `max_off` happened to agree, which is why the existing gates missed it.
+// The pre-scaled `qlen*max_sc` reach lives in the `qlen` SoA already, so `-A > 1` (max_sc
+// > 1) is covered by the wide-arithmetic clamp without re-multiplying.
+//
+// The wrap condition is exactly `qlen*max_sc + end_bonus < o`, so it is NOT exotic: at bwa's
+// DEFAULT -O 6 it fires for any short extension once the end bonus is small (1 + 0 - 6 < 0).
+//
+// Comparison follows the kernel's documented query-end contract (see the gtle CONTRACT
+// comment in bandedSWA.cpp): the local-alignment fields must match unconditionally, while
+// gscore/gtle are only compared when either side reports gscore > 0 -- which is exactly when
+// bwa-mem consumes them. Every pair is inside bsw8_envelope_ok, i.e. reachable in production.
+//
+// Runs on every CI matrix row that defines a vector kernel, so the x86 SSE4.1 (128-bit) and
+// AVX2 (256-bit) wrappers are covered as well as NEON. Deterministic (fixed RNG seed).
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "doctest/doctest.h"
+#include "bandedSWA.h"
+
+#if HAVE_BSW_VECTOR_8_16
+
+namespace {
+
+struct Out { int score, tle, gtle, qle, gscore, max_off; };
+
+/// One (scoring parameters) trial. Returns the number of vector-vs-scalar mismatches over the
+/// pairs the CURRENT 8-bit routing envelope admits, and reports how many were checked so a
+/// vacuous trial cannot masquerade as a pass.
+long trial(int a, int b, int o, int e, int zdrop, int w, int end_bonus,
+           int minq, int maxq, long n, long *checked)
+{
+    const int maxStep = a > 1 ? a : 1;
+    const int STRIDE  = 400;
+
+    int8_t mat[25];
+    { int k = 0;
+      for (int i = 0; i < 4; ++i) { for (int j = 0; j < 4; ++j) mat[k++] = (i == j) ? (int8_t)a : (int8_t)-b; mat[k++] = -1; }
+      for (int j = 0; j < 5; ++j) mat[k++] = -1; }
+
+    BandedPairWiseSW bsw(o, e, o, e, zdrop, end_bonus, mat, (int8_t)a, (int8_t)b, 1);
+
+    std::mt19937_64 rng(0xEC7C0DE4ull);
+    std::vector<uint8_t> ref((size_t)STRIDE * n, 0), qer((size_t)STRIDE * n, 0);
+    std::vector<SeqPair> pairs(n);
+    std::vector<Out> oracle(n);
+    std::uniform_int_distribution<int> lenD(minq, maxq), hD(1, zdrop + 1), unit(3, 12);
+
+    for (long c = 0; c < n; ++c) {
+        int aa = lenD(rng), bb = lenD(rng);
+        int len1 = aa > bb ? aa : bb, len2 = aa > bb ? bb : aa;   /* len1 >= len2 */
+        int h0 = hD(rng);
+        uint8_t *s1 = &ref[(size_t)c * STRIDE];
+        uint8_t *s2 = &qer[(size_t)c * STRIDE];
+        int u = unit(rng); uint8_t ub[16];
+        for (int i = 0; i < u; i++) ub[i] = (uint8_t)(rng() % 4);
+        for (int i = 0; i < len1; i++) s1[i] = ub[i % u];
+        int ti = 0;
+        for (int i = 0; i < len2; i++) {
+            uint8_t base = (ti < len1) ? s1[ti] : (uint8_t)(rng() % 4);
+            if ((int)(rng() % 100) < 5) base = (uint8_t)(rng() % 4);
+            s2[i] = base;
+            if ((rng() % 40) == 0) { if (rng() & 1) ti += 2; } else ti++;
+        }
+        SeqPair &p = pairs[c];
+        p.id = c; p.len1 = len1; p.len2 = len2; p.h0 = h0;
+        p.idr = (int)((size_t)c * STRIDE); p.idq = (int)((size_t)c * STRIDE);
+        p.seqid = c; p.regid = c;
+        p.score = p.tle = p.gtle = p.qle = p.gscore = p.max_off = -1;
+        Out &O = oracle[c];
+        O.score = bsw.scalarBandedSWA(len2, s2, len1, s1, w, h0,
+                                      &O.qle, &O.tle, &O.gtle, &O.gscore, &O.max_off);
+    }
+
+    /* Mirror of bwamem.cpp bsw8_envelope_ok: only pairs it admits may reach getScores8. */
+    std::vector<long> idx;
+    idx.reserve(n);
+    for (long c = 0; c < n; ++c) {
+        const SeqPair &p = pairs[c];
+        int shorter = p.len1 < p.len2 ? p.len1 : p.len2;
+        if (p.len1 < MAX_SEQ_LEN8 && p.len2 < MAX_SEQ_LEN8 && p.len1 >= p.len2 &&
+            w <= 127 && zdrop + maxStep <= 253 && p.h0 <= zdrop + 1 &&
+            (p.h0 + shorter * maxStep) < 255 - maxStep) {
+            idx.push_back(c);
+        }
+    }
+    const long adm = (long)idx.size();
+    *checked = adm;
+    if (adm == 0) return 0;
+
+    const long round_adm = ((adm + SIMD_WIDTH8 - 1) / SIMD_WIDTH8) * SIMD_WIDTH8;
+    std::vector<SeqPair> ap(round_adm);
+    for (long k = 0; k < adm; ++k) ap[k] = pairs[idx[k]];
+    bsw.getScores8(ap.data(), ref.data(), qer.data(), (int32_t)adm, 1, w);
+
+    long diffs = 0;
+    for (long k = 0; k < adm; ++k) {
+        const SeqPair &g = ap[k];
+        const Out &O = oracle[idx[k]];
+        /* Comparison follows the kernel's documented query-end contract (see the
+         * gtle CONTRACT comment in bandedSWA.cpp, and bandedswa_zdrop_eweight_test):
+         * the local-alignment fields must match unconditionally, while gscore/gtle are
+         * only observable when a to-end alignment actually exists. bwa-mem branches on
+         * `gscore <= 0`, so a vector gscore of 0 against a scalar -1 selects the same
+         * branch and cannot reach a SAM record; the vector's row loop stops at
+         * mlenw = min(qlen+myband, tlen) while the scalar runs to its dynamic m==0
+         * break, so it legitimately misses trailing all-zero query-end rows. Anything
+         * with gscore > 0 on either side IS observable and must match exactly. */
+        const bool local_differs = g.score != O.score || g.tle != O.tle ||
+                                   g.qle != O.qle || g.max_off != O.max_off;
+        const bool toend_observable = g.gscore > 0 || O.gscore > 0;
+        const bool toend_differs = toend_observable &&
+                                   (g.gscore != O.gscore || g.gtle != O.gtle);
+        if (local_differs || toend_differs) {
+            if (diffs < 5) {
+                MESSAGE("  len1=" << g.len1 << " len2=" << g.len2 << " h0=" << g.h0
+                        << " | vec " << g.score << "/" << g.tle << "/" << g.gtle << "/"
+                        << g.qle << "/" << g.gscore << "/" << g.max_off
+                        << " | scalar " << O.score << "/" << O.tle << "/" << O.gtle << "/"
+                        << O.qle << "/" << O.gscore << "/" << O.max_off);
+            }
+            diffs++;
+        }
+    }
+    return diffs;
+}
+
+} // namespace
+
+TEST_CASE("bandedSWA 8-bit per-lane band clamp matches the scalar reference") {
+    // Scoring sets straddling the wrap boundary in both directions. The `wrap`
+    // sets are the ones that reproduced the bug: they make
+    // qlen*max_sc + end_bonus - o negative for the shortest generated query.
+    struct Case { int a, o, e, b, end_bonus, minq, maxq; const char *label; };
+    const Case cases[] = {
+        {1,  6, 1, 4,  5, 10, 120, "bwa defaults"},
+        {1, 16, 1, 4,  5, 10, 120, "-O16 (wrap)"},
+        {1, 16, 1, 9,  5, 10, 120, "-B9 -O16 (wrap)"},
+        {1, 16, 3, 9,  5, 10, 120, "-B9 -O16 -E3 (wrap)"},
+        {1,  6, 1, 4,  0,  1, 120, "-O6 -L0 short query (wrap, DEFAULT -O)"},
+        {1,  6, 1, 4,  0,  3, 120, "-O6 -L0 minq=3 (wrap, DEFAULT -O)"},
+        {1, 16, 1, 4, 20, 10, 120, "-O16 large end bonus (no wrap)"},
+        {1, 16, 1, 4,  5, 15, 120, "-O16 longer queries (no wrap)"},
+        {2,  6, 1, 8,  5, 10, 120, "-A2 (max_sc factor)"},
+        {5,  6, 1, 20, 5, 10,  60, "-A5 (max_sc factor)"},
+    };
+
+    for (const Case &c : cases) {
+        INFO("scoring set: " << c.label);
+        long checked = 0;
+        const long diffs = trial(c.a, c.b, c.o, c.e, 100, 100, c.end_bonus,
+                                 c.minq, c.maxq, 8000, &checked);
+        // A trial that admitted nothing would pass vacuously.
+        CHECK(checked > 0);
+        CHECK(diffs == 0);
+    }
+}
+
+#endif // HAVE_BSW_VECTOR_8_16


### PR DESCRIPTION
## What

`scalarBandedSWA` narrows the band before the DP loop ("adjust `$w` if it is too large"):

```c
max_ins = max(1, (qlen*max_sc + end_bonus - o_ins)/e_ins + 1)
max_del = max(1, (qlen*max_sc + end_bonus - o_del)/e_del + 1)
w       = min(w, max_ins, max_del)
```

All three vector wrappers computed that same quantity in 8-bit SIMD:

```c
__m128i sum128 = _mm_add_epi8(qlen128, eb_ins128);   // int8 add, eb_ins = end_bonus - o_ins
_mm_store_si128((__m128i *) temp, sum128);           // temp is uint8_t[]
double val = temp[l]/e_ins + 1.0;                    // read back UNSIGNED
```

Whenever `qlen*max_sc + end_bonus - o` is **negative**, the int8 add wraps, the byte reads back near 255, the clamp evaluates to ~256 and effectively disappears. The kernel then runs the full band `w` where the scalar runs a band as narrow as **1** — exploring cells the scalar never visits and returning a different `gscore`/`gtle`. `score`, `tle`, `qle` and `max_off` happen to agree, which is why the existing gates did not catch it.

Two further defects in the same expression: the multiply by `max_sc` was missing (which narrows the clamp whenever `-A > 1`), and `bsize` was mutated inside the lane loop.

## Reachability

The wrap condition is exactly **`qlen*max_sc + end_bonus < o`**. That is not exotic — at the default `-O 6` it fires for any short extension once the end bonus is small (`1 + 0 - 6 < 0`). It was found by sweeping scoring parameters; the pairs involved are admitted by the current `bsw8_envelope_ok`, so this is reachable today.

Confined to the query-end fields, so it affects to-end alignment decisions (soft-clip vs extend-to-end, the `gscore`-based branches in `mem_reg2aln`), not the primary local score or its coordinates. Silent: no assert, no warning.

## Fix

Compute the clamp in wide `int` per lane, mirroring the scalar exactly, including `* max_sc`. The enclosing loop was already scalar per-lane, so the SIMD add bought nothing — this is both simpler than the code it replaces and free, being per-batch over `SIMD_WIDTH8` lanes rather than per-cell. Applied to all three wrappers (128 / 256 / 512).

## Validation

| check | parent commit | this PR |
|---|---|---|
| `test_bandedswa_band_clamp` (10 scoring sets) | **FAIL — 21 mismatches** | **PASS** |
| …of which at the default `-O 6` | 6 | 0 |
| sw-kernel-bench golden, 8-bit | PASS | **PASS — byte-identical** |
| sw-kernel-bench golden, 8-bit `--n-pct 10` | PASS | **PASS — byte-identical** |
| sw-kernel-bench golden, 16-bit | PASS | **PASS — byte-identical** |
| `bandedswa_highzdrop_seed_test` | OK | OK |
| `bandedswa_padding_test` | OK | OK |
| `kswv_nrow_zero_test`, `kswv_freed_cell_test` | OK | OK |

Byte-identical at default scoring — the clamp evaluates the same either way there — so no output change for standard invocations.

## Notes for review

- The new test lives in `test/unit/`, so it runs on **every CI matrix row**: the x86 SSE4.1 (128-bit) and AVX2 (256-bit) wrappers are covered alongside NEON. The AVX-512 wrapper is fixed identically but **no CI runner exercises it** — that path is unvalidated by this PR.
- The test compares the local-alignment fields unconditionally and `gscore`/`gtle` only when either side reports `gscore > 0`, matching the kernel's documented query-end contract and `bandedswa_zdrop_eweight_test`. Widening the band to match the scalar *increases* the benign `gscore ∈ {0,-1}` tail; those cases select the same `gscore <= 0` branch in `bwamem.cpp` and cannot reach a SAM record.
- Suggested reading order: the `bandedSWA.cpp` hunk in `smithWatermanBatchWrapper8` (128-bit) carries the full rationale; the 256/512 hunks are the same change with a back-reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 8-bit banded alignment band clamping to avoid overflow/wrapping behavior that could incorrectly weaken constraints.
  * Restored consistent per-lane clamping across AVX2, AVX-512BW, and SSE2/NEON acceleration paths.
  * Improved agreement between vectorized and scalar alignment scoring behavior, especially near clamp boundaries.

* **Tests**
  * Added a regression test to verify vector results match the scalar reference for edge cases around band admission/clamping.
  * Coverage includes multiple scoring configurations and deterministic randomized inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->