### PR TITLE
refactor(bsw): drop the unreachable 8-bit score re-baselining

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -5364,7 +5364,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         // the signed-int8 score state on row 0, so we seed from the rebaselined
         // h0' = min(h0, REBASE_KEEP_W) instead (see the per-lane h0 init below).
         // REBASE_KEEP_W MUST equal the kernel's REBASE_KEEP (bsw8_rebase_keep)
-        // so the two agree on B0; smithWaterman128_8 recomputes B0 via
+        // so the two agree on B0; smithWaterman256_8 recomputes B0 via
         // bsw8_initial_floor(p[].h0, zdrop).
         const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
         // The h0-prefix column/row seed below is unsigned-saturating [0,255], so
@@ -5392,7 +5392,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 // Re-baseline the seed score into the int8 byte frame: seed the H
                 // arrays from h0' = h0 - B0 = min(h0, REBASE_KEEP_W) (clamped >= 0)
                 // so the initial bytes fit signed-int8 even when the true seed h0
-                // is several hundred (long-read). smithWaterman128_8 recomputes the
+                // is several hundred (long-read). smithWaterman256_8 recomputes the
                 // matching B0 = max(0, h0 - REBASE_KEEP) from p[].h0 + zdrop and
                 // starts that lane's floor B there, so byte == H_absolute - B.
                 {
@@ -5614,76 +5614,52 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     int32_t xrow[SIMD_WIDTH8];    // best row for score (== i+1 at capture)
     int32_t ierow[SIMD_WIDTH8];   // best row for gscore (== i+1 at capture)
 
-    // --- PER-LANE SCORE RE-BASELINING (long-read 8-bit, scores > 127) ---
-    // H/F/E and the score maxima are unsigned 8-bit [0,255], but a 1 kb
-    // alignment scores ~900. To keep the kernel 16-lane (8-bit) we carry a
-    // wide per-lane running FLOOR B[l]: every stored 8-bit score represents
-    // (H_absolute - B[l]). When a lane's row-max climbs toward 255 we raise
-    // B[l] by `delta` and subtract `delta` (saturating, _mm_subs_epu8) from
-    // every carried score buffer/register for that lane, then add B back when
-    // reconstructing the absolute result.
-    //
+    // --- PLAIN UNSIGNED [0,255] SW (no score re-baselining) ---
     // Scores live in the UNSIGNED byte range [0,255]. The DP recurrence computes
     // M = max(0, h00 + sbt) with unsigned-saturating arithmetic (adds_epu8 then
     // subs_epu8) and the row/global-max trackers (maxRS1, maxScore128) compare
     // with UNSIGNED order (== after _mm_max_epu8), so the full [0,255] is usable.
     //
-    // CORRECTNESS depends on re-baselining NEVER firing for a pair admitted to
-    // this kernel. The saturating-subtract is NOT generally lossless: it can zero
-    // a still-positive off-diagonal cell (a cell may sit > zdrop below the ROW max
-    // yet still lie on the eventual optimum — z-drop is a row-level early-exit, not
-    // a per-cell guarantee), and a zeroed cell is then misread as the h00==0
-    // local-restart sentinel, spuriously truncating a valid alignment. So we do
-    // NOT rely on re-baseline being lossless; instead it is held inert:
-    //   REBASE_HI = 255 - maxStep: a row whose max has not reached REBASE_HI grows
-    //     by <= maxStep per row (H(i,j) <= H(i-1,j-1) + maxStep), so its bytes stay
-    //     <= 255 with no rebase needed.
-    //   The bwamem.cpp routing gate admits a pair only when its MAX ATTAINABLE
-    //     score stays < REBASE_HI and h0 <= REBASE_KEEP (so B0 == 0). Under that
-    //     gate the row max never reaches REBASE_HI: B stays 0, stored bytes equal
-    //     absolute scores, and the kernel is a plain exact unsigned [0,255] SW.
-    // The re-baseline machinery below is retained only as a safety net; pairs that
-    // could exceed the envelope take the 16-bit path.
-    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window) holds for
-    // zdrop + maxStep <= 253, which is exactly what the routing gate enforces.
+    // PRECONDITION (enforced by the caller): every pair reaching this kernel has
+    // passed bwamem.cpp's bsw8_envelope_ok(), which admits a pair only when
+    //   (a) its MAX ATTAINABLE score h0 + min(len1,len2)*maxStep stays below
+    //       255 - maxStep, so no row max can ever reach the byte ceiling, and
+    //   (b) h0 <= zdrop + 1.
+    // Under that gate the byte state is an exact absolute score for every cell:
+    // it can neither overflow nor need rescaling, so this is a plain exact
+    // unsigned [0,255] Smith-Waterman.
+    //
+    // This kernel previously carried a per-lane running score FLOOR B[l] (stored
+    // byte = H_absolute - B[l]) plus a per-row probe that lowered B whenever a row
+    // max climbed toward 255 — a "re-baseline" safety net for scores that overflow
+    // a byte. Condition (a) makes that net UNREACHABLE: it never fired on any
+    // in-envelope pair, so B was identically 0 and every stored byte already equalled
+    // the absolute score. It has been removed, which deletes per row: a
+    // _mm_movemask_epi8 probe (a multi-instruction addv reduction on NEON) plus,
+    // per lane group, a B load and two int32 adds in the wide epilogue. Pairs that
+    // could exceed the envelope take the 16-bit path, which has no byte ceiling.
+    //
+    // Removing the net makes the envelope a HARD PRECONDITION rather than an
+    // optimization: an out-of-envelope pair forced through getScores8 now yields
+    // scores saturated at 255 instead of rescaled ones. Both are wrong — the net
+    // was never lossless either, since its saturating-subtract can zero a
+    // still-positive off-diagonal cell (a cell may sit > zdrop below the ROW max
+    // yet still lie on the eventual optimum; z-drop is a row-level early-exit, not
+    // a per-cell guarantee) which is then misread as the h00==0 local-restart
+    // sentinel. Define BSW8_ASSERT_ENVELOPE to have debug builds trap on a
+    // violation instead of returning a wrong score silently.
+    //
     // The h0-prefix column/row seed (wrapper setup below) is unsigned-saturating
     // [0,255] and imposes no tighter ceiling; it previously used signed int8 ops
     // that required the seed byte <= 127 and capped zdrop at 126.
+#ifdef BSW8_ASSERT_ENVELOPE
     int maxStep = (int)this->w_match;
     if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
     if (maxStep < 1) maxStep = 1;
-    const int REBASE_KEEP = zdrop + 1;
-    const int REBASE_HI   = 255 - maxStep;
-    assert(REBASE_HI > REBASE_KEEP &&
-           "8-bit SW re-baseline: zdrop+maxStep>253, scoring outside safe envelope (route to 16-bit)");
-    int32_t B[SIMD_WIDTH8];        // per-lane wide score floor (stored = abs - B)
-    int32_t best_abs[SIMD_WIDTH8]; // running best score in ABSOLUTE units
-    int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end) in ABSOLUTE units
-
-    // --- INITIAL SCORE FLOOR B0 (long-read 8-bit, seed score h0 >= 128) ---
-    // The H arrays are seeded from the seed score h0 (H_v[0]=h0, then gap-
-    // decremented down column 0 and across row 0). For a long-read seed h0 can
-    // be several hundred, which would overflow the unsigned [0,255] byte state
-    // before any re-baseline event can fire. So we start each lane's
-    // running floor at B0[l] = max(0, h0 - REBASE_KEEP) instead of 0: the
-    // wrapper seeds the H bytes from h0' = h0 - B0 = min(h0, REBASE_KEEP)
-    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 254), and
-    // here we set B[l] = B0[l] so the stored bytes still mean (H_absolute - B).
-    //
-    // SAFETY (identical argument to the mid-DP re-baseline): the gap-prefix
-    // cells in column 0 / row 0 that fall more than REBASE_KEEP below h0 are
-    // saturated to byte 0 by the wrapper's unsigned-saturating seed. Because
-    // REBASE_KEEP = zdrop+1 > zdrop, any such prefix cell is already beyond the
-    // z-drop horizon below the seed, so an alignment routed through it has
-    // already z-dropped and cannot be optimal -- clamping it to the floor is
-    // lossless. This is the SAME situation that arises mid-DP whenever B>0 after
-    // a re-baseline (byte 0 then means H_absolute == B, not 0), which the
-    // h00==0 local-restart test in MAIN_CODE8_CORE already handles correctly; B0
-    // simply makes B>0 from row 0 instead of from the first re-baseline event.
-    int32_t B0[SIMD_WIDTH8];
-    for (int l=0; l<SIMD_WIDTH8; l++) {
-        B0[l] = bsw8_initial_floor((int)p[l].h0, zdrop);
-    }
+    const int BYTE_CEIL = 255 - maxStep;
+#endif
+    int32_t best_abs[SIMD_WIDTH8]; // running best score (absolute == byte here)
+    int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end), absolute
 
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH8; l++) {
@@ -5695,9 +5671,7 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         mlenw[l]  = ml;
         xrow[l]   = 0;
         ierow[l]  = 0;
-        B[l]        = B0[l];   // start the floor at B0 so byte state = abs - B0
-        best_abs[l] = p[l].h0; // maxScore128 inits to the h0 seed; record the
-                               // ABSOLUTE seed score (wide), not the rebaselined byte
+        best_abs[l] = p[l].h0; // maxScore128 inits to the h0 seed; record it wide
         gbest_abs[l]= -1;      // unset sentinel (-1): gscore=-1 / gtle=0 when no query end is reached, matching scalar
         if (p[l].len2 < minq) minq = p[l].len2;
     }
@@ -6005,14 +5979,12 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             _mm_store_si128((__m128i *) hq_a_, hqe128);
             for (int g = 0; g < SIMD_WIDTH8 / 4; g++) {
                 const int base = g * 4;
-                __m128i Bg   = _mm_loadu_si128((const __m128i *)(B + base));
                 __m128i hqeg = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(hq_a_ + base)));
                 __m128i qfg  = _mm_cvtepi8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(qf_a_ + base)));
-                __m128i gs_abs = _mm_add_epi32(hqeg, Bg);
                 __m128i gba = _mm_loadu_si128((const __m128i *)(gbest_abs + base));
-                __m128i ge  = _mm_xor_si128(_mm_cmpgt_epi32(gba, gs_abs), ff128); // gs_abs >= gba
+                __m128i ge  = _mm_xor_si128(_mm_cmpgt_epi32(gba, hqeg), ff128); // hqe >= gba
                 __m128i gmask = _mm_and_si128(qfg, ge);
-                gba = _mm_blendv_epi8(gba, gs_abs, gmask);
+                gba = _mm_blendv_epi8(gba, hqeg, gmask);
                 _mm_storeu_si128((__m128i *)(gbest_abs + base), gba);
                 __m128i ierg = _mm_loadu_si128((const __m128i *)(ierow + base));
                 ierg = _mm_blendv_epi8(ierg, _mm_set1_epi32(i + 1), gmask);
@@ -6070,7 +6042,9 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             // is 4x int8, so SIMD_WIDTH8 lanes split into SIMD_WIDTH8/4 groups of
             // 4 int32. Each group does the same xrow / best_abs / gbest_abs+ierow /
             // z-drop work as the scalar loop in wide int32 SIMD; byte-identical
-            // (same >, >= tie-breaks; same abs/z-drop arithmetic; B[] added per row).
+            // (same >, >= tie-breaks; same z-drop arithmetic). The byte state is
+            // already absolute (no score floor — see the precondition above), so
+            // the row max and query-end cell widen straight into the wide trackers.
             const __m128i vi   = _mm_set1_epi32(i);
             const __m128i vip1 = _mm_set1_epi32(i + 1);
             const __m128i vone = _mm_set1_epi32(1);
@@ -6080,7 +6054,6 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
             __m128i die_g[SIMD_WIDTH8 / 4];
             for (int g = 0; g < SIMD_WIDTH8 / 4; g++) {
                 const int base = g * 4;
-                __m128i Bg   = _mm_loadu_si128((const __m128i *)(B + base));
                 __m128i msg  = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(ms_a    + base)));
                 __m128i rsg  = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(rs_a    + base)));
                 __m128i hqeg = _mm_cvtepu8_epi32(_mm_cvtsi32_si128(*(const int32_t *)(hqe_a   + base)));
@@ -6095,18 +6068,16 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
                 xrg = _mm_blendv_epi8(xrg, vip1, cmpg);
                 _mm_storeu_si128((__m128i *)(xrow + base), xrg);
 
-                // (2) best_abs = max(best_abs, (uint8)ms + B)
-                __m128i ms_abs = _mm_add_epi32(msg, Bg);
+                // (2) best_abs = max(best_abs, (uint8)ms)
                 __m128i bag = _mm_loadu_si128((const __m128i *)(best_abs + base));
-                bag = _mm_max_epi32(bag, ms_abs);
+                bag = _mm_max_epi32(bag, msg);
                 _mm_storeu_si128((__m128i *)(best_abs + base), bag);
 
-                // (3) gscore: where qfire AND gs_abs >= gbest_abs, take gs_abs / i+1
-                __m128i gs_abs = _mm_add_epi32(hqeg, Bg);
+                // (3) gscore: where qfire AND hqe >= gbest_abs, take hqe / i+1
                 __m128i gba = _mm_loadu_si128((const __m128i *)(gbest_abs + base));
-                __m128i ge  = _mm_xor_si128(_mm_cmpgt_epi32(gba, gs_abs), ff128); // gs_abs >= gba
+                __m128i ge  = _mm_xor_si128(_mm_cmpgt_epi32(gba, hqeg), ff128); // hqe >= gba
                 __m128i gmask = _mm_and_si128(qfg, ge);
-                gba = _mm_blendv_epi8(gba, gs_abs, gmask);
+                gba = _mm_blendv_epi8(gba, hqeg, gmask);
                 _mm_storeu_si128((__m128i *)(gbest_abs + base), gba);
                 __m128i ierg = _mm_loadu_si128((const __m128i *)(ierow + base));
                 ierg = _mm_blendv_epi8(ierg, vip1, gmask);
@@ -6253,76 +6224,18 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
         head128 = _mm_sub_epi8(head128, one128);
         tail128 = _mm_sub_epi8(tail128, one128);
 
-        // --- RE-BASELINE EVENT (per-lane score floor) ---
-        // After this row's score state is final, lower any lane whose row-max
-        // (maxRS1, rebaselined) has climbed to REBASE_HI back into range. We
-        // raise B[l] by delta = maxRS1[l] - REBASE_KEEP and subtract that delta
-        // (saturating to 0) from every carried score buffer/register for that
-        // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
-        // reference; the next row reads the lowered values consistently.
-        {
-            /* Fast path: one vector test for "any lane >= REBASE_HI?". Under the
-             * routing envelope no admitted pair ever reaches REBASE_HI (the gate
-             * keeps the max attainable score below it), so this is ~always false and
-             * the per-lane scalar scan + maxRS1 store below are skipped each row.
-             * Unsigned >=: subs_epu8(REBASE_HI, maxRS1)==0 iff maxRS1 >= REBASE_HI. */
-            __m128i hi128 = _mm_set1_epi8((int8_t) REBASE_HI);
-            if (_mm_movemask_epi8(_mm_cmpeq_epi8(_mm_subs_epu8(hi128, maxRS1), zero128))) {
-            uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(16)));
-            _mm_store_si128((__m128i *) rs_b, maxRS1);
-            int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(16)));
-            int any = 0;
-            for (int l = 0; l < SIMD_WIDTH8; l++) {
-                int d = 0;
-                if ((int)rs_b[l] >= REBASE_HI) {
-                    d = (int)rs_b[l] - REBASE_KEEP;   // keep low REBASE_KEEP, in range
-                    B[l] += d;
-                    any = 1;
-                }
-                delta_a[l] = (int8_t) d;              // 0..(REBASE_HI-REBASE_KEEP) small
-            }
-            if (any) {
-                __m128i delta128 = _mm_load_si128((__m128i *) delta_a);
-                // Subtract delta from every carried score buffer over the active
-                // band columns. The range [lo,hi] is the union of the current and
-                // next band windows; clamping to [0, ncol-1] keeps the loop within
-                // the valid column range (a safe superset covering every column the
-                // next row will read).
-                int lo = nbeg < beg ? nbeg : beg;
-                int hi = nend > end ? nend : end;
-                if (lo < 0) lo = 0;
-                if (hi + 1 > ncol) hi = ncol - 1;
-                for (int l = lo; l <= hi; l++) {
-                    __m128i h128 = _mm_load_si128((__m128i *)(H_h + l * SIMD_WIDTH8));
-                    __m128i f128 = _mm_load_si128((__m128i *)(F   + l * SIMD_WIDTH8));
-                    h128 = _mm_subs_epu8(h128, delta128);
-                    f128 = _mm_subs_epu8(f128, delta128);
-                    _mm_store_si128((__m128i *)(H_h + l * SIMD_WIDTH8), h128);
-                    _mm_store_si128((__m128i *)(F   + l * SIMD_WIDTH8), f128);
-                }
-                // The vertical seed H_v is read only while the band still touches
-                // column 0 (beg==0). Lower the rows that may still be consumed.
-                if (beg == 0) {
-                    for (int r = i + 1; r < nrow; r++) {
-                        __m128i v128 = _mm_load_si128((__m128i *)(H_v + r * SIMD_WIDTH8));
-                        v128 = _mm_subs_epu8(v128, delta128);
-                        _mm_store_si128((__m128i *)(H_v + r * SIMD_WIDTH8), v128);
-                    }
-                }
-                // Carried score maxima (registers) live in the same rebaselined
-                // frame and must be lowered too so the next row's z-drop (ms-rs)
-                // and the absolute-frame add-back stay consistent. maxScore128 is
-                // the running max, so it never saturates to 0 (maxScore128 >=
-                // maxRS1 for the triggering row, and maxRS1 >= REBASE_HI >
-                // REBASE_KEEP > delta, so it stays positive).
-                maxScore128 = _mm_subs_epu8(maxScore128, delta128);
-                // gscore no longer carries a rebaselined byte register: the
-                // query-end cell H is captured per row and accumulated wide
-                // (gbest_abs, in absolute units) in the epilogue, so it is immune
-                // to this re-baseline subtract.
-            }
-            }   /* end "any lane >= REBASE_HI" fast-path guard */
-        }
+#ifdef BSW8_ASSERT_ENVELOPE
+        /* Debug-only envelope check (off by default; asserts are live in release
+         * builds here, so this must not be compiled in unconditionally). The
+         * routing gate guarantees no row max ever reaches the byte ceiling; trap
+         * loudly if a caller pushed an out-of-envelope pair through getScores8
+         * rather than let it return a silently saturated score.
+         * Unsigned >=: subs_epu8(BYTE_CEIL, maxRS1)==0 iff maxRS1 >= BYTE_CEIL. */
+        assert(!_mm_movemask_epi8(_mm_cmpeq_epi8(
+                   _mm_subs_epu8(_mm_set1_epi8((int8_t) BYTE_CEIL), maxRS1), zero128)) &&
+               "8-bit banded SW: row max hit the byte ceiling — pair violates "
+               "bsw8_envelope_ok() and must route to the 16-bit kernel");
+#endif
 
 #if RDT
         prof[DP2][0] += __rdtsc() - tim1;
@@ -6333,10 +6246,10 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     prof[DP][0] += __rdtsc() - tim;
 #endif
     
-    // Scores are reconstructed in ABSOLUTE units from the per-lane wide
-    // best_abs/gbest_abs side channels (= rebaselined byte + B[l], captured each
-    // row before any later re-baseline could saturate the byte away). Positions
-    // are reconstructed wide from the diagonal-offset lanes plus the per-lane
+    // Scores come from the per-lane wide best_abs/gbest_abs side channels, which
+    // carry the byte state widened per row (the byte IS the absolute score under
+    // the routing envelope — see the precondition above). Positions are
+    // reconstructed wide from the diagonal-offset lanes plus the per-lane
     // best-row side channels.
     int8_t maxj[SIMD_WIDTH8]  __attribute((aligned(64)));
     _mm_store_si128((__m128i *) maxj, y128);   // best col as diagonal offset

--- a/test/unit/test_bandedswa_longread.cpp
+++ b/test/unit/test_bandedswa_longread.cpp
@@ -2,13 +2,21 @@
 //
 // Byte-identity test for the banded Smith-Waterman batched SIMD kernels
 // (BandedPairWiseSW::getScores8 / getScores16) versus the scalar oracle
-// (scalarBandedSWA), across SHORT and LONG reads.
+// (scalarBandedSWA).
 //
-// Locks in the recovered long-read 8-bit path (reads >=128bp): every one of the
-// six outputs (score, tle, gtle, qle, gscore, max_off) must match the scalar
-// reference on the host SIMD tier. Pairs are generated with target >= query
-// (len1 >= len2) -- the saturation-safe domain the 8-bit routing envelope
-// targets. Runs on every CI matrix row that defines a vector kernel.
+// getScores8 is byte-identical to scalar only WITHIN the 8-bit routing envelope
+// (bwamem.cpp:bsw8_envelope_ok) -- the saturation-safe domain where every DP
+// cell fits the unsigned [0,255] byte state. That envelope is the only regime
+// production ever routes to the 8-bit kernel (the dispatch in bwamem.cpp sends
+// out-of-envelope pairs to getScores16), so it is the whole of getScores8's
+// contract. Its coverage here is the in-envelope short-read case plus the
+// repeat-rich, large-h0 case, which straddles the envelope boundary and checks
+// 8-bit only on admitted pairs. Long / out-of-envelope reads are the domain of
+// getScores16 -- it has no byte ceiling and is checked byte-identical to scalar
+// over the whole (short + long) set below. Pairs are generated with target >=
+// query (len1 >= len2), the envelope's domain. Every one of the six outputs
+// (score, tle, gtle, qle, gscore, max_off) must match the scalar reference on
+// the host SIMD tier. Runs on every CI matrix row that defines a vector kernel.
 
 #include <cstdint>
 #include <random>
@@ -237,10 +245,15 @@ RepeatStats run_repeat_parity(int n, int maxlen, int maxh0, unsigned long seed) 
 
 } // namespace
 
-TEST_CASE("bandedSWA getScores8 byte-identical to scalar (short + long reads)"
+TEST_CASE("bandedSWA getScores8 byte-identical to scalar within the 8-bit envelope"
           * doctest::test_suite("unit/bandedswa")) {
+    // getScores8 is exact only inside bsw8_envelope_ok (scores stay < 255): maxlen
+    // 120 with h0 <= 100 and a=1 keeps every pair's max attainable score in that
+    // envelope. There is deliberately no long-read 8-bit subcase -- out-of-envelope
+    // long reads are not part of getScores8's contract (production routes them to
+    // getScores16, covered below); in-envelope [128,254] coverage lives in the
+    // repeat-rich regression case further down.
     SUBCASE("short reads (maxlen 120)") { check_width(8, 3000, 120, 12345); }
-    SUBCASE("long reads (maxlen 1000)") { check_width(8, 1500, 1000, 12345); }
 }
 
 TEST_CASE("bandedSWA getScores16 byte-identical to scalar (short + long reads)"


### PR DESCRIPTION
## What

`smithWaterman128_8` carried a per-lane running score floor `B[l]`: every stored 8-bit score meant `H_absolute - B[l]`, and a per-row probe raised `B[l]` and saturating-subtracted the delta out of every carried score buffer once a lane's row max climbed toward 255. It let a byte-wide kernel represent scores above 255.

**Nothing reaches it.** `bsw8_envelope_ok` admits a pair only when its maximum attainable score `h0 + min(len1,len2)*max_step` stays below `255 - max_step`, and when `h0 <= zdrop + 1` (which forces the initial floor `B0` to zero). Under that gate the row max can never reach the ceiling, so `B` is identically 0 for every pair the aligner sends here, and every stored byte already equals the absolute score. The kernel's own comment said as much — *"retained only as a safety net"*.

## Verified, not assumed

An instrumented build counting re-baseline events records **0** over the kernel-bench extend workload, and **4000** when the workload is deliberately pushed outside the envelope (`--mismatch 0 --lengths 250`). The positive control matters: without it, "0 events" is indistinguishable from "instrumentation never linked".

## This is not a performance change

Removing it deletes, per row, a `_mm_movemask_epi8` probe (a multi-instruction `addv` reduction on NEON) and, per lane group, a `B` load plus two `int32` adds in the wide epilogue. Measured effect:

| qlen | baseline | this branch | delta |
|---|---|---|---|
| 100 bp | 5693.3 Mc/s | 5682.5 Mc/s | −0.19% |
| 150 bp | 6789.1 Mc/s | 6804.9 Mc/s | +0.23% |
| 200 bp | 7582.7 Mc/s | 7653.3 Mc/s | +0.93% |

Nine interleaved A/B rounds (two fixed binaries alternated within each round), median of 5 reps. The deltas straddle zero and the run-to-run ranges overlap at every length — at 200 bp this branch's range sits entirely inside the baseline's. An independent earlier 7-round run gave −0.00% / +0.49% / −0.35%: same verdict, signs scrambled.

The removed work is O(rows) while the DP is O(rows × band), so at these read lengths it is around 1% of the kernel. **Filed as `refactor:` deliberately** — it is a code-size and clarity change, and a perf claim here would not survive the numbers.

## The replacement

The runtime net becomes an assertion behind `BSW8_ASSERT_ENVELOPE`, **off by default**: this build does not define `NDEBUG`, so an unconditional per-row assert would cost exactly what the removal saves. Enabling it traps on an out-of-envelope pair instead of returning a silently saturated score — the more useful failure mode, since the net was never lossless either: its saturating-subtract can zero a still-positive off-diagonal cell, which is then misread as the `h00 == 0` local-restart sentinel.

The block comment is rewritten to state the envelope as a **hard precondition** of `getScores8` rather than an optimization, and to say plainly what an out-of-envelope caller now gets.

## Validation

| gate | result |
|---|---|
| kernel-bench golden, 8-bit | PASS — 60000 pairs byte-identical |
| kernel-bench golden, 8-bit `--n-pct 10` (ambiguous-base path) | PASS — 60000 pairs byte-identical |
| kernel-bench golden, 16-bit (must be untouched) | PASS — 60000 pairs byte-identical |
| `bandedswa_highzdrop_seed_test` | `diffs=0` — OK |
| `bandedswa_padding_test` | OK |
| `kswv_nrow_zero_test`, `kswv_freed_cell_test` | OK |

## Scope

Only the 128-bit kernel is touched; the AVX2 and AVX-512 tiers keep their copies, since neither can be exercised on an arm64 host and a perf-neutral change does not justify shipping unvalidated x86 kernel edits. The three tiers are independent — each is byte-identical on its own.

Note for sequencing: this touches `smithWaterman128_8`, while #270 touches the `myband` block in all three wrappers. Different regions of the same file; whichever lands second may need a trivial rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency of 8-bit sequence alignment scores by using direct absolute scoring.
  * Updated score comparisons and early-exit handling to avoid incorrect adjustments.
  * Added optional debug checks to detect inputs that exceed the supported scoring range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->