### PR TITLE
fix(bsw): correct 8-bit banded-SW z-drop and seed clamp at high seed scores (all tiers)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ ifneq ($(strip $(DISABLE_BATCHED_MATESW)),)
     CPPFLAGS += -DDISABLE_BATCHED_MATESW=$(DISABLE_BATCHED_MATESW)
 endif
 
-.PHONY:all myall arm64 clean depend single all-single print-mimalloc-config kswv_nrow_zero_test kswv_freed_cell_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test kt_for_pool_test test test-injection FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean docs docs-serve docs-cli docs-clean docs-install-tools
+.PHONY:all myall arm64 clean depend single all-single print-mimalloc-config kswv_nrow_zero_test kswv_freed_cell_test bandedswa_padding_test bandedswa_highzdrop_seed_test bandedswa_high_h0_zdrop_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test kt_for_pool_test test test-injection FORCE pgo-generate pgo-use pgo-clean profile-build profile-clean lto-build lto-clean docs docs-serve docs-cli docs-clean docs-install-tools
 .SUFFIXES:.cpp .o
 
 .cpp.o:
@@ -607,6 +607,13 @@ bandedswa_padding_test: $(BWA_LIB) $(HTS_LIB) src/bandedSWA.native.o test/banded
 bandedswa_highzdrop_seed_test: $(BWA_LIB) $(HTS_LIB) src/bandedSWA.native.o test/bandedswa_highzdrop_seed_test.o
 	$(CXX) $(BASE_CXXFLAGS) -march=native $(LDFLAGS) test/bandedswa_highzdrop_seed_test.o src/bandedSWA.native.o $(BWA_LIB) $(LIBS) -o $@
 
+# High-h0 / small-zdrop z-drop regression: getScores8 vs scalar with the seed
+# score h0 above zdrop+1 at small zdrop (the region a relaxed 8-bit routing
+# envelope would newly admit), where the z-drop drift's unset-best sentinel used
+# to fire the z-drop one row early.
+bandedswa_high_h0_zdrop_test: $(BWA_LIB) $(HTS_LIB) src/bandedSWA.native.o test/bandedswa_high_h0_zdrop_test.o
+	$(CXX) $(BASE_CXXFLAGS) -march=native $(LDFLAGS) test/bandedswa_high_h0_zdrop_test.o src/bandedSWA.native.o $(BWA_LIB) $(LIBS) -o $@
+
 # Build the test binaries with the same ARCH_FLAGS as libbwa.a so the
 # test binary's kswv.h preprocessor state (SIMD_WIDTH8, BWA_TESTS_HAVE_KSWV)
 # matches what libbwa.a was compiled with. Consumed by ci.yml so that e.g.
@@ -708,13 +715,14 @@ test/shm_pack_round_trip_test.o: test/shm_pack_round_trip_test.cpp
 # Note: depends on `bwa-mem3` so version_banner.sh has a binary to grep —
 # previously `test:` only built the test harness binaries, not the main
 # executable.
-test: test-binaries kswv_nrow_zero_test kswv_freed_cell_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_lock_destroy_test kt_for_pool_test bwa-mem3
+test: test-binaries kswv_nrow_zero_test kswv_freed_cell_test bandedswa_padding_test bandedswa_highzdrop_seed_test bandedswa_high_h0_zdrop_test shm_section_find_test shm_lock_destroy_test kt_for_pool_test bwa-mem3
 	./test/bwa_mem3_tests_unit
 	./test/bwa_mem3_tests_integration
 	./kswv_nrow_zero_test
 	./kswv_freed_cell_test
 	./bandedswa_padding_test
 	./bandedswa_highzdrop_seed_test
+	./bandedswa_high_h0_zdrop_test
 	./shm_section_find_test
 	./kt_for_pool_test
 	./shm_lock_destroy_test
@@ -743,6 +751,9 @@ test/bandedswa_padding_test.o: test/bandedswa_padding_test.cpp
 	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 test/bandedswa_highzdrop_seed_test.o: test/bandedswa_highzdrop_seed_test.cpp
+	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
+
+test/bandedswa_high_h0_zdrop_test.o: test/bandedswa_high_h0_zdrop_test.cpp
 	$(CXX) -c $(BASE_CXXFLAGS) -march=native $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 test/shm_section_find_test.o: test/shm_section_find_test.cpp

--- a/Makefile
+++ b/Makefile
@@ -844,7 +844,7 @@ $(ZLIBNG_LIB):
 	cd $(ZLIBNG_BUILD) && cmake $(ZLIBNG_CMAKE_FLAGS) .. && $(MAKE)
 
 clean: pgo-clean profile-clean lto-clean
-	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test kswv_freed_cell_test bandedswa_padding_test bandedswa_highzdrop_seed_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test kt_for_pool_test bwa-mem3.arm64
+	rm -fr src/*.o src/version.h test/*.o $(BWA_LIB) $(EXE) kswv_nrow_zero_test kswv_freed_cell_test bandedswa_padding_test bandedswa_highzdrop_seed_test bandedswa_high_h0_zdrop_test shm_section_find_test shm_pack_round_trip_test shm_lock_destroy_test kt_for_pool_test bwa-mem3.arm64
 	rm -f $(LIBSAIS_OBJS)
 	rm -f src/*.gcno src/*.gcda
 	$(MAKE) -C test clean

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -162,21 +162,13 @@ static inline void build_amat16(int8_t out[16], const int8_t *mat)
 template <typename T>
 static inline T effective_threads(T n) { return n < 1 ? T(1) : n; }
 
-// ---------------------------------------------------------------------------
-// 8-bit re-baseline floor helpers (shared by wrapper + every SIMD kernel tier)
-//
-// Initial 8-bit score floor: keep the seed score h0 inside the re-baseline
-// keep-window so the stored byte (= H_abs - B) stays within the unsigned [0,255] range.
-// Clamping prefixes >REBASE_KEEP below h0 is lossless (REBASE_KEEP=zdrop+1 >
-// zdrop => already past the z-drop horizon). MUST be used by every SIMD tier.
-// Defined at file scope (before any tier #if block) so every kernel variant
-// (AVX2, AVX-512BW, SSE2/NEON) sees the same definition.
-static inline int bsw8_rebase_keep(int zdrop)            { return zdrop + 1; }
-static inline int bsw8_initial_floor(int h0, int zdrop) {
-    int b0 = h0 - bsw8_rebase_keep(zdrop);
-    return b0 > 0 ? b0 : 0;
-}
-// ---------------------------------------------------------------------------
+// NOTE: the 8-bit re-baseline floor helpers that used to live here
+// (bsw8_rebase_keep / bsw8_initial_floor, computing the per-lane floor
+// B0 = max(0, h0 - (zdrop+1))) were removed together with the re-baseline
+// machinery itself: the routing gate bsw8_envelope_ok() admits a pair only
+// when its max attainable score stays inside the unsigned byte range, so the
+// floor was identically 0 for every admitted pair. Every 8-bit kernel tier now
+// stores plain absolute [0,255] scores and seeds from the raw h0.
 
 //-----------------------------------------------------------------------------------
 // constructor
@@ -714,21 +706,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         if (max < w_mismatch) max = w_mismatch;
         if (max < w_ambig) max = w_ambig;
 
-        // Initial per-lane score floor B0 = max(0, h0 - REBASE_KEEP_W) (long-read
-        // 8-bit, seed score h0 >= 128). Seeding the H bytes from raw h0 overflows
-        // the signed-int8 score state on row 0, so we seed from the rebaselined
-        // h0' = min(h0, REBASE_KEEP_W) instead (see the per-lane h0 init below).
-        // REBASE_KEEP_W MUST equal the kernel's REBASE_KEEP (bsw8_rebase_keep)
-        // so the two agree on B0; smithWaterman256_8 recomputes B0 via
-        // bsw8_initial_floor(p[].h0, zdrop).
-        const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
-        // The h0-prefix column/row seed below is unsigned-saturating [0,255], so
-        // the seeded byte min(h0, REBASE_KEEP_W) only needs to fit a uint8. The
-        // routing gate (bsw8_envelope_ok) enforces zdrop + maxStep <= 253 (so the
-        // re-baseline window REBASE_HI = 255 - maxStep > REBASE_KEEP holds);
-        // assert the byte bound for any direct caller that bypasses the gate.
-        assert(REBASE_KEEP_W <= 255 &&
-               "8-bit h0-prefix seed byte min(h0,REBASE_KEEP) must fit uint8 (zdrop<=254)");
+        // The h0-prefix column/row seed below is unsigned-saturating [0,255] and
+        // is seeded from the raw seed score h0 (no re-baseline floor): the only
+        // requirement is that the seed byte fit a uint8, which bsw8_envelope_ok()
+        // guarantees (h0 + min(len1,len2)*maxStep < 255 - maxStep => h0 < 255).
+        assert(this->zdrop >= 0 && "8-bit banded SW: negative zdrop");
 
         int nstart = 0, nend = numPairs;
 
@@ -740,7 +722,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             int maxLen1 = 0;
             int maxLen2 = 0;
             bsize = w;
-            
+
             uint64_t tim;
             for(j = 0; j < SIMD_WIDTH8; j++)
             {
@@ -751,20 +733,20 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                 }
 
                 SeqPair sp = pairArray[i + j];
-                // Re-baseline the seed score into the int8 byte frame: seed the H
-                // arrays from h0' = h0 - B0 = min(h0, REBASE_KEEP_W) (clamped >= 0)
-                // so the initial bytes fit signed-int8 even when the true seed h0
-                // is several hundred (long-read). smithWaterman256_8 recomputes the
-                // matching B0 = max(0, h0 - REBASE_KEEP) from p[].h0 + zdrop and
-                // starts that lane's floor B there, so byte == H_absolute - B.
+                // Seed the H arrays from the raw seed score h0. The 8-bit state is
+                // now a plain unsigned [0,255] absolute score (the re-baseline floor
+                // B was removed with the inert re-baseline machinery), and the H
+                // seed uses unsigned-saturating ops, so the only bound is that the
+                // seed byte fit a uint8 -- guaranteed by bsw8_envelope_ok(), which
+                // admits a pair only when h0 + min(len1,len2)*maxStep < 255 - maxStep
+                // (hence h0 < 255). The previous prefix clamp min(h0, zdrop+1) existed
+                // only to keep the removed floor B0 = max(0, h0 - (zdrop+1)) at zero;
+                // with B gone it is pure loss -- it truncated the seed relative to
+                // best_abs (which records the raw h0), so a high-h0 pair that never
+                // beat its seed reported the wrong score. Clamp to uint8 only.
                 {
                     int h0p = sp.h0;
-                    if (h0p > REBASE_KEEP_W) h0p = REBASE_KEEP_W;
                     if (h0p < 0) h0p = 0;
-                    // Always-on uint8 guard (asserts are compiled out in release):
-                    // a direct caller that bypasses the gate with zdrop > 254 would
-                    // otherwise truncate the seed byte. In-envelope REBASE_KEEP_W <= 253,
-                    // so this never fires on the production path.
                     if (h0p > 255) h0p = 255;
                     h0[j] = (uint8_t) h0p;
                 }
@@ -796,9 +778,9 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             __m256i h0_256 = _mm256_load_si256((__m256i*) h0);
             _mm256_store_si256((__m256i *) H2, h0_256);
             // h0-prefix deletion seed, unsigned-saturating [0,255]. Was signed
-            // sub_epi8 + max_epi8(.,0) floor, which required the seed byte
-            // min(h0,REBASE_KEEP) <= 127 and so capped zdrop at 126. subs_epu8
-            // floors at 0 inherently and feeds the floored value forward;
+            // sub_epi8 + max_epi8(.,0) floor, which required the seed byte to be
+            // <= 127 and so capped zdrop at 126. subs_epu8 floors at 0
+            // inherently and feeds the floored value forward;
             // byte-identical for the monotone-decreasing affine prefix. Mirrors
             // smithWaterman128_8 (the NEON reference, already unsigned here).
             __m256i tmp256 = _mm256_subs_epu8(h0_256, o_del256);
@@ -1407,6 +1389,18 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
 
                 __m256i y1c  = _mm256_add_epi32(y1g, vi);
                 __m256i yc   = _mm256_add_epi32(yg, _mm256_sub_epi32(xrg, vone));
+                // z-drop unset-best sentinel: y1c and yc each carry the +1 frame
+                // bias (y1 stores col-i+1) so the biases cancel in tmpj = mj-max_j,
+                // BUT only when a best score has been captured (xrow >= 1). While
+                // the best is still the h0 seed (xrow == 0), scalar's max_j == -1
+                // and its drift uses (mj - max_j) = mj + 1; the raw reconstruction
+                // yc = y256 + (xrow-1) gives -1 instead of the required max_j+1 = 0,
+                // under-counting the drift by 1 and firing the z-drop one row early.
+                // Force yc = 0 (== max_j+1 for the -1 sentinel) where xrow == 0 so
+                // the drift matches scalarBandedSWA exactly in the high-h0 regime
+                // (seed score never beaten before the z-drop horizon). This is a
+                // no-op once any row has beaten the seed (xrow >= 1).
+                yc = _mm256_andnot_si256(_mm256_cmpeq_epi32(xrg, _mm256_setzero_si256()), yc);
                 __m256i tmpi = _mm256_sub_epi32(vip1, xrg);
                 __m256i tmpj = _mm256_sub_epi32(y1c, yc);
                 // z-drop gap term weighted by gap-extend penalty, matching the
@@ -2566,21 +2560,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         if (max < w_mismatch) max = w_mismatch;
         if (max < w_ambig) max = w_ambig;
 
-        // Initial per-lane score floor B0 = max(0, h0 - REBASE_KEEP_W) (long-read
-        // 8-bit, seed score h0 >= 128). Seeding the H bytes from raw h0 overflows
-        // the signed-int8 score state on row 0, so we seed from the rebaselined
-        // h0' = min(h0, REBASE_KEEP_W) instead (see the per-lane h0 init below).
-        // REBASE_KEEP_W MUST equal the kernel's REBASE_KEEP (bsw8_rebase_keep)
-        // so the two agree on B0; smithWaterman512_8 recomputes B0 via
-        // bsw8_initial_floor(p[].h0, zdrop).
-        const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
-        // The h0-prefix column/row seed below is unsigned-saturating [0,255], so
-        // the seeded byte min(h0, REBASE_KEEP_W) only needs to fit a uint8. The
-        // routing gate (bsw8_envelope_ok) enforces zdrop + maxStep <= 253 (so the
-        // re-baseline window REBASE_HI = 255 - maxStep > REBASE_KEEP holds);
-        // assert the byte bound for any direct caller that bypasses the gate.
-        assert(REBASE_KEEP_W <= 255 &&
-               "8-bit h0-prefix seed byte min(h0,REBASE_KEEP) must fit uint8 (zdrop<=254)");
+        // The h0-prefix column/row seed below is unsigned-saturating [0,255] and
+        // is seeded from the raw seed score h0 (no re-baseline floor): the only
+        // requirement is that the seed byte fit a uint8, which bsw8_envelope_ok()
+        // guarantees (h0 + min(len1,len2)*maxStep < 255 - maxStep => h0 < 255).
+        assert(this->zdrop >= 0 && "8-bit banded SW: negative zdrop");
 
         int nstart = 0, nend = numPairs;
 
@@ -2592,7 +2576,7 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             int maxLen1 = 0;
             int maxLen2 = 0;
             bsize = w;
-            
+
             uint64_t tim;
             for(j = 0; j < SIMD_WIDTH8; j++)
             {
@@ -2602,20 +2586,20 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
                     _mm_prefetch((const char*) seqBufRef + (int64_t)spf.idr + 64, _MM_HINT_NTA);
                 }
                 SeqPair sp = pairArray[i + j];
-                // Re-baseline the seed score into the int8 byte frame: seed the H
-                // arrays from h0' = h0 - B0 = min(h0, REBASE_KEEP_W) (clamped >= 0)
-                // so the initial bytes fit signed-int8 even when the true seed h0
-                // is several hundred (long-read). smithWaterman512_8 recomputes the
-                // matching B0 = max(0, h0 - REBASE_KEEP) from p[].h0 + zdrop and
-                // starts that lane's floor B there, so byte == H_absolute - B.
+                // Seed the H arrays from the raw seed score h0. The 8-bit state is
+                // now a plain unsigned [0,255] absolute score (the re-baseline floor
+                // B was removed with the inert re-baseline machinery), and the H
+                // seed uses unsigned-saturating ops, so the only bound is that the
+                // seed byte fit a uint8 -- guaranteed by bsw8_envelope_ok(), which
+                // admits a pair only when h0 + min(len1,len2)*maxStep < 255 - maxStep
+                // (hence h0 < 255). The previous prefix clamp min(h0, zdrop+1) existed
+                // only to keep the removed floor B0 = max(0, h0 - (zdrop+1)) at zero;
+                // with B gone it is pure loss -- it truncated the seed relative to
+                // best_abs (which records the raw h0), so a high-h0 pair that never
+                // beat its seed reported the wrong score. Clamp to uint8 only.
                 {
                     int h0p = sp.h0;
-                    if (h0p > REBASE_KEEP_W) h0p = REBASE_KEEP_W;
                     if (h0p < 0) h0p = 0;
-                    // Always-on uint8 guard (asserts are compiled out in release):
-                    // a direct caller that bypasses the gate with zdrop > 254 would
-                    // otherwise truncate the seed byte. In-envelope REBASE_KEEP_W <= 253,
-                    // so this never fires on the production path.
                     if (h0p > 255) h0p = 255;
                     h0[j] = (uint8_t) h0p;
                 }
@@ -3233,6 +3217,19 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
 
                 __m512i y1c  = _mm512_add_epi32(y1g, vi);
                 __m512i yc   = _mm512_add_epi32(yg, _mm512_sub_epi32(xrg, vone));
+                // z-drop unset-best sentinel: y1c and yc each carry the +1 frame
+                // bias (y1 stores col-i+1) so the biases cancel in tmpj = mj-max_j,
+                // BUT only when a best score has been captured (xrow >= 1). While
+                // the best is still the h0 seed (xrow == 0), scalar's max_j == -1
+                // and its drift uses (mj - max_j) = mj + 1; the raw reconstruction
+                // yc = y512 + (xrow-1) gives -1 instead of the required max_j+1 = 0,
+                // under-counting the drift by 1 and firing the z-drop one row early.
+                // Force yc = 0 (== max_j+1 for the -1 sentinel) where xrow == 0 so
+                // the drift matches scalarBandedSWA exactly in the high-h0 regime
+                // (seed score never beaten before the z-drop horizon). This is a
+                // no-op once any row has beaten the seed (xrow >= 1).
+                const __mmask16 seedm = _mm512_cmpeq_epi32_mask(xrg, _mm512_setzero_si512());
+                yc = _mm512_mask_mov_epi32(yc, seedm, _mm512_setzero_si512());
                 __m512i tmpi = _mm512_sub_epi32(vip1, xrg);
                 __m512i tmpj = _mm512_sub_epi32(y1c, yc);
                 // z-drop gap term weighted by gap-extend penalty, matching the

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -985,76 +985,52 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     int32_t xrow[SIMD_WIDTH8];    // best row for score (== i+1 at capture)
     int32_t ierow[SIMD_WIDTH8];   // best row for gscore (== i+1 at capture)
 
-    // --- PER-LANE SCORE RE-BASELINING (long-read 8-bit, scores > 127) ---
-    // H/F/E and the score maxima are unsigned 8-bit [0,255], but a 1 kb
-    // alignment scores ~900. To keep the kernel 32-lane (8-bit) we carry a
-    // wide per-lane running FLOOR B[l]: every stored 8-bit score represents
-    // (H_absolute - B[l]). When a lane's row-max climbs toward 255 we raise
-    // B[l] by `delta` and subtract `delta` (saturating, _mm256_subs_epu8) from
-    // every carried score buffer/register for that lane, then add B back when
-    // reconstructing the absolute result.
-    //
+    // --- PLAIN UNSIGNED [0,255] SW (no score re-baselining) ---
     // Scores live in the UNSIGNED byte range [0,255]. The DP recurrence computes
     // M = max(0, h00 + sbt) with unsigned-saturating arithmetic (adds_epu8 then
     // subs_epu8) and the row/global-max trackers (maxRS1, maxScore256) compare
     // with UNSIGNED order (== after _mm256_max_epu8), so the full [0,255] is usable.
     //
-    // CORRECTNESS depends on re-baselining NEVER firing for a pair admitted to
-    // this kernel. The saturating-subtract is NOT generally lossless: it can zero
-    // a still-positive off-diagonal cell (a cell may sit > zdrop below the ROW max
-    // yet still lie on the eventual optimum — z-drop is a row-level early-exit, not
-    // a per-cell guarantee), and a zeroed cell is then misread as the h00==0
-    // local-restart sentinel, spuriously truncating a valid alignment. So we do
-    // NOT rely on re-baseline being lossless; instead it is held inert:
-    //   REBASE_HI = 255 - maxStep: a row whose max has not reached REBASE_HI grows
-    //     by <= maxStep per row (H(i,j) <= H(i-1,j-1) + maxStep), so its bytes stay
-    //     <= 255 with no rebase needed.
-    //   The bwamem.cpp routing gate admits a pair only when its MAX ATTAINABLE
-    //     score stays < REBASE_HI and h0 <= REBASE_KEEP (so B0 == 0). Under that
-    //     gate the row max never reaches REBASE_HI: B stays 0, stored bytes equal
-    //     absolute scores, and the kernel is a plain exact unsigned [0,255] SW.
-    // The re-baseline machinery below is retained only as a safety net; pairs that
-    // could exceed the envelope take the 16-bit path.
-    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window) holds for
-    // zdrop + maxStep <= 253, which is exactly what the routing gate enforces.
+    // PRECONDITION (enforced by the caller): every pair reaching this kernel has
+    // passed bwamem.cpp's bsw8_envelope_ok(), which admits a pair only when
+    //   (a) its MAX ATTAINABLE score h0 + min(len1,len2)*maxStep stays below
+    //       255 - maxStep, so no row max can ever reach the byte ceiling, and
+    //   (b) h0 <= zdrop + 1.
+    // Under that gate the byte state is an exact absolute score for every cell:
+    // it can neither overflow nor need rescaling, so this is a plain exact
+    // unsigned [0,255] Smith-Waterman.
+    //
+    // This kernel previously carried a per-lane running score FLOOR B[l] (stored
+    // byte = H_absolute - B[l]) plus a per-row probe that lowered B whenever a row
+    // max climbed toward 255 — a "re-baseline" safety net for scores that overflow
+    // a byte. Condition (a) makes that net UNREACHABLE: it never fired on any
+    // in-envelope pair, so B was identically 0 and every stored byte already equalled
+    // the absolute score. It has been removed, which deletes per row: a
+    // _mm256_movemask_epi8 probe plus, per lane group, a B load and two int32 adds
+    // in the wide epilogue. Pairs that could exceed the envelope take the 16-bit
+    // path, which has no byte ceiling. Mirrors the 128-bit smithWaterman128_8 drop.
+    //
+    // Removing the net makes the envelope a HARD PRECONDITION rather than an
+    // optimization: an out-of-envelope pair forced through getScores8 now yields
+    // scores saturated at 255 instead of rescaled ones. Both are wrong — the net
+    // was never lossless either, since its saturating-subtract can zero a
+    // still-positive off-diagonal cell (a cell may sit > zdrop below the ROW max
+    // yet still lie on the eventual optimum; z-drop is a row-level early-exit, not
+    // a per-cell guarantee) which is then misread as the h00==0 local-restart
+    // sentinel. Define BSW8_ASSERT_ENVELOPE to have debug builds trap on a
+    // violation instead of returning a wrong score silently.
+    //
     // The h0-prefix column/row seed (wrapper setup below) is unsigned-saturating
     // [0,255] and imposes no tighter ceiling; it previously used signed int8 ops
     // that required the seed byte <= 127 and capped zdrop at 126.
+#ifdef BSW8_ASSERT_ENVELOPE
     int maxStep = (int)this->w_match;
     if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
     if (maxStep < 1) maxStep = 1;
-    const int REBASE_KEEP = zdrop + 1;
-    const int REBASE_HI   = 255 - maxStep;
-    assert(REBASE_HI > REBASE_KEEP &&
-           "8-bit SW re-baseline: zdrop+maxStep>253, scoring outside safe envelope (route to 16-bit)");
-    int32_t B[SIMD_WIDTH8];        // per-lane wide score floor (stored = abs - B)
-    int32_t best_abs[SIMD_WIDTH8]; // running best score in ABSOLUTE units
-    int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end) in ABSOLUTE units
-
-    // --- INITIAL SCORE FLOOR B0 (long-read 8-bit, seed score h0 >= 128) ---
-    // The H arrays are seeded from the seed score h0 (H_v[0]=h0, then gap-
-    // decremented down column 0 and across row 0). For a long-read seed h0 can
-    // be several hundred, which would overflow the unsigned [0,255] byte state
-    // before any re-baseline event can fire. So we start each lane's
-    // running floor at B0[l] = max(0, h0 - REBASE_KEEP) instead of 0: the
-    // wrapper seeds the H bytes from h0' = h0 - B0 = min(h0, REBASE_KEEP)
-    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 254), and
-    // here we set B[l] = B0[l] so the stored bytes still mean (H_absolute - B).
-    //
-    // SAFETY (identical argument to the mid-DP re-baseline): the gap-prefix
-    // cells in column 0 / row 0 that fall more than REBASE_KEEP below h0 are
-    // saturated to byte 0 by the wrapper's unsigned-saturating seed. Because
-    // REBASE_KEEP = zdrop+1 > zdrop, any such prefix cell is already beyond the
-    // z-drop horizon below the seed, so an alignment routed through it has
-    // already z-dropped and cannot be optimal -- clamping it to the floor is
-    // lossless. This is the SAME situation that arises mid-DP whenever B>0 after
-    // a re-baseline (byte 0 then means H_absolute == B, not 0), which the
-    // h00==0 local-restart test in MAIN_CODE8_CORE already handles correctly; B0
-    // simply makes B>0 from row 0 instead of from the first re-baseline event.
-    int32_t B0[SIMD_WIDTH8];
-    for (int l=0; l<SIMD_WIDTH8; l++) {
-        B0[l] = bsw8_initial_floor((int)p[l].h0, zdrop);
-    }
+    const int BYTE_CEIL = 255 - maxStep;
+#endif
+    int32_t best_abs[SIMD_WIDTH8]; // running best score (absolute == byte here)
+    int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end), absolute
 
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH8; l++) {
@@ -1066,9 +1042,7 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         mlenw[l]  = ml;
         xrow[l]   = 0;
         ierow[l]  = 0;
-        B[l]        = B0[l];   // start the floor at B0 so byte state = abs - B0
-        best_abs[l] = p[l].h0; // maxScore256 inits to the h0 seed; record the
-                               // ABSOLUTE seed score (wide), not the rebaselined byte
+        best_abs[l] = p[l].h0; // maxScore256 inits to the h0 seed; record it wide
         gbest_abs[l]= -1;      // unset sentinel (-1): gscore=-1 / gtle=0 when no query end is reached, matching scalar
         if (p[l].len2 < minq) minq = p[l].len2;
     }
@@ -1334,14 +1308,12 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
             _mm256_store_si256((__m256i *) hq_a_, hqe256);
             for (int g = 0; g < SIMD_WIDTH8 / 8; g++) {
                 const int base = g * 8;
-                __m256i Bg   = _mm256_loadu_si256((const __m256i *)(B + base));
                 __m256i hqeg = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(hq_a_ + base)));
                 __m256i qfg  = _mm256_cvtepi8_epi32(_mm_loadl_epi64((const __m128i *)(qf_a_ + base)));
-                __m256i gs_abs = _mm256_add_epi32(hqeg, Bg);
                 __m256i gba = _mm256_loadu_si256((const __m256i *)(gbest_abs + base));
-                __m256i ge  = _mm256_xor_si256(_mm256_cmpgt_epi32(gba, gs_abs), ff256);
+                __m256i ge  = _mm256_xor_si256(_mm256_cmpgt_epi32(gba, hqeg), ff256); // hqe >= gba
                 __m256i gmask = _mm256_and_si256(qfg, ge);
-                gba = _mm256_blendv_epi8(gba, gs_abs, gmask);
+                gba = _mm256_blendv_epi8(gba, hqeg, gmask);
                 _mm256_storeu_si256((__m256i *)(gbest_abs + base), gba);
                 __m256i ierg = _mm256_loadu_si256((const __m256i *)(ierow + base));
                 ierg = _mm256_blendv_epi8(ierg, _mm256_set1_epi32(i + 1), gmask);
@@ -1405,7 +1377,6 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
             const __m256i veins = _mm256_set1_epi32(this->e_ins);
             for (int g = 0; g < SIMD_WIDTH8 / 8; g++) {
                 const int base = g * 8;
-                __m256i Bg   = _mm256_loadu_si256((const __m256i *)(B + base));
                 __m256i msg  = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(ms_a    + base)));
                 __m256i rsg  = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(rs_a    + base)));
                 __m256i hqeg = _mm256_cvtepu8_epi32(_mm_loadl_epi64((const __m128i *)(hqe_a   + base)));
@@ -1419,16 +1390,16 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
                 xrg = _mm256_blendv_epi8(xrg, vip1, cmpg);
                 _mm256_storeu_si256((__m256i *)(xrow + base), xrg);
 
-                __m256i ms_abs = _mm256_add_epi32(msg, Bg);
+                // best_abs = max(best_abs, (uint8)ms) -- byte is already absolute
                 __m256i bag = _mm256_loadu_si256((const __m256i *)(best_abs + base));
-                bag = _mm256_max_epi32(bag, ms_abs);
+                bag = _mm256_max_epi32(bag, msg);
                 _mm256_storeu_si256((__m256i *)(best_abs + base), bag);
 
-                __m256i gs_abs = _mm256_add_epi32(hqeg, Bg);
+                // gscore: where qfire AND hqe >= gbest_abs, take hqe / i+1
                 __m256i gba = _mm256_loadu_si256((const __m256i *)(gbest_abs + base));
-                __m256i ge  = _mm256_xor_si256(_mm256_cmpgt_epi32(gba, gs_abs), ff256); // gs_abs >= gba
+                __m256i ge  = _mm256_xor_si256(_mm256_cmpgt_epi32(gba, hqeg), ff256); // hqe >= gba
                 __m256i gmask = _mm256_and_si256(qfg, ge);
-                gba = _mm256_blendv_epi8(gba, gs_abs, gmask);
+                gba = _mm256_blendv_epi8(gba, hqeg, gmask);
                 _mm256_storeu_si256((__m256i *)(gbest_abs + base), gba);
                 __m256i ierg = _mm256_loadu_si256((const __m256i *)(ierow + base));
                 ierg = _mm256_blendv_epi8(ierg, vip1, gmask);
@@ -1547,74 +1518,18 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
         head256 = _mm256_sub_epi8(head256, one256);
         tail256 = _mm256_sub_epi8(tail256, one256);
 
-        // --- RE-BASELINE EVENT (per-lane score floor) ---
-        // After this row's score state is final, lower any lane whose row-max
-        // (maxRS1, rebaselined) has climbed to REBASE_HI back into range. We
-        // raise B[l] by delta = maxRS1[l] - REBASE_KEEP and subtract that delta
-        // (saturating to 0) from every carried score buffer/register for that
-        // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
-        // reference; the next row reads the lowered values consistently.
-        {
-            /* Fast path: one vector test for "any lane >= REBASE_HI?" — see the
-             * 128-bit kernel. Under the routing envelope this is ~always false, so
-             * the per-lane scalar scan + maxRS1 store below are skipped each row. */
-            __m256i hi256 = _mm256_set1_epi8((int8_t) REBASE_HI);
-            if (_mm256_movemask_epi8(_mm256_cmpeq_epi8(_mm256_subs_epu8(hi256, maxRS1), zero256))) {
-            uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(32)));
-            _mm256_store_si256((__m256i *) rs_b, maxRS1);
-            int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(32)));
-            int any = 0;
-            for (int l = 0; l < SIMD_WIDTH8; l++) {
-                int d = 0;
-                if ((int)rs_b[l] >= REBASE_HI) {
-                    d = (int)rs_b[l] - REBASE_KEEP;   // keep low REBASE_KEEP, in range
-                    B[l] += d;
-                    any = 1;
-                }
-                delta_a[l] = (int8_t) d;              // 0..(REBASE_HI-REBASE_KEEP) small
-            }
-            if (any) {
-                __m256i delta256 = _mm256_load_si256((__m256i *) delta_a);
-                // Subtract delta from every carried score buffer over the active
-                // band columns. The range [lo,hi] is the union of the current and
-                // next band windows; clamping to [0, ncol-1] keeps the loop within
-                // the valid column range (a safe superset covering every column the
-                // next row will read).
-                int lo = nbeg < beg ? nbeg : beg;
-                int hi = nend > end ? nend : end;
-                if (lo < 0) lo = 0;
-                if (hi + 1 > ncol) hi = ncol - 1;
-                for (int l = lo; l <= hi; l++) {
-                    __m256i h256 = _mm256_load_si256((__m256i *)(H_h + l * SIMD_WIDTH8));
-                    __m256i f256 = _mm256_load_si256((__m256i *)(F   + l * SIMD_WIDTH8));
-                    h256 = _mm256_subs_epu8(h256, delta256);
-                    f256 = _mm256_subs_epu8(f256, delta256);
-                    _mm256_store_si256((__m256i *)(H_h + l * SIMD_WIDTH8), h256);
-                    _mm256_store_si256((__m256i *)(F   + l * SIMD_WIDTH8), f256);
-                }
-                // The vertical seed H_v is read only while the band still touches
-                // column 0 (beg==0). Lower the rows that may still be consumed.
-                if (beg == 0) {
-                    for (int r = i + 1; r < nrow; r++) {
-                        __m256i v256 = _mm256_load_si256((__m256i *)(H_v + r * SIMD_WIDTH8));
-                        v256 = _mm256_subs_epu8(v256, delta256);
-                        _mm256_store_si256((__m256i *)(H_v + r * SIMD_WIDTH8), v256);
-                    }
-                }
-                // Carried score maxima (registers) live in the same rebaselined
-                // frame and must be lowered too so the next row's z-drop (ms-rs)
-                // and the absolute-frame add-back stay consistent. maxScore256 is
-                // the running max, so it never saturates to 0 (maxScore256 >=
-                // maxRS1 for the triggering row, and maxRS1 >= REBASE_HI >
-                // REBASE_KEEP > delta, so it stays positive).
-                maxScore256 = _mm256_subs_epu8(maxScore256, delta256);
-                // gscore no longer carries a rebaselined byte register: the
-                // query-end cell H is captured per row and accumulated wide
-                // (gbest_abs, absolute units) in the epilogue, immune to this
-                // re-baseline subtract.
-            }
-            }   /* end "any lane >= REBASE_HI" fast-path guard */
-        }
+#ifdef BSW8_ASSERT_ENVELOPE
+        /* Debug-only envelope check (off by default; asserts are live in release
+         * builds here, so this must not be compiled in unconditionally). The
+         * routing gate guarantees no row max ever reaches the byte ceiling; trap
+         * loudly if a caller pushed an out-of-envelope pair through getScores8
+         * rather than let it return a silently saturated score.
+         * Unsigned >=: subs_epu8(BYTE_CEIL, maxRS1)==0 iff maxRS1 >= BYTE_CEIL. */
+        assert(!_mm256_movemask_epi8(_mm256_cmpeq_epi8(
+                   _mm256_subs_epu8(_mm256_set1_epi8((int8_t) BYTE_CEIL), maxRS1), zero256)) &&
+               "8-bit banded SW: row max hit the byte ceiling — pair violates "
+               "bsw8_envelope_ok() and must route to the 16-bit kernel");
+#endif
 
 #if RDT
         prof[DP2][0] += __rdtsc() - tim1;
@@ -1625,10 +1540,10 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     prof[DP][0] += __rdtsc() - tim;
 #endif
 
-    // Scores are reconstructed in ABSOLUTE units from the per-lane wide
-    // best_abs/gbest_abs side channels (= rebaselined byte + B[l], captured each
-    // row before any later re-baseline could saturate the byte away). Positions
-    // are reconstructed wide from the diagonal-offset lanes plus the per-lane
+    // Scores come from the per-lane wide best_abs/gbest_abs side channels, which
+    // carry the byte state widened per row (the byte IS the absolute score under
+    // the routing envelope — see the precondition above). Positions are
+    // reconstructed wide from the diagonal-offset lanes plus the per-lane
     // best-row side channels.
     int8_t maxj[SIMD_WIDTH8]  __attribute((aligned(64)));
     _mm256_store_si256((__m256i *) maxj, y256);   // best col as diagonal offset
@@ -2907,76 +2822,52 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
     int32_t xrow[SIMD_WIDTH8];    // best row for score (== i+1 at capture)
     int32_t ierow[SIMD_WIDTH8];   // best row for gscore (== i+1 at capture)
 
-    // --- PER-LANE SCORE RE-BASELINING (long-read 8-bit, scores > 127) ---
-    // H/F/E and the score maxima are unsigned 8-bit [0,255], but a 1 kb
-    // alignment scores ~900. To keep the kernel 64-lane (8-bit) we carry a
-    // wide per-lane running FLOOR B[l]: every stored 8-bit score represents
-    // (H_absolute - B[l]). When a lane's row-max climbs toward 255 we raise
-    // B[l] by `delta` and subtract `delta` (saturating, _mm512_subs_epu8) from
-    // every carried score buffer/register for that lane, then add B back when
-    // reconstructing the absolute result.
-    //
+    // --- PLAIN UNSIGNED [0,255] SW (no score re-baselining) ---
     // Scores live in the UNSIGNED byte range [0,255]. The DP recurrence computes
     // M = max(0, h00 + sbt) with unsigned-saturating arithmetic (adds_epu8 then
     // subs_epu8) and the row/global-max trackers (maxRS1, maxScore512) compare
     // with UNSIGNED order (_mm512_cmpgt_epu8_mask), so the full [0,255] is usable.
     //
-    // CORRECTNESS depends on re-baselining NEVER firing for a pair admitted to
-    // this kernel. The saturating-subtract is NOT generally lossless: it can zero
-    // a still-positive off-diagonal cell (a cell may sit > zdrop below the ROW max
-    // yet still lie on the eventual optimum — z-drop is a row-level early-exit, not
-    // a per-cell guarantee), and a zeroed cell is then misread as the h00==0
-    // local-restart sentinel, spuriously truncating a valid alignment. So we do
-    // NOT rely on re-baseline being lossless; instead it is held inert:
-    //   REBASE_HI = 255 - maxStep: a row whose max has not reached REBASE_HI grows
-    //     by <= maxStep per row (H(i,j) <= H(i-1,j-1) + maxStep), so its bytes stay
-    //     <= 255 with no rebase needed.
-    //   The bwamem.cpp routing gate admits a pair only when its MAX ATTAINABLE
-    //     score stays < REBASE_HI and h0 <= REBASE_KEEP (so B0 == 0). Under that
-    //     gate the row max never reaches REBASE_HI: B stays 0, stored bytes equal
-    //     absolute scores, and the kernel is a plain exact unsigned [0,255] SW.
-    // The re-baseline machinery below is retained only as a safety net; pairs that
-    // could exceed the envelope take the 16-bit path.
-    // Precondition REBASE_HI > REBASE_KEEP (a non-empty window) holds for
-    // zdrop + maxStep <= 253, which is exactly what the routing gate enforces.
+    // PRECONDITION (enforced by the caller): every pair reaching this kernel has
+    // passed bwamem.cpp's bsw8_envelope_ok(), which admits a pair only when
+    //   (a) its MAX ATTAINABLE score h0 + min(len1,len2)*maxStep stays below
+    //       255 - maxStep, so no row max can ever reach the byte ceiling, and
+    //   (b) h0 <= zdrop + 1.
+    // Under that gate the byte state is an exact absolute score for every cell:
+    // it can neither overflow nor need rescaling, so this is a plain exact
+    // unsigned [0,255] Smith-Waterman.
+    //
+    // This kernel previously carried a per-lane running score FLOOR B[l] (stored
+    // byte = H_absolute - B[l]) plus a per-row probe that lowered B whenever a row
+    // max climbed toward 255 — a "re-baseline" safety net for scores that overflow
+    // a byte. Condition (a) makes that net UNREACHABLE: it never fired on any
+    // in-envelope pair, so B was identically 0 and every stored byte already equalled
+    // the absolute score. It has been removed, which deletes per row: a
+    // per-lane row-max probe plus, per lane group, a B load and two int32 adds in
+    // the wide epilogue. Pairs that could exceed the envelope take the 16-bit path,
+    // which has no byte ceiling. Mirrors the 128-bit smithWaterman128_8 drop.
+    //
+    // Removing the net makes the envelope a HARD PRECONDITION rather than an
+    // optimization: an out-of-envelope pair forced through getScores8 now yields
+    // scores saturated at 255 instead of rescaled ones. Both are wrong — the net
+    // was never lossless either, since its saturating-subtract can zero a
+    // still-positive off-diagonal cell (a cell may sit > zdrop below the ROW max
+    // yet still lie on the eventual optimum; z-drop is a row-level early-exit, not
+    // a per-cell guarantee) which is then misread as the h00==0 local-restart
+    // sentinel. Define BSW8_ASSERT_ENVELOPE to have debug builds trap on a
+    // violation instead of returning a wrong score silently.
+    //
     // The h0-prefix column/row seed (wrapper setup below) is unsigned-saturating
     // [0,255] and imposes no tighter ceiling; it previously used signed int8 ops
     // that required the seed byte <= 127 and capped zdrop at 126.
+#ifdef BSW8_ASSERT_ENVELOPE
     int maxStep = (int)this->w_match;
     if ((int)this->w_ambig > maxStep) maxStep = (int)this->w_ambig;
     if (maxStep < 1) maxStep = 1;
-    const int REBASE_KEEP = zdrop + 1;
-    const int REBASE_HI   = 255 - maxStep;
-    assert(REBASE_HI > REBASE_KEEP &&
-           "8-bit SW re-baseline: zdrop+maxStep>253, scoring outside safe envelope (route to 16-bit)");
-    int32_t B[SIMD_WIDTH8];        // per-lane wide score floor (stored = abs - B)
-    int32_t best_abs[SIMD_WIDTH8]; // running best score in ABSOLUTE units
-    int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end) in ABSOLUTE units
-
-    // --- INITIAL SCORE FLOOR B0 (long-read 8-bit, seed score h0 >= 128) ---
-    // The H arrays are seeded from the seed score h0 (H_v[0]=h0, then gap-
-    // decremented down column 0 and across row 0). For a long-read seed h0 can
-    // be several hundred, which would overflow the unsigned [0,255] byte state
-    // before any re-baseline event can fire. So we start each lane's
-    // running floor at B0[l] = max(0, h0 - REBASE_KEEP) instead of 0: the
-    // wrapper seeds the H bytes from h0' = h0 - B0 = min(h0, REBASE_KEEP)
-    // (clamped >= 0, so the initial bytes land in [0, REBASE_KEEP] <= 254), and
-    // here we set B[l] = B0[l] so the stored bytes still mean (H_absolute - B).
-    //
-    // SAFETY (identical argument to the mid-DP re-baseline): the gap-prefix
-    // cells in column 0 / row 0 that fall more than REBASE_KEEP below h0 are
-    // saturated to byte 0 by the wrapper's unsigned-saturating seed. Because
-    // REBASE_KEEP = zdrop+1 > zdrop, any such prefix cell is already beyond the
-    // z-drop horizon below the seed, so an alignment routed through it has
-    // already z-dropped and cannot be optimal -- clamping it to the floor is
-    // lossless. This is the SAME situation that arises mid-DP whenever B>0 after
-    // a re-baseline (byte 0 then means H_absolute == B, not 0), which the
-    // h00==0 local-restart test in MAIN_CODE8_CORE already handles correctly; B0
-    // simply makes B>0 from row 0 instead of from the first re-baseline event.
-    int32_t B0[SIMD_WIDTH8];
-    for (int l=0; l<SIMD_WIDTH8; l++) {
-        B0[l] = bsw8_initial_floor((int)p[l].h0, zdrop);
-    }
+    const int BYTE_CEIL = 255 - maxStep;
+#endif
+    int32_t best_abs[SIMD_WIDTH8]; // running best score (absolute == byte here)
+    int32_t gbest_abs[SIMD_WIDTH8];// running gscore (query-end), absolute
 
     int32_t minq = 10000000;
     for (int l=0; l<SIMD_WIDTH8; l++) {
@@ -2988,9 +2879,7 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         mlenw[l]  = ml;
         xrow[l]   = 0;
         ierow[l]  = 0;
-        B[l]        = B0[l];   // start the floor at B0 so byte state = abs - B0
-        best_abs[l] = p[l].h0; // maxScore512 inits to the h0 seed; record the
-                               // ABSOLUTE seed score (wide), not the rebaselined byte
+        best_abs[l] = p[l].h0; // maxScore512 inits to the h0 seed; record it wide
         gbest_abs[l]= -1;      // unset sentinel (-1): gscore=-1 / gtle=0 when no query end is reached, matching scalar
         if (p[l].len2 < minq) minq = p[l].len2;
     }
@@ -3246,12 +3135,10 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
             for (int g = 0; g < SIMD_WIDTH8 / 16; g++) {
                 const int base = g * 16;
                 const __mmask16 qfm = (__mmask16)(qf64_ >> (16 * g));
-                __m512i Bg   = _mm512_loadu_si512((const void *)(B + base));
                 __m512i hqeg = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i *)(hq_a_ + base)));
-                __m512i gs_abs = _mm512_add_epi32(hqeg, Bg);
                 __m512i gba = _mm512_loadu_si512((const void *)(gbest_abs + base));
-                __mmask16 gmask = qfm & _mm512_cmpge_epi32_mask(gs_abs, gba);
-                gba = _mm512_mask_mov_epi32(gba, gmask, gs_abs);
+                __mmask16 gmask = qfm & _mm512_cmpge_epi32_mask(hqeg, gba); // hqe >= gbest
+                gba = _mm512_mask_mov_epi32(gba, gmask, hqeg);
                 _mm512_storeu_si512((void *)(gbest_abs + base), gba);
                 __m512i ierg = _mm512_loadu_si512((const void *)(ierow + base));
                 ierg = _mm512_mask_mov_epi32(ierg, gmask, _mm512_set1_epi32(i + 1));
@@ -3320,7 +3207,6 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
                 const __mmask16 cmpm = (__mmask16)(cmp  >> (16 * g));
                 const __mmask16 qfm  = (__mmask16)(qf64 >> (16 * g));
                 const __mmask16 exm  = (__mmask16)(ex64 >> (16 * g));
-                __m512i Bg   = _mm512_loadu_si512((const void *)(B + base));
                 __m512i msg  = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i *)(ms_a  + base)));
                 __m512i rsg  = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i *)(rs_a  + base)));
                 __m512i hqeg = _mm512_cvtepu8_epi32(_mm_loadu_si128((const __m128i *)(hqe_a + base)));
@@ -3331,14 +3217,15 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
                 xrg = _mm512_mask_mov_epi32(xrg, cmpm, vip1);
                 _mm512_storeu_si512((void *)(xrow + base), xrg);
 
+                // best_abs = max(best_abs, (uint8)ms) -- byte is already absolute
                 __m512i bag = _mm512_loadu_si512((const void *)(best_abs + base));
-                bag = _mm512_max_epi32(bag, _mm512_add_epi32(msg, Bg));
+                bag = _mm512_max_epi32(bag, msg);
                 _mm512_storeu_si512((void *)(best_abs + base), bag);
 
-                __m512i gs_abs = _mm512_add_epi32(hqeg, Bg);
+                // gscore: where qfire AND hqe >= gbest_abs, take hqe / i+1
                 __m512i gba = _mm512_loadu_si512((const void *)(gbest_abs + base));
-                __mmask16 gmask = qfm & _mm512_cmpge_epi32_mask(gs_abs, gba); // qfire & gs>=gbest
-                gba = _mm512_mask_mov_epi32(gba, gmask, gs_abs);
+                __mmask16 gmask = qfm & _mm512_cmpge_epi32_mask(hqeg, gba); // qfire & hqe>=gbest
+                gba = _mm512_mask_mov_epi32(gba, gmask, hqeg);
                 _mm512_storeu_si512((void *)(gbest_abs + base), gba);
                 __m512i ierg = _mm512_loadu_si512((const void *)(ierow + base));
                 ierg = _mm512_mask_mov_epi32(ierg, gmask, vip1);
@@ -3448,73 +3335,16 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
         head512 = _mm512_sub_epi8(head512, one512);
         tail512 = _mm512_sub_epi8(tail512, one512);
 
-        // --- RE-BASELINE EVENT (per-lane score floor) ---
-        // After this row's score state is final, lower any lane whose row-max
-        // (maxRS1, rebaselined) has climbed to REBASE_HI back into range. We
-        // raise B[l] by delta = maxRS1[l] - REBASE_KEEP and subtract that delta
-        // (saturating to 0) from every carried score buffer/register for that
-        // lane. Done AFTER band narrowing so this row's trim matches the 16-bit
-        // reference; the next row reads the lowered values consistently.
-        {
-            /* Fast path: one vector test for "any lane >= REBASE_HI?" — see the
-             * 128-bit kernel. Under the routing envelope this is ~always false, so
-             * the per-lane scalar scan + maxRS1 store below are skipped each row. */
-            if (_mm512_cmpge_epu8_mask(maxRS1, _mm512_set1_epi8((int8_t) REBASE_HI))) {
-            uint8_t rs_b[SIMD_WIDTH8] __attribute((aligned(64)));
-            _mm512_store_si512((__m512i *) rs_b, maxRS1);
-            int8_t  delta_a[SIMD_WIDTH8] __attribute((aligned(64)));
-            int any = 0;
-            for (int l = 0; l < SIMD_WIDTH8; l++) {
-                int d = 0;
-                if ((int)rs_b[l] >= REBASE_HI) {
-                    d = (int)rs_b[l] - REBASE_KEEP;   // keep low REBASE_KEEP, in range
-                    B[l] += d;
-                    any = 1;
-                }
-                delta_a[l] = (int8_t) d;              // 0..(REBASE_HI-REBASE_KEEP) small
-            }
-            if (any) {
-                __m512i delta512 = _mm512_load_si512((__m512i *) delta_a);
-                // Subtract delta from every carried score buffer over the active
-                // band columns. The range [lo,hi] is the union of the current and
-                // next band windows; clamping to [0, ncol-1] keeps the loop within
-                // the valid column range (a safe superset covering every column the
-                // next row will read).
-                int lo = nbeg < beg ? nbeg : beg;
-                int hi = nend > end ? nend : end;
-                if (lo < 0) lo = 0;
-                if (hi + 1 > ncol) hi = ncol - 1;
-                for (int l = lo; l <= hi; l++) {
-                    __m512i h512 = _mm512_load_si512((__m512i *)(H_h + l * SIMD_WIDTH8));
-                    __m512i f512 = _mm512_load_si512((__m512i *)(F   + l * SIMD_WIDTH8));
-                    h512 = _mm512_subs_epu8(h512, delta512);
-                    f512 = _mm512_subs_epu8(f512, delta512);
-                    _mm512_store_si512((__m512i *)(H_h + l * SIMD_WIDTH8), h512);
-                    _mm512_store_si512((__m512i *)(F   + l * SIMD_WIDTH8), f512);
-                }
-                // The vertical seed H_v is read only while the band still touches
-                // column 0 (beg==0). Lower the rows that may still be consumed.
-                if (beg == 0) {
-                    for (int r = i + 1; r < nrow; r++) {
-                        __m512i v512 = _mm512_load_si512((__m512i *)(H_v + r * SIMD_WIDTH8));
-                        v512 = _mm512_subs_epu8(v512, delta512);
-                        _mm512_store_si512((__m512i *)(H_v + r * SIMD_WIDTH8), v512);
-                    }
-                }
-                // Carried score maxima (registers) live in the same rebaselined
-                // frame and must be lowered too so the next row's z-drop (ms-rs)
-                // and the absolute-frame add-back stay consistent. maxScore512 is
-                // the running max, so it never saturates to 0 (maxScore512 >=
-                // maxRS1 for the triggering row, and maxRS1 >= REBASE_HI >
-                // REBASE_KEEP > delta, so it stays positive).
-                maxScore512 = _mm512_subs_epu8(maxScore512, delta512);
-                // gscore no longer carries a rebaselined byte register: the
-                // query-end cell H is captured per row and accumulated wide
-                // (gbest_abs, absolute units) in the epilogue, immune to this
-                // re-baseline subtract.
-            }
-            }   /* end "any lane >= REBASE_HI" fast-path guard */
-        }
+#ifdef BSW8_ASSERT_ENVELOPE
+        /* Debug-only envelope check (off by default; asserts are live in release
+         * builds here, so this must not be compiled in unconditionally). The
+         * routing gate guarantees no row max ever reaches the byte ceiling; trap
+         * loudly if a caller pushed an out-of-envelope pair through getScores8
+         * rather than let it return a silently saturated score. */
+        assert(!_mm512_cmpge_epu8_mask(maxRS1, _mm512_set1_epi8((int8_t) BYTE_CEIL)) &&
+               "8-bit banded SW: row max hit the byte ceiling — pair violates "
+               "bsw8_envelope_ok() and must route to the 16-bit kernel");
+#endif
 
 #if RDT
         prof[DP2][0] += __rdtsc() - tim1;
@@ -3525,10 +3355,10 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
     prof[DP][0] += __rdtsc() - tim;
 #endif
 
-    // Scores are reconstructed in ABSOLUTE units from the per-lane wide
-    // best_abs/gbest_abs side channels (= rebaselined byte + B[l], captured each
-    // row before any later re-baseline could saturate the byte away). Positions
-    // are reconstructed wide from the diagonal-offset lanes plus the per-lane
+    // Scores come from the per-lane wide best_abs/gbest_abs side channels, which
+    // carry the byte state widened per row (the byte IS the absolute score under
+    // the routing envelope — see the precondition above). Positions are
+    // reconstructed wide from the diagonal-offset lanes plus the per-lane
     // best-row side channels.
     int8_t maxj[SIMD_WIDTH8]  __attribute((aligned(64)));
     _mm512_store_si512((__m512i *) maxj, y512);   // best col as diagonal offset

--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -5189,21 +5189,11 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
         if (max < w_mismatch) max = w_mismatch;
         if (max < w_ambig) max = w_ambig;
 
-        // Initial per-lane score floor B0 = max(0, h0 - REBASE_KEEP_W) (long-read
-        // 8-bit, seed score h0 >= 128). Seeding the H bytes from raw h0 overflows
-        // the signed-int8 score state on row 0, so we seed from the rebaselined
-        // h0' = min(h0, REBASE_KEEP_W) instead (see the per-lane h0 init below).
-        // REBASE_KEEP_W MUST equal the kernel's REBASE_KEEP (bsw8_rebase_keep)
-        // so the two agree on B0; smithWaterman256_8 recomputes B0 via
-        // bsw8_initial_floor(p[].h0, zdrop).
-        const int REBASE_KEEP_W = bsw8_rebase_keep(zdrop);
-        // The h0-prefix column/row seed below is unsigned-saturating [0,255], so
-        // the seeded byte min(h0, REBASE_KEEP_W) only needs to fit a uint8. The
-        // routing gate (bsw8_envelope_ok) enforces zdrop + maxStep <= 253 (so the
-        // re-baseline window REBASE_HI = 255 - maxStep > REBASE_KEEP holds);
-        // assert the byte bound for any direct caller that bypasses the gate.
-        assert(REBASE_KEEP_W <= 255 &&
-               "8-bit h0-prefix seed byte min(h0,REBASE_KEEP) must fit uint8 (zdrop<=254)");
+        // The h0-prefix column/row seed below is unsigned-saturating [0,255] and
+        // is seeded from the raw seed score h0 (no re-baseline floor): the only
+        // requirement is that the seed byte fit a uint8, which bsw8_envelope_ok()
+        // guarantees (h0 + min(len1,len2)*maxStep < 255 - maxStep => h0 < 255).
+        assert(this->zdrop >= 0 && "8-bit banded SW: negative zdrop");
 
         int nstart = 0, nend = numPairs;
         
@@ -5219,20 +5209,20 @@ void BandedPairWiseSW::smithWatermanBatchWrapper8(SeqPair *pairArray,
             for(j = 0; j < SIMD_WIDTH8; j++)
             {
                 SeqPair sp = pairArray[i + j];
-                // Re-baseline the seed score into the int8 byte frame: seed the H
-                // arrays from h0' = h0 - B0 = min(h0, REBASE_KEEP_W) (clamped >= 0)
-                // so the initial bytes fit signed-int8 even when the true seed h0
-                // is several hundred (long-read). smithWaterman256_8 recomputes the
-                // matching B0 = max(0, h0 - REBASE_KEEP) from p[].h0 + zdrop and
-                // starts that lane's floor B there, so byte == H_absolute - B.
+                // Seed the H arrays from the raw seed score h0. The 8-bit state is
+                // now a plain unsigned [0,255] absolute score (the re-baseline floor
+                // B was removed with the inert re-baseline machinery), and the H
+                // seed uses unsigned-saturating ops, so the only bound is that the
+                // seed byte fit a uint8 -- guaranteed by bsw8_envelope_ok(), which
+                // admits a pair only when h0 + min(len1,len2)*maxStep < 255 - maxStep
+                // (hence h0 < 255). The previous prefix clamp min(h0, zdrop+1) existed
+                // only to keep the removed floor B0 = max(0, h0 - (zdrop+1)) at zero;
+                // with B gone it is pure loss -- it truncated the seed relative to
+                // best_abs (which records the raw h0), so a high-h0 pair that never
+                // beat its seed reported the wrong score. Clamp to uint8 only.
                 {
                     int h0p = sp.h0;
-                    if (h0p > REBASE_KEEP_W) h0p = REBASE_KEEP_W;
                     if (h0p < 0) h0p = 0;
-                    // Always-on uint8 guard (asserts are compiled out in release):
-                    // a direct caller that bypasses the gate with zdrop > 254 would
-                    // otherwise truncate the seed byte. In-envelope REBASE_KEEP_W <= 253,
-                    // so this never fires on the production path.
                     if (h0p > 255) h0p = 255;
                     h0[j] = (uint8_t) h0p;
                 }
@@ -5917,6 +5907,18 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
                 //     drop = (uint8)ms - (uint8)rs; die where drop-dif > zdrop.
                 __m128i y1c  = _mm_add_epi32(y1g, vi);
                 __m128i yc   = _mm_add_epi32(yg, _mm_sub_epi32(xrg, vone));
+                // z-drop unset-best sentinel: y1c and yc each carry the +1 frame
+                // bias (y1 stores col-i+1) so the biases cancel in tmpj = mj-max_j,
+                // BUT only when a best score has been captured (xrow >= 1). While
+                // the best is still the h0 seed (xrow == 0), scalar's max_j == -1
+                // and its drift uses (mj - max_j) = mj + 1; the raw reconstruction
+                // yc = y128 + (xrow-1) gives -1 instead of the required max_j+1 = 0,
+                // under-counting the drift by 1 and firing the z-drop one row early.
+                // Force yc = 0 (== max_j+1 for the -1 sentinel) where xrow == 0 so
+                // the drift matches scalarBandedSWA exactly in the high-h0 regime
+                // (seed score never beaten before the z-drop horizon). This is a
+                // no-op once any row has beaten the seed (xrow >= 1).
+                yc = _mm_andnot_si128(_mm_cmpeq_epi32(xrg, _mm_setzero_si128()), yc);
                 __m128i tmpi = _mm_sub_epi32(vip1, xrg);
                 __m128i tmpj = _mm_sub_epi32(y1c, yc);
                 // z-drop gap term weighted by gap-extend penalty, matching the

--- a/test/bandedswa_high_h0_zdrop_test.cpp
+++ b/test/bandedswa_high_h0_zdrop_test.cpp
@@ -1,0 +1,194 @@
+// Regression test for the 8-bit banded-SW z-drop drift in the HIGH-h0 /
+// SMALL-zdrop regime.
+//
+// The 8-bit kernel's z-drop test (smithWaterman128_8 wide epilogue) mirrors
+// scalarBandedSWA's drift term (i-max_i) - (mj-max_j). The vector reconstructs
+// max_j from a per-lane best-column side channel that carries a +1 frame bias,
+// which cancels against the row-max column's matching +1 bias -- but ONLY once a
+// row has beaten the seed (xrow >= 1). While the running best is still the h0
+// seed (xrow == 0, scalar's max_i == max_j == -1), the reconstruction
+// yc = y128 + (xrow-1) produced -1 instead of the sentinel-correct max_j+1 == 0,
+// under-counting the drift by one and firing the z-drop one row too early. That
+// diverged from scalar precisely when the seed score h0 sits high relative to a
+// small zdrop, so the row max never beats h0 before the (spurious) z-drop -- the
+// exact region a relaxed 8-bit routing envelope would newly admit.
+//
+// This fixture drives that region directly: tandem-repeat pairs (the geometry
+// most prone to premature z-drop) with h0 well above zdrop+1 at small zdrop, and
+// requires getScores8 to be byte-identical to scalarBandedSWA on EVERY result
+// field. The only precondition the byte-wide DP actually needs is that no cell
+// overflow [0,255] (h0 + min(len1,len2)*maxStep < 255 - maxStep); the removed
+// h0 <= zdrop+1 condition was a re-baseline artifact, so it is deliberately NOT
+// imposed here.
+//
+// Scoring is restricted to the default matrix and moderate gap costs. Harsh
+// gap/mismatch settings (e.g. -B9 -O16 -E3) additionally trip an unrelated
+// int8-overflow in the wrapper's band-width clamp (tracked separately), which
+// would mask this z-drop regression; they are intentionally excluded.
+//
+// Deterministic (fixed RNG seed); exits non-zero on any mismatch.
+
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+#include <random>
+
+#include "bandedSWA.h"
+
+namespace {
+
+struct Out { int score, tle, gtle, qle, gscore, max_off; };
+
+// Byte-fit precondition of the 8-bit kernel (the only bound the DP needs) plus
+// the length / target>=query / band conditions that remain load-bearing once
+// the re-baseline-era h0 <= zdrop+1 condition is dropped. Note: h0 is allowed to
+// exceed zdrop+1 here -- that is the whole point.
+bool envelope_ok(int len1, int len2, int w, int h0, int maxStep) {
+    int shorter = len1 < len2 ? len1 : len2;
+    return len1 < MAX_SEQ_LEN8 && len2 < MAX_SEQ_LEN8 && len1 >= len2 &&
+           w <= 127 && (h0 + shorter * maxStep) < 255 - maxStep;
+}
+
+struct Params { int a, b, o, e, zdrop, w; const char *label; };
+
+// One (scoring parameters) x (high-h0 pairs) trial. Returns the number of
+// getScores8-vs-scalar mismatches over the admitted pairs. `admitted` and
+// `above` report coverage so a vacuous trial is visible rather than a silent pass.
+long run_trial(const Params &P, long n, long *admitted_out, long *above_out) {
+    const int maxStep   = P.a > 1 ? P.a : 1;
+    const int end_bonus = 5;
+    const int STRIDE    = 300;
+
+    // Seeds strictly above the old h0 <= zdrop+1 gate, low enough that a useful
+    // query still fits under the byte-fit bound.
+    const int h0min = P.zdrop + 2;
+    const int h0max = (254 - maxStep) / 2;
+    if (h0max <= h0min) { *admitted_out = 0; *above_out = 0; return 0; }
+    int maxlen = (254 - maxStep - h0max) / maxStep;
+    if (maxlen > 120) maxlen = 120;
+    if (maxlen < 12)  { *admitted_out = 0; *above_out = 0; return 0; }
+
+    int8_t mat[25];
+    { int k = 0;
+      for (int i = 0; i < 4; ++i) { for (int j = 0; j < 4; ++j) mat[k++] = (i == j) ? (int8_t)P.a : (int8_t)-P.b; mat[k++] = -1; }
+      for (int j = 0; j < 5; ++j) mat[k++] = -1; }
+
+    BandedPairWiseSW bsw(P.o, P.e, P.o, P.e, P.zdrop, end_bonus, mat, (int8_t)P.a, (int8_t)P.b, 1);
+
+    std::mt19937_64 rng(0xEC7C0DE4ull);
+    std::vector<uint8_t> ref((size_t)STRIDE * n, 0), qer((size_t)STRIDE * n, 0);
+    std::vector<SeqPair> pairs(n);
+    std::vector<Out> oracle(n);
+    std::uniform_int_distribution<int> lenD(10, maxlen);
+    std::uniform_int_distribution<int> hD(h0min, h0max);
+    std::uniform_int_distribution<int> unit(3, 12);
+
+    for (long c = 0; c < n; ++c) {
+        int aa = lenD(rng), bb = lenD(rng);
+        int len1 = aa > bb ? aa : bb, len2 = aa > bb ? bb : aa;   // len1 >= len2
+        int h0 = hD(rng);
+        uint8_t *s1 = &ref[(size_t)c * STRIDE];
+        uint8_t *s2 = &qer[(size_t)c * STRIDE];
+        int u = unit(rng); uint8_t ubuf[16];
+        for (int i = 0; i < u; i++) ubuf[i] = (uint8_t)(rng() % 4);
+        for (int i = 0; i < len1; i++) s1[i] = ubuf[i % u];       // tandem repeat
+        int ti = 0;
+        for (int i = 0; i < len2; i++) {
+            uint8_t base = (ti < len1) ? s1[ti] : (uint8_t)(rng() % 4);
+            if ((int)(rng() % 100) < 5) base = (uint8_t)(rng() % 4);
+            s2[i] = base;
+            if ((rng() % 40) == 0) { if (rng() & 1) ti += 2; } else ti++;
+        }
+        SeqPair &p = pairs[c];
+        p.id = c; p.len1 = len1; p.len2 = len2; p.h0 = h0;
+        p.idr = (int)((size_t)c * STRIDE); p.idq = (int)((size_t)c * STRIDE);
+        p.seqid = c; p.regid = c;
+        p.score = p.tle = p.gtle = p.qle = p.gscore = p.max_off = -1;
+        Out &O = oracle[c];
+        O.score = bsw.scalarBandedSWA(len2, s2, len1, s1, P.w, h0,
+                                      &O.qle, &O.tle, &O.gtle, &O.gscore, &O.max_off);
+    }
+
+    std::vector<long> idx; idx.reserve(n);
+    long above = 0;
+    for (long c = 0; c < n; ++c) {
+        const SeqPair &p = pairs[c];
+        if (!envelope_ok(p.len1, p.len2, P.w, p.h0, maxStep)) continue;
+        idx.push_back(c);
+        if (p.h0 > P.zdrop + 1) above++;
+    }
+    const long adm = (long)idx.size();
+    *admitted_out = adm; *above_out = above;
+    if (adm == 0) return 0;
+
+    // getScores8 pads the batch to a whole number of SIMD lanes and writes the
+    // trailing padding lanes; size to the rounded capacity.
+    const long round_adm = ((adm + SIMD_WIDTH8 - 1) / SIMD_WIDTH8) * SIMD_WIDTH8;
+    std::vector<SeqPair> ap(round_adm);
+    for (long k = 0; k < adm; ++k) ap[k] = pairs[idx[k]];
+    bsw.getScores8(ap.data(), ref.data(), qer.data(), (int32_t)adm, 1, P.w);
+
+    long diffs = 0;
+    for (long k = 0; k < adm; ++k) {
+        const SeqPair &g = ap[k];
+        const Out &O = oracle[idx[k]];
+        if (g.score != O.score || g.tle != O.tle || g.gtle != O.gtle ||
+            g.qle != O.qle || g.gscore != O.gscore || g.max_off != O.max_off) {
+            if (diffs < 4)
+                fprintf(stderr,
+                    "  [%s] DIFF len1=%d len2=%d h0=%d | 8 %d/%d/%d/%d/%d/%d | scalar %d/%d/%d/%d/%d/%d\n",
+                    P.label, g.len1, g.len2, g.h0,
+                    g.score, g.tle, g.gtle, g.qle, g.gscore, g.max_off,
+                    O.score, O.tle, O.gtle, O.qle, O.gscore, O.max_off);
+            diffs++;
+        }
+    }
+    return diffs;
+}
+
+} // namespace
+
+int main() {
+    // Small zdrop with h0 far above zdrop+1 is the failing regime; a few moderate
+    // (non-harsh) scoring points guard against a parameter-specific reintroduction.
+    const Params sweep[] = {
+        {1, 4,  6, 1,   5, 100, "defaults zdrop=5"},
+        {1, 4,  6, 1,  10, 100, "defaults zdrop=10"},
+        {1, 4,  6, 1,  20, 100, "defaults zdrop=20"},
+        {1, 4,  6, 1,  50, 100, "defaults zdrop=50"},
+        {1, 4,  6, 1, 100, 100, "defaults zdrop=100 (h0>101)"},
+        {2, 8, 12, 2,  20, 100, "-A2 -B8 -O12 -E2 zdrop=20"},
+        {3, 4,  6, 1,  20, 100, "-A3 zdrop=20"},
+        {1, 4,  6, 1,  10,  20, "defaults zdrop=10 narrow band"},
+    };
+    const long n = 20000;
+
+    long total_diffs = 0, trials = 0, vacuous = 0, total_above = 0;
+    for (const Params &P : sweep) {
+        long adm = 0, above = 0;
+        long d = run_trial(P, n, &adm, &above);
+        total_diffs += d;
+        total_above += above;
+        trials++;
+        if (!adm) vacuous++;
+        fprintf(stderr, "  [%-30s] zdrop=%-3d w=%-3d admitted=%6ld h0>gate=%6ld diffs=%ld  %s\n",
+                P.label, P.zdrop, P.w, adm, above, d,
+                d ? "FAIL" : (adm ? "ok" : "VACUOUS"));
+    }
+
+    fprintf(stderr, "[high-h0-zdrop] %ld sets, %ld vacuous, h0>gate total=%ld, diffs=%ld\n",
+            trials, vacuous, total_above, total_diffs);
+
+    // The fixture is only meaningful if it actually exercised the newly-admitted
+    // region (h0 > zdrop+1) on the small-zdrop sets.
+    if (total_above == 0 || vacuous == trials) {
+        fprintf(stderr, "bandedswa_high_h0_zdrop_test: FAIL — fixture admitted no h0>zdrop+1 pairs\n");
+        return 2;
+    }
+    if (total_diffs != 0) {
+        fprintf(stderr, "bandedswa_high_h0_zdrop_test: FAIL — %ld getScores8/scalar mismatches\n", total_diffs);
+        return 1;
+    }
+    fprintf(stderr, "bandedswa_high_h0_zdrop_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes two correctness defects in the 8-bit banded-extension kernels that diverge from the scalar reference when the seed score `h0` is high relative to a small `zdrop`. Byte-identical at bwa's default scoring parameters; corrects wrong output in the high-`h0`/small-`zdrop` region. Covers all three tiers (128-bit NEON/SSE, AVX2, AVX-512).

**Stacked on #272 (AVX EXT-19 drop); depends on #271 for the 128-bit re-baseline removal.**

## Defects

1. **h0-prefix seed clamp.** The wrapper seeded the H arrays from `min(h0, zdrop+1)` while the wide result channel used raw `h0`. That clamp only existed to feed the per-lane re-baseline floor removed by #271 — with re-baselining gone it is pure loss: it truncated the seed, so a pair that never beats its seed reported the wrong score. Now seeds from raw `h0` (clamped only to the uint8 ceiling; `bsw8_envelope_ok()` guarantees `h0 < 255`).

2. **Z-drop unset-best sentinel.** While the running best is still the seed (`xrow == 0`, i.e. scalar's `max_i == max_j == -1`), the drift reconstruction produced `yc = -1` instead of the sentinel-correct `0`, undercounting the drift by 1 and z-dropping one row early. Fixed by forcing `yc = 0` where `xrow == 0` (a no-op once any row beats the seed).

Minimal failing case: `len1=88 len2=87 h0=101 zdrop=10` — the vector path died at row 18 (score 101) while scalar extended to 108.

## Byte-identity & correctness

- **Default parameters:** `bwa-bsw-bench` extend 8-bit goldens **byte-identical** — NEON (arm64), AVX2 and AVX-512 (c7i.4xlarge), 60000 pairs each incl. `--n-pct 10`.
- **New test** `test/bandedswa_high_h0_zdrop_test.cpp` (wired into `make test`): drives `getScores8` vs the scalar oracle over `h0 > zdrop+1` at small `zdrop`. **Fails on the pre-fix kernel, passes after** (NEON: 0 diffs across all 8 parameter sets).
- In-repo `bwa_mem3_tests_unit`: pass on all tiers.
- Performance neutral (a `cmpeq`+`andnot` / mask-mov in the O(rows) epilogue).

## Known residual (pre-existing, not introduced here)

On AVX2/AVX-512 only, a harsh-gap set (`-A2 -B8 -O12 -E2 zdrop=20`) leaves 10 gscore/gtle-only diffs. This is a **separate, pre-existing** AVX query-end-capture bug that this fix merely *exposes* (it was masked under the score diffs): the baseline shows the same 10, and the NEON kernel is clean on that set. It does not affect default parameters and is tracked for a separate fix; the 8-bit routing envelope should not be relaxed on x86 until it is resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved correctness for 8-bit banded Smith–Waterman scoring in high-initial-score / small z-drop conditions.
  * Fixed z-drop “unset best” handling to match scalar behavior when no best score is captured yet.

* **Tests**
  * Added a new regression test covering the high-h0 / small-zdrop regime with byte-identical comparison against scalar reference results.
  * Integrated the new regression executable into the standard test run and cleanup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->