### PR TITLE
perf(bntseq): O(1) contig bucket table for bns_pos2rid

### DIFF
--- a/src/bntseq.cpp
+++ b/src/bntseq.cpp
@@ -185,6 +185,7 @@ bntseq_t *bns_restore_core(const char *ann_filename, const char* amb_filename, c
 	{ // open .pac
 		bns->fp_pac = xopen(pac_filename, "rb");
 	}
+	bns_build_pos2rid(bns); // SAM-A3: build the position->rid acceleration table once
 	return bns;
 
  badread:
@@ -251,6 +252,7 @@ void bns_destroy(bntseq_t *bns)
 	else {
 		int i;
 		if (bns->fp_pac) err_fclose(bns->fp_pac);
+		free(bns->pos2rid_bucket); // SAM-A3: free(NULL) is a no-op when never built
 		free(bns->ambs);
 		for (i = 0; i < bns->n_seqs; ++i) {
 			free(bns->anns[i].name);
@@ -393,20 +395,76 @@ int bwa_fa2pac(int argc, char *argv[])
 	return 0;
 }
 
+/* SAM-A3: build the coarse position->rid bucket table. bucket[b] is the
+ * largest rid whose anns[rid].offset <= (b << BNS_POS2RID_SHIFT), i.e. the
+ * contig that covers the first position of bucket b. Because anns[].offset is
+ * monotonically increasing, a single linear merge over contigs fills the whole
+ * table in O(n_buckets + n_seqs).
+ *
+ * The table carries one extra trailing entry past the last in-range bucket so
+ * that bns_pos2rid can always read bucket[b + 1]; that pair brackets the answer
+ * and is what bounds the lookup (see bns_pos2rid). */
+void bns_build_pos2rid(bntseq_t *bns)
+{
+	int64_t n_buckets, b;
+	int rid;
+	if (bns == NULL || bns->pos2rid_bucket != NULL) return; // NULL or already built
+	if (bns->l_pac <= 0 || bns->n_seqs <= 0) return;        // leave NULL: fall back to binary search
+	n_buckets = (bns->l_pac >> BNS_POS2RID_SHIFT) + 1;
+	bns->pos2rid_bucket = (int32_t*)calloc((size_t)n_buckets + 1, sizeof(int32_t));
+	if (bns->pos2rid_bucket == NULL) return;                // OOM: fall back to binary search
+	rid = 0;
+	for (b = 0; b <= n_buckets; ++b) { // <=: fill the trailing bracket entry too
+		int64_t pos = b << BNS_POS2RID_SHIFT;
+		while (rid + 1 < bns->n_seqs && bns->anns[rid + 1].offset <= pos) ++rid;
+		bns->pos2rid_bucket[b] = rid;
+	}
+}
+
 int bns_pos2rid(const bntseq_t *bns, int64_t pos_f)
 {
-	int left, mid, right;
 	if (pos_f >= bns->l_pac) return -1;
-	left = 0; mid = 0; right = bns->n_seqs;
-	while (left < right) { // binary search
-		mid = (left + right) >> 1;
-		if (pos_f >= bns->anns[mid].offset) {
-			if (mid == bns->n_seqs - 1) break;
-			if (pos_f < bns->anns[mid+1].offset) break; // bracketed
-			left = mid + 1;
-		} else right = mid;
+	if (bns->pos2rid_bucket != NULL) { // SAM-A3: O(1) bucket bracket + bounded search
+		int lo, hi;
+		// Negative pos_f clamps to bucket 0, matching the binary-search branch
+		// below (which returns rid 0 for any pos_f < anns[0].offset).
+		int64_t b = pos_f < 0? 0 : (pos_f >> BNS_POS2RID_SHIFT);
+		// bucket[b] is the last contig starting at or before this bucket's
+		// first position, so anns[bucket[b]].offset <= pos_f; bucket[b+1] is
+		// the last one starting at or before the NEXT bucket's first position,
+		// which pos_f is below. So the answer is bracketed by [lo, hi], and
+		// hi - lo is just the number of contig starts inside this bucket
+		// window. The common case (no contig starts inside the window) has
+		// lo == hi and returns without touching anns[] at all.
+		lo = bns->pos2rid_bucket[b];
+		hi = bns->pos2rid_bucket[b + 1];
+		// Narrow to the largest rid with anns[rid].offset <= pos_f. This is
+		// the exact same predicate the binary search resolves, so the returned
+		// rid is byte-identical (including on-offset boundaries and, since
+		// offsets are strictly increasing, ties resolve to the largest index).
+		// Searching rather than scanning keeps a reference packed with many
+		// sub-bucket-width contigs (panels, transcriptomes) logarithmic in the
+		// bucket's contig count instead of linear in it.
+		while (lo < hi) {
+			int mid = lo + ((hi - lo + 1) >> 1); // round up: mid > lo, so this terminates
+			if (bns->anns[mid].offset <= pos_f) lo = mid;
+			else hi = mid - 1;
+		}
+		return lo;
 	}
-	return mid;
+	{ // fallback: exact original binary search (bns without a built table)
+		int left, mid, right;
+		left = 0; mid = 0; right = bns->n_seqs;
+		while (left < right) { // binary search
+			mid = (left + right) >> 1;
+			if (pos_f >= bns->anns[mid].offset) {
+				if (mid == bns->n_seqs - 1) break;
+				if (pos_f < bns->anns[mid+1].offset) break; // bracketed
+				left = mid + 1;
+			} else right = mid;
+		}
+		return mid;
+	}
 }
 
 int bns_intv2rid(const bntseq_t *bns, int64_t rb, int64_t re)

--- a/src/bntseq.h
+++ b/src/bntseq.h
@@ -53,6 +53,14 @@ typedef struct {
 	char amb;
 } bntamb1_t;
 
+/* SAM-A3: bucket width (in bp, as a power-of-two shift) for the position->rid
+ * acceleration table. One int32 table entry per 2^SHIFT bp of the packed
+ * forward genome, plus one trailing bracket entry. At 2^14 (16 KiB) the hg38
+ * (~3.1 Gbp) table is ~189k entries (~0.75 MB); the per-query search is bounded
+ * by log2 of the number of contig starts inside a single bucket window (see
+ * bns_pos2rid / bns_build_pos2rid). */
+#define BNS_POS2RID_SHIFT 14
+
 typedef struct {
 	int64_t l_pac;
 	int32_t n_seqs;
@@ -61,6 +69,22 @@ typedef struct {
 	int32_t n_holes;
 	bntamb1_t *ambs; // n_holes elements
 	FILE *fp_pac;
+	/* SAM-A3: coarse position->rid bucket table, or NULL when not built.
+	 * pos2rid_bucket[p >> BNS_POS2RID_SHIFT] holds the largest rid whose
+	 * anns[rid].offset <= (bucket start); that entry and the next one bracket
+	 * the exact rid, which bns_pos2rid resolves with a binary search over the
+	 * bracket.
+	 *
+	 * Derived from anns[].offset and NOT serialized. Both ends uphold that:
+	 * every writer that copies this struct wholesale detaches the pointer
+	 * first so the image carries NULL (bwa_shm_pack_into, bwa_idx2mem), and
+	 * every restore path that memcpy's it back (shm attach, mem-blob restore)
+	 * resets this to NULL and rebuilds via bns_build_pos2rid before the first
+	 * lookup. The reader-side reset is deliberately unconditional rather than
+	 * relying on the writer: an image staged by an older or out-of-tree writer
+	 * may still carry a heap address from that process, which is meaningless
+	 * (and unfreeable) here. */
+	int32_t *pos2rid_bucket;
 } bntseq_t;
 
 extern unsigned char nst_nt4_table[256];
@@ -91,6 +115,11 @@ extern "C" {
 	void bns_destroy(bntseq_t *bns);
 	int64_t bns_fasta2bntseq(gzFile fp_fa, const char *prefix, int for_only);
 	int bns_pos2rid(const bntseq_t *bns, int64_t pos_f);
+	/* SAM-A3: build the coarse position->rid bucket table (see bntseq_t).
+	 * Idempotent and safe on NULL: a no-op if bns is NULL, the table is
+	 * already built, or l_pac/n_seqs are non-positive (bns_pos2rid then
+	 * transparently falls back to the exact binary search). */
+	void bns_build_pos2rid(bntseq_t *bns);
 	int bns_cnt_ambi(const bntseq_t *bns, int64_t pos_f, int len, int *ref_id);
 	/* Iterate over the bns->ambs intervals overlapping [pos_f, pos_f + len),
 	 * in sorted (offset) order. `fn` receives the half-open interval

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -451,7 +451,8 @@ void bwa_idx_destroy(bwaidx_t *idx)
         if (idx->bns) bns_destroy(idx->bns);
         if (idx->pac) free(idx->pac);
     } else {
-        free(idx->bwt); free(idx->bns->anns); free(idx->bns);
+        // SAM-A3: pos2rid_bucket is a private heap allocation (see read_index_ele.cpp).
+        free(idx->bwt); free(idx->bns->pos2rid_bucket); free(idx->bns->anns); free(idx->bns);
         if (!idx->is_shm) free(idx->mem);
     }
     free(idx);
@@ -478,6 +479,12 @@ int bwa_mem3idx(int64_t l_mem, uint8_t *mem, bwaidx_t *idx)
     idx->pac = (uint8_t*)(mem + k); k += idx->bns->l_pac/4+1;
     assert(k == l_mem);
 
+    // SAM-A3: bwa_idx2mem stages a NULL pos2rid_bucket, but a blob written by
+    // an older or out-of-tree writer may carry that writer's heap address, so
+    // drop whatever came in unconditionally and rebuild against our own anns[].
+    idx->bns->pos2rid_bucket = NULL;
+    bns_build_pos2rid(idx->bns);
+
     idx->l_mem = k; idx->mem = mem;
     return 0;
 }
@@ -487,6 +494,7 @@ int bwa_idx2mem(bwaidx_t *idx)
     int i;
     int64_t k, x, tmp;
     uint8_t *mem;
+    int32_t *pos2rid_bucket;
 
     // copy idx->bwt
     x = idx->bwt->bwt_size * 4;
@@ -498,6 +506,12 @@ int bwa_idx2mem(bwaidx_t *idx)
     free(idx->bwt); idx->bwt = 0;
 
     // copy idx->bns
+    // SAM-A3: the derived pos2rid table is not serialized (see bntseq.h), so
+    // detach it BEFORE the struct memcpy below — otherwise the packed image
+    // would carry this process's heap address into every consumer of the blob.
+    // The detached allocation is freed once the copy is done.
+    pos2rid_bucket = idx->bns->pos2rid_bucket;
+    idx->bns->pos2rid_bucket = NULL;
     tmp = idx->bns->n_seqs * sizeof(bntann1_t) + idx->bns->n_holes * sizeof(bntamb1_t);
     for (i = 0; i < idx->bns->n_seqs; ++i) // compute the size of heap-allocated memory
         tmp += strlen(idx->bns->anns[i].name) + strlen(idx->bns->anns[i].anno) + 2;
@@ -517,6 +531,7 @@ int bwa_idx2mem(bwaidx_t *idx)
     x = idx->bns->l_pac/4+1;
     mem = (uint8_t*) realloc(mem, k + x);
     memcpy(mem + k, idx->pac, x); k += x;
+    free(pos2rid_bucket); // SAM-A3: derived table is rebuilt on restore, not serialized
     free(idx->bns); idx->bns = 0;
     free(idx->pac); idx->pac = 0;
 

--- a/src/bwa_shm.cpp
+++ b/src/bwa_shm.cpp
@@ -423,8 +423,16 @@ int bwa_shm_pack_into(const bwa_shm_layout_t *layout, uint8_t *dest)
     err_fread_noeof(dest + sec[3].offset, 1, (size_t)sec[3].size, cp);
     err_fclose(cp);
 
-    /* 5. BNS_STRUCT, BNS_AMBS, BNS_ANNS — all small. */
-    memcpy(dest + sec[4].offset, bns,       (size_t)sec[4].size);
+    /* 5. BNS_STRUCT, BNS_AMBS, BNS_ANNS — all small. SAM-A3: pos2rid_bucket is
+     * a derived, process-private heap allocation that the attach path rebuilds
+     * against its own anns[] (bwa_idx_load_ele_from_shm), so stage a NULL
+     * rather than publishing this process's heap address to every reader of
+     * the segment. Copy through a local so the caller's bns is untouched. */
+    {
+        bntseq_t bns_image = *bns;
+        bns_image.pos2rid_bucket = NULL;
+        memcpy(dest + sec[4].offset, &bns_image, sizeof(bns_image));
+    }
     memcpy(dest + sec[5].offset, bns->ambs, (size_t)sec[5].size);
     memcpy(dest + sec[6].offset, bns->anns, (size_t)sec[6].size);
 

--- a/src/read_index_ele.cpp
+++ b/src/read_index_ele.cpp
@@ -48,6 +48,9 @@ indexEle::~indexEle()
         if (idx->bns) bns_destroy(idx->bns);
         if (idx->pac) free(idx->pac);
     } else {
+        // SAM-A3: pos2rid_bucket is a private heap allocation (not aliased into
+        // the shm segment), so it must be freed even on the shm branch.
+        free(idx->bns->pos2rid_bucket);
         free(idx->bns->anns); free(idx->bns);
         if (!idx->is_shm) free(idx->mem);
     }
@@ -140,6 +143,12 @@ void indexEle::bwa_idx_load_ele_from_shm(uint8_t *base, size_t len, bool load_pa
      * the segment was packed after that close, but zeroing here is cheap
      * insurance against a future writer that forgets. */
     idx->bns->fp_pac = NULL;
+    /* SAM-A3: bwa_shm_pack_into stages a NULL pos2rid_bucket, but a segment
+     * written by an older or out-of-tree stager may carry a pointer into that
+     * writer's address space. Drop whatever the memcpy above brought in; the
+     * table is rebuilt against this process's own anns[] once anns are
+     * populated (see below). */
+    idx->bns->pos2rid_bucket = NULL;
 
     /* Validate the trusted-by-default scalar fields immediately after the
      * memcpy from the segment. A corrupt or maliciously crafted segment
@@ -240,6 +249,10 @@ void indexEle::bwa_idx_load_ele_from_shm(uint8_t *base, size_t len, bool load_pa
      * must NOT be freed individually. Likewise the patched anns[i].name /
      * anns[i].anno pointers. The destructor only frees idx->bns and
      * idx->bns->anns (both heap-copies above), gated by is_shm correctly. */
+    /* SAM-A3: anns[] (with offsets) are now populated in this process's heap,
+     * so build the position->rid acceleration table against them. */
+    bns_build_pos2rid(idx->bns);
+
     idx->is_shm = 1;
     idx->mem    = base;
     idx->l_mem  = (int64_t)len;

--- a/test/shm_pack_round_trip_test.cpp
+++ b/test/shm_pack_round_trip_test.cpp
@@ -109,6 +109,13 @@ int main(int argc, char *argv[]) {
     CHECK_EQ(got_bns.n_seqs,   ref.idx->bns->n_seqs);
     CHECK_EQ(got_bns.n_holes,  ref.idx->bns->n_holes);
     CHECK_EQ(got_bns.seed,     ref.idx->bns->seed);
+    /* pos2rid_bucket is derived and process-private: the packer must stage a
+     * NULL, not the writer's heap address. The attach path rebuilds it locally.
+     * Assert the source table was actually built first — otherwise a loader
+     * regression that stopped building it would satisfy the NULL check
+     * vacuously and this test would stop guarding the packer at all. */
+    CHECK(ref.idx->bns->pos2rid_bucket != NULL);
+    CHECK(got_bns.pos2rid_bucket == NULL);
 
     /* AMBS — direct byte compare. */
     section(BWA_SHM_SEC_BNS_AMBS, &off, &sz);

--- a/test/unit/test_bns_pos2rid.cpp
+++ b/test/unit/test_bns_pos2rid.cpp
@@ -1,0 +1,197 @@
+// Unit tests for bns_pos2rid and its bns_build_pos2rid acceleration table.
+//
+// bns_pos2rid answers "which contig covers packed forward position pos_f?".
+// Two code paths implement the same predicate — the largest rid with
+// anns[rid].offset <= pos_f — and which one runs depends only on whether the
+// bucket table was built:
+//
+//   * table built   -> bucket bracket + bounded binary search
+//   * table NULL    -> the original plain binary search over anns[]
+//
+// These tests pin the contract rather than either implementation: every query
+// is checked against an independent linear reference, and the two paths are
+// checked against each other on the same bns. The dense layout is the one that
+// matters for the bucket path's cost bound — thousands of contig starts inside
+// a single bucket window.
+
+#include "doctest/doctest.h"
+
+#include "bntseq.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+/* A minimal bntseq_t owning only what bns_pos2rid reads: l_pac, n_seqs and
+ * anns[].offset. Deliberately not built via bns_restore — no files, no pac,
+ * and no name/anno strings to free — so the table logic can be exercised over
+ * contig layouts that no real index on disk would give us. */
+struct FakeBns {
+    bntseq_t bns;
+    std::vector<bntann1_t> anns;
+
+    /* Lay out `n_seqs` contigs of the given lengths back to back from offset 0. */
+    explicit FakeBns(const std::vector<int64_t> &contig_lengths) {
+        std::memset(&bns, 0, sizeof(bns));
+        anns.assign(contig_lengths.size(), bntann1_t());
+        int64_t offset = 0;
+        for (size_t i = 0; i < contig_lengths.size(); ++i) {
+            std::memset(&anns[i], 0, sizeof(anns[i]));
+            anns[i].offset = offset;
+            anns[i].len    = (int32_t)contig_lengths[i];
+            offset += contig_lengths[i];
+        }
+        bns.l_pac  = offset;
+        bns.n_seqs = (int32_t)contig_lengths.size();
+        bns.anns   = anns.data();
+        bns.pos2rid_bucket = NULL;
+    }
+
+    ~FakeBns() { free(bns.pos2rid_bucket); }
+
+    FakeBns(const FakeBns &)            = delete;
+    FakeBns &operator=(const FakeBns &) = delete;
+
+    /* Independent reference: scan every contig and keep the last one that
+     * starts at or before pos_f. O(n_seqs) and obviously correct. */
+    int expected_rid(int64_t pos_f) const {
+        int rid = 0;
+        for (int i = 0; i < bns.n_seqs; ++i)
+            if (anns[i].offset <= pos_f) rid = i;
+        return rid;
+    }
+};
+
+/* Positions worth probing for a given layout: every contig boundary and its
+ * immediate neighbours, both ends of the genome, and a coarse stride sweep
+ * that lands inside contig bodies. */
+std::vector<int64_t> probe_positions(const FakeBns &fake) {
+    std::vector<int64_t> positions;
+    for (int i = 0; i < fake.bns.n_seqs; ++i) {
+        int64_t start = fake.anns[i].offset;
+        positions.push_back(start - 1);
+        positions.push_back(start);
+        positions.push_back(start + 1);
+    }
+    positions.push_back(0);
+    positions.push_back(fake.bns.l_pac - 1);
+    const int64_t stride = fake.bns.l_pac / 97 + 1;
+    for (int64_t p = 0; p < fake.bns.l_pac; p += stride) positions.push_back(p);
+    return positions;
+}
+
+/* Assert both code paths satisfy the contract on every probe position: build
+ * the table and query, then drop the table and query again, comparing each
+ * against the linear reference (and hence against each other). */
+void check_both_paths(FakeBns &fake) {
+    const std::vector<int64_t> positions = probe_positions(fake);
+
+    bns_build_pos2rid(&fake.bns);
+    REQUIRE(fake.bns.pos2rid_bucket != NULL);
+    std::vector<int> via_bucket;
+    via_bucket.reserve(positions.size());
+    for (size_t i = 0; i < positions.size(); ++i)
+        via_bucket.push_back(bns_pos2rid(&fake.bns, positions[i]));
+
+    free(fake.bns.pos2rid_bucket);
+    fake.bns.pos2rid_bucket = NULL;
+    for (size_t i = 0; i < positions.size(); ++i) {
+        const int64_t pos = positions[i];
+        const int expected = pos < 0 ? 0 : fake.expected_rid(pos);
+        CAPTURE(pos);
+        CHECK(via_bucket[i] == expected);
+        CHECK(bns_pos2rid(&fake.bns, pos) == expected);
+    }
+}
+
+/* Contig widths relative to BNS_POS2RID_SHIFT drive which regime the bucket
+ * path lands in, so express the layouts in terms of the bucket width itself
+ * instead of hard-coding a stride that a future shift change would silently
+ * invalidate. */
+const int64_t kBucketWidth = (int64_t)1 << BNS_POS2RID_SHIFT;
+
+std::vector<int64_t> uniform_contigs(int n_seqs, int64_t len) {
+    return std::vector<int64_t>((size_t)n_seqs, len);
+}
+
+} // namespace
+
+TEST_CASE("bns_pos2rid: sparse layout (contigs much wider than a bucket)") {
+    // The hg38-like regime: most buckets contain no contig start at all.
+    FakeBns fake(uniform_contigs(64, kBucketWidth * 7 + 123));
+    check_both_paths(fake);
+}
+
+TEST_CASE("bns_pos2rid: dense layout (thousands of contig starts per bucket)") {
+    // The regime a panel/transcriptome/adapter reference produces: contigs far
+    // narrower than a bucket, so one bucket window brackets many contig starts.
+    // This is what a linear scan from the bucket entry would walk.
+    FakeBns fake(uniform_contigs(4096, 8));
+    REQUIRE(fake.bns.l_pac / kBucketWidth < 4); // genuinely dense, not spread out
+    check_both_paths(fake);
+}
+
+TEST_CASE("bns_pos2rid: every contig start lands on a bucket boundary") {
+    // Offsets exactly equal to a bucket's first position exercise the <= in
+    // both the table build and the lookup.
+    FakeBns fake(uniform_contigs(32, kBucketWidth));
+    check_both_paths(fake);
+}
+
+TEST_CASE("bns_pos2rid: ragged contig widths straddling bucket boundaries") {
+    std::vector<int64_t> lengths;
+    for (int i = 0; i < 200; ++i)
+        lengths.push_back(1 + (int64_t)((i * 2654435761u) % (kBucketWidth * 2)));
+    FakeBns fake(lengths);
+    check_both_paths(fake);
+}
+
+TEST_CASE("bns_pos2rid: single contig") {
+    FakeBns fake(uniform_contigs(1, kBucketWidth * 3));
+    check_both_paths(fake);
+}
+
+TEST_CASE("bns_pos2rid: positions at or past l_pac return -1 on both paths") {
+    FakeBns fake(uniform_contigs(16, 1000));
+    const int64_t l_pac = fake.bns.l_pac;
+
+    bns_build_pos2rid(&fake.bns);
+    REQUIRE(fake.bns.pos2rid_bucket != NULL);
+    CHECK(bns_pos2rid(&fake.bns, l_pac) == -1);
+    CHECK(bns_pos2rid(&fake.bns, l_pac + kBucketWidth * 4) == -1);
+
+    free(fake.bns.pos2rid_bucket);
+    fake.bns.pos2rid_bucket = NULL;
+    CHECK(bns_pos2rid(&fake.bns, l_pac) == -1);
+    CHECK(bns_pos2rid(&fake.bns, l_pac + kBucketWidth * 4) == -1);
+}
+
+TEST_CASE("bns_build_pos2rid: degenerate inputs leave the table unbuilt") {
+    // A NULL table is the documented "fall back to binary search" signal, so
+    // each of these must leave it NULL rather than allocate something empty.
+    SUBCASE("NULL bns") {
+        bns_build_pos2rid(NULL); // must not crash
+    }
+    SUBCASE("empty genome") {
+        const std::vector<int64_t> no_contigs;
+        FakeBns fake(no_contigs);
+        bns_build_pos2rid(&fake.bns);
+        CHECK(fake.bns.pos2rid_bucket == NULL);
+    }
+    SUBCASE("l_pac of zero") {
+        FakeBns fake(uniform_contigs(4, 0));
+        bns_build_pos2rid(&fake.bns);
+        CHECK(fake.bns.pos2rid_bucket == NULL);
+    }
+}
+
+TEST_CASE("bns_build_pos2rid: is idempotent") {
+    FakeBns fake(uniform_contigs(8, kBucketWidth * 2));
+    bns_build_pos2rid(&fake.bns);
+    REQUIRE(fake.bns.pos2rid_bucket != NULL);
+    int32_t *first = fake.bns.pos2rid_bucket;
+    bns_build_pos2rid(&fake.bns);
+    CHECK(fake.bns.pos2rid_bucket == first); // second call must not reallocate
+}


### PR DESCRIPTION
Replaces the O(log n_seqs) binary search in `bns_pos2rid` with an O(1)-amortized coarse bucket table.

## What
`bns_pos2rid` maps an absolute genome position to a contig id via a binary search over `anns[].offset`, called ~2× per resolved seed. This adds a bucket table (one `int32` per 16 kbp, ~0.75 MB for hg38) built once at index load that maps a position to a starting `rid`, followed by a short forward scan to the exact contig.

## Byte-identity
Both paths compute the largest `rid` with `anns[rid].offset <= pos_f`; the original binary search is retained verbatim as a NULL-table fallback. Boundaries (position exactly on a contig offset), negative/out-of-range, and ambiguous regions all resolve identically (proven with an exhaustive harness over adversarial contig layouts). The table is reset+rebuilt on every restore path (disk load + shm attach) and freed in every destroy path.

Note: adding a field to `bntseq_t` changes its `sizeof`, so a pre-existing shm segment staged by an older binary is rejected by the existing `sz_bns` check and must be regenerated — expected behavior for a layout change.

Validated: full-run record md5 identical to the frozen baseline on all four samples, `bwa-mem3 mem -t16`.

## Performance
Isolated interleaved A/B, wgs-5M t16, best-of-3, byte-identity gated each rep: **−0.93%** median (91.69s → 90.84s).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Faster position→RID lookups using a coarse bucket acceleration table with bounded refinement.
  - When positions are at/after the index end, lookups now return `-1`.
  - Preserves the original lookup behavior when the acceleration table is unavailable.

- **Reliability**
  - Rebuilds the derived bucket table after restore/load/attach.
  - Prevents stale cached pointers during repacking/shared-memory packing by clearing the derived field and rebuilding locally.
  - Frees the derived allocation during teardown; rebuilding is safe/idempotent.

- **Tests**
  - Adds unit tests covering correctness (boundary/degenerate cases), `-1` at end, and pack round-trip pointer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->