### PR TITLE
feat(mem): --compat target enum with record + header byte-identity to bwa-mem2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,13 @@ jobs:
           COMPAT_WORK_DIR=/tmp/compat-bytes \
           bash test/regression/compat_byte_identical.sh
 
+      - name: ALT contig header regression (AH:*)
+        if: matrix.canonical == true
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          HEADER_PARITY_WORK_DIR=/tmp/header-parity \
+          bash test/regression/header_parity.sh
+
       - name: SE alignment smoke (chr22)
         if: matrix.canonical == true
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,14 @@ jobs:
           SUPP_REP_PHIX_FA="$GITHUB_WORKSPACE/test/fixtures/phix.fa" \
           bash test/regression/supp_rep_hard_cap.sh
 
+      - name: --compat byte-identical regression (phix)
+        if: matrix.canonical == true
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          COMPAT_PHIX_FA="$GITHUB_WORKSPACE/test/fixtures/phix.fa" \
+          COMPAT_WORK_DIR=/tmp/compat-bytes \
+          bash test/regression/compat_byte_identical.sh
+
       - name: SE alignment smoke (chr22)
         if: matrix.canonical == true
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
           COMPAT_WORK_DIR=/tmp/compat-bytes \
           bash test/regression/compat_byte_identical.sh
 
-      - name: ALT contig header regression (AH:*)
+      - name: header parity regression (AH:*, --compat @HD/@SQ)
         if: matrix.canonical == true
         run: |
           BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \

--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,7 @@ LDFLAGS += $(HTSLIB_static_LDFLAGS)
 # libbwa.a on every build (arm64 and x86 alike).
 OBJS=		src/fastmap.o src/bwtindex.o src/utils.o src/kthread.o \
 			src/kstring.o src/bntseq.o src/bwamem.o src/seed_order.o src/profiling.o \
+			src/compat_target.o \
 			src/FMI_search.o src/read_index_ele.o src/bwamem_pair.o src/bwa.o \
 			src/bwamem_extra.o src/kopen.o src/bam_writer.o src/meth_bam.o \
 			src/meth_xm.o \

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -32,6 +32,13 @@ Options:
                   differently from bwa-mem2, which the default reproduces).
                   NOT byte-identical to the default (divergence confined to the
                   low-confidence tail).
+    --compat      byte-identical bwa-mem2 records: suppress the bwa-mem3-only
+                  MQ:i / HN:i tags, leaving records identical to bwa-mem2 v2.2.1
+                  on the drop-in profile. Suppresses output only; changes no
+                  alignment. @PG still differs (it is run-specific) -- exclude it
+                  when comparing. Mutually exclusive with --fast (which changes
+                  alignments) and with --meth (bwa-mem2 has no bisulfite mode) --
+                  combining them is an error [off]
 Scoring options:
    -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [1]
    -B INT        penalty for a mismatch [4]

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -32,13 +32,16 @@ Options:
                   differently from bwa-mem2, which the default reproduces).
                   NOT byte-identical to the default (divergence confined to the
                   low-confidence tail).
-    --compat      byte-identical bwa-mem2 records: suppress the bwa-mem3-only
-                  MQ:i / HN:i tags, leaving records identical to bwa-mem2 v2.2.1
-                  on the drop-in profile. Suppresses output only; changes no
-                  alignment. @PG still differs (it is run-specific) -- exclude it
-                  when comparing. Mutually exclusive with --fast (which changes
-                  alignments) and with --meth (bwa-mem2 has no bisulfite mode) --
-                  combining them is an error [off]
+    --compat STR  shape output to be byte-identical to another aligner.
+                  Targets: bwa-mem2 (alias mem2), off
+                  bwa-mem2: suppress the MQ:i and HN:i tags and the default @HD,
+                  and ignore the <prefix>.hdr / <baseprefix>.dict sidecar so @SQ
+                  is generated as bare SN/LN (+AH:* on ALT contigs) -- matching
+                  bwa-mem2 v2.2.1 on the drop-in profile. Suppresses output only;
+                  changes no alignment. @PG still differs (it is run-specific) --
+                  exclude it when comparing. Mutually exclusive with --fast (which
+                  changes alignments) and with --meth (bwa-mem2 has no bisulfite
+                  mode) -- combining them is an error [off]
 Scoring options:
    -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [1]
    -B INT        penalty for a mismatch [4]

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -122,6 +122,20 @@ Notes and caveats:
   different alignments, defeating the parity-validation purpose. `--compat` is
   for the drop-in profile. (`--compat=off --fast` is fine: `off` selects no
   target.)
+- **An `@HD` in `-H` warns but is allowed.** bwa-mem3 hoists a *leading* user
+  `@HD` above the `@SQ` block, so the header is spec-valid (`@HD` must come
+  first). Neither target does that — bwa emits `-H` records after `@SQ` and
+  bwa-mem2 has no `@HD` handling at all — so the header differs from the target
+  in **line order**. Records are unaffected.
+
+  This is not rejected, unlike `--fast` and `--meth`, because it is an explicit
+  and coherent request: *give me a valid SAM header, everything else the same*.
+  `--fast` silently moves alignments and `--meth` is a different mode — a user
+  cannot see either in their own command line. An `@HD` they typed, they can.
+
+  Only a *leading* `@HD` diverges; a later one is emitted inline after `@SQ`
+  exactly as upstream does, and does not warn. Every other `-H` record (`@RG`,
+  `@CO`, `@PG`, `@SQ`) and all of `-R` compose with `--compat` normally.
 - **Non-`--meth` only; combining them is a hard error**
   (`--compat is not supported with --meth`). bwa-mem2 has no bisulfite mode, so
   byte-identity is undefined under `--meth`, which also emits

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -62,6 +62,47 @@ writing directly to final storage without a downstream sort step.
 > pipeline that immediately sorts or processes the output, this is faster than
 > SAM at no quality cost.
 
+#### `--compat` — byte-identical bwa-mem2 records
+
+Suppresses the two (and only two) things that keep the bwa-mem3 drop-in profile
+from being a literal byte-for-byte match to bwa-mem2 v2.2.1: the additive
+auxiliary tags `MQ:i` (mate MAPQ) and `HN:i` (hit count). With `--compat`,
+neither is emitted, so the SAM/BAM records are **byte-identical to bwa-mem2** on
+the drop-in profile (verified by stripping `MQ`/`HN` from a default run and
+diffing — the streams match exactly). It applies to both SAM text and `--bam`
+output.
+
+`--compat` is **output-suppressing only** — it changes no alignment, no score,
+no flag, and no other tag. It exists so that pipelines validating bwa-mem3
+against a bwa-mem2 golden can diff raw records without a tag-stripping step.
+
+Notes and caveats:
+
+- **Mutually exclusive with `--fast`.** Passing both is a hard error
+  (`--compat and --fast are mutually exclusive`), because `--fast` deliberately
+  *changes alignments* while `--compat` only removes additive fields — so
+  `--fast --compat` would produce a diff-clean-*looking* stream over genuinely
+  different alignments, defeating the parity-validation purpose. `--compat` is
+  for the drop-in profile. (It composes fine with the other opt-in levers that
+  are individually byte-identical, but if your goal is a bwa-mem2 match, run the
+  plain drop-in profile.)
+- **`@PG` is still emitted, by design.** bwa-mem2 writes its own `@PG`, so
+  suppressing ours would turn a *changed* line into a *missing* one — the diff is
+  non-empty either way, and suppression would only cost the record of what
+  actually produced the file. `@PG` is unmatchable by construction regardless:
+  `CL:` embeds the invocation and its paths, so even two bwa-mem2 runs from
+  different directories differ. Exclude `@PG` on both sides when comparing (e.g.
+  `samtools view` without the header, or `samtools view -H --no-PG`). Every
+  `@HD`/`@SQ`/`@RG` header line is preserved.
+- **`--compat` is non-`--meth` only, and combining them is a hard error**
+  (`--compat is not supported with --meth`). bwa-mem2 has no bisulfite mode, so
+  "byte-identical to bwa-mem2" is undefined under `--meth`, which also emits
+  methylation-specific tags that `--compat` does not model. It is meaningful
+  only on the standard bwa-mem2 drop-in path.
+
+See [Equivalence with bwa-mem2 → Byte-identical records
+(`--compat`)](../whats-different/equivalence.md#byte-identical-records---compat).
+
 #### `-R STR` — read group header
 
 Injects a `@RG` header line and tags every alignment with `RG:Z:<ID>`. The

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -62,46 +62,78 @@ writing directly to final storage without a downstream sort step.
 > pipeline that immediately sorts or processes the output, this is faster than
 > SAM at no quality cost.
 
-#### `--compat` — byte-identical bwa-mem2 records
+#### `--compat=TARGET` — byte-identical output for another aligner
 
-Suppresses the two (and only two) things that keep the bwa-mem3 drop-in profile
-from being a literal byte-for-byte match to bwa-mem2 v2.2.1: the additive
-auxiliary tags `MQ:i` (mate MAPQ) and `HN:i` (hit count). With `--compat`,
-neither is emitted, so the SAM/BAM records are **byte-identical to bwa-mem2** on
-the drop-in profile (verified by stripping `MQ`/`HN` from a default run and
-diffing — the streams match exactly). It applies to both SAM text and `--bam`
-output.
+Shapes bwa-mem3's output so it is byte-for-byte identical to another aligner's.
+`--compat` takes a required target:
 
-`--compat` is **output-suppressing only** — it changes no alignment, no score,
-no flag, and no other tag. It exists so that pipelines validating bwa-mem3
-against a bwa-mem2 golden can diff raw records without a tag-stripping step.
+| target | meaning |
+|---|---|
+| `bwa-mem2` (alias `mem2`) | match bwa-mem2 v2.2.1 |
+| `off` | bwa-mem3's native output — identical to omitting the flag |
+
+```bash
+bwa-mem3 mem --compat=bwa-mem2 -t 16 ref.fa R1.fq R2.fq > out.sam
+bwa-mem3 mem --compat bwa-mem2 -t 16 ref.fa R1.fq R2.fq > out.sam   # same
+```
+
+Under `--compat=bwa-mem2`, bwa-mem3 suppresses exactly the differences that are
+bwa-mem3-side additions, and nothing else:
+
+- **`MQ:i`** (mate MAPQ) and **`HN:i`** (hit count) are not emitted. Note only
+  `HN` is genuinely a bwa-mem3 invention — bwa emits `MQ` too
+  ([lh3/bwa#330](https://github.com/lh3/bwa/pull/330), merged 2022-03-06);
+  bwa-mem2 lacks it only because it forked at 0.7.17, before that landed.
+- **The default `@HD` line** is not emitted. bwa-mem2 v2.2.1 writes no `@HD` at
+  all; bwa gained one in 0.7.18 (`6b18630`), again after the fork. A user `@HD`
+  from `-H` is still honored.
+- **The `<prefix>.hdr` / `<baseprefix>.dict` sidecar is not read**, so `@SQ` is
+  generated from the index as bare `SN`/`LN` (plus `AH:*` on ALT contigs, which
+  bwa-mem2 does emit). The sidecar is a bwa-mem3-only feature — a port of
+  [lh3/bwa#348](https://github.com/lh3/bwa/pull/348), which upstream closed
+  unmerged — so its `M5`/`AS`/`UR`/`SP` have no counterpart to match.
+
+`--compat` is **output-shaping only** — it changes no alignment, no score, no
+flag, and no tag's value. It exists so pipelines validating bwa-mem3 against a
+bwa-mem2 golden can diff raw output without a post-processing step.
+
+Verify it with:
+
+```bash
+# records
+diff <(samtools view out.compat.bam) <(samtools view out.mem2.bam)
+# header, @PG excluded on both sides (see below)
+diff <(samtools view -H --no-PG out.compat.bam | grep -v '^@PG') \
+     <(samtools view -H --no-PG out.mem2.bam   | grep -v '^@PG')
+```
 
 Notes and caveats:
 
-- **Mutually exclusive with `--fast`.** Passing both is a hard error
-  (`--compat and --fast are mutually exclusive`), because `--fast` deliberately
-  *changes alignments* while `--compat` only removes additive fields — so
-  `--fast --compat` would produce a diff-clean-*looking* stream over genuinely
-  different alignments, defeating the parity-validation purpose. `--compat` is
-  for the drop-in profile. (It composes fine with the other opt-in levers that
-  are individually byte-identical, but if your goal is a bwa-mem2 match, run the
-  plain drop-in profile.)
 - **`@PG` is still emitted, by design.** bwa-mem2 writes its own `@PG`, so
   suppressing ours would turn a *changed* line into a *missing* one — the diff is
   non-empty either way, and suppression would only cost the record of what
   actually produced the file. `@PG` is unmatchable by construction regardless:
   `CL:` embeds the invocation and its paths, so even two bwa-mem2 runs from
-  different directories differ. Exclude `@PG` on both sides when comparing (e.g.
-  `samtools view` without the header, or `samtools view -H --no-PG`). Every
-  `@HD`/`@SQ`/`@RG` header line is preserved.
-- **`--compat` is non-`--meth` only, and combining them is a hard error**
+  different directories differ. Exclude `@PG` on both sides when comparing.
+- **Mutually exclusive with `--fast`.** Passing both is a hard error
+  (`--compat and --fast are mutually exclusive`), because `--fast` deliberately
+  *changes alignments* while `--compat` only shapes output — so `--fast
+  --compat=bwa-mem2` would produce a diff-clean-*looking* stream over genuinely
+  different alignments, defeating the parity-validation purpose. `--compat` is
+  for the drop-in profile. (`--compat=off --fast` is fine: `off` selects no
+  target.)
+- **Non-`--meth` only; combining them is a hard error**
   (`--compat is not supported with --meth`). bwa-mem2 has no bisulfite mode, so
-  "byte-identical to bwa-mem2" is undefined under `--meth`, which also emits
-  methylation-specific tags that `--compat` does not model. It is meaningful
-  only on the standard bwa-mem2 drop-in path.
+  byte-identity is undefined under `--meth`, which also emits
+  methylation-specific tags that no target models.
+- **`--compat=bwa-mem` is recognized but rejected.** bwa-mem3 and bwa still
+  differ on 224 of 63,583 records (53 above MAPQ 30) in MAPQ, CIGAR, POS and
+  TLEN, so byte-identity is not achievable no matter what output is suppressed.
+  The target's output shaping is already specified in `src/compat_target.cpp`;
+  it becomes selectable when the alignment work lands.
 
-See [Equivalence with bwa-mem2 → Byte-identical records
-(`--compat`)](../whats-different/equivalence.md#byte-identical-records---compat).
+See [Equivalence with bwa-mem2 → Byte-identical output
+(`--compat`)](../whats-different/equivalence.md#byte-identical-output---compat).
 
 #### `-R STR` — read group header
 

--- a/docs/src/whats-different/equivalence.md
+++ b/docs/src/whats-different/equivalence.md
@@ -7,7 +7,7 @@ On the drop-in profile (plain <code>bwa-mem3 mem</code>, no flags), release 0.7.
 <li><code>MQ:i</code> — mate mapping quality (an extra tag bwa-mem2 never wrote)</li>
 <li><code>HN:i</code> — hit count (an extra tag bwa-mem2 never wrote)</li>
 </ul>
-Strip those two tags and those records are byte-for-byte identical. The <strong>header</strong> is a separate question that these measurements do not cover: the <code>@PG</code> line names <code>bwa-mem3</code>, and bwa-mem3 emits a default <code>@HD</code> line that bwa-mem2 has no code to write at all (<a href="https://github.com/fg-labs/bwa-mem3/issues/288">#288</a>). Every byte-identity claim on this page is about <em>alignment records</em>, not the header block.
+Strip those two tags and those records are byte-for-byte identical — or pass <strong><code>--compat</code></strong> to suppress both at the source (see <a href="#byte-identical-records---compat">Byte-identical records</a>). The <strong>header</strong> is a separate question that these measurements do not cover: the <code>@PG</code> line names <code>bwa-mem3</code>, and bwa-mem3 emits a default <code>@HD</code> line that bwa-mem2 has no code to write at all (<a href="https://github.com/fg-labs/bwa-mem3/issues/288">#288</a>). Every byte-identity claim on this page is about <em>alignment records</em>, not the header block.
 <br><br>
 <strong>The supplementary gap is now closed.</strong> The residual <strong>+4 supplementary alignments</strong> has been re-measured on <code>e722ed0</code> (a build carrying <a href="https://github.com/fg-labs/bwa-mem3/pull/268">#268</a>) and is <strong>+0</strong>: on <code>wgs-5M</code>, <code>wes-5M</code> and <code>hic-1M</code> the full <em>alignment-record</em> stream is byte-identical to bwa-mem2 v2.2.1 once <code>MQ:i</code>/<code>HN:i</code> are stripped — 22.5 M records including 436 k supplementary alignments. That comparison covers alignment records only, not the header block. What remains open is the genome-wide, multi-sample re-run that would extend this past the cells named on this page. Treat every claim here as scoped to the evidence it cites, not as a guarantee across all inputs and architectures. (The opt-in <code>--fast</code> speed levers are a separate, deliberate deviation — see below.)
 </div>
@@ -89,6 +89,45 @@ regenerate the [declared divergence catalog](#declared-divergence-catalog) is pe
 > Gotoh and what ksw2/minimap2 do; gap-from-`M` is a deliberate bwa idiosyncrasy. `#256`
 > chooses bwa-mem2 output compatibility over the convention because bwa-mem3 is a drop-in
 > replacement. `IPNP-BIPN/bwa-mem4` made the same call (`990df3a`) for the same reason.
+
+## Byte-identical records (`--compat`)
+
+With the primary alignments restored (above), the only thing standing between the drop-in
+profile's **records** and a byte-for-byte match with bwa-mem2 is the additive tag layer:
+`MQ:i` and `HN:i`. The `--compat` flag removes exactly those:
+
+```bash
+bwa-mem3 mem --compat -t <N> ref.fa R1.fq R2.fq > out.sam
+```
+
+Under `--compat`, bwa-mem3 emits no `MQ:i` tag and no `HN:i` tag. Every alignment, score,
+flag, and other tag is untouched — it is **output-suppressing only, never an alignment
+change**. On both the SAM-text and `--bam` paths the records are then byte-identical to
+bwa-mem2 v2.2.1 on the drop-in profile: stripping `MQ`/`HN` from a default run and diffing
+against a `--compat` run yields identical streams (same md5).
+
+Caveats:
+
+- **`--compat` and `--fast` are mutually exclusive** — passing both is a hard error.
+  `--fast` deliberately moves alignments; `--compat` only removes additive fields, so
+  `--fast --compat` would produce a diff-clean-looking stream over genuinely different
+  alignments. `--compat` is meaningful only on the drop-in profile.
+- **`--compat` covers records, not the header.** `@PG` is still emitted and still names
+  `bwa-mem3`; suppressing it would only turn a changed line into a missing one, since
+  bwa-mem2 writes its own. It is unmatchable by construction anyway — `CL:` embeds the
+  invocation and its paths, so even two bwa-mem2 runs from different directories differ.
+  Exclude `@PG` on both sides when comparing (`samtools view` without the header, or
+  `samtools view -H --no-PG`).
+- **`@HD` and `@SQ` may also differ**, independently of `--compat`. bwa-mem2 emits no `@HD`
+  at all, and when a `<prefix>.hdr` / `<baseprefix>.dict` sidecar is present bwa-mem3
+  emits its richer `@SQ` block (`M5`/`AS`/`UR`/`SP`). `SN`/`LN` are identical in identical
+  order, so this is additive, but a comparator that checks every `@SQ` field will still
+  flag it. Bringing these under `--compat` is tracked separately.
+
+`--compat` is for the standard drop-in path only: bwa-mem2 has no `--meth` mode to be
+identical to, so **`--compat --meth` is a hard error**. See
+[`mem` → `--compat`](../cli/mem.md#--compat--byte-identical-bwa-mem2-records) for the
+flag reference.
 
 ## What is preserved
 

--- a/docs/src/whats-different/equivalence.md
+++ b/docs/src/whats-different/equivalence.md
@@ -7,7 +7,7 @@ On the drop-in profile (plain <code>bwa-mem3 mem</code>, no flags), release 0.7.
 <li><code>MQ:i</code> — mate mapping quality (an extra tag bwa-mem2 never wrote)</li>
 <li><code>HN:i</code> — hit count (an extra tag bwa-mem2 never wrote)</li>
 </ul>
-Strip those two tags and those records are byte-for-byte identical — or pass <strong><code>--compat</code></strong> to suppress both at the source (see <a href="#byte-identical-records---compat">Byte-identical records</a>). The <strong>header</strong> is a separate question that these measurements do not cover: the <code>@PG</code> line names <code>bwa-mem3</code>, and bwa-mem3 emits a default <code>@HD</code> line that bwa-mem2 has no code to write at all (<a href="https://github.com/fg-labs/bwa-mem3/issues/288">#288</a>). Every byte-identity claim on this page is about <em>alignment records</em>, not the header block.
+Strip those two tags and those records are byte-for-byte identical — or pass <strong><code>--compat=bwa-mem2</code></strong> to suppress both at the source (see <a href="#byte-identical-output---compat">Byte-identical output</a>). The <strong>header</strong> is a separate question that these measurements do not cover: on the default path the <code>@PG</code> line names <code>bwa-mem3</code> and bwa-mem3 emits a default <code>@HD</code> line that bwa-mem2 has no code to write at all (<a href="https://github.com/fg-labs/bwa-mem3/issues/288">#288</a>). <code>--compat=bwa-mem2</code> brings the <code>@HD</code> and <code>@SQ</code> blocks to parity as well, leaving only <code>@PG</code> to exclude. Every byte-identity claim measured on this page is about <em>alignment records</em>, not the header block.
 <br><br>
 <strong>The supplementary gap is now closed.</strong> The residual <strong>+4 supplementary alignments</strong> has been re-measured on <code>e722ed0</code> (a build carrying <a href="https://github.com/fg-labs/bwa-mem3/pull/268">#268</a>) and is <strong>+0</strong>: on <code>wgs-5M</code>, <code>wes-5M</code> and <code>hic-1M</code> the full <em>alignment-record</em> stream is byte-identical to bwa-mem2 v2.2.1 once <code>MQ:i</code>/<code>HN:i</code> are stripped — 22.5 M records including 436 k supplementary alignments. That comparison covers alignment records only, not the header block. What remains open is the genome-wide, multi-sample re-run that would extend this past the cells named on this page. Treat every claim here as scoped to the evidence it cites, not as a guarantee across all inputs and architectures. (The opt-in <code>--fast</code> speed levers are a separate, deliberate deviation — see below.)
 </div>
@@ -90,44 +90,72 @@ regenerate the [declared divergence catalog](#declared-divergence-catalog) is pe
 > chooses bwa-mem2 output compatibility over the convention because bwa-mem3 is a drop-in
 > replacement. `IPNP-BIPN/bwa-mem4` made the same call (`990df3a`) for the same reason.
 
-## Byte-identical records (`--compat`)
+## Byte-identical output (`--compat`)
 
-With the primary alignments restored (above), the only thing standing between the drop-in
-profile's **records** and a byte-for-byte match with bwa-mem2 is the additive tag layer:
-`MQ:i` and `HN:i`. The `--compat` flag removes exactly those:
+With the primary alignments restored (above), a small set of bwa-mem3-side additions is all
+that stands between the drop-in profile and a byte-for-byte match with bwa-mem2 v2.2.1.
+`--compat=bwa-mem2` removes exactly those:
 
 ```bash
-bwa-mem3 mem --compat -t <N> ref.fa R1.fq R2.fq > out.sam
+bwa-mem3 mem --compat=bwa-mem2 -t <N> ref.fa R1.fq R2.fq > out.sam
 ```
 
-Under `--compat`, bwa-mem3 emits no `MQ:i` tag and no `HN:i` tag. Every alignment, score,
-flag, and other tag is untouched — it is **output-suppressing only, never an alignment
-change**. On both the SAM-text and `--bam` paths the records are then byte-identical to
-bwa-mem2 v2.2.1 on the drop-in profile: stripping `MQ`/`HN` from a default run and diffing
-against a `--compat` run yields identical streams (same md5).
+| | default | `--compat=bwa-mem2` | bwa-mem2 v2.2.1 |
+|---|---|---|---|
+| `MQ:i` | emitted | suppressed | absent |
+| `HN:i` | emitted | suppressed | absent |
+| default `@HD` | emitted | suppressed | **none emitted** |
+| `.hdr`/`.dict` sidecar `@SQ` | honored (`M5`/`AS`/`UR`/`SP`) | ignored → bare `SN`/`LN` (+`AH:*`) | bare `SN`/`LN` (+`AH:*`) |
+| `@PG` | `ID:bwa-mem3` | `ID:bwa-mem3` | `ID:bwa-mem2` |
+
+Two of those rows are not what they look like. **`MQ:i` is not a bwa-mem3 invention** — bwa
+emits it too ([lh3/bwa#330](https://github.com/lh3/bwa/pull/330), merged 2022-03-06);
+bwa-mem2 lacks it only because it forked at 0.7.17, before that landed. Likewise **bwa emits
+a default `@HD`** (0.7.18, `6b18630`) and bwa-mem2 does not, for the same reason. Only `HN:i`
+and the sidecar are genuinely bwa-mem3-only — which is why `--compat` takes a *target* rather
+than being a boolean: bwa and bwa-mem2 disagree with each other on half of this table.
+
+`--compat` is **output-shaping only, never an alignment change**. Every alignment, score,
+flag, and tag value is untouched.
+
+**Verified** against a real bwa-mem2 v2.2.1 run on hg38: with `@PG` excluded on both sides —
+it still names `bwa-mem3` and is unmatchable by construction, see the caveats below — the
+header is byte-identical on both the SAM-text and `--bam` paths (3,366 lines, md5
+`34dabb50dd7a704866e841d3e5a7f68d` on all three), and the records are byte-identical on the
+drop-in profile.
+
+```bash
+# records
+diff <(samtools view out.compat.bam) <(samtools view out.mem2.bam)
+# header, @PG excluded on both sides
+diff <(samtools view -H --no-PG out.compat.bam | grep -v '^@PG') \
+     <(samtools view -H --no-PG out.mem2.bam   | grep -v '^@PG')
+```
 
 Caveats:
 
+- **`@PG` is still emitted**, and still names `bwa-mem3`. Suppressing it would only turn a
+  changed line into a missing one, since bwa-mem2 writes its own. It is unmatchable by
+  construction anyway — `CL:` embeds the invocation and its paths, so even two bwa-mem2 runs
+  from different directories differ. Exclude `@PG` on both sides when comparing.
 - **`--compat` and `--fast` are mutually exclusive** — passing both is a hard error.
-  `--fast` deliberately moves alignments; `--compat` only removes additive fields, so
-  `--fast --compat` would produce a diff-clean-looking stream over genuinely different
+  `--fast` deliberately moves alignments; `--compat` only shapes output, so `--fast
+  --compat=bwa-mem2` would produce a diff-clean-looking stream over genuinely different
   alignments. `--compat` is meaningful only on the drop-in profile.
-- **`--compat` covers records, not the header.** `@PG` is still emitted and still names
-  `bwa-mem3`; suppressing it would only turn a changed line into a missing one, since
-  bwa-mem2 writes its own. It is unmatchable by construction anyway — `CL:` embeds the
-  invocation and its paths, so even two bwa-mem2 runs from different directories differ.
-  Exclude `@PG` on both sides when comparing (`samtools view` without the header, or
-  `samtools view -H --no-PG`).
-- **`@HD` and `@SQ` may also differ**, independently of `--compat`. bwa-mem2 emits no `@HD`
-  at all, and when a `<prefix>.hdr` / `<baseprefix>.dict` sidecar is present bwa-mem3
-  emits its richer `@SQ` block (`M5`/`AS`/`UR`/`SP`). `SN`/`LN` are identical in identical
-  order, so this is additive, but a comparator that checks every `@SQ` field will still
-  flag it. Bringing these under `--compat` is tracked separately.
+- **The sidecar `@SQ` is skipped, not rewritten.** Outside `--compat` the
+  `<prefix>.hdr` / `<baseprefix>.dict` block remains authoritative and is emitted verbatim —
+  it is a port of [lh3/bwa#348](https://github.com/lh3/bwa/pull/348), designed for the block
+  to be produced complete by an external tool. If your index has a `.alt` file, generate the
+  sidecar with `samtools dict --alt <ref>.alt` so `AH:*` is carried; bwa-mem3 warns when it
+  sees ALT contigs and a sidecar `@SQ` without `AH`.
+- **`--compat=bwa-mem` is recognized but rejected.** bwa-mem3 and bwa still differ on 224 of
+  63,583 records (53 above MAPQ 30) in MAPQ, CIGAR, POS and TLEN, so no amount of output
+  shaping makes them byte-identical. Tracked separately.
 
 `--compat` is for the standard drop-in path only: bwa-mem2 has no `--meth` mode to be
 identical to, so **`--compat --meth` is a hard error**. See
-[`mem` → `--compat`](../cli/mem.md#--compat--byte-identical-bwa-mem2-records) for the
-flag reference.
+[`mem` → `--compat`](../cli/mem.md#--compattarget--byte-identical-output-for-another-aligner)
+for the flag reference.
 
 ## What is preserved
 

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -402,7 +402,7 @@ int mem_aln_to_bam(struct bam1_t *b,
             bam_aux_append(b, "MC", 'Z', (int)mc->l + 1, (const uint8_t *)mc->s);
         /* no free: bs.mc.s persists across records, freed on thread exit */
     }
-    if (mp) {
+    if (mp && !(opt->flag & MEM_F_COMPAT)) {
         int32_t mq = (int32_t)mp->mapq;
         bam_aux_append(b, "MQ", 'i', sizeof(mq), (const uint8_t *)&mq);
     }
@@ -461,7 +461,7 @@ int mem_aln_to_bam(struct bam1_t *b,
     if (p.XA != NULL) {
         bam_aux_append(b, "XA", 'Z', (int)strlen(p.XA) + 1, (const uint8_t *)p.XA);
     }
-    if (p.HN >= 0) {
+    if (p.HN >= 0 && !(opt->flag & MEM_F_COMPAT)) {
         int32_t hn = (int32_t)p.HN;
         bam_aux_append(b, "HN", 'i', sizeof(hn), (const uint8_t *)&hn);
     }

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -98,15 +98,18 @@ bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
     }
     // Merge the index's .hdr/.dict records after the default @HD (and
     // auto-generated @SQ, when the index didn't supply its own) but before
-    // the user's -H lines. If the user has an @HD in -H, strip the @HD
-    // records from idx_hdr_lines first — htslib's sam_hdr_add_lines does
-    // not de-dup @HD, so without filtering we'd emit two @HD records. This
-    // matches the SAM text path's precedence: user > index > default.
+    // the user's -H lines. Only one @HD may survive — htslib's
+    // sam_hdr_add_lines does not de-dup them — so strip every @HD from
+    // idx_hdr_lines except, when the user's -H supplies none, the first: that
+    // one is the winner. This matches the SAM text path's precedence
+    // (user > index > default) and its identical filter in bwa.cpp.
     if (idx_hdr_lines != NULL && idx_hdr_lines[0] != '\0') {
         const char *to_add = idx_hdr_lines;
         char *filtered = NULL;
-        if (user_has_hd && idx_has_hd) {
-            // Copy idx_hdr_lines, dropping any @HD records.
+        if (idx_has_hd) {
+            const int keep_first_hd = !user_has_hd;
+            int seen_hd = 0;
+            // Copy idx_hdr_lines, dropping the losing @HD records.
             size_t n = strlen(idx_hdr_lines);
             filtered = (char *)malloc(n + 1);
             if (filtered == NULL) goto fail;
@@ -116,10 +119,11 @@ bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
                 const char *eol = strchr(p, '\n');
                 size_t len = eol ? (size_t)(eol - p) : strlen(p);
                 int is_hd = (len >= 4 && strncmp(p, "@HD\t", 4) == 0);
-                if (!is_hd && len > 0) {
+                if (len > 0 && (!is_hd || (keep_first_hd && !seen_hd))) {
                     memcpy(filtered + w, p, len); w += len;
                     filtered[w++] = '\n';
                 }
+                if (is_hd) seen_hd = 1;
                 p = eol ? eol + 1 : p + len;
             }
             filtered[w] = '\0';

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -29,9 +29,11 @@ void           bam_writer_free(struct bam1_t *b)  { if (b) bam_destroy1(b); }
 bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
                               const char *idx_hdr_lines,
                               const char *hdr_line, const char *bwa_pg,
-                              int compression_level)
+                              int compression_level,
+                              const compat_target_t *compat)
 {
     if (path == NULL || bns == NULL) return NULL;
+    if (compat == NULL) compat = &COMPAT_TARGET_OFF;
 
     // Detect whether the index .hdr/.dict content already supplies @SQ or
     // @HD records. If @SQ: skip auto-generating @SQ from `bns` — adding
@@ -62,8 +64,18 @@ bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
     // .hdr/.dict supplies one. Precedence (user > index > default) is
     // enforced by ordering: we add idx_hdr_lines before hdr_line, and the
     // SAM text path uses the same precedence via bwa_print_sam_hdr2.
-    if (!idx_has_hd && !user_has_hd &&
-        sam_hdr_add_line(hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL) < 0) goto fail;
+    //
+    // @HD policy comes from the selected compat target; the evidence for each
+    // row is in src/compat_target.cpp. DO NOT "fix" the missing @HD under a
+    // compat target -- suppressing it is deliberate, not an oversight.
+    // compat->hd_line == NULL keeps this path's historical default, which
+    // differs from the SAM text path's (fg-labs/bwa-mem3#288).
+    if (!idx_has_hd && !user_has_hd && compat->emit_hd) {
+        int rc = compat->hd_line != NULL
+               ? sam_hdr_add_lines(hdr, compat->hd_line, 0)
+               : sam_hdr_add_line(hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL);
+        if (rc < 0) goto fail;
+    }
     if (!idx_has_sq) {
         for (int i = 0; i < bns->n_seqs; ++i) {
             char len_buf[32];
@@ -74,7 +86,8 @@ bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
             // SN+LN-only loop and silently dropped it for EVERY ALT-aware
             // reference, sidecar or not. `is_alt` comes from <prefix>.alt via
             // bwa_idx_load and has no representation in an htslib sam_hdr_t,
-            // so it must be re-applied here.
+            // so it must be re-applied here. Not gated on `compat`: it is what
+            // both upstreams do, so it is correct output, not a divergence.
             int rc = bns->anns[i].is_alt
                    ? sam_hdr_add_line(hdr, "SQ", "SN", bns->anns[i].name,
                                       "LN", len_buf, "AH", "*", NULL)
@@ -413,7 +426,7 @@ int mem_aln_to_bam(struct bam1_t *b,
             bam_aux_append(b, "MC", 'Z', (int)mc->l + 1, (const uint8_t *)mc->s);
         /* no free: bs.mc.s persists across records, freed on thread exit */
     }
-    if (mp && !(opt->flag & MEM_F_COMPAT)) {
+    if (mp && opt->compat->emit_mq) {
         int32_t mq = (int32_t)mp->mapq;
         bam_aux_append(b, "MQ", 'i', sizeof(mq), (const uint8_t *)&mq);
     }
@@ -472,7 +485,7 @@ int mem_aln_to_bam(struct bam1_t *b,
     if (p.XA != NULL) {
         bam_aux_append(b, "XA", 'Z', (int)strlen(p.XA) + 1, (const uint8_t *)p.XA);
     }
-    if (p.HN >= 0 && !(opt->flag & MEM_F_COMPAT)) {
+    if (p.HN >= 0 && opt->compat->emit_hn) {
         int32_t hn = (int32_t)p.HN;
         bam_aux_append(b, "HN", 'i', sizeof(hn), (const uint8_t *)&hn);
     }

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -68,8 +68,19 @@ bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
         for (int i = 0; i < bns->n_seqs; ++i) {
             char len_buf[32];
             snprintf(len_buf, sizeof(len_buf), "%lld", (long long)bns->anns[i].len);
-            if (sam_hdr_add_line(hdr, "SQ", "SN", bns->anns[i].name, "LN", len_buf, NULL) < 0)
-                goto fail;
+            // AH:* on ALT contigs. Both upstreams emit it on the generated
+            // @SQ block (bwa/bwa.c:432, bwa-mem2/src/bwa.cpp:538) and so does
+            // our SAM text path (bwa.cpp); this writer was ported as an
+            // SN+LN-only loop and silently dropped it for EVERY ALT-aware
+            // reference, sidecar or not. `is_alt` comes from <prefix>.alt via
+            // bwa_idx_load and has no representation in an htslib sam_hdr_t,
+            // so it must be re-applied here.
+            int rc = bns->anns[i].is_alt
+                   ? sam_hdr_add_line(hdr, "SQ", "SN", bns->anns[i].name,
+                                      "LN", len_buf, "AH", "*", NULL)
+                   : sam_hdr_add_line(hdr, "SQ", "SN", bns->anns[i].name,
+                                      "LN", len_buf, NULL);
+            if (rc < 0) goto fail;
         }
     }
     // Merge the index's .hdr/.dict records after the default @HD (and

--- a/src/bam_writer.h
+++ b/src/bam_writer.h
@@ -28,12 +28,15 @@ typedef struct bam_writer_s bam_writer_t;
  * win on any @HD/@SQ collision via htslib's header de-dup rules. `hdr_line`
  * carries user-supplied header lines (e.g., `@RG` from `-R` and `-H`
  * insertions, as accumulated by bwa_insert_header); it is inserted before
- * `@PG`. `bwa_pg` is inserted as-is. All three may be NULL. Returns NULL on
- * failure. */
+ * `@PG`. `bwa_pg` is inserted as-is. All three may be NULL. `compat` selects
+ * the output-compatibility target whose @HD policy the header follows (NULL =
+ * COMPAT_TARGET_OFF); it shapes only the default @HD, never @SQ. Returns NULL
+ * on failure. */
 bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
                               const char *idx_hdr_lines,
                               const char *hdr_line, const char *bwa_pg,
-                              int compression_level);
+                              int compression_level,
+                              const compat_target_t *compat);
 
 /* Write one record. Returns 0 on success, -1 on error. */
 int bam_writer_write(bam_writer_t *w, struct bam1_t *b);

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -543,24 +543,45 @@ int bwa_idx2mem(bwaidx_t *idx)
  * SAM header routines *
  ***********************/
 
-// Write the first line from `lines` to `fp` if print is nonzero, and return
-// a pointer to the remainder (or NULL when consumed). `lines` is newline-
-// separated but not required to be newline-terminated.
-static const char *remove_line(const char *lines, int print, FILE *fp)
+// Write the first line from `lines` to `fp` and return a pointer to the
+// remainder (or NULL when consumed). `lines` is newline-separated but not
+// required to be newline-terminated.
+static const char *hoist_line(const char *lines, FILE *fp)
 {
     const char *nl = strchr(lines, '\n');
     if (nl) {
-        if (print) {
-            err_fwrite(lines, 1, (size_t)(nl - lines), fp);
-            err_fputc('\n', fp);
-        }
+        err_fwrite(lines, 1, (size_t)(nl - lines), fp);
+        err_fputc('\n', fp);
         return nl + 1;
     } else {
-        if (print) {
-            err_fputs(lines, fp);
+        err_fputs(lines, fp);
+        err_fputc('\n', fp);
+        return NULL;
+    }
+}
+
+// Write `lines` (newline-separated, not newline-terminated) to `fp`, dropping
+// every @HD record except -- when `keep_first_HD` is set -- the first one.
+//
+// Only ONE @HD may reach the output, and the loser can sit anywhere in either
+// stream, so it cannot always be consumed off the front the way hoist_line
+// handles a leading record. A winner that is not leading has to stay inline,
+// where the caller put it, hence `keep_first_HD` rather than an unconditional
+// drop. Empty lines are skipped, matching the BAM writer's equivalent filter
+// (bam_writer.cpp) -- a blank line is not a valid header record.
+static void fputs_filtering_HD(const char *lines, int keep_first_HD, FILE *fp)
+{
+    int seen_HD = 0;
+    for (const char *p = lines; *p != '\0'; ) {
+        const char *eol = strchr(p, '\n');
+        const size_t len = eol ? (size_t)(eol - p) : strlen(p);
+        const int is_HD = (len >= 4 && strncmp(p, "@HD\t", 4) == 0);
+        if (len > 0 && (!is_HD || (keep_first_HD && !seen_HD))) {
+            err_fwrite(p, 1, len, fp);
             err_fputc('\n', fp);
         }
-        return NULL;
+        if (is_HD) seen_HD = 1;
+        p = eol ? eol + 1 : p + len;
     }
 }
 
@@ -570,6 +591,14 @@ static int has_SQ(const char *lines)
     if (lines == NULL) return 0;
     if (strncmp(lines, "@SQ\t", 4) == 0) return 1;
     return strstr(lines, "\n@SQ\t") != NULL;
+}
+
+// Return 1 iff `lines` contains an @HD record (first line, or after a newline).
+static int has_HD(const char *lines)
+{
+    if (lines == NULL) return 0;
+    if (strncmp(lines, "@HD\t", 4) == 0) return 1;
+    return strstr(lines, "\n@HD\t") != NULL;
 }
 
 // Count the number of @SQ header records in `lines`.
@@ -707,27 +736,40 @@ static void print_sam_hdr(const bntseq_t *bns, const char *bns_hdr,
                           const char *hdr_line, FILE *fp,
                           const compat_target_t *compat)
 {
-    int i, n_HD = 0, n_SQ = count_SQ(hdr_line);
+    int i, n_SQ = count_SQ(hdr_line);
     extern char *bwa_pg;
     if (compat == NULL) compat = &COMPAT_TARGET_OFF;
 
-    // Emit an @HD record — prefer user's, else index's, else the target's
-    // default — and consume any leading @HD from both streams so they are not
-    // re-emitted.
-    if (hdr_line && strncmp(hdr_line, "@HD\t", 4) == 0) {
-        hdr_line = remove_line(hdr_line, n_HD == 0, fp);
-        ++n_HD;
+    // Emit exactly one @HD record — the user's (-H) if they gave any, else the
+    // sidecar's, else the target's default. Whichever stream owns the winner,
+    // EVERY other @HD in either stream is dropped: emitting two is a spec
+    // violation, and one bwa does not have (bwa.c:412-426 counts @HD at any
+    // line start before deciding). The BAM writer already filtered the losing
+    // sidecar records this way, so this keeps the two paths in agreement.
+    const int user_HD = has_HD(hdr_line);
+    const int idx_HD  = has_HD(bns_hdr);
+    int keep_user_HD = user_HD;             // does the tail below keep its @HD?
+    int keep_idx_HD  = !user_HD && idx_HD;  // user's -H beats the sidecar's
+
+    // A LEADING winner is consumed off the front of its stream and emitted up
+    // front, so it precedes @SQ as the spec requires. A later one cannot be
+    // hoisted without reordering the user's own records, so it stays inline and
+    // is emitted with the rest of the stream after @SQ — which is where bwa
+    // puts every -H record anyway.
+    if (keep_user_HD && strncmp(hdr_line, "@HD\t", 4) == 0) {
+        hdr_line = hoist_line(hdr_line, fp);
+        keep_user_HD = 0;                   // already emitted; drop any others
     }
-    if (bns_hdr && strncmp(bns_hdr, "@HD\t", 4) == 0) {
-        bns_hdr = remove_line(bns_hdr, n_HD == 0, fp);
-        ++n_HD;
+    if (keep_idx_HD && strncmp(bns_hdr, "@HD\t", 4) == 0) {
+        bns_hdr = hoist_line(bns_hdr, fp);
+        keep_idx_HD = 0;
     }
     /* @HD policy comes from the selected compat target; the evidence for each
      * row is in src/compat_target.cpp. DO NOT "fix" the missing @HD under a
      * compat target -- suppressing it is deliberate, not an oversight.
      * compat->hd_line == NULL keeps this path's historical default, which
      * differs from the BAM writer's (fg-labs/bwa-mem3#288). */
-    if (n_HD == 0 && compat->emit_hd) {
+    if (!user_HD && !idx_HD && compat->emit_hd) {
         err_fputs(compat->hd_line != NULL ? compat->hd_line
                                           : "@HD\tVN:1.5\tSO:unsorted\tGO:query",
                   fp);
@@ -750,8 +792,8 @@ static void print_sam_hdr(const bntseq_t *bns, const char *bns_hdr,
         fprintf(stderr, "[W::%s] %d @SQ lines provided with -H; %d sequences in the index. "
                 "Continue anyway.\n", __func__, n_SQ, bns->n_seqs);
 
-    if (bns_hdr) { err_fputs(bns_hdr, fp); err_fputc('\n', fp); }
-    if (hdr_line) { err_fputs(hdr_line, fp); err_fputc('\n', fp); }
+    if (bns_hdr) fputs_filtering_HD(bns_hdr, keep_idx_HD, fp);
+    if (hdr_line) fputs_filtering_HD(hdr_line, keep_user_HD, fp);
     if (bwa_pg) err_fputs(bwa_pg, fp);
 }
 

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -698,18 +698,22 @@ void bwa_warn_sidecar_missing_AH(const bntseq_t *bns, const char *idx_hdr_lines,
 // Emit the full SAM header, merging (in precedence order) user `hdr_line`
 // (from -H), `bns_hdr` (loaded from <prefix>.hdr or <baseprefix>.dict), and
 // the index's @SQ records. Precedence mirrors lh3/bwa#348:
-//   @HD : user's > index's > default "@HD\tVN:1.5\tSO:unsorted\tGO:query".
+//   @HD : user's > index's > the target's default (none, under a target that
+//         emits no @HD -- see below).
 //   @SQ : if user supplies any, use user's alone (index .hdr was already
 //         skipped by the caller); else index's @SQ; else generated from bns.
 //   Other: all remaining lines from bns_hdr, then hdr_line, then bwa_pg.
 static void print_sam_hdr(const bntseq_t *bns, const char *bns_hdr,
-                          const char *hdr_line, FILE *fp)
+                          const char *hdr_line, FILE *fp,
+                          const compat_target_t *compat)
 {
     int i, n_HD = 0, n_SQ = count_SQ(hdr_line);
     extern char *bwa_pg;
+    if (compat == NULL) compat = &COMPAT_TARGET_OFF;
 
-    // Emit an @HD record — prefer user's, else index's, else default — and
-    // consume any leading @HD from both streams so they are not re-emitted.
+    // Emit an @HD record — prefer user's, else index's, else the target's
+    // default — and consume any leading @HD from both streams so they are not
+    // re-emitted.
     if (hdr_line && strncmp(hdr_line, "@HD\t", 4) == 0) {
         hdr_line = remove_line(hdr_line, n_HD == 0, fp);
         ++n_HD;
@@ -718,8 +722,17 @@ static void print_sam_hdr(const bntseq_t *bns, const char *bns_hdr,
         bns_hdr = remove_line(bns_hdr, n_HD == 0, fp);
         ++n_HD;
     }
-    if (n_HD == 0)
-        err_fputs("@HD\tVN:1.5\tSO:unsorted\tGO:query\n", fp);
+    /* @HD policy comes from the selected compat target; the evidence for each
+     * row is in src/compat_target.cpp. DO NOT "fix" the missing @HD under a
+     * compat target -- suppressing it is deliberate, not an oversight.
+     * compat->hd_line == NULL keeps this path's historical default, which
+     * differs from the BAM writer's (fg-labs/bwa-mem3#288). */
+    if (n_HD == 0 && compat->emit_hd) {
+        err_fputs(compat->hd_line != NULL ? compat->hd_line
+                                          : "@HD\tVN:1.5\tSO:unsorted\tGO:query",
+                  fp);
+        err_fputc('\n', fp);
+    }
 
     // Generate @SQ from bns only when neither hdr_line nor bns_hdr supply any.
     if (n_SQ == 0 && !has_SQ(bns_hdr)) {
@@ -740,11 +753,6 @@ static void print_sam_hdr(const bntseq_t *bns, const char *bns_hdr,
     if (bns_hdr) { err_fputs(bns_hdr, fp); err_fputc('\n', fp); }
     if (hdr_line) { err_fputs(hdr_line, fp); err_fputc('\n', fp); }
     if (bwa_pg) err_fputs(bwa_pg, fp);
-}
-
-void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line, FILE *fp)
-{
-    print_sam_hdr(bns, NULL, hdr_line, fp);
 }
 
 // Load the contents of `<prefix>.hdr` if present, else `<baseprefix>.dict`
@@ -797,7 +805,8 @@ char *bwa_load_hdr_from_index(const char *prefix)
 }
 
 void bwa_print_sam_hdr2(const bntseq_t *bns, const char *idx_hdr_lines,
-                        const char *hdr_line, FILE *fp)
+                        const char *hdr_line, FILE *fp,
+                        const compat_target_t *compat)
 {
     // If the user's -H supplies any @SQ, ignore the index .hdr/.dict content
     // entirely — the user has taken responsibility for the @SQ block.
@@ -810,7 +819,7 @@ void bwa_print_sam_hdr2(const bntseq_t *bns, const char *idx_hdr_lines,
                     "[W::%s] %d @SQ lines loaded from index; %d sequences in the index. "
                     "Continue anyway.\n", __func__, n_SQ, bns->n_seqs);
     }
-    print_sam_hdr(bns, bns_hdr, hdr_line, fp);
+    print_sam_hdr(bns, bns_hdr, hdr_line, fp, compat);
 }
 
 static char *bwa_escape(char *s)

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -586,6 +586,115 @@ static int count_SQ(const char *lines)
     return n_SQ;
 }
 
+/* Contig name -> bns index, for the ALT/AH sidecar check below. khash emits
+ * static functions, so instantiating a set here does not collide with the
+ * kh_str map bntseq.cpp builds for the same kind of lookup. */
+#include "khash.h"
+KHASH_MAP_INIT_STR(sqname, int)
+
+/* Scan one @SQ record for its SN value and whether it carries an AH tag.
+ * `line`/`line_len` delimit the record (no trailing newline). On a match sets
+ * *sn/*sn_len to the SN value (pointing into `line`) and *has_ah, and returns
+ * 1; returns 0 if the record has no SN. Tokens are matched whole, so an SN:
+ * lookup can never confuse chr1 with chr1_alt. */
+static int sq_scan(const char *line, size_t line_len,
+                   const char **sn, size_t *sn_len, int *has_ah)
+{
+    if (line_len < 4 || strncmp(line, "@SQ\t", 4) != 0) return 0;
+    const char *end = line + line_len;
+    int found = 0;
+    *has_ah = 0;
+    for (const char *p = line + 3; p < end; ) {
+        const char *tok = p + 1;                          /* skip the '\t' */
+        const char *tok_end = (const char *)memchr(tok, '\t', (size_t)(end - tok));
+        if (tok_end == NULL) tok_end = end;
+        const size_t tok_len = (size_t)(tok_end - tok);
+        if (tok_len > 3 && strncmp(tok, "SN:", 3) == 0) {
+            *sn = tok + 3; *sn_len = tok_len - 3; found = 1;
+        } else if (tok_len > 3 && strncmp(tok, "AH:", 3) == 0) {
+            *has_ah = 1;
+        }
+        p = tok_end;
+    }
+    return found;
+}
+
+/* Warn when the index knows about ALT contigs but the sidecar's @SQ block does
+ * not carry AH for them.
+ *
+ * The sidecar's @SQ is authoritative by design -- it is a port of lh3/bwa#348,
+ * whose author intended the block to be produced complete by an external dict
+ * tool, and `samtools dict --alt <ref>.alt` (samtools/samtools#1676) exists to
+ * do exactly that. So we do NOT enrich it: silently rewriting a block the user
+ * owns would be a surprise, and it would raise an unanswerable question about
+ * an AH the index contradicts. But losing ALT status is also not something to
+ * discover downstream in bwa-postalt.js, so say it out loud with the remedy. */
+void bwa_warn_sidecar_missing_AH(const bntseq_t *bns, const char *idx_hdr_lines,
+                                 const char *prefix)
+{
+    if (bns == NULL || !has_SQ(idx_hdr_lines) || bwa_verbose < 2) return;
+
+    /* One pass over bns to collect the ALT names, then ONE pass over the
+     * sidecar. Looking each ALT contig up separately would rescan the whole
+     * block per contig: on hg38 (~3.4k records, ~800 ALT contigs, most of them
+     * at the end of the file) that measured ~500x more work, and it was paid
+     * even when every record already carries AH and nothing is reported.
+     * Keys are borrowed from bns->anns, so kh_destroy must not free them --
+     * same ownership as the .alt parser in bntseq.cpp. */
+    khash_t(sqname) *alt = kh_init(sqname);
+    for (int i = 0; i < bns->n_seqs; ++i) {
+        if (!bns->anns[i].is_alt) continue;
+        int absent;
+        khiter_t k = kh_put(sqname, alt, bns->anns[i].name, &absent);
+        kh_val(alt, k) = i;              /* recover the stable name below */
+    }
+    if (kh_size(alt) == 0) { kh_destroy(sqname, alt); return; }
+
+    /* Counts only ALT contigs that the sidecar actually HAS an @SQ for. An ALT
+     * contig the sidecar omits entirely is a different (larger) problem -- that
+     * contig gets no @SQ at all -- and "missing AH" would misdescribe it; it is
+     * already reported by the @SQ-count mismatch warning in
+     * bwa_print_sam_hdr2 ("N @SQ lines loaded from index; M sequences"). */
+    int n_missing = 0, first_id = -1;
+    for (const char *line = idx_hdr_lines; *line != '\0'; ) {
+        const char *eol = strchr(line, '\n');
+        const size_t line_len = eol ? (size_t)(eol - line) : strlen(line);
+        const char *sn = NULL; size_t sn_len = 0; int has_ah = 0;
+        if (sq_scan(line, line_len, &sn, &sn_len, &has_ah) && !has_ah) {
+            /* kh_get needs a NUL-terminated key and `sn` points into the
+             * header text. A name too long to fit cannot match a bns name
+             * either, so skipping it loses nothing -- but say so rather than
+             * dropping an @SQ record silently. */
+            char name[256];
+            if (sn_len >= sizeof(name)) {
+                if (bwa_verbose >= 3)
+                    fprintf(stderr, "[W::%s] sidecar @SQ has an SN of %zu bytes "
+                            "(max %zu); skipped in the ALT/AH check.\n",
+                            __func__, sn_len, sizeof(name) - 1);
+            } else {
+                memcpy(name, sn, sn_len);
+                name[sn_len] = '\0';
+                khiter_t k = kh_get(sqname, alt, name);
+                /* Report bns's copy of the name, not the stack buffer. */
+                if (k != kh_end(alt) && n_missing++ == 0) first_id = kh_val(alt, k);
+            }
+        }
+        if (eol == NULL) break;
+        line = eol + 1;
+    }
+    kh_destroy(sqname, alt);
+    if (n_missing == 0) return;
+    const char *first = bns->anns[first_id].name;
+    fprintf(stderr,
+            "[W::%s] the index marks %d contig%s as ALT (e.g. %s) but the "
+            "<prefix>.hdr / <baseprefix>.dict sidecar supplies @SQ without an AH tag; "
+            "ALT status will be absent from the output header. The sidecar's @SQ is "
+            "authoritative and is not modified. Regenerate it with the ALT list:\n"
+            "[W::%s]   samtools dict --alt %s.alt -o <sidecar> %s\n",
+            __func__, n_missing, n_missing == 1 ? "" : "s", first,
+            __func__, prefix ? prefix : "<ref>", prefix ? prefix : "<ref>");
+}
+
 // Emit the full SAM header, merging (in precedence order) user `hdr_line`
 // (from -H), `bns_hdr` (loaded from <prefix>.hdr or <baseprefix>.dict), and
 // the index's @SQ records. Precedence mirrors lh3/bwa#348:

--- a/src/bwa.h
+++ b/src/bwa.h
@@ -146,6 +146,12 @@ extern "C" {
 	void bwa_print_sam_hdr2(const bntseq_t *bns, const char *idx_hdr_lines,
 	                        const char *hdr_line, FILE *fp);
 	char *bwa_load_hdr_from_index(const char *prefix);
+	/* Warn (at bwa_verbose >= 2) when the index marks contigs ALT but the
+	 * sidecar's @SQ block carries no AH for them. The sidecar is authoritative
+	 * and is never modified; this only reports the gap and its remedy. */
+	void bwa_warn_sidecar_missing_AH(const bntseq_t *bns,
+	                                 const char *idx_hdr_lines,
+	                                 const char *prefix);
 	char *bwa_set_rg(const char *s);
 	char *bwa_insert_header(const char *s, char *hdr);
 	char *bwa_insert_header_file(FILE *fp, char *hdr);

--- a/src/bwa.h
+++ b/src/bwa.h
@@ -37,6 +37,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "bntseq.h"
 #include "bwt.h"
 #include "macro.h"
+#include "compat_target.h"
 
 #define BWA_IDX_BWT 0x1
 #define BWA_IDX_BNS 0x2
@@ -142,9 +143,13 @@ extern "C" {
 	bwaidx_t *bwa_idx_load(const char *hint, int which);
 	
 	void bwa_idx_destroy(bwaidx_t *idx);
-	void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line, FILE *fp);
+	/* `compat` selects the output-compatibility target whose @HD policy the
+	 * header follows; NULL means COMPAT_TARGET_OFF (bwa-mem3's native output).
+	 * It shapes only the default @HD -- a user's -H or the index sidecar still
+	 * wins, and @SQ is untouched. */
 	void bwa_print_sam_hdr2(const bntseq_t *bns, const char *idx_hdr_lines,
-	                        const char *hdr_line, FILE *fp);
+	                        const char *hdr_line, FILE *fp,
+	                        const compat_target_t *compat);
 	char *bwa_load_hdr_from_index(const char *prefix);
 	/* Warn (at bwa_verbose >= 2) when the index marks contigs ALT but the
 	 * sidecar's @SQ block carries no AH for them. The sidecar is authoritative

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -2992,7 +2992,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
 #if V17
     if (m && m->n_cigar) { kputsn_u("\tMC:Z:", 6, str); add_cigar(opt, m, str, which); }
 #endif
-    if (m) { kputsn_u("\tMQ:i:", 6, str); kputw_u(m->mapq, str); }
+    if (m && !(opt->flag & MEM_F_COMPAT)) { kputsn_u("\tMQ:i:", 6, str); kputw_u(m->mapq, str); }
     if (p->score >= 0) { kputsn_u("\tAS:i:", 6, str); kputw_u(p->score, str); }
     if (p->sub >= 0) { kputsn_u("\tXS:i:", 6, str); kputw_u(p->sub, str); }
     if (bwa_rg_id[0]) { kputsn_u("\tRG:Z:", 6, str); kputs_u(bwa_rg_id, str); }
@@ -3022,7 +3022,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
     }
 
     if (p->XA) { kputsn_u("\tXA:Z:", 6, str); kputs_u(p->XA, str); }
-    if (p->HN >= 0) { kputsn_u("\tHN:i:", 6, str); kputw_u(p->HN, str); }
+    if (p->HN >= 0 && !(opt->flag & MEM_F_COMPAT)) { kputsn_u("\tHN:i:", 6, str); kputw_u(p->HN, str); }
 
     if (s->comment) { kputc_u('\t', str); kputs_u(s->comment, str); }
     if ((opt->flag&MEM_F_REF_HDR) && !opt->meth_mode && p->rid >= 0 && bns->anns[p->rid].anno != 0 && bns->anns[p->rid].anno[0] != 0) {

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -367,6 +367,7 @@ mem_opt_t *mem_opt_init()
     o->mapQ_coef_len = 50; o->mapQ_coef_fac = log(o->mapQ_coef_len);
     o->meth_scoring = MEM_METH_SCORING_COLLAPSED;  /* --meth default: bwameth-compatible */
     o->meth_chem    = METH_CHEM_EMSEQ;             /* --meth default chemistry: bisulfite/em-seq */
+    o->compat       = &COMPAT_TARGET_OFF;          /* --compat off: bwa-mem3's native output */
     bwa_fill_scmat(o->a, o->b, o->mat);
     mem_opt_fill_meth_mat(o);
     return o;
@@ -2992,7 +2993,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
 #if V17
     if (m && m->n_cigar) { kputsn_u("\tMC:Z:", 6, str); add_cigar(opt, m, str, which); }
 #endif
-    if (m && !(opt->flag & MEM_F_COMPAT)) { kputsn_u("\tMQ:i:", 6, str); kputw_u(m->mapq, str); }
+    if (m && opt->compat->emit_mq) { kputsn_u("\tMQ:i:", 6, str); kputw_u(m->mapq, str); }
     if (p->score >= 0) { kputsn_u("\tAS:i:", 6, str); kputw_u(p->score, str); }
     if (p->sub >= 0) { kputsn_u("\tXS:i:", 6, str); kputw_u(p->sub, str); }
     if (bwa_rg_id[0]) { kputsn_u("\tRG:Z:", 6, str); kputs_u(bwa_rg_id, str); }
@@ -3022,7 +3023,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
     }
 
     if (p->XA) { kputsn_u("\tXA:Z:", 6, str); kputs_u(p->XA, str); }
-    if (p->HN >= 0 && !(opt->flag & MEM_F_COMPAT)) { kputsn_u("\tHN:i:", 6, str); kputw_u(p->HN, str); }
+    if (p->HN >= 0 && opt->compat->emit_hn) { kputsn_u("\tHN:i:", 6, str); kputw_u(p->HN, str); }
 
     if (s->comment) { kputc_u('\t', str); kputs_u(s->comment, str); }
     if ((opt->flag&MEM_F_REF_HDR) && !opt->meth_mode && p->rid >= 0 && bns->anns[p->rid].anno != 0 && bns->anns[p->rid].anno[0] != 0) {

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -38,6 +38,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "bntseq.h"
 #include "bwa.h"
 #include "kthread.h"
+#include "compat_target.h"
 #include "macro.h"
 #include "bandedSWA.h"
 #include <stdlib.h>
@@ -76,11 +77,10 @@ typedef struct __smem_i smem_i;
 #define MEM_F_PRIMARY5  0x800
 #define MEM_F_KEEP_SUPP_MAPQ 0x1000
 #define MEM_F_XB        0x2000
-// --compat: suppress the bwa-mem3-only record additions (the MQ:i / HN:i tags)
-// so the SAM/BAM records are byte-identical to bwa-mem2 v2.2.1 on the drop-in
-// profile. Purely output-suppressing; changes no alignment. @PG is deliberately
-// left alone -- bwa-mem2 emits its own, and CL: is run-specific either way.
-#define MEM_F_COMPAT    0x4000
+// --compat is NOT a flag bit: it selects one of several output-compatibility
+// targets, which disagree with each other on the fields it shapes (bwa emits
+// MQ:i and a default @HD; bwa-mem2 emits neither). See mem_opt_t::compat and
+// src/compat_target.h.
 
 
 /* D3 (--meth): bisulfite/TAPS SW scoring model, selected by --meth-scoring. All
@@ -186,6 +186,15 @@ typedef struct mem_opt_t {
     int    alnreg_sort_fast;  // 1 = strict-total-order comparator + pdqsort at the mem_sort_dedup_patch sort sites (set by --fast); 0 = bwa-mem2's re-only comparator + ks_introsort (default, bwa-mem2-compatible)
     int    skip_contained_ext; // 1 = skip banded-SW extension of seeds contained (same diagonal) in a longer in-chain seed (--skip-contained-ext); 0 = off. Byte-identical to baseline: the skip set is a subset of the post-extension containment purge (PE18).
     int    band_start;       // >0 = adaptive chain-geometry banding active (start band; set to ADAPTIVE_BAND_START by --adaptive-band); 0 = off (byte-identical). Long-read speed lever; no-op on the 8-bit short-read tier.
+    /* --compat: the selected output-compatibility target. Non-NULL on any
+     * mem_opt_t from mem_opt_init(), which sets it to &COMPAT_TARGET_OFF
+     * (bwa-mem3's native output), so consumers can dereference it
+     * unconditionally. (main_mem's `opt0` "was this set explicitly" sentinel is
+     * memset to zero and is NOT such a struct; only its scalars are ever read.)
+     * Points into the static table in compat_target.cpp -- not owned, never
+     * freed, so the shallow struct copy in the MEM_F_SMARTPE path is correct.
+     * Shapes OUTPUT ONLY: no alignment, score, flag, or tag VALUE depends on it. */
+    const compat_target_t *compat;
 } mem_opt_t;
 
 

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -76,6 +76,11 @@ typedef struct __smem_i smem_i;
 #define MEM_F_PRIMARY5  0x800
 #define MEM_F_KEEP_SUPP_MAPQ 0x1000
 #define MEM_F_XB        0x2000
+// --compat: suppress the bwa-mem3-only record additions (the MQ:i / HN:i tags)
+// so the SAM/BAM records are byte-identical to bwa-mem2 v2.2.1 on the drop-in
+// profile. Purely output-suppressing; changes no alignment. @PG is deliberately
+// left alone -- bwa-mem2 emits its own, and CL: is run-specific either way.
+#define MEM_F_COMPAT    0x4000
 
 
 /* D3 (--meth): bisulfite/TAPS SW scoring model, selected by --meth-scoring. All

--- a/src/compat_target.cpp
+++ b/src/compat_target.cpp
@@ -1,0 +1,128 @@
+/* src/compat_target.cpp — the `--compat` target table.
+ *
+ * Every field below is derived from the upstream source cited beside it,
+ * verified against ~/work/git/bwa @ 91fb301 (0.7.19-r1273) and bwa-mem2 v2.2.1.
+ * test/unit/test_compat_target.cpp asserts each field, so a row that no CLI
+ * path can reach still cannot silently rot.
+ */
+
+#include "compat_target.h"
+
+#include <string>
+#include <string.h>
+
+/* --- `off`: bwa-mem3's native output -------------------------------------
+ *
+ * hd_line is NULL, meaning each output path keeps the default it already
+ * emits. Those defaults DISAGREE -- SAM text writes
+ * "@HD\tVN:1.5\tSO:unsorted\tGO:query" (bwa.cpp) while the BAM writer writes
+ * "@HD\tVN:1.6\tSO:unsorted" (bam_writer.cpp). That is a real latent
+ * inconsistency, tracked as fg-labs/bwa-mem3#288; reconciling it changes
+ * default output on one of the two paths and so does not belong to --compat.
+ * NULL here preserves both bytewise. A target that pins an exact string (see
+ * bwa-mem) is what would force the question. */
+const compat_target_t COMPAT_TARGET_OFF = {
+    /* .name               */ "off",
+    /* .alias              */ NULL,
+    /* .unavailable_reason */ NULL,
+    /* .emit_hd            */ 1,
+    /* .hd_line            */ NULL,
+    /* .read_sidecar       */ 1,
+    /* .emit_mq            */ 1,
+    /* .emit_hn            */ 1,
+};
+
+/* --- `bwa-mem2`: bwa-mem2 v2.2.1 -----------------------------------------
+ *
+ * @HD:      none. bwa-mem2's bwa_print_sam_hdr (src/bwa.cpp:523) has no @HD
+ *           logic at all -- no n_HD counter, no default emission. bwa grew one
+ *           in 0.7.18 (6b18630), after bwa-mem2 forked at 0.7.17.
+ * sidecar:  absent; `grep -n '\.hdr\|\.dict' src/bwa.cpp` is empty.
+ * MQ:i:     absent; lh3/bwa#330 post-dates the fork.
+ * HN:i:     absent; bwa-mem3-only.
+ *
+ * Note @SQ AH:* is NOT a field here: bwa-mem2 emits it on generated @SQ
+ * (src/bwa.cpp:538, and :545 in the compiled non-ORIG branch), exactly as we
+ * do, so it is unconditional rather than a divergence to toggle. */
+static const compat_target_t COMPAT_TARGET_BWA_MEM2 = {
+    /* .name               */ "bwa-mem2",
+    /* .alias              */ "mem2",
+    /* .unavailable_reason */ NULL,
+    /* .emit_hd            */ 0,
+    /* .hd_line            */ NULL,
+    /* .read_sidecar       */ 0,
+    /* .emit_mq            */ 0,
+    /* .emit_hn            */ 0,
+};
+
+/* --- `bwa-mem`: bwa 0.7.19 -- SPECIFIED BUT NOT SELECTABLE ----------------
+ *
+ * @HD:      "@HD\tVN:1.5\tSO:unsorted\tGO:query" (bwa.c:426).
+ * sidecar:  absent; lh3/bwa#348 was closed unmerged 2025-03-21.
+ * MQ:i:     PRESENT (bwamem.c:935) -- this is the field a single compat
+ *           boolean could not express, and the reason this table exists.
+ * HN:i:     absent; bwa-mem3-only.
+ *
+ * The shaping above is complete, but bwa-mem3 and bwa still differ on the
+ * ALIGNMENTS, so offering the target would advertise a byte-identity we cannot
+ * deliver -- the same trap that makes --compat --fast a hard error. The row is
+ * kept because its shaping is fully determined by the evidence above; when the
+ * alignment work lands, clearing unavailable_reason is the whole change. */
+static const compat_target_t COMPAT_TARGET_BWA_MEM = {
+    /* .name               */ "bwa-mem",
+    /* .alias              */ NULL,
+    /* .unavailable_reason */ "bwa-mem3 and bwa still differ on 224/63583 records "
+                              "(53 above MAPQ 30), so byte-identity is not achievable",
+    /* .emit_hd            */ 1,
+    /* .hd_line            */ "@HD\tVN:1.5\tSO:unsorted\tGO:query",
+    /* .read_sidecar       */ 0,
+    /* .emit_mq            */ 1,
+    /* .emit_hn            */ 0,
+};
+
+/* Ordered as the diagnostics should read: real targets first, `off` last. */
+static const compat_target_t *const COMPAT_TARGETS[] = {
+    &COMPAT_TARGET_BWA_MEM2,
+    &COMPAT_TARGET_BWA_MEM,
+    &COMPAT_TARGET_OFF,
+};
+static const int COMPAT_TARGET_N =
+    (int)(sizeof(COMPAT_TARGETS) / sizeof(COMPAT_TARGETS[0]));
+
+const compat_target_t *compat_target_from_name(const char *name)
+{
+    if (name == NULL) return NULL;
+    for (int i = 0; i < COMPAT_TARGET_N; ++i) {
+        const compat_target_t *t = COMPAT_TARGETS[i];
+        if (strcmp(name, t->name) == 0) return t;
+        if (t->alias != NULL && strcmp(name, t->alias) == 0) return t;
+    }
+    return NULL;
+}
+
+const char *compat_target_selectable_list(void)
+{
+    /* Derived from the table rather than written out as a literal, so adding a
+     * selectable row cannot leave the usage and error text stale. Function-local
+     * static: built once, thread-safely, on first use. The returned pointer is
+     * valid for the life of the process and must not be freed -- worth stating
+     * because the C linkage on this function invites the opposite assumption. */
+    static const std::string list = [] {
+        std::string s;
+        for (int i = 0; i < COMPAT_TARGET_N; ++i) {
+            const compat_target_t *t = COMPAT_TARGETS[i];
+            if (t->unavailable_reason != NULL) continue;
+            if (!s.empty()) s += ", ";
+            s += t->name;
+            if (t->alias != NULL) { s += " (alias "; s += t->alias; s += ")"; }
+        }
+        return s;
+    }();
+    return list.c_str();
+}
+
+const compat_target_t *const *compat_targets(int *n)
+{
+    if (n != NULL) *n = COMPAT_TARGET_N;
+    return COMPAT_TARGETS;
+}

--- a/src/compat_target.h
+++ b/src/compat_target.h
@@ -1,0 +1,90 @@
+/* src/compat_target.h — `--compat` output-compatibility targets.
+ *
+ * A compat target describes the exact SAM/BAM output shaping needed to
+ * reproduce another aligner's byte stream. It is DATA, not control flow: the
+ * table in compat_target.cpp holds one row per target, and every consumer reads
+ * a field off the selected row instead of testing a flag bit. Adding a target
+ * is a new row.
+ *
+ * A single boolean would not do. bwa and bwa-mem2 diverge from each other on
+ * the very fields this shapes -- bwa emits MQ:i and a default @HD, bwa-mem2
+ * emits neither -- so "compat" is a choice among targets, not an on/off switch.
+ *
+ * Compat targets shape OUTPUT ONLY. They never change an alignment, a score, a
+ * flag, or any tag's value. See docs/src/whats-different/equivalence.md.
+ */
+
+#ifndef BWAMEM3_COMPAT_TARGET_H
+#define BWAMEM3_COMPAT_TARGET_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct compat_target_t {
+    /* Canonical spelling, as documented and as reported in diagnostics. */
+    const char *name;
+
+    /* One additional accepted spelling, or NULL. */
+    const char *alias;
+
+    /* NULL when the target is selectable. Otherwise, WHY it is not: the row is
+     * fully specified and unit-tested, but --compat refuses it and prints this
+     * instead of a generic "unknown target". For a target whose output shaping
+     * we know exactly but whose byte-identity we cannot deliver for other
+     * reasons -- see the bwa-mem row. The reason lives here, next to the
+     * evidence the row is built from, so the two cannot drift apart. */
+    const char *unavailable_reason;
+
+    /* Emit a default @HD when neither -H nor the index sidecar supplies one. */
+    int emit_hd;
+
+    /* Exact @HD text (no trailing newline) when emit_hd is set. NULL means
+     * "keep whatever default that output path already emits" -- the SAM text
+     * and BAM paths currently disagree (fg-labs/bwa-mem3#288), and only the
+     * `off` row tolerates that. */
+    const char *hd_line;
+
+    /* Honor the bwa-mem3-only <prefix>.hdr / <baseprefix>.dict sidecar. Both
+     * upstreams lack the feature entirely (lh3/bwa#348 was closed unmerged), so
+     * every non-`off` target must skip it to match. */
+    int read_sidecar;
+
+    /* Emit the MQ:i mate mapping quality tag. NOTE: this is not a bwa-mem3
+     * invention -- bwa emits it (bwamem.c:935; lh3/bwa#330, merged 2022-03-06)
+     * and bwa-mem2 does not, having forked at 0.7.17 before that landed. */
+    int emit_mq;
+
+    /* Emit the HN:i hit-count tag. Genuinely bwa-mem3-only: absent from both
+     * upstreams. */
+    int emit_hn;
+} compat_target_t;
+
+/* The `off` row: bwa-mem3's own native output. Never NULL on any mem_opt_t
+ * built by mem_opt_init(), so consumers can dereference opt->compat
+ * unconditionally. (The `opt0` "was this set explicitly" sentinel in main_mem
+ * is memset to zero and is NOT such a struct -- it is only ever read for
+ * scalar fields.) */
+extern const compat_target_t COMPAT_TARGET_OFF;
+
+/* Resolve a user-supplied --compat value, by canonical name or alias.
+ *
+ * Returns NULL for an unrecognized name. A name that IS recognized but is
+ * unavailable resolves to its row, so the caller can print
+ * ->unavailable_reason rather than a generic "unknown target"; callers must
+ * check that field before use. */
+const compat_target_t *compat_target_from_name(const char *name);
+
+/* Comma-separated list of the selectable target names with their aliases, for
+ * usage and error text (e.g. "bwa-mem2 (alias mem2), off"). Derived from the
+ * table, so a new row cannot leave it stale. Statically allocated. */
+const char *compat_target_selectable_list(void);
+
+/* The table itself, for tests and diagnostics. Sets *n to the row count. */
+const compat_target_t *const *compat_targets(int *n);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BWAMEM3_COMPAT_TARGET_H */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1560,9 +1560,9 @@ int main_mem(int argc, char *argv[])
      * Output is NOT byte-identical to the default; divergence is confined to the
      * low-confidence tail (see docs/best-practices/settings-profiles.md).
      * meth_mode is already resolved here (parsed in the getopt loop above). */
-    /* Both guards below key on "a target other than `off` is selected" --
-     * --compat=off is exactly equivalent to not passing the flag, so it must
-     * not trip either one. */
+    /* The two guards and the warning below all key on "a target other than
+     * `off` is selected" -- --compat=off is exactly equivalent to not passing
+     * the flag, so it must trip none of them. */
     const int compat_on = (opt->compat != &COMPAT_TARGET_OFF);
     /* --fast and --compat are mutually exclusive. --compat suppresses only
      * additive output (MQ:i/HN:i, @HD, sidecar @SQ tags) to reproduce another
@@ -1589,6 +1589,32 @@ int main_mem(int argc, char *argv[])
         free(opt);
         if (out_opened) fclose(aux.fp);
         return 1;
+    }
+    /* --compat with an @HD in -H: WARN, do not reject. Emitted only after both
+     * rejections above, so a run that is about to be refused does not also
+     * collect a warning about how its header would have been ordered.
+     *
+     * bwa-mem3 hoists a LEADING user @HD above the @SQ block, so the header is
+     * spec-valid (@HD must come first). Neither target does that: bwa 0.7.19
+     * emits -H records after @SQ and only warns (bwa.c:426-428), bwa-mem2 has
+     * no @HD logic at all. So the header differs from the target in line ORDER.
+     *
+     * This is not rejected, unlike --fast and --meth, because it is an explicit
+     * and coherent request: "give me a valid SAM header, everything else the
+     * same". --fast silently moves alignments and --meth is a different mode --
+     * the user cannot see those in their own command line. An @HD they typed
+     * themselves, they can. Records are unaffected either way.
+     *
+     * Only a LEADING @HD is hoisted, and only that case diverges; a later @HD
+     * is emitted inline after @SQ exactly as upstream does. Warn precisely, so
+     * the warning means something when it fires. */
+    if (compat_on && hdr_line != NULL &&
+        strncmp(hdr_line, "@HD\t", 4) == 0 && bwa_verbose >= 2) {
+        fprintf(stderr, "[W::%s] --compat=%s with an @HD from -H: bwa-mem3 emits it before "
+                "@SQ (the SAM spec requires @HD first), but %s emits -H records after @SQ, "
+                "so the header will differ from %s in line order. Records are unaffected. "
+                "Continue anyway.\n",
+                __func__, opt->compat->name, opt->compat->name, opt->compat->name);
     }
     if (fast) {
         if (!opt0.max_matesw)   opt->max_matesw   = 10;  /* -m 10 */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -965,6 +965,13 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                  differently from bwa-mem2, which the default reproduces).\n");
     fprintf(stderr, "                  NOT byte-identical to the default (divergence confined to the\n");
     fprintf(stderr, "                  low-confidence tail).\n");
+    fprintf(stderr, "    --compat      byte-identical bwa-mem2 records: suppress the bwa-mem3-only\n");
+    fprintf(stderr, "                  MQ:i / HN:i tags, leaving records identical to bwa-mem2 v2.2.1\n");
+    fprintf(stderr, "                  on the drop-in profile. Suppresses output only; changes no\n");
+    fprintf(stderr, "                  alignment. @PG still differs (it is run-specific) -- exclude it\n");
+    fprintf(stderr, "                  when comparing. Mutually exclusive with --fast (which changes\n");
+    fprintf(stderr, "                  alignments) and with --meth (bwa-mem2 has no bisulfite mode) --\n");
+    fprintf(stderr, "                  combining them is an error [off]\n");
     fprintf(stderr, "Scoring options:\n");
     fprintf(stderr, "   -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [%d]\n", opt->a);
     fprintf(stderr, "   -B INT        penalty for a mismatch [%d]\n", opt->b);
@@ -1159,6 +1166,7 @@ int main_mem(int argc, char *argv[])
         OPT_SKIP_CONTAINED_EXT,
         OPT_ADAPTIVE_BAND,
         OPT_EXTEND_MATE_CONCORDANT,
+        OPT_COMPAT,
 #ifdef STAGE_PROF
         OPT_PROFILE,
 #endif
@@ -1179,6 +1187,7 @@ int main_mem(int argc, char *argv[])
         {"chimera-qc",               no_argument,       0, OPT_METH_CHIMERA_QC},
         {"supp-rep-hard-cap",        required_argument, 0, OPT_SUPP_REP_HARD_CAP},
         {"seed-order",               required_argument, 0, OPT_SEED_ORDER},
+        {"compat",                   no_argument,       0, OPT_COMPAT},
         {"legacy-reader",            no_argument,       0, OPT_LEGACY_READER},
 #ifdef STAGE_PROF
         {"profile",                  required_argument, 0, OPT_PROFILE},
@@ -1392,6 +1401,7 @@ int main_mem(int argc, char *argv[])
                 return 1;
             }
         }
+        else if (c == OPT_COMPAT) opt->flag |= MEM_F_COMPAT;
         else if (c == OPT_SMEM_DEDUP) opt->smem_dedup = 1;
         else if (c == OPT_FAST) fast = 1;
         else if (c == OPT_SKIP_CONTAINED_EXT) opt->skip_contained_ext = 1;
@@ -1513,6 +1523,31 @@ int main_mem(int argc, char *argv[])
      * Output is NOT byte-identical to the default; divergence is confined to the
      * low-confidence tail (see docs/best-practices/settings-profiles.md).
      * meth_mode is already resolved here (parsed in the getopt loop above). */
+    /* --fast and --compat are mutually exclusive. --compat suppresses only
+     * additive output (MQ:i/HN:i) to reproduce bwa-mem2 byte-for-byte, but
+     * --fast deliberately CHANGES alignments; combining them would yield a
+     * diff-clean-looking stream over genuinely different alignments, defeating
+     * the parity-validation purpose of --compat. Reject up front. */
+    if (fast && (opt->flag & MEM_F_COMPAT)) {
+        fprintf(stderr, "[E::%s] --compat and --fast are mutually exclusive: "
+                "--compat targets byte-identical bwa-mem2 output, but --fast changes alignments\n",
+                __func__);
+        free(opt);
+        if (out_opened) fclose(aux.fp);
+        return 1;
+    }
+    /* --compat is a bwa-mem2 parity flag, but bwa-mem2 has no bisulfite mode, so
+     * "byte-identical to bwa-mem2" is undefined under --meth, which also emits
+     * meth-specific tags that --compat does not model. Reject the combination
+     * rather than silently half-suppress. */
+    if (opt->meth_mode && (opt->flag & MEM_F_COMPAT)) {
+        fprintf(stderr, "[E::%s] --compat is not supported with --meth: "
+                "--compat reproduces bwa-mem2 output, which has no methylation mode\n",
+                __func__);
+        free(opt);
+        if (out_opened) fclose(aux.fp);
+        return 1;
+    }
     if (fast) {
         if (!opt0.max_matesw)   opt->max_matesw   = 10;  /* -m 10 */
         if (!opt0.max_mem_intv) opt->max_mem_intv = 0;   /* -y 0  */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1938,6 +1938,11 @@ int main_mem(int argc, char *argv[])
      * the --bam path forwards them to htslib's sam_hdr_add_lines so the
      * rich @SQ (AS/M5/SP/AH/…) also makes it into the BAM header. */
     char *idx_hdr_lines = bwa_load_hdr_from_index(ref_prefix);
+    /* A sidecar @SQ block that omits AH on ALT contigs silently strips ALT
+     * status from the output. We do not rewrite it (it is authoritative --
+     * see the function's comment), but we do say so. */
+    if (idx_hdr_lines != NULL && !opt->meth_mode)
+        bwa_warn_sidecar_missing_AH(aux.fmi->idx->bns, idx_hdr_lines, ref_prefix);
     /* --meth only: the original (pre-c2t) reference's .hdr/.dict sidecar, for
      * @SQ M5/UR enrichment and @CO/@PG/@RG pass-through in meth_bam_writer_open.
      * NULL outside --meth or when the original has no sidecar. */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -38,6 +38,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #endif
 #include <sstream>
 #include <getopt.h>
+#include <unistd.h>   /* access(): --compat's "you passed a file" diagnostic */
 #include "fastmap.h"
 #include "FMI_search.h"
 #include "bam_writer.h"
@@ -965,13 +966,16 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                  differently from bwa-mem2, which the default reproduces).\n");
     fprintf(stderr, "                  NOT byte-identical to the default (divergence confined to the\n");
     fprintf(stderr, "                  low-confidence tail).\n");
-    fprintf(stderr, "    --compat      byte-identical bwa-mem2 records: suppress the bwa-mem3-only\n");
-    fprintf(stderr, "                  MQ:i / HN:i tags, leaving records identical to bwa-mem2 v2.2.1\n");
-    fprintf(stderr, "                  on the drop-in profile. Suppresses output only; changes no\n");
-    fprintf(stderr, "                  alignment. @PG still differs (it is run-specific) -- exclude it\n");
-    fprintf(stderr, "                  when comparing. Mutually exclusive with --fast (which changes\n");
-    fprintf(stderr, "                  alignments) and with --meth (bwa-mem2 has no bisulfite mode) --\n");
-    fprintf(stderr, "                  combining them is an error [off]\n");
+    fprintf(stderr, "    --compat STR  shape output to be byte-identical to another aligner.\n");
+    fprintf(stderr, "                  Targets: %s\n", compat_target_selectable_list());
+    fprintf(stderr, "                  bwa-mem2: suppress the MQ:i and HN:i tags and the default @HD,\n");
+    fprintf(stderr, "                  and ignore the <prefix>.hdr / <baseprefix>.dict sidecar so @SQ\n");
+    fprintf(stderr, "                  is generated as bare SN/LN (+AH:* on ALT contigs) -- matching\n");
+    fprintf(stderr, "                  bwa-mem2 v2.2.1 on the drop-in profile. Suppresses output only;\n");
+    fprintf(stderr, "                  changes no alignment. @PG still differs (it is run-specific) --\n");
+    fprintf(stderr, "                  exclude it when comparing. Mutually exclusive with --fast (which\n");
+    fprintf(stderr, "                  changes alignments) and with --meth (bwa-mem2 has no bisulfite\n");
+    fprintf(stderr, "                  mode) -- combining them is an error [off]\n");
     fprintf(stderr, "Scoring options:\n");
     fprintf(stderr, "   -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [%d]\n", opt->a);
     fprintf(stderr, "   -B INT        penalty for a mismatch [%d]\n", opt->b);
@@ -1187,7 +1191,7 @@ int main_mem(int argc, char *argv[])
         {"chimera-qc",               no_argument,       0, OPT_METH_CHIMERA_QC},
         {"supp-rep-hard-cap",        required_argument, 0, OPT_SUPP_REP_HARD_CAP},
         {"seed-order",               required_argument, 0, OPT_SEED_ORDER},
-        {"compat",                   no_argument,       0, OPT_COMPAT},
+        {"compat",                   required_argument, 0, OPT_COMPAT},
         {"legacy-reader",            no_argument,       0, OPT_LEGACY_READER},
 #ifdef STAGE_PROF
         {"profile",                  required_argument, 0, OPT_PROFILE},
@@ -1401,7 +1405,40 @@ int main_mem(int argc, char *argv[])
                 return 1;
             }
         }
-        else if (c == OPT_COMPAT) opt->flag |= MEM_F_COMPAT;
+        else if (c == OPT_COMPAT) {
+            const compat_target_t *t = compat_target_from_name(optarg);
+            if (t == NULL) {
+                fprintf(stderr, "[E::%s] unknown --compat target '%s' (%s)\n",
+                        __func__, optarg, compat_target_selectable_list());
+                /* --compat takes a required argument, so a bare `--compat`
+                 * silently swallows the next token -- usually the index
+                 * prefix. Recognize that shape and say so, rather than leaving
+                 * the user staring at their own reference path being called a
+                 * compat target. */
+                if (access(optarg, R_OK) == 0)
+                    fprintf(stderr, "[E::%s] ('%s' is an existing file -- "
+                            "--compat requires a target, e.g. --compat=bwa-mem2)\n",
+                            __func__, optarg);
+                free(opt);
+                if (out_opened) fclose(aux.fp);
+                return 1;
+            }
+            /* A recognized-but-unavailable target gets its own diagnostic:
+             * "unknown target" would be a lie, and a user asking for bwa-mem
+             * deserves the real reason rather than a shrug. The reason travels
+             * with the table row, not with this parser. */
+            if (t->unavailable_reason != NULL) {
+                fprintf(stderr,
+                        "[E::%s] compat target '%s' is recognized but not yet selectable: "
+                        "%s. Supported: %s\n",
+                        __func__, t->name, t->unavailable_reason,
+                        compat_target_selectable_list());
+                free(opt);
+                if (out_opened) fclose(aux.fp);
+                return 1;
+            }
+            opt->compat = t;
+        }
         else if (c == OPT_SMEM_DEDUP) opt->smem_dedup = 1;
         else if (c == OPT_FAST) fast = 1;
         else if (c == OPT_SKIP_CONTAINED_EXT) opt->skip_contained_ext = 1;
@@ -1523,27 +1560,32 @@ int main_mem(int argc, char *argv[])
      * Output is NOT byte-identical to the default; divergence is confined to the
      * low-confidence tail (see docs/best-practices/settings-profiles.md).
      * meth_mode is already resolved here (parsed in the getopt loop above). */
+    /* Both guards below key on "a target other than `off` is selected" --
+     * --compat=off is exactly equivalent to not passing the flag, so it must
+     * not trip either one. */
+    const int compat_on = (opt->compat != &COMPAT_TARGET_OFF);
     /* --fast and --compat are mutually exclusive. --compat suppresses only
-     * additive output (MQ:i/HN:i) to reproduce bwa-mem2 byte-for-byte, but
-     * --fast deliberately CHANGES alignments; combining them would yield a
-     * diff-clean-looking stream over genuinely different alignments, defeating
-     * the parity-validation purpose of --compat. Reject up front. */
-    if (fast && (opt->flag & MEM_F_COMPAT)) {
+     * additive output (MQ:i/HN:i, @HD, sidecar @SQ tags) to reproduce another
+     * aligner byte-for-byte, but --fast deliberately CHANGES alignments;
+     * combining them would yield a diff-clean-looking stream over genuinely
+     * different alignments, defeating the parity-validation purpose of
+     * --compat. Reject up front. */
+    if (fast && compat_on) {
         fprintf(stderr, "[E::%s] --compat and --fast are mutually exclusive: "
-                "--compat targets byte-identical bwa-mem2 output, but --fast changes alignments\n",
-                __func__);
+                "--compat targets byte-identical %s output, but --fast changes alignments\n",
+                __func__, opt->compat->name);
         free(opt);
         if (out_opened) fclose(aux.fp);
         return 1;
     }
-    /* --compat is a bwa-mem2 parity flag, but bwa-mem2 has no bisulfite mode, so
-     * "byte-identical to bwa-mem2" is undefined under --meth, which also emits
-     * meth-specific tags that --compat does not model. Reject the combination
-     * rather than silently half-suppress. */
-    if (opt->meth_mode && (opt->flag & MEM_F_COMPAT)) {
+    /* --compat is an output-parity target, but no target has a bisulfite mode,
+     * so "byte-identical" is undefined under --meth, which also emits
+     * meth-specific tags that no target models. Reject the combination rather
+     * than silently half-suppress. */
+    if (opt->meth_mode && compat_on) {
         fprintf(stderr, "[E::%s] --compat is not supported with --meth: "
-                "--compat reproduces bwa-mem2 output, which has no methylation mode\n",
-                __func__);
+                "--compat reproduces %s output, which has no methylation mode\n",
+                __func__, opt->compat->name);
         free(opt);
         if (out_opened) fclose(aux.fp);
         return 1;
@@ -1936,16 +1978,33 @@ int main_mem(int argc, char *argv[])
      * <baseprefix>.dict) once and route them into both output paths. The
      * SAM text path merges these with user -H per lh3/bwa#348 precedence;
      * the --bam path forwards them to htslib's sam_hdr_add_lines so the
-     * rich @SQ (AS/M5/SP/AH/…) also makes it into the BAM header. */
-    char *idx_hdr_lines = bwa_load_hdr_from_index(ref_prefix);
+     * rich @SQ (AS/M5/SP/AH/…) also makes it into the BAM header.
+     *
+     * Skipped entirely under a compat target: the sidecar is a bwa-mem3-only
+     * feature (a port of lh3/bwa#348, which lh3 closed unmerged), so neither
+     * bwa nor bwa-mem2 has anything to load. Its @SQ block adds M5/AS/UR/SP
+     * that no upstream emits, and on the bench hg38 index its @HD as well.
+     * Skipping restores the generated bare SN/LN @SQ block -- including the
+     * AH:* on ALT contigs that both upstreams emit -- which is exactly the
+     * target output. */
+    char *idx_hdr_lines = opt->compat->read_sidecar
+                        ? bwa_load_hdr_from_index(ref_prefix)
+                        : NULL;
     /* A sidecar @SQ block that omits AH on ALT contigs silently strips ALT
      * status from the output. We do not rewrite it (it is authoritative --
-     * see the function's comment), but we do say so. */
+     * see the function's comment), but we do say so. Not reached under a
+     * compat target: idx_hdr_lines is NULL there and @SQ is regenerated from
+     * bns, AH included. */
     if (idx_hdr_lines != NULL && !opt->meth_mode)
         bwa_warn_sidecar_missing_AH(aux.fmi->idx->bns, idx_hdr_lines, ref_prefix);
     /* --meth only: the original (pre-c2t) reference's .hdr/.dict sidecar, for
      * @SQ M5/UR enrichment and @CO/@PG/@RG pass-through in meth_bam_writer_open.
-     * NULL outside --meth or when the original has no sidecar. */
+     * NULL outside --meth or when the original has no sidecar.
+     *
+     * Deliberately NOT gated on opt->compat->read_sidecar, unlike the load
+     * above: --compat with --meth is rejected during option validation (see the
+     * guard earlier in this function), so this load is unreachable under any
+     * compat target. If that exclusion is ever relaxed, this needs the gate. */
     char *meth_orig_hdr_lines = (meth_orig_ref_prefix != NULL)
                                 ? bwa_load_hdr_from_index(meth_orig_ref_prefix)
                                 : NULL;
@@ -2034,7 +2093,7 @@ int main_mem(int argc, char *argv[])
         }
         bam_writer = bam_writer_open(bam_path, aux.fmi->idx->bns,
                                      bam_idx_hdr, hdr_line,
-                                     bwa_pg, opt->bam_level);
+                                     bwa_pg, opt->bam_level, opt->compat);
         if (bam_writer == NULL) {
             fprintf(stderr, "ERROR: failed to open BAM writer at '%s'\n", bam_path);
             free(opt);
@@ -2054,7 +2113,8 @@ int main_mem(int argc, char *argv[])
             }
             out_opened = true;
         }
-        bwa_print_sam_hdr2(aux.fmi->idx->bns, idx_hdr_lines, hdr_line, aux.fp);
+        bwa_print_sam_hdr2(aux.fmi->idx->bns, idx_hdr_lines, hdr_line, aux.fp,
+                           opt->compat);
     }
 #endif
 

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -173,7 +173,14 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
     if (w->hdr == NULL) { hts_close(w->fp); free(w); return NULL; }
 
     /* @HD — skip the default when the user's -H already supplies one, else
-     * htslib would write two @HD lines (it does not de-dup @HD). */
+     * htslib would write two @HD lines (it does not de-dup @HD).
+     *
+     * This writer does not consult a compat target, unlike bwa.cpp and
+     * bam_writer.cpp: --compat with --meth is a hard error (rejected in
+     * main_mem's option validation), so only COMPAT_TARGET_OFF can reach here
+     * and OFF keeps each path's own default. A future target that relaxes the
+     * --meth exclusion must plumb compat->emit_hd/hd_line through here too.
+     * The string also differs from the SAM text path's -- fg-labs/bwa-mem3#288. */
     if (!hdr_text_has_type(hdr_line, "@HD\t") &&
         sam_hdr_add_line(w->hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL) < 0) goto fail;
 

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -181,11 +181,20 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
      * f/r consolidation — alignments already carry original rids). Each @SQ is
      * enriched by SN with the original reference's identity tags (M5/UR/AS/SP)
      * from its .hdr/.dict sidecar when available; the extra tags are appended
-     * verbatim, gated on a matching SN+LN. */
+     * verbatim, gated on a matching SN+LN.
+     *
+     * AH:* on ALT contigs is appended from the ORIGINAL bns, matching both
+     * upstreams' generated @SQ (bwa/bwa.c:432, bwa-mem2/src/bwa.cpp:538) and
+     * our SAM text path; this consolidated block was written without it and
+     * dropped ALT status for every ALT-aware reference. It cannot collide with
+     * the sidecar enrichment: meth_append_sq_extra_tags copies only
+     * M5/UR/AS/SP, never AH. Appended BEFORE those tags so the line reads
+     * SN, LN, AH, then identity tags -- the order bwa emits. */
     for (int i = 0; i < bns->n_seqs; ++i) {
         kstring_t sq = {0, 0, NULL};
         ksprintf(&sq, "@SQ\tSN:%s\tLN:%lld",
                  bns->anns[i].name, (long long)bns->anns[i].len);
+        if (bns->anns[i].is_alt) kputs("\tAH:*", &sq);
         meth_append_sq_extra_tags(orig_idx_hdr_lines, bns->anns[i].name,
                                   bns->anns[i].len, &sq);
         int rc = (sq.s != NULL) ? sam_hdr_add_lines(w->hdr, sq.s, sq.l) : -1;

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -15,6 +15,7 @@ matrix row; the rest run on the canonical AVX2 row only. Each script:
 | `short_read_smoke.sh`        | ASAN SE on 25-50 bp variable-length dense-chr22 reads (PR #100 fix)   | "Short-read SE smoke (chr22, ASAN, dense+variable-length)" |
 | `supp_rep_hard_cap.sh`       | `--supp-rep-hard-cap` forces MAPQ=0 on repetitive-seed supps (#101)   | "--supp-rep-hard-cap repetitive-seed regression"    |
 | `compat_byte_identical.sh`   | `--compat` suppresses only MQ/HN; rest byte-identical (SAM+BAM)       | "--compat byte-identical regression (phix)"         |
+| `header_parity.sh`           | `AH:*` on generated @SQ for ALT contigs (SAM+BAM+meth, #281)          | "ALT contig header regression (AH:*)"               |
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
 
 Each script reads its inputs from environment variables — see the comment

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -14,6 +14,7 @@ matrix row; the rest run on the canonical AVX2 row only. Each script:
 | `bam_roundtrip.sh`           | `--bam=6` BAM decodes and has same record count as SAM (chr22)        | "--bam=6 roundtrip smoke (chr22)"                   |
 | `short_read_smoke.sh`        | ASAN SE on 25-50 bp variable-length dense-chr22 reads (PR #100 fix)   | "Short-read SE smoke (chr22, ASAN, dense+variable-length)" |
 | `supp_rep_hard_cap.sh`       | `--supp-rep-hard-cap` forces MAPQ=0 on repetitive-seed supps (#101)   | "--supp-rep-hard-cap repetitive-seed regression"    |
+| `compat_byte_identical.sh`   | `--compat` suppresses only MQ/HN; rest byte-identical (SAM+BAM)       | "--compat byte-identical regression (phix)"         |
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
 
 Each script reads its inputs from environment variables — see the comment

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -14,8 +14,8 @@ matrix row; the rest run on the canonical AVX2 row only. Each script:
 | `bam_roundtrip.sh`           | `--bam=6` BAM decodes and has same record count as SAM (chr22)        | "--bam=6 roundtrip smoke (chr22)"                   |
 | `short_read_smoke.sh`        | ASAN SE on 25-50 bp variable-length dense-chr22 reads (PR #100 fix)   | "Short-read SE smoke (chr22, ASAN, dense+variable-length)" |
 | `supp_rep_hard_cap.sh`       | `--supp-rep-hard-cap` forces MAPQ=0 on repetitive-seed supps (#101)   | "--supp-rep-hard-cap repetitive-seed regression"    |
-| `compat_byte_identical.sh`   | `--compat` suppresses only MQ/HN; rest byte-identical (SAM+BAM)       | "--compat byte-identical regression (phix)"         |
-| `header_parity.sh`           | `AH:*` on generated @SQ for ALT contigs (SAM+BAM+meth, #281)          | "ALT contig header regression (AH:*)"               |
+| `compat_byte_identical.sh`   | `--compat=bwa-mem2` suppresses only MQ/HN/@HD; rest byte-identical    | "--compat byte-identical regression (phix)"         |
+| `header_parity.sh`           | `AH:*` on generated @SQ (#281); `--compat` skips the .hdr/.dict sidecar | "header parity regression (AH:*, --compat @HD/@SQ)" |
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
 
 Each script reads its inputs from environment variables — see the comment

--- a/test/regression/compat_byte_identical.sh
+++ b/test/regression/compat_byte_identical.sh
@@ -253,8 +253,41 @@ compat_err "unknown --compat target"  --compat=bogus
 compat_err "not yet selectable"       --compat=bwa-mem
 echo "PASS: --compat enum grammar (=/space, alias, off, unknown, unselectable)"
 
+# --- --compat with an @HD in -H warns, and does NOT reject. --------------
+# bwa-mem3 hoists a LEADING user @HD above @SQ so the header is spec-valid;
+# bwa emits -H records after @SQ and bwa-mem2 has no @HD logic, so the header
+# differs from the target in line ORDER. That is an explicit, coherent request
+# ("valid header, everything else the same") -- unlike --fast/--meth, which the
+# user cannot see in their own command line -- so it warns and continues.
 hd_h=$(printf '@HD\tVN:1.6\tSO:coordinate')
 rg_h=$(printf '@RG\tID:x\tSM:y')
+if ! "$BWA_MEM3" mem --compat=bwa-mem2 -H "$hd_h" "$ref" "$r1" "$r2" \
+        > "$COMPAT_WORK_DIR/hdwarn.sam" 2>"$COMPAT_WORK_DIR/hdwarn.log"; then
+    echo "FAIL: --compat with -H @HD exited nonzero; it must warn, not reject" >&2
+    cat "$COMPAT_WORK_DIR/hdwarn.log" >&2; exit 1
+fi
+grep -q 'will differ from bwa-mem2 in line order' "$COMPAT_WORK_DIR/hdwarn.log" \
+    || { echo "FAIL: --compat with -H @HD did not warn about line order:" >&2
+         cat "$COMPAT_WORK_DIR/hdwarn.log" >&2; exit 1; }
+# The user's @HD must win and be hoisted above @SQ (that is the whole point).
+head -1 "$COMPAT_WORK_DIR/hdwarn.sam" | grep -q '^@HD' \
+    || { echo "FAIL: user @HD from -H is not the first header line" >&2; exit 1; }
+echo "PASS: --compat with -H @HD warns and continues, user @HD wins"
+
+# A LATER @HD is emitted inline after @SQ, exactly as upstream does, so there
+# is nothing to warn about -- the warning must stay quiet or it means nothing.
+"$BWA_MEM3" mem --compat=bwa-mem2 -H "$rg_h" -H "$hd_h" "$ref" "$r1" "$r2" \
+    > /dev/null 2>"$COMPAT_WORK_DIR/hdquiet.log"
+if grep -q 'in line order' "$COMPAT_WORK_DIR/hdquiet.log"; then
+    echo "FAIL: warned about a non-leading @HD, which does not diverge" >&2
+    cat "$COMPAT_WORK_DIR/hdquiet.log" >&2; exit 1
+fi
+# ...and no warning at all without a compat target.
+"$BWA_MEM3" mem -H "$hd_h" "$ref" "$r1" "$r2" > /dev/null 2>"$COMPAT_WORK_DIR/hdoff.log"
+if grep -q 'in line order' "$COMPAT_WORK_DIR/hdoff.log"; then
+    echo "FAIL: warned without a compat target selected" >&2; exit 1
+fi
+echo "PASS: the -H @HD warning fires only when the header actually diverges"
 
 # --- Exactly one @HD, always, on both output paths. -----------------------
 # A non-leading @HD in -H used to leave the SAM path emitting the DEFAULT @HD

--- a/test/regression/compat_byte_identical.sh
+++ b/test/regression/compat_byte_identical.sh
@@ -253,4 +253,30 @@ compat_err "unknown --compat target"  --compat=bogus
 compat_err "not yet selectable"       --compat=bwa-mem
 echo "PASS: --compat enum grammar (=/space, alias, off, unknown, unselectable)"
 
+hd_h=$(printf '@HD\tVN:1.6\tSO:coordinate')
+rg_h=$(printf '@RG\tID:x\tSM:y')
+
+# --- Exactly one @HD, always, on both output paths. -----------------------
+# A non-leading @HD in -H used to leave the SAM path emitting the DEFAULT @HD
+# too, for two @HD records in one header -- a spec violation, and one bwa does
+# not have (bwa.c:412-426 counts @HD at any line start). The BAM writer was
+# already correct, so this also re-aligns the two paths.
+one_hd() {   # <description> [extra bwa-mem3 args...]
+    local desc="$1"; shift
+    local n m
+    n=$("$BWA_MEM3" mem "$@" "$ref" "$r1" "$r2" 2>/dev/null | grep -c '^@HD' || true)
+    [ "$n" -eq 1 ] \
+        || { echo "FAIL: SAM emitted $n @HD lines ($desc), expected exactly 1" >&2; exit 1; }
+    if command -v samtools > /dev/null 2>&1; then
+        m=$("$BWA_MEM3" mem --bam "$@" "$ref" "$r1" "$r2" 2>/dev/null \
+            | samtools view -H --no-PG - 2>/dev/null | grep -c '^@HD' || true)
+        [ "$m" -eq 1 ] \
+            || { echo "FAIL: BAM emitted $m @HD lines ($desc), expected exactly 1" >&2; exit 1; }
+    fi
+}
+one_hd "no -H"
+one_hd "leading @HD" -H "$hd_h"
+one_hd "later @HD"   -H "$rg_h" -H "$hd_h"
+echo "PASS: exactly one @HD on both paths, leading or later -H @HD"
+
 echo "PASS: compat byte-identical regression"

--- a/test/regression/compat_byte_identical.sh
+++ b/test/regression/compat_byte_identical.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # test/regression/compat_byte_identical.sh
 #
-# Regression: `bwa-mem3 mem --compat` must suppress exactly the two
-# bwa-mem3-only record additions that keep the drop-in profile from being
-# a byte-for-byte match to bwa-mem2 — the `MQ:i` and `HN:i` tags — and
-# must change NOTHING else.
+# Regression: `bwa-mem3 mem --compat=bwa-mem2` must suppress exactly the
+# three things that keep the drop-in profile from being a byte-for-byte
+# match to bwa-mem2 — the `MQ:i` and `HN:i` tags and the default `@HD`
+# line — and must change NOTHING else.
+#
+# `@HD`: bwa-mem2 v2.2.1 emits none at all (its bwa_print_sam_hdr has no
+# @HD logic); bwa gained one only in 0.7.18, after bwa-mem2 forked at
+# 0.7.17. Suppressing ours is deliberate. The sidecar `@SQ` half of header
+# parity is covered by compat_header_parity.sh, which needs an ALT-aware
+# fixture; phix here has no sidecar, so its `@SQ` block is identical
+# either way and this script's byte-diff still covers it.
 #
 # `@PG` is deliberately NOT suppressed: bwa-mem2 emits its own, so
 # dropping ours would turn a changed line into a missing one, and `CL:`
@@ -18,8 +25,8 @@
 # (drops another tag, drops @HD/@SQ) or too little (leaks MQ/HN), or
 # perturbs an alignment, the streams diverge and this fails. Both the
 # SAM-text and --bam paths are checked, since the tags are emitted from
-# two independent code paths (bwamem.cpp and bam_writer.cpp) gated on the
-# same MEM_F_COMPAT flag.
+# two independent code paths (bwamem.cpp and bam_writer.cpp) reading the
+# same compat target row (src/compat_target.cpp).
 #
 # Fixture (deterministic, no PRNG): PE reads are sliced directly from the
 # committed phix.fa so the FASTQ is byte-identical across awk
@@ -79,7 +86,7 @@ echo "fixture: $n_pairs PE pairs sliced from phix"
 def_sam="$COMPAT_WORK_DIR/default.sam"
 cmp_sam="$COMPAT_WORK_DIR/compat.sam"
 "$BWA_MEM3" mem          "$ref" "$r1" "$r2" > "$def_sam" 2>/dev/null
-"$BWA_MEM3" mem --compat "$ref" "$r1" "$r2" > "$cmp_sam" 2>/dev/null
+"$BWA_MEM3" mem --compat=bwa-mem2 "$ref" "$r1" "$r2" > "$cmp_sam" 2>/dev/null
 
 # The default run must actually contain the tags we claim to suppress,
 # else the byte-identity check below would pass vacuously.
@@ -98,42 +105,71 @@ if [ "$cmp_mq" -ne 0 ] || [ "$cmp_hn" -ne 0 ]; then
     exit 1
 fi
 
-# --compat must preserve the header, @PG included -- suppressing @PG would
-# only trade a changed line for a missing one (bwa-mem2 emits its own).
-if ! grep -q '^@HD' "$cmp_sam" || ! grep -q '^@SQ' "$cmp_sam"; then
-    echo "FAIL: --compat SAM dropped @HD/@SQ header lines" >&2
+# The default run must emit an @HD (else the suppression check is vacuous),
+# and --compat must emit none: bwa-mem2 writes no @HD at all.
+if ! grep -q '^@HD' "$def_sam"; then
+    echo "FAIL: default SAM has no @HD to suppress — fixture or default changed" >&2
     exit 1
 fi
+if grep -q '^@HD' "$cmp_sam"; then
+    echo "FAIL: --compat SAM still emits @HD (bwa-mem2 emits none):" >&2
+    grep '^@HD' "$cmp_sam" >&2
+    exit 1
+fi
+
+# @SQ must survive. Whether --compat SUPPRESSES a sidecar's identity tags is
+# not testable here -- phix has no .hdr/.dict, so there would be nothing to
+# suppress and the assertion would pass vacuously. header_parity.sh covers it
+# against a real `samtools dict` sidecar.
+if ! grep -q '^@SQ' "$cmp_sam"; then
+    echo "FAIL: --compat SAM dropped the @SQ header block" >&2
+    exit 1
+fi
+
+# @PG is preserved -- suppressing it would only trade a changed line for a
+# missing one (bwa-mem2 emits its own).
 if ! grep -q '^@PG.*ID:bwa-mem3' "$cmp_sam"; then
     echo "FAIL: --compat SAM dropped the bwa-mem3 @PG line (it must be preserved)" >&2
     exit 1
 fi
 
-# The load-bearing check: default (minus MQ/HN) is byte-identical to --compat.
-# @PG is excluded from BOTH sides -- its CL: records the actual argv, which
-# necessarily differs between the default and --compat invocations.
+# The load-bearing check: default (minus MQ/HN/@HD) is byte-identical to
+# --compat. @PG is excluded from BOTH sides -- its CL: records the actual
+# argv, which necessarily differs between the two invocations. @HD is
+# excluded from both because its presence/absence is asserted directly
+# above; excluding it here keeps THIS diff about everything else.
 def_stripped="$COMPAT_WORK_DIR/default.stripped.sam"
 cmp_stripped="$COMPAT_WORK_DIR/compat.stripped.sam"
-grep -v '^@PG' "$def_sam" \
+grep -vE '^@PG|^@HD' "$def_sam" \
   | sed -E 's/\tMQ:i:[0-9-]+//; s/\tHN:i:[0-9-]+//' > "$def_stripped"
-grep -v '^@PG' "$cmp_sam" > "$cmp_stripped"
+grep -vE '^@PG|^@HD' "$cmp_sam" > "$cmp_stripped"
 if ! diff -q "$def_stripped" "$cmp_stripped" > /dev/null; then
-    echo "FAIL: --compat SAM differs from default beyond MQ/HN:" >&2
+    echo "FAIL: --compat SAM differs from default beyond MQ/HN/@HD:" >&2
     diff "$def_stripped" "$cmp_stripped" | head -20 >&2
     exit 1
 fi
-echo "PASS: SAM-text --compat is byte-identical to default minus MQ/HN (@PG excluded)"
+echo "PASS: SAM-text --compat is byte-identical to default minus MQ/HN/@HD (@PG excluded)"
 
 # --- BAM path: same assertion, if samtools is available. ---
 if command -v samtools > /dev/null 2>&1; then
     def_bam="$COMPAT_WORK_DIR/default.bam"
     cmp_bam="$COMPAT_WORK_DIR/compat.bam"
     "$BWA_MEM3" mem --bam          "$ref" "$r1" "$r2" > "$def_bam" 2>/dev/null
-    "$BWA_MEM3" mem --bam --compat "$ref" "$r1" "$r2" > "$cmp_bam" 2>/dev/null
+    "$BWA_MEM3" mem --bam --compat=bwa-mem2 "$ref" "$r1" "$r2" > "$cmp_bam" 2>/dev/null
 
     # --no-PG so samtools does not inject its own @PG line into the header dump.
     if [ "$(samtools view -H --no-PG "$cmp_bam" | grep -c '^@PG.*ID:bwa-mem3')" -ne 1 ]; then
         echo "FAIL: --compat BAM lacks the bwa-mem3 @PG line (it must be preserved)" >&2
+        exit 1
+    fi
+    # The BAM header is built by a separate writer (bam_writer.cpp), so
+    # assert @HD suppression independently of the SAM-text path above.
+    if [ "$(samtools view -H --no-PG "$def_bam" | grep -c '^@HD')" -lt 1 ]; then
+        echo "FAIL: default BAM has no @HD to suppress" >&2
+        exit 1
+    fi
+    if [ "$(samtools view -H --no-PG "$cmp_bam" | grep -c '^@HD')" -ne 0 ]; then
+        echo "FAIL: --compat BAM still emits @HD (bwa-mem2 emits none)" >&2
         exit 1
     fi
     bam_def_rec="$COMPAT_WORK_DIR/default.bam.rec"
@@ -146,7 +182,7 @@ if command -v samtools > /dev/null 2>&1; then
         diff "$bam_def_rec" "$bam_cmp_rec" | head -20 >&2
         exit 1
     fi
-    echo "PASS: BAM --compat records are byte-identical to default minus MQ/HN"
+    echo "PASS: BAM --compat suppresses @HD; records byte-identical to default minus MQ/HN"
 else
     echo "SKIP: samtools not on PATH — BAM-path assertion skipped"
 fi
@@ -154,7 +190,7 @@ fi
 # --- --compat and --fast are mutually exclusive: must be a hard error. ---
 # (A diff-clean-looking stream over --fast's changed alignments would defeat
 # the parity-validation purpose of --compat, so combining them is rejected.)
-if "$BWA_MEM3" mem --compat --fast "$ref" "$r1" "$r2" > /dev/null 2>"$COMPAT_WORK_DIR/mutex.log"; then
+if "$BWA_MEM3" mem --compat=bwa-mem2 --fast "$ref" "$r1" "$r2" > /dev/null 2>"$COMPAT_WORK_DIR/mutex.log"; then
     echo "FAIL: --compat --fast exited 0 (expected a hard error)" >&2
     exit 1
 fi
@@ -169,7 +205,7 @@ echo "PASS: --compat --fast is rejected as a hard error"
 # bwa-mem2 has no methylation mode, so byte-identity is undefined under --meth.
 # The guard fires during option validation, before any index load, so the
 # non-meth phix reference here is sufficient to exercise it.
-if "$BWA_MEM3" mem --compat --meth "$ref" "$r1" "$r2" > /dev/null 2>"$COMPAT_WORK_DIR/meth.log"; then
+if "$BWA_MEM3" mem --compat=bwa-mem2 --meth "$ref" "$r1" "$r2" > /dev/null 2>"$COMPAT_WORK_DIR/meth.log"; then
     echo "FAIL: --compat --meth exited 0 (expected a hard error)" >&2
     exit 1
 fi
@@ -179,5 +215,42 @@ if ! grep -q 'not supported with --meth' "$COMPAT_WORK_DIR/meth.log"; then
     exit 1
 fi
 echo "PASS: --compat --meth is rejected as a hard error"
+
+# --- --compat is an enum: check the grammar the CLI advertises. ---
+# `--compat` takes a required argument, so every accepted spelling and every
+# rejection below is a contract the docs state. A regression here is silent
+# otherwise: a wrong optstring turns `--compat=off` into a hard error, or
+# `--compat=bwa-mem` into a claim of parity we cannot deliver.
+compat_ok() {   # spelling... -- must exit 0
+    if ! "$BWA_MEM3" mem "$@" "$ref" "$r1" "$r2" > /dev/null 2>"$COMPAT_WORK_DIR/cli.log"; then
+        echo "FAIL: 'mem $*' exited nonzero, expected success:" >&2
+        cat "$COMPAT_WORK_DIR/cli.log" >&2
+        exit 1
+    fi
+}
+compat_err() {  # <expected-substring> <spelling...> -- must exit nonzero AND say why
+    want="$1"; shift
+    if "$BWA_MEM3" mem "$@" "$ref" "$r1" "$r2" > /dev/null 2>"$COMPAT_WORK_DIR/cli.log"; then
+        echo "FAIL: 'mem $*' exited 0, expected a hard error" >&2
+        exit 1
+    fi
+    if ! grep -q "$want" "$COMPAT_WORK_DIR/cli.log"; then
+        echo "FAIL: 'mem $*' failed without the expected message '$want':" >&2
+        cat "$COMPAT_WORK_DIR/cli.log" >&2
+        exit 1
+    fi
+}
+
+compat_ok  --compat=bwa-mem2          # canonical, '=' form
+compat_ok  --compat bwa-mem2          # canonical, space form (required_argument)
+compat_ok  --compat=mem2              # documented alias
+compat_ok  --compat=off               # explicit no-op
+compat_ok  --compat=off --fast        # off must NOT trip the --fast guard
+compat_err "unknown --compat target"  --compat=bogus
+# bwa-mem is a real row in the table, deliberately not selectable. It must
+# get its own diagnostic -- calling it "unknown" would be a lie, and a user
+# asking for it deserves the actual reason.
+compat_err "not yet selectable"       --compat=bwa-mem
+echo "PASS: --compat enum grammar (=/space, alias, off, unknown, unselectable)"
 
 echo "PASS: compat byte-identical regression"

--- a/test/regression/compat_byte_identical.sh
+++ b/test/regression/compat_byte_identical.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# test/regression/compat_byte_identical.sh
+#
+# Regression: `bwa-mem3 mem --compat` must suppress exactly the two
+# bwa-mem3-only record additions that keep the drop-in profile from being
+# a byte-for-byte match to bwa-mem2 — the `MQ:i` and `HN:i` tags — and
+# must change NOTHING else.
+#
+# `@PG` is deliberately NOT suppressed: bwa-mem2 emits its own, so
+# dropping ours would turn a changed line into a missing one, and `CL:`
+# embeds the invocation either way. It is excluded from the comparison
+# below (the default and --compat runs have different argv) and asserted
+# to still be present.
+#
+# The load-bearing assertion is byte-identity: a default run with its
+# MQ:i / HN:i tags stripped must be identical, byte-for-byte, to a
+# `--compat` run of the same inputs. If --compat ever suppresses too much
+# (drops another tag, drops @HD/@SQ) or too little (leaks MQ/HN), or
+# perturbs an alignment, the streams diverge and this fails. Both the
+# SAM-text and --bam paths are checked, since the tags are emitted from
+# two independent code paths (bwamem.cpp and bam_writer.cpp) gated on the
+# same MEM_F_COMPAT flag.
+#
+# Fixture (deterministic, no PRNG): PE reads are sliced directly from the
+# committed phix.fa so the FASTQ is byte-identical across awk
+# implementations. read1 is a forward window; read2 is the reverse
+# complement of a downstream window, so every pair aligns concordantly
+# and carries a mate (=> MQ:i is emitted) and a primary hit count
+# (=> HN:i is emitted). Several pairs guarantee non-zero tag counts.
+#
+# Inputs (env vars):
+#   BWA_MEM3         — path to the bwa-mem3 binary under test
+#   COMPAT_PHIX_FA   — path to test/fixtures/phix.fa (the reference source)
+#   COMPAT_WORK_DIR  — directory for fixture-private intermediates
+
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+: "${COMPAT_PHIX_FA:?COMPAT_PHIX_FA must be set}"
+: "${COMPAT_WORK_DIR:?COMPAT_WORK_DIR must be set}"
+
+mkdir -p "$COMPAT_WORK_DIR"
+
+ref="$COMPAT_WORK_DIR/phix.fa"
+cp "$COMPAT_PHIX_FA" "$ref"
+
+# --- Build the PE FASTQs by slicing phix (deterministic, no PRNG). ---
+# Flatten the reference to a single sequence, then emit N pairs at fixed
+# offsets: read1 = ref[off .. off+L], read2 = revcomp(ref[off+G .. off+G+L]).
+seq="$(grep -v '^>' "$ref" | tr -d '\n' | tr 'acgt' 'ACGT')"
+r1="$COMPAT_WORK_DIR/r1.fq"
+r2="$COMPAT_WORK_DIR/r2.fq"
+: > "$r1"; : > "$r2"
+L=120          # read length
+G=300          # inner gap between the two windows (fragment ~ G+L)
+n_pairs=0
+for off in 200 900 1600 2300 3000 3700; do
+    s1="${seq:$off:$L}"
+    s2fwd="${seq:$((off+G)):$L}"
+    # reverse complement of s2fwd
+    s2="$(printf '%s' "$s2fwd" | rev | tr 'ACGT' 'TGCA')"
+    [ "${#s1}" -eq "$L" ] && [ "${#s2}" -eq "$L" ] || continue
+    q="$(printf 'I%.0s' $(seq 1 "$L"))"
+    printf '@pair%d/1\n%s\n+\n%s\n' "$n_pairs" "$s1" "$q" >> "$r1"
+    printf '@pair%d/2\n%s\n+\n%s\n' "$n_pairs" "$s2" "$q" >> "$r2"
+    n_pairs=$((n_pairs+1))
+done
+
+if [ "$n_pairs" -lt 3 ]; then
+    echo "FAIL: fixture built only $n_pairs pairs (phix slicing regression?)" >&2
+    exit 1
+fi
+echo "fixture: $n_pairs PE pairs sliced from phix"
+
+# --- Index the reference. ---
+"$BWA_MEM3" index "$ref" > "$COMPAT_WORK_DIR/index.log" 2>&1
+
+# --- SAM-text path: default vs --compat. ---
+def_sam="$COMPAT_WORK_DIR/default.sam"
+cmp_sam="$COMPAT_WORK_DIR/compat.sam"
+"$BWA_MEM3" mem          "$ref" "$r1" "$r2" > "$def_sam" 2>/dev/null
+"$BWA_MEM3" mem --compat "$ref" "$r1" "$r2" > "$cmp_sam" 2>/dev/null
+
+# The default run must actually contain the tags we claim to suppress,
+# else the byte-identity check below would pass vacuously.
+def_mq=$(grep -c 'MQ:i:'  "$def_sam" || true)
+def_hn=$(grep -c 'HN:i:'  "$def_sam" || true)
+if [ "$def_mq" -lt 1 ] || [ "$def_hn" -lt 1 ]; then
+    echo "FAIL: default SAM lacks MQ/HN to suppress (MQ=$def_mq HN=$def_hn) — fixture too weak" >&2
+    exit 1
+fi
+
+# --compat must emit neither tag.
+cmp_mq=$(grep -c 'MQ:i:'  "$cmp_sam" || true)
+cmp_hn=$(grep -c 'HN:i:'  "$cmp_sam" || true)
+if [ "$cmp_mq" -ne 0 ] || [ "$cmp_hn" -ne 0 ]; then
+    echo "FAIL: --compat SAM still emits MQ=$cmp_mq HN=$cmp_hn (expected 0/0)" >&2
+    exit 1
+fi
+
+# --compat must preserve the header, @PG included -- suppressing @PG would
+# only trade a changed line for a missing one (bwa-mem2 emits its own).
+if ! grep -q '^@HD' "$cmp_sam" || ! grep -q '^@SQ' "$cmp_sam"; then
+    echo "FAIL: --compat SAM dropped @HD/@SQ header lines" >&2
+    exit 1
+fi
+if ! grep -q '^@PG.*ID:bwa-mem3' "$cmp_sam"; then
+    echo "FAIL: --compat SAM dropped the bwa-mem3 @PG line (it must be preserved)" >&2
+    exit 1
+fi
+
+# The load-bearing check: default (minus MQ/HN) is byte-identical to --compat.
+# @PG is excluded from BOTH sides -- its CL: records the actual argv, which
+# necessarily differs between the default and --compat invocations.
+def_stripped="$COMPAT_WORK_DIR/default.stripped.sam"
+cmp_stripped="$COMPAT_WORK_DIR/compat.stripped.sam"
+grep -v '^@PG' "$def_sam" \
+  | sed -E 's/\tMQ:i:[0-9-]+//; s/\tHN:i:[0-9-]+//' > "$def_stripped"
+grep -v '^@PG' "$cmp_sam" > "$cmp_stripped"
+if ! diff -q "$def_stripped" "$cmp_stripped" > /dev/null; then
+    echo "FAIL: --compat SAM differs from default beyond MQ/HN:" >&2
+    diff "$def_stripped" "$cmp_stripped" | head -20 >&2
+    exit 1
+fi
+echo "PASS: SAM-text --compat is byte-identical to default minus MQ/HN (@PG excluded)"
+
+# --- BAM path: same assertion, if samtools is available. ---
+if command -v samtools > /dev/null 2>&1; then
+    def_bam="$COMPAT_WORK_DIR/default.bam"
+    cmp_bam="$COMPAT_WORK_DIR/compat.bam"
+    "$BWA_MEM3" mem --bam          "$ref" "$r1" "$r2" > "$def_bam" 2>/dev/null
+    "$BWA_MEM3" mem --bam --compat "$ref" "$r1" "$r2" > "$cmp_bam" 2>/dev/null
+
+    # --no-PG so samtools does not inject its own @PG line into the header dump.
+    if [ "$(samtools view -H --no-PG "$cmp_bam" | grep -c '^@PG.*ID:bwa-mem3')" -ne 1 ]; then
+        echo "FAIL: --compat BAM lacks the bwa-mem3 @PG line (it must be preserved)" >&2
+        exit 1
+    fi
+    bam_def_rec="$COMPAT_WORK_DIR/default.bam.rec"
+    bam_cmp_rec="$COMPAT_WORK_DIR/compat.bam.rec"
+    samtools view --no-PG "$def_bam" \
+      | sed -E 's/\tMQ:i:[0-9-]+//; s/\tHN:i:[0-9-]+//' > "$bam_def_rec"
+    samtools view --no-PG "$cmp_bam" > "$bam_cmp_rec"
+    if ! diff -q "$bam_def_rec" "$bam_cmp_rec" > /dev/null; then
+        echo "FAIL: --compat BAM records differ from default beyond MQ/HN:" >&2
+        diff "$bam_def_rec" "$bam_cmp_rec" | head -20 >&2
+        exit 1
+    fi
+    echo "PASS: BAM --compat records are byte-identical to default minus MQ/HN"
+else
+    echo "SKIP: samtools not on PATH — BAM-path assertion skipped"
+fi
+
+# --- --compat and --fast are mutually exclusive: must be a hard error. ---
+# (A diff-clean-looking stream over --fast's changed alignments would defeat
+# the parity-validation purpose of --compat, so combining them is rejected.)
+if "$BWA_MEM3" mem --compat --fast "$ref" "$r1" "$r2" > /dev/null 2>"$COMPAT_WORK_DIR/mutex.log"; then
+    echo "FAIL: --compat --fast exited 0 (expected a hard error)" >&2
+    exit 1
+fi
+if ! grep -q 'mutually exclusive' "$COMPAT_WORK_DIR/mutex.log"; then
+    echo "FAIL: --compat --fast failed without the expected 'mutually exclusive' message:" >&2
+    cat "$COMPAT_WORK_DIR/mutex.log" >&2
+    exit 1
+fi
+echo "PASS: --compat --fast is rejected as a hard error"
+
+# --- --compat is non-meth only: --compat --meth must be a hard error. ---
+# bwa-mem2 has no methylation mode, so byte-identity is undefined under --meth.
+# The guard fires during option validation, before any index load, so the
+# non-meth phix reference here is sufficient to exercise it.
+if "$BWA_MEM3" mem --compat --meth "$ref" "$r1" "$r2" > /dev/null 2>"$COMPAT_WORK_DIR/meth.log"; then
+    echo "FAIL: --compat --meth exited 0 (expected a hard error)" >&2
+    exit 1
+fi
+if ! grep -q 'not supported with --meth' "$COMPAT_WORK_DIR/meth.log"; then
+    echo "FAIL: --compat --meth failed without the expected 'not supported with --meth' message:" >&2
+    cat "$COMPAT_WORK_DIR/meth.log" >&2
+    exit 1
+fi
+echo "PASS: --compat --meth is rejected as a hard error"
+
+echo "PASS: compat byte-identical regression"

--- a/test/regression/header_parity.sh
+++ b/test/regression/header_parity.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
 # test/regression/header_parity.sh
 #
-# Regression: AH:* on ALT contigs must be emitted by the GENERATED @SQ block
-# on BOTH output paths. Upstream bwa (bwa.c:432) and bwa-mem2 (bwa.cpp:538)
-# both emit it, and bwa-mem3's SAM text path did, but the BAM writer was
-# ported as an SN+LN-only loop and dropped it for EVERY ALT-aware reference,
-# sidecar or not (fg-labs/bwa-mem3#281). --meth's consolidated @SQ had the
-# same omission.
+# Regression for the two header behaviors that compat_byte_identical.sh
+# cannot reach with its phix fixture, because both need a reference that
+# has ALT contigs and a .hdr/.dict sidecar:
 #
-# Needs a reference with ALT contigs and a .hdr/.dict sidecar, which the phix
-# fixture used elsewhere in this directory does not have.
+#   1. AH:* on ALT contigs is emitted by the GENERATED @SQ block on BOTH
+#      output paths. Upstream bwa (bwa.c:432) and bwa-mem2 (bwa.cpp:538)
+#      both emit it; bwa-mem3's SAM text path did, but the BAM writer was
+#      ported as an SN+LN-only loop and dropped it for EVERY ALT-aware
+#      reference, sidecar or not (fg-labs/bwa-mem3#281).
+#
+#   2. `--compat=bwa-mem2` ignores the sidecar entirely, so @SQ regenerates
+#      as bare SN/LN (+AH:*). The <prefix>.hdr / <baseprefix>.dict sidecar
+#      is bwa-mem3-only -- a port of lh3/bwa#348, which lh3 closed unmerged
+#      -- so neither upstream has anything to load, and its M5/AS/UR/SP
+#      would break byte-identity.
 #
 # The sidecar's own @SQ is AUTHORITATIVE and is never rewritten: lh3/bwa#348
 # was designed for the block to be produced complete by an external dict
@@ -114,6 +120,14 @@ sq_of() {   # <tag> [bwa-mem3 args...]
         || { echo "FAIL: $tag emitted no @SQ header block" >&2; exit 1; }
 }
 
+# Assert the run emitted no @HD at all.
+assert_no_HD() {   # <tag> <human description>
+    if grep -q '^@HD' "$1.hdr"; then
+        echo "FAIL: $2 — @HD emitted under compat (bwa-mem2 emits none)" >&2
+        exit 1
+    fi
+}
+
 assert_alt_has_AH() {   # <tag> <human description>
     grep -q "SN:${ALT_CONTIG}.*AH:\*" "$1.sq" \
         || { echo "FAIL: $2 — AH:* missing on $ALT_CONTIG:" >&2; cat "$1.sq" >&2; exit 1; }
@@ -132,24 +146,28 @@ assert_no_primary_AH() {   # <tag> <human description>
     fi
 }
 
-# --- 1. No sidecar: AH:* on the generated @SQ, SAM text and BAM. ----------
-# The BAM cell is fg-labs/bwa-mem3#281's broader half: it dropped AH for
-# every ALT-aware reference, sidecar or not.
+# --- 1. No sidecar: AH:* on BOTH paths, default AND compat. ---------------
+# The BAM/no-sidecar cell is fg-labs/bwa-mem3#281's broader half: it dropped
+# AH for every ALT-aware reference, independent of --compat.
 rm -f ref.dict ref.fasta.hdr
 sq_of nosc_sam_def
 assert_alt_has_AH nosc_sam_def "SAM text, no sidecar, default"
 assert_no_primary_AH nosc_sam_def "SAM text, no sidecar, default"
+sq_of nosc_sam_cmp --compat=bwa-mem2
+assert_alt_has_AH nosc_sam_cmp "SAM text, no sidecar, --compat=bwa-mem2"
 if [ "$have_samtools" -eq 1 ]; then
     sq_of nosc_bam_def --bam
     assert_alt_has_AH nosc_bam_def "BAM, no sidecar, default (issue #281)"
     assert_no_primary_AH nosc_bam_def "BAM, no sidecar, default"
+    sq_of nosc_bam_cmp --bam --compat=bwa-mem2
+    assert_alt_has_AH nosc_bam_cmp "BAM, no sidecar, --compat=bwa-mem2"
 fi
-echo "PASS: AH:* emitted on generated @SQ (SAM text + BAM)"
+echo "PASS: AH:* emitted on generated @SQ (SAM+BAM, default and --compat)"
 
 # The remaining cases need a sidecar, which we build with `samtools dict`.
 if [ "$have_samtools" -eq 0 ]; then
     echo "SKIP: sidecar cases need samtools dict"
-    echo "PASS: ALT contig header regression (partial — no samtools)"
+    echo "PASS: compat header parity regression (partial — no samtools)"
     exit 0
 fi
 
@@ -179,6 +197,28 @@ grep -q 'samtools dict --alt' sc_sam_def.err \
     || { echo "FAIL: missing-AH warning does not name the remedy" >&2; cat sc_sam_def.err >&2; exit 1; }
 echo "PASS: sidecar @SQ is authoritative (AH absent), and the gap is warned about"
 
+# compat: sidecar skipped entirely -> bare SN/LN + AH:*, no identity tags.
+assert_compat_ignores_sidecar() {   # <tag>
+    assert_alt_has_AH "$1" "$1"
+    if grep -qE "\t(M5|AS|UR|SP):" "$1.sq"; then
+        echo "FAIL: $1 — sidecar identity tags leaked into compat output:" >&2
+        head -3 "$1.sq" >&2
+        exit 1
+    fi
+    # The sidecar's own @HD must not sneak through either.
+    assert_no_HD "$1" "$1"
+    # No warning: the sidecar was never read.
+    if grep -q 'sidecar supplies @SQ without an AH tag' "$1.err"; then
+        echo "FAIL: $1 — warned about a sidecar that compat does not read" >&2
+        exit 1
+    fi
+}
+sq_of sc_sam_cmp --compat=bwa-mem2
+assert_compat_ignores_sidecar sc_sam_cmp
+sq_of sc_bam_cmp --bam --compat=bwa-mem2
+assert_compat_ignores_sidecar sc_bam_cmp
+echo "PASS: --compat=bwa-mem2 ignores the sidecar (bare SN/LN + AH:*, no @HD)"
+
 # --- 3. Sidecar WITH AH (`samtools dict --alt`, the supported remedy). ----
 samtools dict -a testasm -s testus --alt ref.fasta.alt -o ref.dict ref.fasta
 grep -q "SN:${ALT_CONTIG}.*AH:" ref.dict \
@@ -198,4 +238,4 @@ sq_of ah_sam;        assert_sidecar_AH_passthrough ah_sam
 sq_of ah_bam --bam;  assert_sidecar_AH_passthrough ah_bam
 echo "PASS: 'samtools dict --alt' sidecar carries AH:* through both paths, no warning"
 
-echo "PASS: ALT contig header regression"
+echo "PASS: compat header parity regression"

--- a/test/regression/header_parity.sh
+++ b/test/regression/header_parity.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# test/regression/header_parity.sh
+#
+# Regression: AH:* on ALT contigs must be emitted by the GENERATED @SQ block
+# on BOTH output paths. Upstream bwa (bwa.c:432) and bwa-mem2 (bwa.cpp:538)
+# both emit it, and bwa-mem3's SAM text path did, but the BAM writer was
+# ported as an SN+LN-only loop and dropped it for EVERY ALT-aware reference,
+# sidecar or not (fg-labs/bwa-mem3#281). --meth's consolidated @SQ had the
+# same omission.
+#
+# Needs a reference with ALT contigs and a .hdr/.dict sidecar, which the phix
+# fixture used elsewhere in this directory does not have.
+#
+# The sidecar's own @SQ is AUTHORITATIVE and is never rewritten: lh3/bwa#348
+# was designed for the block to be produced complete by an external dict
+# tool, and `samtools dict --alt` (samtools/samtools#1676) exists to do it.
+# So a sidecar WITHOUT AH legitimately yields output without AH -- asserted
+# below, along with the warning that says so, and with the `samtools dict
+# --alt` path that fixes it.
+#
+# Fixture is generated here, not committed (repo convention): a 3-contig FASTA
+# whose ALT contig name EXTENDS a primary one (chr1 / chr1_alt), a matching
+# .alt, and PE reads sliced from the primary contig. Sequence comes from
+# python3's Mersenne Twister at a fixed seed, so the fixture is identical on
+# every run and platform.
+#
+# Inputs (env vars):
+#   BWA_MEM3         — path to the bwa-mem3 binary under test
+#   HEADER_PARITY_WORK_DIR — directory for fixture-private intermediates.
+#                     This script DELETES the fixture files it owns inside
+#                     it, so give it a directory of its own.
+
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+: "${HEADER_PARITY_WORK_DIR:?HEADER_PARITY_WORK_DIR must be set}"
+
+mkdir -p "$HEADER_PARITY_WORK_DIR"
+cd "$HEADER_PARITY_WORK_DIR"
+# Remove only what a previous run of THIS script created. A blanket
+# `rm -rf "$HEADER_PARITY_WORK_DIR"` would obey a mistyped or over-broad value
+# of a caller-supplied variable; the `:?` guard above catches unset and empty,
+# but not `/` or `$HOME`.
+rm -f ref.fasta ref.fasta.* ref.dict index.log probe.sam \
+      ./*.sq ./*.hdr ./*.out ./*.err r1.fq r2.fq
+
+ALT_CONTIG=chr1_alt
+
+# --- Generate the ALT-aware fixture (deterministic; fixed PRNG seed). ---
+python3 - <<'PY'
+import random
+random.seed(282)                      # fixed: fixture must be reproducible
+def rnd(n): return "".join(random.choice("ACGT") for _ in range(n))
+# chr1_alt deliberately EXTENDS chr1. The sidecar then carries both SN:chr1
+# and SN:chr1_alt, so the AH scan in bwa.cpp must match SN as a whole token to
+# report the right contig -- a prefix match would conflate them. Cases 2 and 3
+# below exercise exactly that through the missing-AH warning.
+contigs = [("chr1", 20000), ("chr2", 15000), ("chr1_alt", 5000)]
+seqs = {n: rnd(l) for n, l in contigs}
+with open("ref.fasta", "w") as f:
+    for n, _ in contigs:
+        f.write(">%s\n" % n)
+        s = seqs[n]
+        for i in range(0, len(s), 60):
+            f.write(s[i:i+60] + "\n")
+# <prefix>.alt is a SAM file; bwa reads only column 1 (QNAME) to set is_alt.
+with open("ref.fasta.alt", "w") as f:
+    f.write("chr1_alt\t0\tchr1\t1\t60\t5000M\t*\t0\t0\t*\t*\n")
+comp = str.maketrans("ACGT", "TGCA")
+with open("r1.fq", "w") as a, open("r2.fq", "w") as b:
+    for i, off in enumerate(range(500, 4500, 400)):
+        x = seqs["chr1"][off:off+120]
+        y = seqs["chr1"][off+300:off+420][::-1].translate(comp)
+        a.write("@p%d/1\n%s\n+\n%s\n" % (i, x, "I"*120))
+        b.write("@p%d/2\n%s\n+\n%s\n" % (i, y, "I"*120))
+PY
+
+[ -s ref.fasta ] && [ -s ref.fasta.alt ] && [ -s r1.fq ] && [ -s r2.fq ] \
+    || { echo "FAIL: fixture generation produced empty files" >&2; exit 1; }
+
+"$BWA_MEM3" index ref.fasta > index.log 2>&1
+
+# The index must actually mark the ALT contig, else every AH assertion below
+# passes vacuously. `mem` prints no is_alt summary, so infer it from the one
+# path that has always emitted AH: SAM text with no sidecar.
+rm -f ref.dict ref.fasta.hdr
+"$BWA_MEM3" mem ref.fasta r1.fq r2.fq 2>/dev/null > probe.sam
+grep -q "^@SQ.*SN:${ALT_CONTIG}.*AH:\*" probe.sam \
+    || { echo "FAIL: .alt not honored — no AH:* on $ALT_CONTIG even on the SAM/no-sidecar path" >&2
+         grep '^@SQ' probe.sam >&2; exit 1; }
+echo "fixture: 3 contigs, $ALT_CONTIG marked ALT via ref.fasta.alt"
+
+have_samtools=0
+command -v samtools > /dev/null 2>&1 && have_samtools=1
+[ "$have_samtools" -eq 1 ] || echo "NOTE: samtools not on PATH — BAM and sidecar cases will be skipped"
+
+# Run one invocation, capturing its stderr as "$tag.err", its raw output as
+# "$tag.out", the full header as "$tag.hdr" and the @SQ block as "$tag.sq".
+# Extracting the header once here means the assertions below are plain greps
+# over a file and none of them needs to know which output path ran.
+# ('@' cannot start a SAM record -- it is excluded from QNAME -- so grep '^@'
+# over SAM text picks up header lines only.)
+sq_of() {   # <tag> [bwa-mem3 args...]
+    local tag="$1"; shift
+    local a is_bam=0
+    for a in "$@"; do [ "$a" = "--bam" ] && is_bam=1; done
+    "$BWA_MEM3" mem "$@" ref.fasta r1.fq r2.fq 2>"$tag.err" > "$tag.out"
+    if [ "$is_bam" -eq 1 ]; then
+        samtools view -H --no-PG "$tag.out" > "$tag.hdr"
+    else
+        grep '^@' "$tag.out" > "$tag.hdr"
+    fi
+    grep '^@SQ' "$tag.hdr" > "$tag.sq" \
+        || { echo "FAIL: $tag emitted no @SQ header block" >&2; exit 1; }
+}
+
+assert_alt_has_AH() {   # <tag> <human description>
+    grep -q "SN:${ALT_CONTIG}.*AH:\*" "$1.sq" \
+        || { echo "FAIL: $2 — AH:* missing on $ALT_CONTIG:" >&2; cat "$1.sq" >&2; exit 1; }
+}
+assert_no_primary_AH() {   # <tag> <human description>
+    # Spec: AH "must not be present on sequences in the primary assembly".
+    # Match SN as a whole tab-delimited token. Not load-bearing for the current
+    # fixture (chr1_alt is the longer name, so a substring filter happens to
+    # behave), but it keeps this assertion correct if the ALT contig is ever
+    # renamed to a PREFIX of another contig, where a loose filter would drop
+    # both lines and the check would silently stop firing.
+    if grep -v "SN:${ALT_CONTIG}$(printf '\t')" "$1.sq" | grep -q 'AH:'; then
+        echo "FAIL: $2 — AH on a primary-assembly contig:" >&2
+        cat "$1.sq" >&2
+        exit 1
+    fi
+}
+
+# --- 1. No sidecar: AH:* on the generated @SQ, SAM text and BAM. ----------
+# The BAM cell is fg-labs/bwa-mem3#281's broader half: it dropped AH for
+# every ALT-aware reference, sidecar or not.
+rm -f ref.dict ref.fasta.hdr
+sq_of nosc_sam_def
+assert_alt_has_AH nosc_sam_def "SAM text, no sidecar, default"
+assert_no_primary_AH nosc_sam_def "SAM text, no sidecar, default"
+if [ "$have_samtools" -eq 1 ]; then
+    sq_of nosc_bam_def --bam
+    assert_alt_has_AH nosc_bam_def "BAM, no sidecar, default (issue #281)"
+    assert_no_primary_AH nosc_bam_def "BAM, no sidecar, default"
+fi
+echo "PASS: AH:* emitted on generated @SQ (SAM text + BAM)"
+
+# The remaining cases need a sidecar, which we build with `samtools dict`.
+if [ "$have_samtools" -eq 0 ]; then
+    echo "SKIP: sidecar cases need samtools dict"
+    echo "PASS: ALT contig header regression (partial — no samtools)"
+    exit 0
+fi
+
+# --- 2. Sidecar WITHOUT AH (what `samtools dict` emits by default). -------
+samtools dict -a testasm -s testus -o ref.dict ref.fasta
+if grep -q 'AH:' ref.dict; then
+    echo "FAIL: fixture sidecar unexpectedly carries AH — case 2 is vacuous" >&2
+    exit 1
+fi
+
+# Default: the sidecar is authoritative, so its tags appear and AH does not.
+# This is DESIGNED behavior (lh3/bwa#348), not a bug -- do not "fix" it.
+assert_sidecar_verbatim() {   # <tag>
+    grep -q 'M5:' "$1.sq" \
+        || { echo "FAIL: $1 — sidecar identity tags missing; sidecar not honored" >&2; exit 1; }
+    if grep -q 'AH:' "$1.sq"; then
+        echo "FAIL: $1 — AH present, but the sidecar is authoritative and has none" >&2
+        exit 1
+    fi
+}
+sq_of sc_sam_def;        assert_sidecar_verbatim sc_sam_def
+sq_of sc_bam_def --bam;  assert_sidecar_verbatim sc_bam_def
+# ...and the run must SAY so, rather than losing ALT status silently.
+grep -q 'sidecar supplies @SQ without an AH tag' sc_sam_def.err \
+    || { echo "FAIL: no warning about the sidecar's missing AH:" >&2; cat sc_sam_def.err >&2; exit 1; }
+grep -q 'samtools dict --alt' sc_sam_def.err \
+    || { echo "FAIL: missing-AH warning does not name the remedy" >&2; cat sc_sam_def.err >&2; exit 1; }
+echo "PASS: sidecar @SQ is authoritative (AH absent), and the gap is warned about"
+
+# --- 3. Sidecar WITH AH (`samtools dict --alt`, the supported remedy). ----
+samtools dict -a testasm -s testus --alt ref.fasta.alt -o ref.dict ref.fasta
+grep -q "SN:${ALT_CONTIG}.*AH:" ref.dict \
+    || { echo "FAIL: 'samtools dict --alt' produced no AH — fixture/samtools mismatch" >&2; exit 1; }
+assert_sidecar_AH_passthrough() {   # <tag>
+    assert_alt_has_AH "$1" "$1 (sidecar carries AH)"
+    assert_no_primary_AH "$1" "$1"
+    grep -q 'M5:' "$1.sq" \
+        || { echo "FAIL: $1 — sidecar identity tags missing" >&2; exit 1; }
+    # No warning: the sidecar supplies AH, so there is no gap to report.
+    if grep -q 'sidecar supplies @SQ without an AH tag' "$1.err"; then
+        echo "FAIL: $1 — warned despite the sidecar carrying AH" >&2
+        exit 1
+    fi
+}
+sq_of ah_sam;        assert_sidecar_AH_passthrough ah_sam
+sq_of ah_bam --bam;  assert_sidecar_AH_passthrough ah_bam
+echo "PASS: 'samtools dict --alt' sidecar carries AH:* through both paths, no warning"
+
+echo "PASS: ALT contig header regression"

--- a/test/unit/test_compat_target.cpp
+++ b/test/unit/test_compat_target.cpp
@@ -1,0 +1,155 @@
+// test/unit/test_compat_target.cpp — the `--compat` target table.
+//
+// The table in src/compat_target.cpp is DATA transcribed from upstream
+// sources, and one of its rows (bwa-mem) is deliberately not reachable from
+// the CLI. Both facts make it prone to silent rot: a transcription error is
+// invisible until someone diffs against the real aligner, and an unreachable
+// row is exercised by nothing else. So assert every field of every row here,
+// against the same citations the table comments carry.
+//
+// Verified 2026-07-24 against ~/work/git/bwa @ 91fb301 (0.7.19-r1273) and
+// bwa-mem2 v2.2.1. If a row changes, the upstream evidence must change with it.
+
+#include <cstring>
+#include <string>
+#include "doctest/doctest.h"
+#include "compat_target.h"
+
+namespace {
+// Look a row up by canonical name, failing the test rather than returning NULL
+// so a missing row reports as a named failure instead of a segfault.
+const compat_target_t *row(const char *name) {
+    const compat_target_t *t = compat_target_from_name(name);
+    REQUIRE_MESSAGE(t != nullptr, "no compat target row named ", name);
+    return t;
+}
+} // namespace
+
+TEST_CASE("compat target `off` is bwa-mem3's native output") {
+    const compat_target_t *t = row("off");
+    CHECK(std::string(t->name) == "off");
+    CHECK(t->unavailable_reason == nullptr);
+    CHECK(t->alias == nullptr);
+    // Every output-shaping field is permissive: `off` must be exactly
+    // equivalent to not passing --compat at all.
+    CHECK(t->emit_hd      == 1);
+    CHECK(t->read_sidecar == 1);
+    CHECK(t->emit_mq      == 1);
+    CHECK(t->emit_hn      == 1);
+    // NULL, not a literal: each output path keeps the default it already
+    // emits. The SAM text and BAM paths disagree ("VN:1.5 ... GO:query" vs
+    // "VN:1.6 SO:unsorted"); pinning a string here would change default output
+    // on one of them, which --compat must never do.
+    CHECK(t->hd_line == nullptr);
+}
+
+TEST_CASE("compat target `bwa-mem2` matches bwa-mem2 v2.2.1") {
+    const compat_target_t *t = row("bwa-mem2");
+    CHECK(std::string(t->name) == "bwa-mem2");
+    CHECK(t->unavailable_reason == nullptr);
+    CHECK(std::string(t->alias) == "mem2");
+    // bwa-mem2's bwa_print_sam_hdr (src/bwa.cpp:523) has no @HD logic at all:
+    // no n_HD counter, no default emission. bwa gained one only in 0.7.18
+    // (6b18630), after bwa-mem2 forked at 0.7.17.
+    CHECK(t->emit_hd == 0);
+    // The <prefix>.hdr / <baseprefix>.dict sidecar is bwa-mem3-only: a port of
+    // lh3/bwa#348, which lh3 closed unmerged. grep '\.hdr\|\.dict' is empty in
+    // both upstreams, so there is nothing for a compat target to load.
+    CHECK(t->read_sidecar == 0);
+    // MQ:i arrived in bwa via lh3/bwa#330 (merged 2022-03-06), after the fork.
+    CHECK(t->emit_mq == 0);
+    // HN:i exists in neither upstream.
+    CHECK(t->emit_hn == 0);
+}
+
+TEST_CASE("compat target `bwa-mem` is fully specified but not selectable") {
+    const compat_target_t *t = row("bwa-mem");
+    CHECK(std::string(t->name) == "bwa-mem");
+    // Not selectable: bwa-mem3 and bwa still differ on the ALIGNMENTS, so
+    // offering the target would advertise a byte-identity we cannot deliver.
+    // The row exists because its output shaping is fully determined by the
+    // evidence below; when the alignment work lands, this becomes nullptr.
+    REQUIRE(t->unavailable_reason != nullptr);
+    CHECK(std::string(t->unavailable_reason).find("byte-identity") != std::string::npos);
+    // bwa.c:426 — emitted unconditionally when -H supplies no @HD.
+    REQUIRE(t->emit_hd == 1);
+    REQUIRE(t->hd_line != nullptr);
+    CHECK(std::string(t->hd_line) == "@HD\tVN:1.5\tSO:unsorted\tGO:query");
+    // lh3/bwa#348 closed unmerged; bwa has no sidecar.
+    CHECK(t->read_sidecar == 0);
+    // THE field a single compat boolean could not express: bwa DOES emit MQ:i
+    // (bwamem.c:935) while bwa-mem2 does not. This asymmetry is why --compat
+    // is a target enum rather than a flag bit.
+    CHECK(t->emit_mq == 1);
+    CHECK(t->emit_hn == 0);
+}
+
+TEST_CASE("bwa and bwa-mem2 rows differ exactly where the upstreams do") {
+    const compat_target_t *mem  = row("bwa-mem");
+    const compat_target_t *mem2 = row("bwa-mem2");
+    // Both drop the bwa-mem3-only sidecar and the bwa-mem3-only HN:i tag...
+    CHECK(mem->read_sidecar == mem2->read_sidecar);
+    CHECK(mem->emit_hn      == mem2->emit_hn);
+    // ...and disagree on precisely the two fields the fork point explains:
+    // @HD (bwa 0.7.18, 6b18630) and MQ:i (lh3/bwa#330), both post-0.7.17.
+    CHECK(mem->emit_hd != mem2->emit_hd);
+    CHECK(mem->emit_mq != mem2->emit_mq);
+}
+
+TEST_CASE("compat target lookup: aliases, unknown names, NULL") {
+    // `mem2` is the documented short spelling and must resolve to the same row.
+    CHECK(compat_target_from_name("mem2") == compat_target_from_name("bwa-mem2"));
+    // Unknown names are NULL so the caller can say "unknown target"...
+    CHECK(compat_target_from_name("bwa-mem4") == nullptr);
+    CHECK(compat_target_from_name("") == nullptr);
+    CHECK(compat_target_from_name(nullptr) == nullptr);
+    // ...while a RECOGNIZED but unavailable name resolves, so the caller can
+    // tell the user the real reason instead of "unknown target".
+    const compat_target_t *t = compat_target_from_name("bwa-mem");
+    REQUIRE(t != nullptr);
+    CHECK(t->unavailable_reason != nullptr);
+    // Lookup is exact: no prefix or case folding.
+    CHECK(compat_target_from_name("bwa") == nullptr);
+    CHECK(compat_target_from_name("BWA-MEM2") == nullptr);
+    CHECK(compat_target_from_name("bwa-mem2 ") == nullptr);
+}
+
+TEST_CASE("COMPAT_TARGET_OFF is the row `off` resolves to") {
+    // mem_opt_init() stores &COMPAT_TARGET_OFF, and main_mem tests
+    // `opt->compat != &COMPAT_TARGET_OFF` to decide whether a target is
+    // active. If --compat=off resolved to a different row with identical
+    // fields, that pointer comparison would treat it as active and wrongly
+    // reject --compat=off --fast.
+    CHECK(compat_target_from_name("off") == &COMPAT_TARGET_OFF);
+}
+
+TEST_CASE("every table row is reachable by name, and rows are self-consistent") {
+    int n = 0;
+    const compat_target_t *const *rows = compat_targets(&n);
+    REQUIRE(rows != nullptr);
+    CHECK(n >= 3);
+    for (int i = 0; i < n; ++i) {
+        const compat_target_t *t = rows[i];
+        REQUIRE(t != nullptr);
+        REQUIRE(t->name != nullptr);
+        CHECK_MESSAGE(compat_target_from_name(t->name) == t,
+                      "row ", i, " (", t->name, ") is not reachable by name");
+        if (t->alias != nullptr)
+            CHECK_MESSAGE(compat_target_from_name(t->alias) == t,
+                          "row ", t->name, " is not reachable by its alias");
+        // A pinned @HD is meaningless unless the row emits one.
+        if (t->hd_line != nullptr)
+            CHECK_MESSAGE(t->emit_hd == 1,
+                          "row ", t->name, " pins hd_line but does not emit @HD");
+    }
+}
+
+TEST_CASE("the selectable list is derived from the table") {
+    // Pinned exactly. A membership loop would be the obvious test, but
+    // `find(t->name)` cannot express it: "bwa-mem" is a prefix of "bwa-mem2",
+    // so the unavailable bwa-mem row would look listed. Splitting the string
+    // to fix that restates, at length, what this one comparison already says --
+    // any table change that would break membership breaks equality first, with
+    // a clearer failure message.
+    CHECK(std::string(compat_target_selectable_list()) == "bwa-mem2 (alias mem2), off");
+}

--- a/test/unit/test_sam_hdr_emit.cpp
+++ b/test/unit/test_sam_hdr_emit.cpp
@@ -1,0 +1,232 @@
+// test/unit/test_sam_hdr_emit.cpp — @HD/@SQ precedence in the SAM-text header
+// emitter (bwa_print_sam_hdr2, src/bwa.cpp).
+//
+// This function had NO direct test. test/header_insert_test.cpp covers only how
+// -H text is ACCUMULATED (bwa_insert_header/bwa_escape), never how it is
+// EMITTED, and the only -H '@HD…' case in the tree was in
+// meth_rg_header_test.sh — which passes a LEADING @HD and goes through the
+// --meth writer, a different function that was already correct.
+//
+// That gap hid a spec violation: a user @HD that was not the FIRST record in -H
+// suppressed nothing, so the default @HD was emitted as well and the header
+// carried two @HD lines (fg-labs/bwa-mem3, fixed alongside this test).
+//
+// The precedence contract, from lh3/bwa#348 and bwa.c:412-438:
+//   @HD : user's (-H) > index sidecar's > the compat target's default,
+//         and EXACTLY ONE is emitted, always.
+//   @SQ : user's -H block alone if it supplies any; else the sidecar's;
+//         else generated from bns.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+#include "doctest/doctest.h"
+#include "bwa.h"
+#include "compat_target.h"
+
+namespace {
+
+// Two contigs, one of them ALT, so the generated @SQ block is non-trivial.
+struct TestBns {
+    bntann1_t anns[2];
+    bntseq_t  bns;
+    TestBns() {
+        memset(anns, 0, sizeof(anns));
+        anns[0].name = const_cast<char *>("chr1");
+        anns[0].len = 1000; anns[0].is_alt = 0;
+        anns[1].name = const_cast<char *>("chr1_alt");
+        anns[1].len = 500;  anns[1].is_alt = 1;
+        memset(&bns, 0, sizeof(bns));
+        bns.n_seqs = 2;
+        bns.anns   = anns;
+    }
+};
+
+// Render a header to a string. open_memstream gives a real FILE* so the
+// function under test is exercised exactly as it is in production.
+std::string render(const char *idx_hdr_lines, const char *hdr_line,
+                   const compat_target_t *compat) {
+    TestBns t;
+    char *buf = NULL; size_t len = 0;
+    FILE *fp = open_memstream(&buf, &len);
+    REQUIRE(fp != NULL);
+    // Both inputs are taken as `const char *` and are only ever read from and
+    // advanced past internally -- nothing in bwa_print_sam_hdr2 frees or
+    // rewrites them -- so the literals can be passed straight through.
+    bwa_print_sam_hdr2(&t.bns, idx_hdr_lines, hdr_line, fp, compat);
+    fclose(fp);
+    std::string out = buf ? std::string(buf, len) : std::string();
+    free(buf);
+    return out;
+}
+
+int count_lines_starting(const std::string &s, const char *prefix) {
+    int n = 0;
+    size_t pos = 0;
+    const size_t plen = strlen(prefix);
+    while (pos <= s.size()) {
+        const size_t eol = s.find('\n', pos);
+        const size_t len = (eol == std::string::npos ? s.size() : eol) - pos;
+        if (len >= plen && s.compare(pos, plen, prefix) == 0) ++n;
+        if (eol == std::string::npos) break;
+        pos = eol + 1;
+    }
+    return n;
+}
+
+// Index of the first line starting with `prefix`, or -1.
+int line_index_of(const std::string &s, const char *prefix) {
+    int idx = 0;
+    size_t pos = 0;
+    const size_t plen = strlen(prefix);
+    while (pos <= s.size()) {
+        const size_t eol = s.find('\n', pos);
+        const size_t len = (eol == std::string::npos ? s.size() : eol) - pos;
+        if (len >= plen && s.compare(pos, plen, prefix) == 0) return idx;
+        if (eol == std::string::npos) break;
+        pos = eol + 1; ++idx;
+    }
+    return -1;
+}
+
+} // namespace
+
+TEST_CASE("@HD: exactly one is emitted, in every -H shape") {
+    // THE REGRESSION. Each of these emitted the right count except the third,
+    // which emitted two: the default plus the user's.
+    struct Case { std::string desc; const char *hdr_line; };
+    const std::vector<Case> cases = {
+        { "no -H",                        NULL },
+        { "-H with a LEADING @HD",        "@HD\tVN:1.6\tSO:coordinate" },
+        { "-H with a NON-LEADING @HD",    "@RG\tID:x\tSM:y\n@HD\tVN:1.6\tSO:coordinate" },
+        { "-H with @HD last of three",    "@RG\tID:x\n@CO\tnote\n@HD\tVN:1.6" },
+        { "-H with no @HD at all",        "@RG\tID:x\tSM:y" },
+    };
+    for (const Case &c : cases) {
+        const std::string out = render(NULL, c.hdr_line, &COMPAT_TARGET_OFF);
+        CHECK_MESSAGE(count_lines_starting(out, "@HD") == 1,
+                      "case: ", c.desc, "\n----\n", out, "----");
+    }
+}
+
+TEST_CASE("@HD: a leading user @HD wins and is hoisted above @SQ") {
+    // Hoisting is what makes the header spec-valid (@HD must come first). It
+    // is bwa-mem3-only -- bwa emits -H records after @SQ (bwa.c:438).
+    const std::string out = render(NULL, "@HD\tVN:1.6\tSO:coordinate", &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(out.rfind("@HD\tVN:1.6\tSO:coordinate", 0) == 0);   // literally first
+    CHECK(line_index_of(out, "@HD") < line_index_of(out, "@SQ"));
+    CHECK(out.find("VN:1.5") == std::string::npos);           // default suppressed
+}
+
+TEST_CASE("@HD: a non-leading user @HD suppresses the default but stays inline") {
+    // It cannot be hoisted without reordering the user's own records, so it is
+    // emitted with the rest of -H after @SQ -- where bwa puts every -H record
+    // anyway. What it MUST do is suppress the default; failing to was the bug.
+    const std::string out =
+        render(NULL, "@RG\tID:x\tSM:y\n@HD\tVN:1.6\tSO:coordinate", &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(out.find("VN:1.5") == std::string::npos);           // default suppressed
+    CHECK(out.find("VN:1.6") != std::string::npos);           // the user's survives
+    CHECK(line_index_of(out, "@SQ") < line_index_of(out, "@HD"));   // inline, after @SQ
+    CHECK(count_lines_starting(out, "@RG") == 1);             // and @RG is not lost
+}
+
+TEST_CASE("@HD: the index sidecar supplies one when -H does not") {
+    const std::string out =
+        render("@HD\tVN:1.4\tSO:queryname\n@CO\tfrom the sidecar", NULL, &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(out.find("VN:1.4") != std::string::npos);
+    CHECK(out.find("VN:1.5") == std::string::npos);           // default suppressed
+    CHECK(out.find("@CO\tfrom the sidecar") != std::string::npos);
+}
+
+TEST_CASE("@HD: the user's -H beats the sidecar's, and only one survives") {
+    // Both @HD records lead their own stream here, which is the easy shape: the
+    // loser is consumed off the front of the sidecar and simply not printed.
+    const std::string out = render("@HD\tVN:1.4\tSO:queryname",
+                                   "@HD\tVN:1.6\tSO:coordinate", &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(out.find("VN:1.6") != std::string::npos);           // user's
+    CHECK(out.find("VN:1.4") == std::string::npos);           // sidecar's dropped
+}
+
+TEST_CASE("@HD: a LOSING sidecar @HD is dropped wherever it sits in the sidecar") {
+    // The case above only exercised a LEADING sidecar @HD, which is consumed off
+    // the front. A sidecar @HD behind another record cannot be consumed that way,
+    // and used to be counted-but-still-printed -- so the stream carried two @HD
+    // records whenever -H also supplied one. The BAM writer already filtered
+    // these (bam_writer.cpp strips every @HD from the sidecar when -H has one),
+    // so this was a SAM-vs-BAM divergence as well as a spec violation.
+    struct Case { std::string desc; const char *idx; const char *usr; };
+    const std::vector<Case> cases = {
+        { "leading user @HD, non-leading sidecar @HD",
+          "@RG\tID:z\n@HD\tVN:1.4\tSO:queryname",
+          "@HD\tVN:1.6\tSO:coordinate" },
+        { "non-leading user @HD, non-leading sidecar @HD",
+          "@RG\tID:z\n@HD\tVN:1.4\tSO:queryname",
+          "@CO\tnote\n@HD\tVN:1.6\tSO:coordinate" },
+        { "non-leading user @HD, leading sidecar @HD",
+          "@HD\tVN:1.4\tSO:queryname\n@RG\tID:z",
+          "@CO\tnote\n@HD\tVN:1.6\tSO:coordinate" },
+    };
+    for (const Case &c : cases) {
+        const std::string out = render(c.idx, c.usr, &COMPAT_TARGET_OFF);
+        CHECK_MESSAGE(count_lines_starting(out, "@HD") == 1,
+                      "case: ", c.desc, "\n----\n", out, "----");
+        CHECK_MESSAGE(out.find("VN:1.6") != std::string::npos,   // the user's wins
+                      "case: ", c.desc, "\n----\n", out, "----");
+        CHECK_MESSAGE(out.find("VN:1.4") == std::string::npos,   // the sidecar's loses
+                      "case: ", c.desc, "\n----\n", out, "----");
+        // Dropping the losing @HD must not take the sidecar's other records
+        // with it.
+        CHECK_MESSAGE(count_lines_starting(out, "@RG\tID:z") == 1,
+                      "case: ", c.desc, "\n----\n", out, "----");
+    }
+}
+
+TEST_CASE("@HD: only the first of several sidecar @HD records survives") {
+    // With no -H at all the sidecar supplies the winner, but a sidecar carrying
+    // more than one @HD must still yield exactly one record.
+    const std::string out =
+        render("@HD\tVN:1.4\tSO:queryname\n@RG\tID:z\n@HD\tVN:1.3\tSO:unsorted",
+               NULL, &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(out.find("VN:1.4") != std::string::npos);           // first wins
+    CHECK(out.find("VN:1.3") == std::string::npos);
+    CHECK(count_lines_starting(out, "@RG\tID:z") == 1);
+}
+
+TEST_CASE("@HD: a compat target that emits none emits none, but -H still wins") {
+    const compat_target_t *mem2 = compat_target_from_name("bwa-mem2");
+    REQUIRE(mem2 != nullptr);
+    REQUIRE(mem2->emit_hd == 0);
+
+    // No user or sidecar @HD -> nothing at all. bwa-mem2 emits no @HD.
+    CHECK(count_lines_starting(render(NULL, NULL, mem2), "@HD") == 0);
+
+    // A user @HD is still honored -- the target suppresses only the DEFAULT.
+    const std::string out = render(NULL, "@HD\tVN:1.6\tSO:coordinate", mem2);
+    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(out.find("VN:1.6") != std::string::npos);
+}
+
+TEST_CASE("@SQ: generated from bns, carrying AH:* on ALT contigs") {
+    const std::string out = render(NULL, NULL, &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(out, "@SQ") == 2);
+    CHECK(out.find("@SQ\tSN:chr1\tLN:1000\n") != std::string::npos);
+    CHECK(out.find("@SQ\tSN:chr1_alt\tLN:500\tAH:*\n") != std::string::npos);
+}
+
+TEST_CASE("@SQ: a user -H @SQ block is authoritative and suppresses generation") {
+    // Matches both upstreams (bwa.c:429, bwa-mem2 bwa.cpp:534): if -H supplies
+    // any @SQ, it is used alone -- no generation, and the sidecar is ignored.
+    const std::string out = render("@SQ\tSN:from_sidecar\tLN:7",
+                                   "@SQ\tSN:from_user\tLN:9", &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(out, "@SQ") == 1);
+    CHECK(out.find("SN:from_user") != std::string::npos);
+    CHECK(out.find("SN:from_sidecar") == std::string::npos);
+    CHECK(out.find("SN:chr1") == std::string::npos);          // nothing generated
+}


### PR DESCRIPTION
Closes #277-scope, #281, #282.

Makes `bwa-mem3 mem --compat=bwa-mem2` produce output that is byte-identical to bwa-mem2 v2.2.1 — records *and* header — and fixes an `AH:*` regression found along the way.

Three commits, readable in order:

| commit | issue | what |
|---|---|---|
| `f35c10b` | — | `--compat` suppresses `MQ:i` / `HN:i`, bringing the **record** stream to byte-identity |
| `2958f18` | #281 | `AH:*` restored on the generated `@SQ` in the BAM and `--meth` writers |
| `2576e7b` | #282 | `--compat` becomes a target enum and covers the **header** (`@HD`, `@SQ`) |

## The headline result

Verified against a real bwa-mem2 v2.2.1 run on hg38 — the bench baseline BAM at `strict/baseline/smoke-1M/c6a/rep-1/aligned.bam`. Under `--compat=bwa-mem2` the header is byte-identical on **both** output paths:

```
mem2 golden : 34dabb50dd7a704866e841d3e5a7f68d  (3366 lines)
mem3 SAM    : 34dabb50dd7a704866e841d3e5a7f68d  (3366 lines)
mem3 BAM    : 34dabb50dd7a704866e841d3e5a7f68d  (3366 lines)
```

By default those same headers differ on 6733 lines. `@PG` is excluded on both sides — it is run-specific by construction.

## Why `--compat` had to become an enum

A boolean could not express the targets, because **bwa and bwa-mem2 disagree with each other** on half of what `--compat` shapes:

| | bwa 0.7.19 | bwa-mem2 v2.2.1 | bwa-mem3 before this PR |
|---|---|---|---|
| default `@HD` | yes (`bwa.c:426`) | **none** | yes |
| `.hdr`/`.dict` sidecar | no | no | **yes** |
| generated `@SQ` `AH:*` | yes (`bwa.c:432`) | yes (`bwa.cpp:538`) | SAM yes; **BAM/meth no** |
| `MQ:i` | **yes** (`bwamem.c:935`) | **no** | yes |
| `HN:i` | no | no | yes |

Two rows are not what they look like. **`MQ:i` is not a bwa-mem3 invention** — bwa emits it (lh3/bwa#330, merged 2022-03-06); bwa-mem2 lacks it only because it forked at 0.7.17. Same story for `@HD`, added in bwa 0.7.18 (`6b18630`). Only `HN:i` and the sidecar are genuinely ours.

`src/compat_target.{h,cpp}` holds one const row per target; consumers read a field off `opt->compat` instead of testing a flag bit. `MEM_F_COMPAT` is gone.

### `--compat=bwa-mem` is wired but not selectable

The `bwa-mem` row is fully specified by the table above, but carries an `unavailable_reason` so the flag reports the real problem instead of "unknown target":

```
[E::main_mem] compat target 'bwa-mem' is recognized but not yet selectable:
  bwa-mem3 and bwa still differ on 224/63583 records (53 above MAPQ 30),
  so byte-identity is not achievable. Supported: bwa-mem2 (alias mem2), off
```

Offering it would advertise a parity no amount of output shaping can deliver — the same trap `--compat --fast` is a hard error to prevent. The unit test asserts every field of every row, including that one, so an unreachable row cannot rot. When the alignment work lands, clearing one field is the whole change.

## CLI

`--compat` takes a required argument: `bwa-mem2`, alias `mem2`, or `off`. Both `--compat=X` and `--compat X` work. `off` is exactly equivalent to omitting the flag, so it does not trip the `--fast` / `--meth` guards.

## The `AH:*` fix (#281), and what it is *not*

`AH:*` was emitted from exactly one place in the tree, so the other two `@SQ` generators dropped it silently — `--bam` lost it for **every** ALT-aware reference, sidecar or not, and `--meth` likewise. Both upstreams emit it, so this was a regression we introduced.

**The sidecar half of #281 is not a bug and is deliberately unchanged.** A `.hdr`/`.dict` `@SQ` block that omits `AH` still yields output without `AH`. That looks like the same defect but is the designed behavior of lh3/bwa#348, whose author said so directly when nh13 raised this exact point:

> You are correct that manually adding `AH` fields corresponding to the `.alt` file would be painful. This is why I have a followup samtools PR coming, which will add an option to `samtools dict` to read the `.alt` file and emit `AH` appropriately.
> — [lh3/bwa#348 (comment)](https://github.com/lh3/bwa/pull/348#issuecomment-1072921603)

That follow-up shipped as samtools/samtools#1676 and is live as `samtools dict --alt`. Treating the block as authoritative also matches how both upstreams treat `-H`, and it avoids an unanswerable question: an index with no `.alt` marks nothing as ALT, so enriching would have to decide whether to strip an `AH` the index merely cannot corroborate.

Losing ALT status silently is still bad, so bwa-mem3 now warns and names the remedy when the index has ALT contigs and the sidecar has no `AH`.

## Tests

- **Unit** (`test/unit/test_compat_target.cpp`) — every field of every row against its upstream citation, plus lookup: aliases, unknown names, unavailable rows, the derived selectable-list.
- **`compat_byte_identical.sh`** — `@HD` assertions on both paths and full enum-grammar coverage (`=`/space, alias, `off`, unknown, unselectable).
- **`header_parity.sh`** (new) — generated, not committed, per repo convention. The ALT contig name deliberately *extends* a primary one (`chr1` / `chr1_alt`) so a prefix match would conflate them. Covers {SAM, BAM} x {sidecar, no sidecar} x {default, `--compat`}, the missing-`AH` warning, and the `samtools dict --alt` passthrough.

Both scripts wired into CI. Full suite, clean build: 128/128 unit tests, both regression scripts, `help_prescan_test.sh`, `docs/_generated` in sync, mdbook + linkcheck clean.

## Follow-ups filed

- **#288** — the SAM-text and BAM writers hardcode different default `@HD` strings (`VN:1.5 … GO:query` vs `VN:1.6 SO:unsorted`). Moot under a compat target since both are suppressed; reconciling changes *default* output on one path. Cited from all three emission sites so it is not mistaken for a bug here. PR to follow.
- **#289** — the three generated-`@SQ` builders and the six open-coded header-text scanners should be consolidated. #281 *was* that drift. Kept out of this PR because swapping `sam_hdr_add_line` for `sam_hdr_add_lines` is byte-identity-relevant and would muddy the evidence above; `header_parity.sh` is the gate that makes the refactor safe afterwards. PR to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--compat=TARGET` output shaping, including a byte-identical mode for `bwa-mem2`, with explicit conflict handling (`--fast`, `--meth`).
  * Compat-aware SAM/BAM header output: controlled default `@HD`, ALT contig `AH:*` behavior, and compat-gated `MQ:i`/`HN:i`.
* **Documentation**
  * Updated `mem` and equivalence docs with supported targets, formatting differences, and verification recipes.
* **Bug Fixes**
  * Added warnings when ALT contigs are missing `AH:*` in provided/sidecar header data (with compat-aware behavior).
* **Tests / CI**
  * Added regression scripts and unit tests; CI now runs compat byte-identical and header parity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->