### PR TITLE
perf(seed): reuse the sortSMEMs counting-sort scratch across batches

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -1686,7 +1686,8 @@ void FMI_search::sortSMEMs(SMEM *matchArray,
         int64_t numTotalSmem[],
         int32_t numReads,
         int32_t readlength,
-        int nthreads)
+        int nthreads,
+        SmemSortScratch &scratch)
 {
     /* The only property the caller needs from this sort is that every SMEM of a
      * given read (rid) is contiguous and the reads appear in ascending rid
@@ -1697,9 +1698,14 @@ void FMI_search::sortSMEMs(SMEM *matchArray,
      * unstable re-sort's handling of them cannot depend on their incoming order.
      *
      * rid is a dense index in [0, numReads), so a counting sort by rid replaces
-     * the O(n log n) function-pointer qsort with an O(n + rid_range) pass. Buffers
-     * are call-local: FMI_search is shared across worker threads, so no member
-     * scratch may be used here. */
+     * the O(n log n) function-pointer qsort with an O(n + rid_range) pass.
+     *
+     * The count/offset array (`cnt`) and the stable-scatter buffer (`tmp`) live
+     * in caller-owned scratch that is allocated once and reused across batches
+     * (audit SEED-15), replacing the old per-batch calloc/_mm_malloc + free.
+     * FMI_search is shared across worker threads, so no member scratch may be
+     * used here; the scratch instead comes from the caller's per-thread
+     * mem_cache slot (mmc->smem_sort_scratch[tid]) and is never shared. */
     int tid;
     int32_t perThreadQuota = (numReads + (nthreads - 1)) / nthreads;
     for(tid = 0; tid < nthreads; tid++)
@@ -1720,12 +1726,32 @@ void FMI_search::sortSMEMs(SMEM *matchArray,
         }
         int64_t range = (int64_t)maxRid - (int64_t)minRid + 1;
 
-        int64_t *cnt = (int64_t *) calloc((size_t)range, sizeof(int64_t));
-        SMEM    *tmp = (SMEM *) _mm_malloc((size_t)smem_count * sizeof(SMEM), 64);
-        if (cnt == NULL || tmp == NULL) {
-            fprintf(stderr, "ERROR: out of memory in %s\n", __func__);
-            exit(EXIT_FAILURE);
+        /* Grow the reused scratch on demand; it is never shrunk. cnt is zeroed
+         * over [0, range) below — exactly what the old per-call calloc did — so
+         * only the used prefix must be reset, not the whole capacity. tmp is
+         * fully overwritten by the scatter, so it needs no initialization. */
+        if (range > scratch.cntCap) {
+            _mm_free(scratch.cnt);
+            scratch.cnt = (int64_t *) _mm_malloc((size_t)range * sizeof(int64_t), 64);
+            if (scratch.cnt == NULL) {
+                fprintf(stderr, "ERROR: out of memory in %s\n", __func__);
+                exit(EXIT_FAILURE);
+            }
+            scratch.cntCap = range;
         }
+        if (smem_count > scratch.tmpCap) {
+            _mm_free(scratch.tmp);
+            scratch.tmp = (SMEM *) _mm_malloc((size_t)smem_count * sizeof(SMEM), 64);
+            if (scratch.tmp == NULL) {
+                fprintf(stderr, "ERROR: out of memory in %s\n", __func__);
+                exit(EXIT_FAILURE);
+            }
+            scratch.tmpCap = smem_count;
+        }
+        int64_t *cnt = scratch.cnt;
+        SMEM    *tmp = scratch.tmp;
+
+        memset(cnt, 0, (size_t)range * sizeof(int64_t));
 
         for (int64_t i = 0; i < smem_count; i++)
             cnt[myMatchArray[i].rid - minRid]++;
@@ -1738,11 +1764,8 @@ void FMI_search::sortSMEMs(SMEM *matchArray,
             int64_t b = (int64_t)myMatchArray[i].rid - minRid;
             tmp[cnt[b]++] = myMatchArray[i];
         }
-        /* tmp is a fresh allocation and cannot overlap myMatchArray */
+        /* tmp is distinct scratch storage and cannot overlap myMatchArray */
         memcpy(myMatchArray, tmp, (size_t)smem_count * sizeof(SMEM));
-
-        _mm_free(tmp);
-        free(cnt);
     }
 }
 

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -88,6 +88,22 @@ typedef struct smem_struct
     int64_t k, l, s;
 }SMEM;
 
+/* Reusable scratch for FMI_search::sortSMEMs' rid counting sort. Hoisted out of
+ * the per-batch malloc/free + memcpy (audit SEED-15): the caller owns one of
+ * these per worker thread (see mem_cache in bwamem.h) and passes it in on every
+ * batch, so the count/offset array (`cnt`) and the stable-scatter buffer (`tmp`)
+ * are allocated once and grown on demand instead of allocated and freed per
+ * call. Zero-initialize the struct before first use (all-NULL, zero caps); the
+ * owner frees `cnt`/`tmp` with _mm_free at teardown (both NULL-safe). One
+ * instance is single-threaded scratch — never share it across threads. */
+typedef struct smem_sort_scratch
+{
+    int64_t *cnt;     /* counting-sort count/offset array; >= observed rid range */
+    int64_t  cntCap;  /* allocated capacity of cnt, in int64_t entries           */
+    SMEM    *tmp;     /* stable-scatter output buffer; >= observed SMEM count     */
+    int64_t  tmpCap;  /* allocated capacity of tmp, in SMEM entries              */
+}SmemSortScratch;
+
 #define SAL_PFD 16
 
 #ifndef SMEM_LOCKSTEP_N
@@ -277,7 +293,8 @@ class FMI_search: public indexEle
                    int64_t numTotalSmem[],
                    int32_t numReads,
                    int32_t readlength,
-                   int nthreads);
+                   int nthreads,
+                   SmemSortScratch &scratch);
     int64_t get_sa_entry(int64_t pos);
     void get_sa_entries(int64_t *posArray,
                         int64_t *coordArray,

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1441,7 +1441,7 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
     tot_smem = num_smem1 + num_smem2 + num_smem3;
     // assert(mmc->wsize_mem[tid] > (tot_smem));
     // fprintf(stderr, "num_smems: %d %d %d, %d\n", num_smem1, num_smem2, num_smem3, tot_smem);
-    fmi->sortSMEMs(matchArray, &tot_smem, nseq, seq_[0].l_seq, 1); // seq_[0].l_seq - only used for blocking when using nthreads
+    fmi->sortSMEMs(matchArray, &tot_smem, nseq, seq_[0].l_seq, 1, mmc->smem_sort_scratch[tid]); // seq_[0].l_seq - only used for blocking when using nthreads
 
     pos = 0;
     int64_t smem_ptr = 0;

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -345,6 +345,13 @@ typedef struct
     SMEM    *lockstep_match_buf[MAX_THREADS];
     int64_t  lockstep_buf_cap[MAX_THREADS];
 
+    // Reusable per-thread scratch for FMI_search::sortSMEMs' rid counting sort
+    // (audit SEED-15). Owned here so the count/offset and stable-scatter buffers
+    // are allocated once and grown on demand instead of malloc/free'd per batch.
+    // Each worker thread touches only its own [tid] slot, so the reuse is safe
+    // by construction even though the FMI_search instance itself is shared.
+    SmemSortScratch smem_sort_scratch[MAX_THREADS];
+
     // Pointer into worker_t::ref_string (the unpacked .0123 reference).
     // Set once in the worker_aln/worker_sam entry points; lets helpers like
     // mem_seed_sw and the mem_matesw_* family invoke bns_fetch_seq_v2 without

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -283,6 +283,11 @@ void worker_alloc(const mem_opt_t *opt, worker_t &w, int32_t nreads, int32_t nth
         w.mmc.lockstep_prev[l]      = NULL;
         w.mmc.lockstep_match_buf[l] = NULL;
         w.mmc.lockstep_buf_cap[l]   = 0;
+
+        w.mmc.smem_sort_scratch[l].cnt    = NULL;
+        w.mmc.smem_sort_scratch[l].cntCap = 0;
+        w.mmc.smem_sort_scratch[l].tmp    = NULL;
+        w.mmc.smem_sort_scratch[l].tmpCap = 0;
     }
 
     allocMem = nthreads * (BATCH_SIZE + 32) * sizeof(int32_t);
@@ -331,6 +336,9 @@ void worker_free(worker_t &w, int32_t nthreads)
 
         _mm_free(w.mmc.lockstep_prev[l]);
         _mm_free(w.mmc.lockstep_match_buf[l]);
+
+        _mm_free(w.mmc.smem_sort_scratch[l].cnt);
+        _mm_free(w.mmc.smem_sort_scratch[l].tmp);
     }
 }
 

--- a/test/integration/bwt_seed_strategy_test.cpp
+++ b/test/integration/bwt_seed_strategy_test.cpp
@@ -178,11 +178,16 @@ int main(int argc, char **argv) {
     }
     printf("totalSmems = %ld\n", totalSmem);
 
+    // sortSMEMs' counting-sort scratch is caller-owned; this call site is
+    // single-threaded (sortSMEMs loops over the per-thread blocks itself), so
+    // one instance suffices.
+    SmemSortScratch sortScratch = {NULL, 0, NULL, 0};
     fmiSearch->sortSMEMs(matchArray,
             numTotalSmem,
             numReads,
             readlength,
-            numthreads);
+            numthreads,
+            sortScratch);
 
     int32_t perThreadQuota = (numReads + (numthreads - 1)) / numthreads;
     for(tid = 0; tid < numthreads; tid++)
@@ -205,6 +210,8 @@ int main(int argc, char **argv) {
     }
     
     free(enc_qdb);
+    _mm_free(sortScratch.cnt);
+    _mm_free(sortScratch.tmp);
     _mm_free(matchArray);
     _mm_free(max_intv_array);
     delete fmiSearch;

--- a/test/integration/fmi_test.cpp
+++ b/test/integration/fmi_test.cpp
@@ -175,6 +175,9 @@ int main(int argc, char **argv) {
     {
         int32_t *rid_array = (int32_t *)_mm_malloc(batch_size * sizeof(int32_t), 64);
         int32_t tid = omp_get_thread_num();
+        // Per-thread sortSMEMs counting-sort scratch: allocated once here and
+        // grown on demand inside sortSMEMs, never shared across threads.
+        SmemSortScratch sortScratch = {NULL, 0, NULL, 0};
         // Initial capacity must hold at least one batch's worst case so the
         // first grow check below has a real budget to compare against. When
         // numthreads > numReads, perThreadQuota is 0 and the legacy
@@ -228,7 +231,8 @@ int main(int argc, char **argv) {
                     numTotalSmem + batch_id,
                     batch_count,
                     max_readlength,
-                    1);
+                    1,
+                    sortScratch);
             for(j = 0; j < numTotalSmem[batch_id]; j++)
             {
                 matchArray[tid][myTotalSmems + j].rid += i;
@@ -241,6 +245,8 @@ int main(int argc, char **argv) {
         int64_t endTick = __rdtsc();
         printf("%d] %ld ticks, workTicks = %ld\n", tid, endTick - startTick, workTicks[tid]);
         _mm_free(rid_array);
+        _mm_free(sortScratch.cnt);
+        _mm_free(sortScratch.tmp);
     }
 
     endTick = __rdtsc();

--- a/test/integration/smem2_test.cpp
+++ b/test/integration/smem2_test.cpp
@@ -191,11 +191,16 @@ int main(int argc, char **argv) {
     }
     printf("totalSmems = %ld\n", totalSmem);
 
+    // sortSMEMs' counting-sort scratch is caller-owned; this call site is
+    // single-threaded (sortSMEMs loops over the per-thread blocks itself), so
+    // one instance suffices.
+    SmemSortScratch sortScratch = {NULL, 0, NULL, 0};
     fmiSearch->sortSMEMs(matchArray,
             numTotalSmem,
             numReads,
             readlength,
-            numthreads);
+            numthreads,
+            sortScratch);
 
     int32_t perThreadQuota = (numReads + (numthreads - 1)) / numthreads;
     for(tid = 0; tid < numthreads; tid++)
@@ -219,6 +224,8 @@ int main(int argc, char **argv) {
 
     free(query_seq);
     free(enc_qdb);
+    _mm_free(sortScratch.cnt);
+    _mm_free(sortScratch.tmp);
     _mm_free(rid_array);
     _mm_free(query_pos_array);
     _mm_free(matchArray);


### PR DESCRIPTION
Reuses the `sortSMEMs` counting-sort scratch across batches instead of allocating it every call.

## What
`sortSMEMs` allocated its counting-sort scratch (`cnt` via `calloc`, `tmp` via `_mm_malloc`) and freed it on **every** batch. This hoists the scratch into per-thread `mem_cache` slots, allocated once and grown on demand — the same per-thread buffer pattern already used for `matchArray[tid]` etc.

## Byte-identity
The sort arithmetic is untouched (count → exclusive prefix-sum → stable forward scatter → `memcpy` back). `cnt` is `memset`-zeroed each batch to reproduce `calloc`'s zeroing of the `[0,range)` prefix it reads; `tmp` is fully written before it's read. Stability is preserved (ascending scatter). Scratch is per-thread (`FMI_search` is shared across threads, so the scratch lives in the per-thread `mem_cache`, never on the shared instance).

Validated: full-run record md5 identical to the frozen baseline on all four samples.

## Performance
Interleaved A/B, wgs-5M t16, byte-identity gated, best-of-5: **−0.53%** median, stable (every rep beats baseline, no overlap).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved SMEM sorting efficiency by reusing per-thread temporary buffers.
  * Reduced repeated memory allocation and cleanup during batch processing.
* **Reliability**
  * Added controlled initialization and cleanup of sorting resources during worker startup and shutdown.
  * Preserved safe concurrent processing through thread-local buffer ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->