### PR TITLE
perf(sam,seed): micro-cleanups in SAM formatting and seeding

### DIFF
--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -229,17 +229,8 @@ FMI_search::FMI_search(const char *fname)
     shm_base = NULL;
     shm_len = 0;
 
-    /* one_hot_mask_array is constant across the FMI's lifetime and is
-     * identical on disk and shm paths; initialize it once at construction. */
-    int64_t one_hot_bytes = 64 * (int64_t)sizeof(uint64_t);
-    one_hot_mask_array = (uint64_t *)_mm_malloc(one_hot_bytes, 64);
-    assert_not_null(one_hot_mask_array, one_hot_bytes, one_hot_bytes);
-    one_hot_mask_array[0] = 0;
-    uint64_t base = 0x8000000000000000L;
-    one_hot_mask_array[1] = base;
-    for (int64_t i = 2; i < 64; ++i) {
-        one_hot_mask_array[i] = (one_hot_mask_array[i - 1] >> 1) | base;
-    }
+    /* one_hot_mask_array is now a file-scope compile-time constant table (see
+     * FMI_search.h); nothing to allocate or initialize here. */
 }
 
 FMI_search::~FMI_search()
@@ -257,7 +248,6 @@ FMI_search::~FMI_search()
         if (sa_ls_word) _mm_free(sa_ls_word);
         if (cp_occ)     _mm_free(cp_occ);
     }
-    if (one_hot_mask_array) _mm_free(one_hot_mask_array);
 }
 
 int64_t FMI_search::cp_occ_size_bytes() const {
@@ -563,6 +553,13 @@ void FMI_search::getSMEMsOnePosOneThread(uint8_t *enc_qdb,
     SMEM *prevArray = (SMEM *)_mm_malloc((size_t)prevArray_bytes, 64);
     assert_not_null(prevArray, prevArray_bytes, prevArray_bytes);
 
+    // Hoist the FM-index cumulative-count table into a local for the batch (as
+    // the bwa-mem2 reference does). count[] is a lifetime-constant member never
+    // mutated during seeding, so this is a pure cache of identical values: it
+    // trades the per-seed `this->count[..]` member loads for stack reads. Byte-
+    // identical to reading the member directly.
+    const int64_t counts[5] = {count[0], count[1], count[2], count[3], count[4]};
+
     uint32_t i;
     // Perform SMEM for original reads
     for(i = 0; i < numReads; i++)
@@ -582,9 +579,9 @@ void FMI_search::getSMEMsOnePosOneThread(uint8_t *enc_qdb,
             smem.rid = rid;
             smem.m = x;
             smem.n = x;
-            smem.k = count[a];
-            smem.l = count[3 - a];
-            smem.s = count[a+1] - count[a];
+            smem.k = counts[a];
+            smem.l = counts[3 - a];
+            smem.s = counts[a+1] - counts[a];
             int numPrev = 0;
             
             int j;
@@ -1999,16 +1996,20 @@ int64_t FMI_search::call_one_step(int64_t pos, int64_t &sa_entry, int64_t &offse
  * worker threads, hence thread_local (not a member). Freed on thread exit. */
 namespace {
 struct SaPrefetchScratch {
-    int64_t *pos = nullptr, *map = nullptr;
+    // Only pos is staged now: the former map_ar array held map_ar[k] == k for
+    // every entry (the staging loop writes map_ar[id] = totalCoordCount + c,
+    // and totalCoordCount == id on entry to each SMEM while both advance in
+    // lockstep with c), so the map index is just the buffer index and the
+    // second allocation was dead. Downstream consumers use the index directly.
+    int64_t *pos = nullptr;
     int64_t  cap = 0;
     void ensure(int64_t n) {
         if (n <= cap) return;
-        _mm_free(pos); _mm_free(map);
+        _mm_free(pos);
         pos = (int64_t *) _mm_malloc((size_t)n * sizeof(int64_t), 64);
-        map = (int64_t *) _mm_malloc((size_t)n * sizeof(int64_t), 64);
         cap = n;
     }
-    ~SaPrefetchScratch() { _mm_free(pos); _mm_free(map); }
+    ~SaPrefetchScratch() { _mm_free(pos); }
 };
 } // namespace
 
@@ -2043,7 +2044,6 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
     static thread_local SaPrefetchScratch t_sa;
     t_sa.ensure(mem_lim);
     int64_t *pos_ar = t_sa.pos;
-    int64_t *map_ar = t_sa.map;
 
     for(int i = 0; i < count; i++)
     {
@@ -2055,8 +2055,9 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
         for(j = smem.k; (j < hi) && (c < max_occ); j+=step, c++)
         {
             int64_t pos = j;
-             pos_ar[id]  = pos;
-             map_ar[id++] = totalCoordCount + c;
+             pos_ar[id++]  = pos;
+            // map_ar[k] == k (== id here), so the staging index is stored
+            // implicitly; map_pos below reads the index directly.
             // int64_t sa_entry = get_sa_entry_compressed(pos, tid);
             // coordArray[totalCoordCount + c] = sa_entry;
         }
@@ -2076,7 +2077,7 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
     {
         int64_t pos =  pos_ar[i];
         working_set[j] = pos;
-        map_pos[j] = map_ar[i];
+        map_pos[j] = i;   // map_ar[i] == i (see staging loop invariant)
         offset[j] = 0;
         
         if ((pos & SA_COMPX_MASK) == 0) {
@@ -2115,7 +2116,7 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
                 {
                     pos = pos_ar[i];
                     working_set[k] = pos;
-                    map_pos[k] = map_ar[i++];
+                    map_pos[k] = i++;   // map_ar[i] == i (staging invariant)
                     offset[k] = 0;
                     
                     if ((pos & SA_COMPX_MASK) == 0) {
@@ -2143,5 +2144,5 @@ void FMI_search::get_sa_entries_prefetch(SMEM *smemArray, int64_t *coordArray,
             }
         }
     }
-    /* pos_ar/map_ar are the reused thread-local scratch — no free here. */
+    /* pos_ar is the reused thread-local scratch — no free here. */
 }

--- a/src/FMI_search.h
+++ b/src/FMI_search.h
@@ -69,6 +69,32 @@ static inline int _mm_countbits_64(unsigned long x) {
 }
 #endif
 
+/* One-hot position masks: entry [i] has the top `i` bits set (entry [0] == 0),
+ * i.e. one_hot_mask_array[i] == (one_hot_mask_array[i-1] >> 1) | 0x8000...
+ * for i in 1..63. The FMI-index lifetime constant is identical on every path,
+ * so it lives inline here as a file-scope table rather than a heap allocation
+ * reached through a per-object pointer: this removes a dependent load in the
+ * (~10^9-call) backwardExt/GET_OCC hot path. Values are byte-identical to the
+ * former runtime-computed array. */
+static const uint64_t one_hot_mask_array[64] = {
+    0x0000000000000000ULL, 0x8000000000000000ULL, 0xc000000000000000ULL, 0xe000000000000000ULL,
+    0xf000000000000000ULL, 0xf800000000000000ULL, 0xfc00000000000000ULL, 0xfe00000000000000ULL,
+    0xff00000000000000ULL, 0xff80000000000000ULL, 0xffc0000000000000ULL, 0xffe0000000000000ULL,
+    0xfff0000000000000ULL, 0xfff8000000000000ULL, 0xfffc000000000000ULL, 0xfffe000000000000ULL,
+    0xffff000000000000ULL, 0xffff800000000000ULL, 0xffffc00000000000ULL, 0xffffe00000000000ULL,
+    0xfffff00000000000ULL, 0xfffff80000000000ULL, 0xfffffc0000000000ULL, 0xfffffe0000000000ULL,
+    0xffffff0000000000ULL, 0xffffff8000000000ULL, 0xffffffc000000000ULL, 0xffffffe000000000ULL,
+    0xfffffff000000000ULL, 0xfffffff800000000ULL, 0xfffffffc00000000ULL, 0xfffffffe00000000ULL,
+    0xffffffff00000000ULL, 0xffffffff80000000ULL, 0xffffffffc0000000ULL, 0xffffffffe0000000ULL,
+    0xfffffffff0000000ULL, 0xfffffffff8000000ULL, 0xfffffffffc000000ULL, 0xfffffffffe000000ULL,
+    0xffffffffff000000ULL, 0xffffffffff800000ULL, 0xffffffffffc00000ULL, 0xffffffffffe00000ULL,
+    0xfffffffffff00000ULL, 0xfffffffffff80000ULL, 0xfffffffffffc0000ULL, 0xfffffffffffe0000ULL,
+    0xffffffffffff0000ULL, 0xffffffffffff8000ULL, 0xffffffffffffc000ULL, 0xffffffffffffe000ULL,
+    0xfffffffffffff000ULL, 0xfffffffffffff800ULL, 0xfffffffffffffc00ULL, 0xfffffffffffffe00ULL,
+    0xffffffffffffff00ULL, 0xffffffffffffff80ULL, 0xffffffffffffffc0ULL, 0xffffffffffffffe0ULL,
+    0xfffffffffffffff0ULL, 0xfffffffffffffff8ULL, 0xfffffffffffffffcULL, 0xfffffffffffffffeULL,
+};
+
 #define \
 GET_OCC(pp, c, occ_id_pp, y_pp, occ_pp, one_hot_bwt_str_c_pp, match_mask_pp) \
                 int64_t occ_id_pp = pp >> CP_SHIFT; \
@@ -325,8 +351,6 @@ private:
         uint32_t *sa_ls_word;
         int8_t *sa_ms_byte;
         CP_OCC *cp_occ;
-
-        uint64_t *one_hot_mask_array;
 
         /* If non-NULL, cp_occ / sa_ms_byte / sa_ls_word point into a shared
          * memory mapping owned by the shm segment rather than being

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -1344,9 +1344,11 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
         // w.mmc.enc_qdb[l]       = (uint8_t *) malloc(w.mmc.wsize_mem[l] * sizeof(uint8_t));
         // w.mmc.rid[l]           = (int32_t *) malloc(w.mmc.wsize_mem[l] * sizeof(int32_t));
         //w.mmc.lim[l]         = (int32_t *) _mm_malloc((BATCH_SIZE + 32) * sizeof(int32_t), 64);
-        for (int i=0; i<num_smem1; i++) {
-            mmc->matchArray[tid][i] = ptr1[i];
-        }
+        // SMEM is trivially copyable POD; ptr1 (old buffer) and the freshly
+        // _mm_malloc'd destination are distinct, non-overlapping allocations, so
+        // a bulk memcpy of num_smem1 records is byte-identical to the per-element
+        // copy it replaces.
+        memcpy(mmc->matchArray[tid], ptr1, (size_t)num_smem1 * sizeof(SMEM));
         _mm_free(ptr1);
     }
     #endif
@@ -1408,9 +1410,10 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
 		    // num_smem1. Preserve both — bwtSeedStrategyAllPosOneThread() below
 		    // appends at offset num_smem1 + num_smem2.
 		    int64_t already_written = (int64_t)num_smem1 + num_smem2;
-		    for (int64_t i = 0; i < already_written; ++i) {
-		        mmc->matchArray[tid][i] = ptr1[i];
-		    }
+		    // Bulk-copy the already-written prefix: SMEM is trivially copyable
+		    // POD and src/dst are distinct non-overlapping allocations, so this
+		    // memcpy is byte-identical to the per-element loop it replaces.
+		    memcpy(mmc->matchArray[tid], ptr1, (size_t)already_written * sizeof(SMEM));
 		    _mm_free(ptr1);
 		}
         #endif
@@ -2309,11 +2312,9 @@ int mem_kernel2_core(FMI_search *fmi,
                                          aln_pac,
                                          dd_query,
                                          regs[l].n, regs[l].a, dd_mat);
-    }
-    free(dd_qbuf);  /* NULL outside --meth; free() is NULL-safe */
-
-    for (int l=0; l<nseq; l++)
-    {
+        /* SAM-A18: stamp is_alt in this same pass. Each read's regions are now
+         * final (dedup done) and is_alt is not read by any later read's dedup,
+         * so folding the former separate full pass in here is byte-identical. */
         for (i = 0; i < regs[l].n; ++i)
         {
             mem_alnreg_t *p = &regs[l].a[i];
@@ -2321,6 +2322,7 @@ int mem_kernel2_core(FMI_search *fmi,
                 p->is_alt = 1;
         }
     }
+    free(dd_qbuf);  /* NULL outside --meth; free() is NULL-safe */
     // tprof[POST_SWA][tid] += __rdtsc() - tim;
 
     return 1;
@@ -2632,10 +2634,29 @@ static void mem_mark_primary_se_core(const mem_opt_t *opt, int n, mem_alnreg_t *
     }
 }
 
+/* Thread-local holder for mem_mark_primary_se's index scratch. Frees the buffer
+ * in its destructor, i.e. at thread exit, which is the whole reason it is a
+ * struct rather than a bare `static thread_local int_v`: a buffer that is never
+ * released is a leak by LeakSanitizer's definition — still-reachable at exit is
+ * still unfreed — and the ASan CI row aborts on it. Same shape and rationale as
+ * u8vec_scratch_t, kept local because this is its only user. */
+struct mark_primary_scratch_t {
+    int_v v;
+    mark_primary_scratch_t() { kv_init(v); }
+    ~mark_primary_scratch_t() { kv_destroy(v); }
+};
+
 int mem_mark_primary_se(const mem_opt_t *opt, int n, mem_alnreg_t *a, int64_t id)
 {
     int i, n_pri;
-    int_v z = {0,0,0};
+    /* Per-thread scratch for the overlap index set. Reused across every read on
+     * this thread instead of malloc/free per call: it is pure scratch (only
+     * indices, never observable in output), so reuse is byte-identical. Held for
+     * the thread's lifetime rather than freed per call, and released at thread
+     * exit by the holder's destructor; mem_mark_primary_se_core resets z.n = 0
+     * before repopulating, so no stale entry is ever read. */
+    static thread_local mark_primary_scratch_t z_scratch;
+    int_v &z = z_scratch.v;
     if (n == 0) return 0;
 
     /* Fast path for the dominant unique-mapper case. With a single region the
@@ -2688,7 +2709,8 @@ int mem_mark_primary_se(const mem_opt_t *opt, int n, mem_alnreg_t *a, int64_t id
         for (i = 0; i < n; ++i)
             a[i].secondary_all = a[i].secondary;
     }
-    free(z.a);
+    /* z.a intentionally NOT freed here: it is a thread-lifetime scratch buffer,
+     * released by z_scratch's destructor at thread exit. */
     return n_pri;
 }
 
@@ -2877,21 +2899,29 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
      * SEQ + QUAL + tags + headers; rare overflow falls back to ks_resize.
      */
     l_name = (int)strlen(s->name);
+    /* Cache lengths that are needed both for pre-sizing and for the actual
+     * unsafe writes below, so each string is measured exactly once per record:
+     *   - md_len   : MD:Z string (SAM-A16)
+     *   - rname_len: RNAME contig name (SAM-A14)
+     *   - rnext_len: RNEXT contig name (SAM-A14)
+     * Each is only *used* at its write site under the same guard that makes it
+     * hold a real strlen here, so the cached value is byte-identical to the
+     * strlen kputs_u() would have recomputed. */
+    size_t md_len = 0;
+    if (p->n_cigar)
+        md_len = strlen((const char*)(p->cigar + p->n_cigar));
+    /* RNAME/RNEXT contig names can be very long (T2T-style assemblies).
+     * Mate CIGAR (MC:Z) under V17 is also written via add_cigar(). */
+    size_t rname_len = (p->rid >= 0) ? strlen(bns->anns[p->rid].name) : 1;
+    size_t rnext_len = (m && m->rid >= 0 && m->rid != p->rid)
+                       ? strlen(bns->anns[m->rid].name) : 1;
     {
-        size_t md_len = 0;
-        if (p->n_cigar)
-            md_len = strlen((const char*)(p->cigar + p->n_cigar));
         size_t comm_len = s->comment ? strlen(s->comment) : 0;
         size_t anno_len = ((opt->flag & MEM_F_REF_HDR) && p->rid >= 0
                            && bns->anns[p->rid].anno && bns->anns[p->rid].anno[0])
                           ? strlen(bns->anns[p->rid].anno) : 0;
         size_t xa_len   = p->XA ? strlen(p->XA) : 0;
         size_t rg_len   = bwa_rg_id[0] ? strlen(bwa_rg_id) : 0;
-        /* RNAME/RNEXT contig names can be very long (T2T-style assemblies).
-         * Mate CIGAR (MC:Z) under V17 is also written via add_cigar(). */
-        size_t rname_len = (p->rid >= 0) ? strlen(bns->anns[p->rid].name) : 1;
-        size_t rnext_len = (m && m->rid >= 0 && m->rid != p->rid)
-                           ? strlen(bns->anns[m->rid].name) : 1;
         size_t mate_cigar_len = (m && m->n_cigar) ? (size_t)m->n_cigar * 16 : 0;
         /* SA:Z worst case (only emitted when n>1 and there are other primary
          * hits, but priced unconditionally so the local ks_resize at the
@@ -2917,7 +2947,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
     kputsn_u(s->name, l_name, str); kputc_u('\t', str); // QNAME
     kputw_u((p->flag&0xffff) | (p->flag&0x10000? 0x100 : 0), str); kputc_u('\t', str); // FLAG
     if (p->rid >= 0) { // with coordinate
-        kputs_u(bns->anns[p->rid].name, str); kputc_u('\t', str); // RNAME
+        kputsn_u(bns->anns[p->rid].name, (int)rname_len, str); kputc_u('\t', str); // RNAME
         kputl_u(p->pos + 1, str); kputc_u('\t', str); // POS
         kputw_u(p->mapq, str); kputc_u('\t', str); // MAPQ
 #if OLD // from v15
@@ -2939,7 +2969,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
     // print the mate position if applicable
     if (m && m->rid >= 0) {
         if (p->rid == m->rid) kputc_u('=', str);
-        else kputs_u(bns->anns[m->rid].name, str);
+        else kputsn_u(bns->anns[m->rid].name, (int)rnext_len, str);
         kputc_u('\t', str);
         kputl_u(m->pos + 1, str); kputc_u('\t', str);
         if (p->rid == m->rid) {
@@ -2987,7 +3017,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
     // print optional tags
     if (p->n_cigar) {
         kputsn_u("\tNM:i:", 6, str); kputw_u(p->NM, str);
-        kputsn_u("\tMD:Z:", 6, str); kputs_u((char*)(p->cigar + p->n_cigar), str);
+        kputsn_u("\tMD:Z:", 6, str); kputsn_u((char*)(p->cigar + p->n_cigar), (int)md_len, str);
     }
 #if V17
     if (m && m->n_cigar) { kputsn_u("\tMC:Z:", 6, str); add_cigar(opt, m, str, which); }
@@ -3072,7 +3102,11 @@ mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *
     static thread_local u8vec_scratch_t t_query;
     if (t_query.v.m < (size_t)l_query) kv_resize(uint8_t, t_query.v, (size_t)l_query);
     query = t_query.v.a;
-    for (i = 0; i < l_query; ++i) // convert to the nt4 encoding
+    /* SAM-A10: only [qb,qe) of `query` is ever read (bwa_gen_cigar2 below is
+     * handed &query[qb] with length qe-qb); the encode was over the whole read.
+     * Encode only the consumed window — the untouched prefix/suffix are never
+     * referenced, so output is byte-identical. */
+    for (i = qb; i < qe; ++i) // convert to the nt4 encoding
         query[i] = regen_query[i] < 5? regen_query[i] : nst_nt4_table[(int)regen_query[i]];
     a.mapq = ar->secondary < 0? mem_approx_mapq_se(opt, ar) : 0;
     if (ar->secondary >= 0) a.flag |= 0x100; // secondary alignment
@@ -3153,8 +3187,13 @@ mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *
             a.cigar[a.n_cigar++] = clip3<<4 | 3;
         }
     }
-    a.rid = bns_pos2rid(bns, pos);
-    assert(a.rid == ar->rid);
+    /* SAM-A9: the region already carries its rid and bns_pos2rid(bns, pos) is
+     * provably equal to it (the original code asserted exactly this). Use the
+     * known value and keep the equality as a debug-only check against the
+     * recompute, so NDEBUG builds skip the bns_pos2rid scan entirely. Output is
+     * byte-identical: a.rid == ar->rid == old bns_pos2rid result. */
+    a.rid = ar->rid;
+    assert(a.rid == bns_pos2rid(bns, pos));
     a.pos = pos - bns->anns[a.rid].offset;
     a.score = ar->score; a.sub = ar->sub > ar->csub? ar->sub : ar->csub;
     a.is_alt = ar->is_alt; a.alt_sc = ar->alt_sc;

--- a/src/kstring.h
+++ b/src/kstring.h
@@ -160,11 +160,33 @@ static inline void kputs_u(const char *p, kstring_t *s) {
 	s->l += l;
 }
 
+/* Two-digit lookup table: entry 2*d/2*d+1 is the tens/ones ASCII of d (00..99).
+ * Lets kputuw_u emit two decimal digits per div/mod, halving the divisions. */
+static const char kputuw_digits2[201] =
+	"0001020304050607080910111213141516171819"
+	"2021222324252627282930313233343536373839"
+	"4041424344454647484950515253545556575859"
+	"6061626364656667686970717273747576777879"
+	"8081828384858687888990919293949596979899";
+
 static inline void kputuw_u(unsigned c, kstring_t *s) {
 	if (c == 0) { s->s[s->l++] = '0'; return; }
 	char buf[12];
 	int l = 0;
-	while (c > 0) { buf[l++] = (char)(c % 10 + '0'); c /= 10; }
+	/* Peel two digits per iteration (ones then tens into the reversed buffer). */
+	while (c >= 100) {
+		unsigned d = (c % 100) << 1;
+		c /= 100;
+		buf[l++] = kputuw_digits2[d + 1];
+		buf[l++] = kputuw_digits2[d];
+	}
+	if (c >= 10) {
+		unsigned d = c << 1;
+		buf[l++] = kputuw_digits2[d + 1];
+		buf[l++] = kputuw_digits2[d];
+	} else {
+		buf[l++] = (char)(c + '0');
+	}
 	while (l-- > 0) s->s[s->l++] = buf[l];
 }
 


### PR DESCRIPTION
## What

Byte-identical micro-cleanups along the SAM-formatting and seeding hot paths; each removes redundant work without changing output.

**SAM formatting (`mem_reg2aln` / `mem_reg2sam`):**
- **SAM-A9** — reuse the region's known `rid` instead of recomputing `bns_pos2rid(bns, pos)`; the old code asserted the two are equal, so the value is identical and `NDEBUG` builds skip the scan.
- **SAM-A10** — encode only the `[qb, qe)` window of the query to nt4 (the only span `bwa_gen_cigar2` reads) instead of the whole read.
- **SAM-A14/A16/A18** — cache a `strlen`, use a two-digit lookup table in the integer formatter, and stamp `is_alt` in an existing per-region pass.

**Seeding (`FMI_search` / `mem_chain_seeds`):**
- Make the one-hot position-mask table a file-scope compile-time constant instead of rebuilding it per call.
- Hoist the FM-index cumulative-count table into a batch-local (as the bwa-mem2 reference does); `count[]` is a lifetime-constant member, so this is a pure cache of identical values.
- Replace a per-element SMEM copy with a bulk `memcpy` between distinct, non-overlapping buffers.
- **SEED-9** — drop the provably-identity `map_ar` staging array in `get_sa_entries_prefetch`: `map_ar[k] == k` for every entry (the staging index and `map` advance in lockstep), so the buffer index is used directly.

## Byte-identity

Each item either reads an already-computed value (SAM-A9), restricts work to the span that is actually consumed (SAM-A10), caches a lifetime-constant table (seeding hoist / one-hot table), or replaces a copy with an equivalent bulk copy (SMEM memcpy, SEED-9). None touches a SIMD kernel TU.

## Validation

Full-output byte-identity (records + headers, excluding the build-dependent `@PG` line) vs `origin/main`, macOS arm64 / NEON, `-t 8`:

| sample | workload | output lines (records + headers, excl `@PG`) | result |
|--------|----------|----------------------------------------------|--------|
| wgs-5M (HG00096) | WGS paired-end | 10,033,925 | ✅ byte-identical |
| wes-5M (HG00100) | exome paired-end | 10,059,655 | ✅ byte-identical |
| panel-twist-5M | targeted panel paired-end | 8,103,637 | ✅ byte-identical |
| sim-wgs-place (~10M) | simulated placement paired-end | 10,728,019 | ✅ byte-identical |
| sbx-1M (HG002) | variable-length single-end | 1,023,529 | ✅ byte-identical |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved search and alignment processing efficiency, including faster seed discovery, prefetching, and numeric formatting.
  * Reduced memory allocation overhead during search and alignment workflows.
  * Streamlined processing of alignment records and sequence data.

* **Bug Fixes**
  * Improved handling of alignment metadata and consumed query regions.
  * Preserved output formatting while making SAM-related string generation more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->