### PR TITLE
feat(bam): warn that in-process compressed BAM is single-threaded

### DIFF
--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -55,6 +55,12 @@ CPU and is the recommended mode for piping to `samtools sort`. Values `1`–`9`
 select increasing BGZF deflate levels; use `--bam=6` or `--bam=9` only when
 writing directly to final storage without a downstream sort step.
 
+Any level above `0` prints a one-line warning to stderr: BGZF deflate runs on
+the single writer thread, so for large outputs that serial compression — not
+alignment — is usually what caps throughput. The warning reflects the resolved
+level, so it is emitted once and not at all when a later `--bam=0` overrides an
+earlier compressed level.
+
 > **Tip — Prefer --bam for production pipelines**
 >
 > Uncompressed BAM (`--bam` or `--bam=0`) eliminates the text-formatting cost on

--- a/docs/src/developer-guide/regression-tests.md
+++ b/docs/src/developer-guide/regression-tests.md
@@ -129,6 +129,7 @@ Additional integration shell scripts in `test/`:
 | `shm_meth_test.sh` | `--meth` index compatibility with `shm` |
 | `help_prescan_test.sh` | `--help` prints without running alignment |
 | `proc_freq_calibration_test.sh` | startup does not sleep to calibrate `proc_freq`, and the calibrated tick rate is plausible |
+| `bam_compress_warn_test.sh` | the `--bam=N` single-writer-thread warning fires once, for the resolved level only |
 | `libsais_*.sh` | libsais index correctness vs. BWA / determinism |
 
 ## Benchmark harness (`bench/`)

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1427,6 +1427,10 @@ int main_mem(int argc, char *argv[])
                     return 1;
                 }
                 opt->bam_level = lvl;
+                /* The compressed-BAM warning is emitted once after parsing,
+                 * from the resolved bam_level -- see below. Warning here would
+                 * fire per occurrence and would warn for a level a later
+                 * --bam=0 goes on to override. */
             }
         }
 #ifdef STAGE_PROF
@@ -1599,6 +1603,23 @@ int main_mem(int argc, char *argv[])
             fclose(aux.fp);
         return 1;
     }
+
+    /* In-process BGZF deflate runs on the single writer thread, so for large
+     * outputs it -- not alignment -- is usually what caps throughput. Warn
+     * once, here rather than in the parsing loop, so the message describes the
+     * *resolved* setting: `--bam=6 --bam=0` must stay silent (the last --bam
+     * wins and it is uncompressed) and `--bam=6 --bam=6` must warn once, not
+     * per occurrence. Placed after the positional-argument check so a usage
+     * error is not preceded by a warning about output it never writes. */
+    if (opt->bam_mode && opt->bam_level > 0)
+        fprintf(stderr,
+            "WARNING: --bam=%d writes compressed BAM on a single writer "
+            "thread; BGZF deflate is not parallelized here, so for large "
+            "outputs this serial compression is usually the bottleneck. "
+            "Prefer uncompressed output (--bam, i.e. --bam=0) piped to a "
+            "threaded compressor, e.g. "
+            "`bwa-mem3 mem --bam ... | samtools view -@ N -b -o out.bam`.\n",
+            opt->bam_level);
 
     /* Further input parsing */
     if (mode)

--- a/test/bam_compress_warn_test.sh
+++ b/test/bam_compress_warn_test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# test/bam_compress_warn_test.sh
+#
+# `--bam=N` with N > 0 compresses BGZF on the single writer thread (bam_writer
+# opens htslib with `wb<level>` and never calls hts_set_threads), so for large
+# outputs that serial compression is usually what caps throughput. `mem` warns
+# and points at `--bam=0` piped to a threaded compressor.
+#
+# The warning describes the *resolved* output setting, so it has to be emitted
+# once, after option parsing, from the final opt->bam_mode / opt->bam_level --
+# not from inside the parsing loop. The cases below pin that:
+#
+#   1. `--bam=6`             exactly one warning.
+#   2. `--bam=6 --bam=0`     none: the last --bam wins and it is uncompressed,
+#                            so there is nothing to warn about.
+#   3. `--bam=0 --bam=6`     exactly one: the last --bam wins the other way.
+#   4. `--bam=6 --bam=6`     exactly one, not one per occurrence.
+#   5. `--bam=0`, bare       none.
+#      `--bam`, no `--bam`
+#   6. usage error           none: the run writes no output, so a warning about
+#      (`--bam=6`, no reads) that output's compression level only buries the
+#                            usage message.
+#
+# Every case also asserts the run's exit status, so a run that died before
+# reaching the warning site cannot pass a "expected 0 warnings" case vacuously.
+#
+# Usage: test/bam_compress_warn_test.sh <bwa-mem3-binary> <fixtures-dir>
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <bwa-mem3-binary> <fixtures-dir>" >&2
+    exit 2
+fi
+
+abspath() { (cd "$(dirname "$1")" && printf '%s/%s\n' "$(pwd)" "$(basename "$1")"); }
+bin="$(abspath "$1")"
+fixtures="$(abspath "$2")"
+ref="$fixtures/phix.fa"
+reads="$fixtures/reads.fa"
+
+[[ -x "$bin" ]]   || { echo "FAIL: bwa-mem3 binary not executable at $bin" >&2; exit 1; }
+[[ -s "$ref" ]]   || { echo "FAIL: phix.fa missing at $ref" >&2; exit 1; }
+[[ -s "$reads" ]] || { echo "FAIL: reads.fa missing at $reads" >&2; exit 1; }
+
+# Build the phiX FMI index if not already present.
+if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.amb" \
+      || ! -s "$ref.ann"       || ! -s "$ref.pac" ]]; then
+    "$bin" index "$ref" >/dev/null 2>&1 \
+        || { echo "FAIL: bwa-mem3 index on phix.fa failed" >&2; exit 1; }
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Run `mem` with the given args and assert both the exit status and the number
+# of compressed-BAM warnings on stderr.
+#
+#   expect <label> <want-rc-shape: zero|nonzero> <want-warnings> [mem args...]
+#
+# The exit status is asserted because it is what makes a zero-warning
+# expectation meaningful: without it, a run that crashed during startup would
+# also print zero warnings and satisfy cases 2, 5 and 6.
+expect() {
+    local label="$1" want_rc="$2" want_warns="$3"; shift 3
+    local err="$tmpdir/$label.err"
+    local rc warns grep_rc
+
+    set +e
+    "$bin" mem "$@" > /dev/null 2> "$err"
+    rc=$?
+    warns="$(grep -c 'WARNING: --bam=' "$err")"
+    grep_rc=$?
+    set -e
+
+    # grep exits 1 when there are no matches -- an expected result here -- and
+    # >1 only on a real error such as an unreadable capture file.
+    if (( grep_rc > 1 )); then
+        echo "FAIL: [$label] could not scan $err for warnings (grep exit $grep_rc)" >&2
+        exit 1
+    fi
+
+    case "$want_rc" in
+        zero)    (( rc == 0 )) || { echo "FAIL: [$label] 'mem $*' exited $rc, expected 0" >&2
+                                    cat "$err" >&2; exit 1; } ;;
+        nonzero) (( rc != 0 )) || { echo "FAIL: [$label] 'mem $*' exited 0, expected non-zero" >&2
+                                    cat "$err" >&2; exit 1; } ;;
+        *)       echo "FAIL: [$label] bad want_rc '$want_rc' (use zero|nonzero)" >&2; exit 1 ;;
+    esac
+
+    if [[ "$warns" != "$want_warns" ]]; then
+        echo "FAIL: [$label] 'mem $*' printed $warns compressed-BAM warning(s), expected $want_warns" >&2
+        echo "---- stderr ----" >&2
+        cat "$err" >&2
+        exit 1
+    fi
+}
+
+# --- 1. A single compressed --bam warns exactly once. -----------------------
+expect single zero 1 --bam=6 "$ref" "$reads"
+
+# --- 2/3. The last --bam wins, in both directions. --------------------------
+expect overridden_off zero 0 --bam=6 --bam=0 "$ref" "$reads"
+expect overridden_on  zero 1 --bam=0 --bam=6 "$ref" "$reads"
+
+# --- 4. Repeating the same compressed level warns once, not per occurrence. -
+expect repeated zero 1 --bam=6 --bam=6 "$ref" "$reads"
+
+# --- 5. Uncompressed BAM and SAM output are silent. -------------------------
+expect level_zero zero 0 --bam=0 "$ref" "$reads"
+expect bare_bam   zero 0 --bam   "$ref" "$reads"
+expect sam        zero 0         "$ref" "$reads"
+
+# --- 6. A usage error produces no warning about output that never happens. --
+# `--bam=6` with the reads file omitted fails the positional-argument check, so
+# the run writes nothing and must exit non-zero without the warning.
+expect usage_error nonzero 0 --bam=6 "$ref"
+
+echo "PASS: compressed-BAM warning fires once for the resolved --bam level only"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -124,6 +124,13 @@ ok "help_prescan_test"
 "$HERE/proc_freq_calibration_test.sh" "$BWAMEM3" "$FIXTURES" || fail "proc_freq_calibration_test failed"
 ok "proc_freq_calibration_test"
 
+# --- bam_compress_warn_test -----------------------------------------------
+# The compressed-BAM (--bam=N, N>0) single-writer-thread warning must fire
+# once, from the resolved --bam level, not once per occurrence and not for a
+# level a later --bam=0 overrides.
+"$HERE/bam_compress_warn_test.sh" "$BWAMEM3" "$FIXTURES" || fail "bam_compress_warn_test failed"
+ok "bam_compress_warn_test"
+
 # --- fast_preset_test -----------------------------------------------------
 # --fast bundles the four characterized speed levers; explicit flags override;
 # default path stays clean. Asserts on the resolved-opts audit line.


### PR DESCRIPTION
## What

Warn when the user requests a compressed BAM level (`--bam=1..9`) that the in-process BGZF deflate runs on the single writer thread and is not parallelized, so for large outputs it is usually the throughput bottleneck. The warning steers the user to the faster idiom: write uncompressed BAM (`--bam` / `--bam=0`) and pipe it to a threaded compressor such as `samtools view -@ N`.

```
WARNING: --bam=6 writes compressed BAM on a single writer thread; BGZF deflate is not
parallelized here, so for large outputs this serial compression is usually the bottleneck.
Prefer uncompressed output (--bam, i.e. --bam=0) piped to a threaded compressor, e.g.
`bwa-mem3 mem --bam ... | samtools view -@ N -b -o out.bam`.
```

## Why (not thread the writer)

An earlier draft plumbed `hts_set_threads` into the BAM writer, but bwa-mem3's default `--bam`/`--bam=0` output is *uncompressed* BGZF (stored blocks, no deflate), where extra threads buy nothing. Only the niche `--bam=1..9` path does real deflate work — and the standard fast pattern is already to write uncompressed and pipe to a threaded `samtools` stage. So this steers users to the right tool rather than half-optimizing a niche in-process path.

## Behavior

Diagnostic only — no change to alignment output or to the default uncompressed path (`--bam=0` stays silent). Fires once, at argument-parse time, for any requested compression level `> 0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the compressed-BAM warning: it now prints exactly once based on the resolved `--bam` level (and won’t appear if a later `--bam=0` overrides it).
  - The warning explains that compression runs on a single writer thread and suggests using uncompressed BAM with an external threaded compressor for better throughput.
- **Documentation**
  - Updated `--bam[=N]` CLI documentation with the new warning behavior.
- **Tests**
  - Added a regression test to verify the warning is emitted the correct number of times, and wired it into the unit test run script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->