### PR TITLE
fix(kswv): zero query padding in the NEON and AVX-512BW 8-bit mate-rescue kernels

### DIFF
--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -63,11 +63,61 @@ extern uint64_t prof[10][112];
 #define AMBR 4
 #define AMBQ 8
 
+/* Query-padding contract, shared by the batch wrappers and the kernels.
+ *
+ * A lane's query occupies columns [0, len2); the wrapper pads [len2, quantum)
+ * with the ambiguous-query code (DUMMY5 in the 8-bit kernels, DUMMY3 in the
+ * 16-bit ones) and every column from the lane's quantum out to the group's
+ * widest quantum with the high-bit sentinel (0xFF / 0xFFFF). The
+ * kernels must therefore zero the DP diagonal term on any cell whose query
+ * byte has bit 7 set, and can derive the FIRST such column for a whole group
+ * as min(query_quantum(len2)) over its lanes.
+ *
+ * Both halves read the quantum from here so the fill and the mask can never
+ * disagree: the lane count is the 8-bit SSE lane width (16) for the 8-bit
+ * kernels and the 16-bit one (8) for the 16-bit kernels, matching bwa-mem2. */
+static inline int query_quantum8(int len2)  { return ((len2 + 16 - 1) / 16) * 16; }
+static inline int query_quantum16(int len2) { return ((len2 + 8 - 1) / 8) * 8; }
+
+/* Why the two query pads differ, since only one of them is inert:
+ *   [len2, quantum)      DUMMY5 -> sbt = shift, i.e. m11 = h00. This
+ *                        reproduces ksw_qinit's profile-0 padding out to
+ *                        slen*p (ksw.cpp:103) -- scalar ksw computes these
+ *                        columns and scans them when picking qe (ksw.cpp:221),
+ *                        so they are part of the answer and MUST be computed.
+ *                        query_quantum8/16 IS ksw's slen*p.
+ *   [quantum, maxLen2]   0xFF/0xFFFF. Pure SoA batching slack with no scalar
+ *                        counterpart, so it must contribute NOTHING. Padding
+ *                        it with DUMMY5 instead would carry the diagonal
+ *                        undamped down-right across rows and can become a
+ *                        later row's maximum -- clearing minsc and inventing a
+ *                        second-best score. The high bit is what lets the
+ *                        kernels zero m11 there instead.
+ * A lane's own inert region therefore starts at query_quantum, and a whole
+ * group's starts at the min over its lanes. */
+
+/* "No freed cell active on this lane" markers for the freed-cell (--meth)
+ * blend, one per kernel width. Each must be a value a query byte can never
+ * take, so the blend provably never fires on a lane with no active freed cell:
+ *   8-bit   s2 holds 0-3, DUMMY5(5), AMBQ(8), or the 0xFF pad  -> 0xFE
+ *   16-bit  s2 holds 0-3, AMBQ16(16), DUMMY3(26), or the 0xFFFF pad -> 0x7FFF
+ * Both deliberately avoid the pad value itself. Aliasing it would make the
+ * blend fire on every padded column, leaving correctness dependent on the
+ * boundary mask zeroing m11 there -- two mechanisms propping each other up.
+ * Spelled as #define to match the sentinel block above (DUMMY5/AMBQ/...). */
+#define FREED_INACTIVE8  0xFE
+#define FREED_INACTIVE16 0x7FFF
+
 
 // -----------------------------------------------------------------------------------
 #if __AVX512BW__
 
-#define MAIN_SAM_CODE8_OPT(s1, s2, h00, h11, e11, f11, f21, max512, sft512) \
+/* BND is the boundary mask: bit 7 set in the reference base (rows past len1) or
+ * the query base (columns past this lane's quantum) marks a padding cell whose
+ * diagonal term must be zeroed. Callers pass the hoisted per-row
+ * rowboundary512 below jsplit, where no query byte can carry the high bit, and
+ * the full per-cell movepi8_mask(or(s1,s2)) from jsplit on. */
+#define MAIN_SAM_CODE8_OPT(s1, s2, h00, h11, e11, f11, f21, max512, sft512, BND) \
     {                                                                   \
         __m512i sbt11, xor11;                                           \
         xor11 = _mm512_xor_si512(s1, s2);                               \
@@ -76,21 +126,15 @@ extern uint64_t prof[10][112];
         sbt11 = _mm512_mask_blend_epi8(cmpq, sbt11, sft512);            \
         if (HasFreed) {                                                 \
             /* One compare + one blend against the per-row active_frread512   \
-             * target (built once per row); sentinel (0xFF) lanes never match \
-             * a real s2. Fewer ops than the two-blend form and, unlike the   \
+             * target (built once per row); FREED_INACTIVE8 lanes never match \
+             * any s2 value. Fewer ops than the two-blend form and, unlike the\
              * mask-OR collapse, no serializing kor on the blend's input.     \
              * The blend target is freedval512 (fr_val biased by +shift), so  \
              * NEUTRAL's zero-scored conversion cell uses the same path. */   \
             __mmask64 freed = _mm512_cmpeq_epi8_mask(s2, active_frread512); \
             sbt11 = _mm512_mask_blend_epi8(freed, sbt11, freedval512);  \
         }                                                               \
-        /* Boundary mask, gated by HasFreed (compile-time). Non-meth    \
-         * hoists the per-row rowboundary512 (a big avx512 win); meth    \
-         * keeps the per-cell s1|s2 form — hoisting there pins a third   \
-         * live k-reg against the two freed masks and slightly regressed.*/ \
-        __mmask64 cmp = HasFreed                                        \
-            ? _mm512_movepi8_mask(_mm512_or_si512(s1, s2))              \
-            : rowboundary512;                                           \
+        __mmask64 cmp = (BND);                                          \
         __m512i m11 = _mm512_adds_epu8(h00, sbt11);                     \
         m11 = _mm512_mask_blend_epi8(cmp, m11, zero512);                \
         m11 = _mm512_subs_epu8(m11, sft512);                            \
@@ -114,7 +158,7 @@ extern uint64_t prof[10][112];
         sbt11 = _mm512_permutexvar_epi16(xor11, perm512);               \
         if (HasFreed) {                                                 \
             /* One compare + one blend against the per-row active_frread512   \
-             * target (built once per row); sentinel (0x7FFF) lanes never     \
+             * target (built once per row); FREED_INACTIVE16 lanes never      \
              * match a real u16 s2 (0-3/AMBQ16=16/DUMMY3=26/0xFFFF pad). */   \
             __mmask32 freed = _mm512_cmpeq_epi16_mask(s2, active_frread512); \
             sbt11 = _mm512_mask_blend_epi16(freed, sbt11, freedval512); \
@@ -385,8 +429,7 @@ void kswv::kswvBatchWrapper8(SeqPair *pairArray,
 #else
                 seq2 = seqBufQer + sp.idq;
 #endif
-                int quanta = (sp.len2 + 16 - 1) / 16;
-                quanta *= 16;
+                int quanta = query_quantum8(sp.len2);
                 for (k = 0; k < sp.len2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k] == AMBIG_ ? AMBQ : seq2[k]);
@@ -402,8 +445,7 @@ void kswv::kswvBatchWrapper8(SeqPair *pairArray,
             for (j = 0; j < SIMD_WIDTH8; j++)
             {
                 SeqPair sp = pairArray[i + j];
-                int quanta = (sp.len2 + 16 - 1) / 16;
-                quanta *= 16;
+                int quanta = query_quantum8(sp.len2);
                 for (k = quanta; k <= maxLen2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH8 + j] = 0xFF;
@@ -518,6 +560,9 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
     uint8x16_t e_ins_vec = vdupq_n_u8(this->e_ins);
     uint8x16_t oe_ins_vec = vdupq_n_u8(this->o_ins + this->e_ins);
     uint8x16_t five_vec = vdupq_n_u8(DUMMY5);
+    /* Padding sentinel test: bit 7 set marks a reference row past len1 or a
+     * query column past this lane's quantum. */
+    const uint8x16_t highbit_vec = vdupq_n_u8(0x80);
     uint8x16_t gmax_vec = zero_vec;
     // 8-bit SW processes 16 pairs per SIMD batch, but te must be tracked in
     // 16-bit precision (ref positions > 255 are possible). Use two
@@ -579,16 +624,30 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
     vst1q_u8(H0, zero_vec);
     vst1q_u8(H1, zero_vec);
 
-    /* Rows below the group's SHORTEST ref window have no padding lane, so the
-     * per-row boundary mask (rowboundary, below) is all-zero there and the vbsl
-     * that applies it is a no-op. Below minLen1 we skip it entirely. For a
-     * uniform-length group (the common case: production ref windows cluster
-     * tightly) minLen1 == nrow, so the vbsl never runs -- recovering the whole
-     * boundary-mask cost -- while mixed-length groups still apply it on exactly
-     * the rows where some lane has started padding. Dummy tail lanes have
-     * len1==0, pinning minLen1 to 0 for a partial final group (no skip, safe). */
-    int minLen1 = p[0].len1;
-    for (int l = 1; l < SIMD_WIDTH8; l++) if (p[l].len1 < minLen1) minLen1 = p[l].len1;
+    /* Boundary-mask fast-path bounds, both derived from the group's lanes:
+     *   jsplit  - first column any lane pads with the 0xFF query sentinel, i.e.
+     *             min(query_quantum8(len2)). Below it no query byte can carry
+     *             bit 7, so the mask reduces to the per-row high_bit(s1).
+     *   minLen1 - shortest reference window. Below it no lane pads its
+     *             reference either, so the mask is provably all-zero and the
+     *             blend is skipped outright.
+     * Together they split the inner loop into three ranges (see below), of
+     * which a uniform-length group only ever runs the cheapest. That is the
+     * common case in PHASE 0 -- production ref windows and read lengths cluster
+     * tightly -- but not in phase 1, where the caller re-enters with
+     * len2 = qe + 1 per pair (bwamem_pair.cpp:875): those groups are ragged
+     * whatever the input lengths were, so jsplit < ncol and the per-cell range
+     * covers most of the row. The measured phase-0 parity therefore does not
+     * carry over to phase 1, and bwa-bsw-bench cannot see it -- that harness
+     * only ever calls getScores* with phase 0.
+     * Dummy tail lanes carry len1 == len2 == 0, pinning both to 0 for
+     * a partial final group: no fast path, still correct. */
+    int minLen1 = p[0].len1, jsplit = ncol;
+    for (int l = 0; l < SIMD_WIDTH8; l++) {
+        if (p[l].len1 < minLen1) minLen1 = p[l].len1;
+        const int quanta = query_quantum8(p[l].len2);
+        if (quanta < jsplit) jsplit = quanta;
+    }
 
     int i, limit = nrow;
     for (i = 0; i < nrow; i++)
@@ -618,11 +677,12 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
          *
          * Fold the pair into ONE per-lane target base, active_frread: a lane whose
          * ref is fr_ref frees against fr_read, a lane whose ref is fr_ref2 frees
-         * against fr_read2, and any other lane gets the sentinel 0xFF. The two
+         * against fr_read2, and any other lane gets FREED_INACTIVE8. The two
          * ref-side comparisons are mutually exclusive (s1 can't equal both fr_ref
-         * and fr_ref2), so at most one wins per lane. s2 only ever holds real bases
-         * 0-3 or the ambig/pad codes DUMMY5(5)/AMBQ(8) — never 0xFF — so on a
-         * sentinel lane the single per-cell compare is unconditionally false. This
+         * and fr_ref2), so at most one wins per lane. s2 holds real bases 0-3, the
+         * ambig/pad codes DUMMY5(5)/AMBQ(8), or the 0xFF query pad — never
+         * FREED_INACTIVE8 — so on a sentinel lane the single per-cell compare is
+         * unconditionally false. This
          * turns the per-cell freed path into one vceqq + one vbslq (down from two
          * compares, two ands, an orr, and a blend). Both cells of the pair score
          * the same fr_val, so one freedval_vec covers the fold. */
@@ -632,89 +692,98 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
             uint8x16_t rowfreed  = vceqq_u8(s1, vdupq_n_u8((uint8_t)fr_ref));
             uint8x16_t rowfreed2 = vceqq_u8(s1, vdupq_n_u8((uint8_t)fr_ref2));
             active_frread = vbslq_u8(rowfreed2, vdupq_n_u8((uint8_t)fr_read2),
-                                     vdupq_n_u8(0xFF));
+                                     vdupq_n_u8(FREED_INACTIVE8));
             active_frread = vbslq_u8(rowfreed,  vdupq_n_u8((uint8_t)fr_read),
                                      active_frread);
         }
 
-        /* Boundary detection hoisted per-row. The per-cell test zeroed m11 where
-         * bit 7 was set in s1 OR s2. In the u8 kernel s2 only ever holds real
-         * bases (0-3) or ambig/padding (DUMMY5=5, AMBQ=8) — never the high bit —
-         * so high_bit(s1|s2) == high_bit(s1), and s1 is loop-invariant across the
-         * inner j loop. Hoist the vorr+vtst pair to a single per-row vtst; only
-         * the per-cell blend remains. The byte-identity golden gate is the safety
-         * net: if any s2 lane ever carried bit 7, the check would fail instantly. */
-        uint8x16_t rowboundary = vtstq_u8(s1, vdupq_n_u8(0x80));
-        /* Apply the mask only once some lane has begun padding (i >= minLen1);
-         * below that every lane still holds a real base, so rowboundary is
-         * all-zero and the blend is a no-op. Loop-invariant across j, so the
-         * compiler unswitches the inner loop into a masked and an unmasked
-         * copy -- no per-cell branch. */
-        const bool apply_bound = (i >= minLen1);
-
         uint8x16_t l_vec = zero_vec;
-        for (j = 0; j < ncol; j++)
-        {
-            uint8x16_t f11, s2, f21;
-            h00 = vld1q_u8(H0 + j * SIMD_WIDTH8);
-            s2 = vld1q_u8(seq2SoA + j * SIMD_WIDTH8);
-            f11 = vld1q_u8(F + (j + 1) * SIMD_WIDTH8);
 
-            /* Core Smith-Waterman computation using NEON */
-            uint8x16_t xor_val = veorq_u8(s1, s2);
-            uint8x16_t sbt = vqtbl1q_u8(permSft, xor_val);
-
-            /* Check for ambiguous query base (DUMMY5) */
-            uint8x16_t cmpq = vceqq_u8(s2, five_vec);
-            sbt = vbslq_u8(cmpq, sft_vec, sbt);
-
-            /* Apply the freed-cell override: force the biased freed score
-             * (fr_val + shift) where this column's read base equals the row's
-             * active freed base (built once per row in active_frread above).
-             * One compare + one blend; sentinel (0xFF) lanes never match a real
-             * s2 (0-3/5/8) so they blend through unchanged. */
-            if (HasFreed) {
-                sbt = vbslq_u8(vceqq_u8(s2, active_frread), freedval_vec, sbt);
-            }
-
-            uint8x16_t m11 = vqaddq_u8(h00, sbt);
-            /* Zero m11 on ref-boundary/padding rows via the hoisted per-row mask
-             * (see rowboundary above). Skipped entirely below minLen1, where no
-             * lane pads and the mask is provably all-zero. */
-            if (apply_bound) m11 = vbslq_u8(rowboundary, zero_vec, m11);
-            m11 = vqsubq_u8(m11, sft_vec);
-
-            /* hme = max(m11, e11); reused verbatim for `me` (gap-D) below, where
-             * the original code recomputed the identical max(m11,e11) -- e11 is
-             * not modified between the two, so this is byte-identical and drops
-             * one vmaxq per cell. */
-            uint8x16_t hme = vmaxq_u8(m11, e11);
-            h11 = vmaxq_u8(hme, f11);
-
-            /* Update imax tracking */
-            uint8x16_t cmp0 = vcgtq_u8(h11, imax_vec);
-            imax_vec = vmaxq_u8(imax_vec, h11);
-            iqe_vec = vbslq_u8(cmp0, l_vec, iqe_vec);
-
-            /* Reassociate BOTH gap recurrences off h11 (Daily-scan algebra).
-             * e uses max(m11,f11), f uses max(m11,e11) — each drops the term
-             * dominated by its own extension arg (O>=0, saturating u8). me must
-             * read the OLD e11, so compute it before the e-update overwrites e11. */
-            uint8x16_t mf = vmaxq_u8(m11, f11);
-            uint8x16_t me = hme;   /* == vmaxq_u8(m11, e11), reused (e11 unchanged) */
-            uint8x16_t gapE = vqsubq_u8(mf, oe_ins_vec);
-            e11 = vqsubq_u8(e11, e_ins_vec);
-            e11 = vmaxq_u8(gapE, e11);
-
-            /* Gap extension for F (reassociated) */
-            uint8x16_t gapD = vqsubq_u8(me, oe_del_vec);
-            f21 = vqsubq_u8(f11, e_del_vec);
-            f21 = vmaxq_u8(gapD, f21);
-
-            vst1q_u8(H1 + (j + 1) * SIMD_WIDTH8, h11);
-            vst1q_u8(F + (j + 1) * SIMD_WIDTH8, f21);
-            l_vec = vaddq_u8(l_vec, one_vec);
+        /* One DP cell. BND is the boundary mask -- bit 7 set in the reference
+         * base (rows past len1) or the query base (columns past this lane's
+         * quantum) -- and APPLY_BND gates whether it is applied at all. Both
+         * are compile-time constants at each call site, so `if (APPLY_BND)`
+         * folds exactly like the `if (HasFreed)` below it and no per-cell
+         * branch survives. Passing them in lets each column range pay only for
+         * the half that can actually fire: nothing below both minLen1 and
+         * jsplit, the hoisted per-row reference mask below jsplit, and the full
+         * per-cell form from jsplit on. */
+#define KSWV_NEON_U8_CELL(APPLY_BND, BND)                                       \
+        {                                                                       \
+            uint8x16_t f11, s2, f21;                                            \
+            h00 = vld1q_u8(H0 + j * SIMD_WIDTH8);                               \
+            s2 = vld1q_u8(seq2SoA + j * SIMD_WIDTH8);                           \
+            f11 = vld1q_u8(F + (j + 1) * SIMD_WIDTH8);                          \
+                                                                                \
+            /* Core Smith-Waterman computation using NEON */                    \
+            uint8x16_t xor_val = veorq_u8(s1, s2);                              \
+            uint8x16_t sbt = vqtbl1q_u8(permSft, xor_val);                      \
+                                                                                \
+            /* Check for ambiguous query base (DUMMY5) */                       \
+            uint8x16_t cmpq = vceqq_u8(s2, five_vec);                           \
+            sbt = vbslq_u8(cmpq, sft_vec, sbt);                                 \
+                                                                                \
+            /* Apply the freed-cell override: force the biased freed score      \
+             * (fr_val + shift) where this column's read base equals the row's  \
+             * active freed base (built once per row in active_frread above).   \
+             * One compare + one blend; FREED_INACTIVE8 lanes never match any  \
+             * s2 value (0-3/5/8 or the 0xFF pad), so they blend through        \
+             * unchanged. */                                                    \
+            if (HasFreed) {                                                     \
+                sbt = vbslq_u8(vceqq_u8(s2, active_frread), freedval_vec, sbt); \
+            }                                                                   \
+                                                                                \
+            uint8x16_t m11 = vqaddq_u8(h00, sbt);                               \
+            if (APPLY_BND) m11 = vbslq_u8((BND), zero_vec, m11);                \
+            m11 = vqsubq_u8(m11, sft_vec);                                      \
+                                                                                \
+            /* hme = max(m11, e11); reused verbatim for `me` (gap-D) below,     \
+             * where the original code recomputed the identical max(m11,e11) -- \
+             * e11 is not modified between the two, so this is byte-identical   \
+             * and drops one vmaxq per cell. */                                 \
+            uint8x16_t hme = vmaxq_u8(m11, e11);                                \
+            h11 = vmaxq_u8(hme, f11);                                           \
+                                                                                \
+            /* Update imax tracking */                                          \
+            uint8x16_t cmp0 = vcgtq_u8(h11, imax_vec);                          \
+            imax_vec = vmaxq_u8(imax_vec, h11);                                 \
+            iqe_vec = vbslq_u8(cmp0, l_vec, iqe_vec);                           \
+                                                                                \
+            /* Reassociate BOTH gap recurrences off h11 (Daily-scan algebra).   \
+             * e uses max(m11,f11), f uses max(m11,e11) — each drops the term   \
+             * dominated by its own extension arg (O>=0, saturating u8). me must\
+             * read the OLD e11, so compute it before e11 is overwritten. */    \
+            uint8x16_t mf = vmaxq_u8(m11, f11);                                 \
+            uint8x16_t me = hme;  /* == vmaxq_u8(m11, e11), e11 unchanged */    \
+            uint8x16_t gapE = vqsubq_u8(mf, oe_ins_vec);                        \
+            e11 = vqsubq_u8(e11, e_ins_vec);                                    \
+            e11 = vmaxq_u8(gapE, e11);                                          \
+                                                                                \
+            /* Gap extension for F (reassociated) */                            \
+            uint8x16_t gapD = vqsubq_u8(me, oe_del_vec);                        \
+            f21 = vqsubq_u8(f11, e_del_vec);                                    \
+            f21 = vmaxq_u8(gapD, f21);                                          \
+                                                                                \
+            vst1q_u8(H1 + (j + 1) * SIMD_WIDTH8, h11);                          \
+            vst1q_u8(F + (j + 1) * SIMD_WIDTH8, f21);                           \
+            l_vec = vaddq_u8(l_vec, one_vec);                                    \
         }
+
+        j = 0;
+        if (i < minLen1) {
+            /* No lane has begun reference padding and no column below jsplit
+             * carries query padding: the mask is provably all-zero here. */
+            for (; j < jsplit; j++)
+                KSWV_NEON_U8_CELL(false, zero_vec)
+        } else {
+            /* Reference half only; loop-invariant across j. */
+            const uint8x16_t rowboundary = vtstq_u8(s1, highbit_vec);
+            for (; j < jsplit; j++)
+                KSWV_NEON_U8_CELL(true, rowboundary)
+        }
+        for (; j < ncol; j++)
+            KSWV_NEON_U8_CELL(true, vtstq_u8(vorrq_u8(s1, s2), highbit_vec))
+#undef KSWV_NEON_U8_CELL
 
         /* Block I - row max tracking */
         if (i > 0)
@@ -1031,8 +1100,7 @@ void kswv::kswvBatchWrapper16(SeqPair *pairArray,
 #else
                 seq2 = seqBufQer + sp.idq;
 #endif
-                int quanta = (sp.len2 + 8 - 1) / 8;
-                quanta *= 8;
+                int quanta = query_quantum16(sp.len2);
                 for (k = 0; k < sp.len2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH16 + j] = (seq2[k] == AMBIG_ ? AMBQ16 : seq2[k]);
@@ -1048,8 +1116,7 @@ void kswv::kswvBatchWrapper16(SeqPair *pairArray,
             for (j = 0; j < SIMD_WIDTH16; j++)
             {
                 SeqPair sp = pairArray[i + j];
-                int quanta = (sp.len2 + 8 - 1) / 8;
-                quanta *= 8;
+                int quanta = query_quantum16(sp.len2);
                 for (k = quanta; k <= maxLen2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH16 + j] = 0xFFFF;
@@ -1234,10 +1301,11 @@ int kswv::kswv_neon_16_impl(int16_t seq1SoA[],
          * kswv_neon_u8_impl's active_frread. A lane whose ref is fr_ref frees
          * against fr_read, a lane whose ref is fr_ref2 frees against fr_read2 (the
          * two ref-side compares are mutually exclusive), and every other lane gets
-         * a sentinel no real s2 ever equals. u16 s2 ∈ {0-3, AMBQ16=16, DUMMY3=26,
-         * 0xFFFF pad}, so 0x7FFF is safe here — the u8 0xFF sentinel is NOT (u16 s2
-         * padding is 0xFFFF). The 16-bit kernel has NO shift bias (m11 = h00 + sbt
-         * directly), so the freed value is just fr_val: fr_val == w_match
+         * a sentinel no s2 ever equals. u16 s2 ∈ {0-3, AMBQ16=16, DUMMY3=26,
+         * 0xFFFF pad}, so FREED_INACTIVE16 is safe here; 0xFFFF, the pad, would
+         * NOT be — the u8 path picks FREED_INACTIVE8 over its own 0xFF pad on
+         * the same reasoning. The 16-bit kernel has NO shift bias (m11 = h00 +
+         * sbt directly), so the freed value is just fr_val: fr_val == w_match
          * (GENOMIC/COLLAPSED) equals temp8[0], NEUTRAL (fr_val==0) scores the
          * conversion as 0. Sign-extended to int16. When !HasFreed, this and the
          * per-cell block below compile out. */
@@ -1247,7 +1315,7 @@ int kswv::kswv_neon_16_impl(int16_t seq1SoA[],
             uint16x8_t rowfreed16   = vceqq_s16(s1, vdupq_n_s16((int16_t)fr_ref));
             uint16x8_t rowfreed2_16 = vceqq_s16(s1, vdupq_n_s16((int16_t)fr_ref2));
             active_frread16 = vbslq_s16(rowfreed2_16, vdupq_n_s16((int16_t)fr_read2),
-                                        vdupq_n_s16((int16_t)0x7FFF));
+                                        vdupq_n_s16((int16_t)FREED_INACTIVE16));
             active_frread16 = vbslq_s16(rowfreed16,  vdupq_n_s16((int16_t)fr_read),
                                         active_frread16);
         }
@@ -1270,7 +1338,7 @@ int kswv::kswv_neon_16_impl(int16_t seq1SoA[],
             /* Rank-1 freed-cell override (issue 173 + TAPS neutral): force the
              * freed score where this column's read base equals the row's active
              * freed base (built once per row in active_frread16 above). One compare
-             * + one blend; sentinel (0x7FFF) lanes never match a real s2 so they
+             * + one blend; FREED_INACTIVE16 lanes never match a real s2 so they
              * pass through. */
             if (HasFreed) {
                 sbt = vbslq_s16(vceqq_s16(s2, active_frread16), freedval_vec16, sbt);
@@ -1691,11 +1759,12 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
             __m256i rowfreed  = _mm256_cmpeq_epi8(s1, _mm256_set1_epi8((char)fr_ref));
             __m256i rowfreed2 = _mm256_cmpeq_epi8(s1, _mm256_set1_epi8((char)fr_ref2));
             /* One per-lane freed target: fr_read where ref==fr_ref, fr_read2 where
-             * ref==fr_ref2, else sentinel 0xFF (a real s2 — 0-3/5/8 — never equals
-             * it). The two ref tests are mutually exclusive. Collapses the per-cell
-             * freed path to one cmpeq + one blendv (see NEON variant). */
+             * ref==fr_ref2, else FREED_INACTIVE8 (no s2 value — 0-3/5/8 or the
+             * 0xFF pad — ever equals it). The two ref tests are mutually exclusive.
+             * Collapses the per-cell freed path to one cmpeq + one blendv (see
+             * NEON variant). */
             active_frread = avx2_blendv_u8(rowfreed2, _mm256_set1_epi8((char)fr_read2),
-                                           _mm256_set1_epi8((char)0xFF));
+                                           _mm256_set1_epi8((char)FREED_INACTIVE8));
             active_frread = avx2_blendv_u8(rowfreed,  _mm256_set1_epi8((char)fr_read),
                                            active_frread);
         }
@@ -1714,8 +1783,8 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
             /* Apply the freed-cell override: force the biased freed score
              * (fr_val + shift) where this column's read base equals the row's
              * active freed base (active_frread, built once per row above). One
-             * cmpeq + one blendv; sentinel (0xFF) lanes never match a real s2
-             * so they pass through. */
+             * cmpeq + one blendv; FREED_INACTIVE8 lanes never match any s2 value
+             * (0-3/5/8 or the 0xFF pad) so they pass through. */
             if (HasFreed) {
                 sbt = _mm256_blendv_epi8(sbt, freedval256,
                                          _mm256_cmpeq_epi8(s2, active_frread));
@@ -1723,10 +1792,13 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
 
             /* High bit of (s1 | s2) indicates boundary (padding 0xFF).
              * Sign compare against zero gives 0xFF wherever high bit is
-             * set in the u8 byte. NB: the boundary hoist that helps NEON and
-             * AVX-512 non-meth regresses here — AVX2's 16-register file spills
-             * once the mask is loop-invariant (however computed), so this tier
-             * keeps the per-cell s1|s2 form. */
+             * set in the u8 byte. NB: the jsplit-bounded hoist that NEON and
+             * AVX-512 use below their group's first padded query column
+             * regresses here — AVX2's 16-register file spills once the mask is
+             * loop-invariant (however computed), so this tier keeps the
+             * per-cell s1|s2 form over the whole row. Never hoist the s2 half
+             * away on any tier: query columns past a lane's quantum DO carry
+             * bit 7 (see the query-padding contract at the top of this file). */
             __m256i or_val      = _mm256_or_si256(s1, s2);
             __m256i is_boundary = _mm256_cmpgt_epi8(zero_vec, or_val);
 
@@ -1982,7 +2054,7 @@ void kswv::kswvBatchWrapper8_avx2(SeqPair *pairArray,
         for (int j = 0; j < SIMD_WIDTH8; j++) {
             SeqPair sp = pairArray[i + j];
             uint8_t *seq2 = seqBufQer + sp.idq;
-            int quanta = ((sp.len2 + 16 - 1) / 16) * 16;
+            int quanta = query_quantum8(sp.len2);
             for (int k = 0; k < sp.len2; k++)
                 mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k] == AMBIG_ ? AMBQ : seq2[k]);
             for (int k = sp.len2; k < quanta; k++)
@@ -1991,7 +2063,7 @@ void kswv::kswvBatchWrapper8_avx2(SeqPair *pairArray,
         }
         for (int j = 0; j < SIMD_WIDTH8; j++) {
             SeqPair sp = pairArray[i + j];
-            int quanta = ((sp.len2 + 16 - 1) / 16) * 16;
+            int quanta = query_quantum8(sp.len2);
             for (int k = quanta; k <= maxLen2; k++)
                 mySeq2SoA[k * SIMD_WIDTH8 + j] = 0xFF;
         }
@@ -2160,7 +2232,7 @@ int kswv::kswv256_16_impl(int16_t seq1SoA[],
          * active_frread. A lane whose ref is fr_ref frees against fr_read, a lane
          * whose ref is fr_ref2 frees against fr_read2 (the two ref-side compares
          * are mutually exclusive), and every other lane gets a sentinel no real s2
-         * ever equals. u16 s2 ∈ {0-3, AMBQ16=16, DUMMY3=26, 0xFFFF pad}, so 0x7FFF
+         * ever equals. u16 s2 ∈ {0-3, AMBQ16=16, DUMMY3=26, 0xFFFF pad}, so FREED_INACTIVE16
          * is safe here. cmpeq_epi16 produces whole-int16 masks, so the byte-wise
          * blendv selects whole lanes correctly. The 16-bit kernel has NO shift bias
          * (m11 = h00 + sbt directly), so the freed value is just fr_val: fr_val ==
@@ -2172,7 +2244,7 @@ int kswv::kswv256_16_impl(int16_t seq1SoA[],
             freedval256 = _mm256_set1_epi16((int16_t)fr_val);
             __m256i rowfreed  = _mm256_cmpeq_epi16(s1, _mm256_set1_epi16((int16_t)fr_ref));
             __m256i rowfreed2 = _mm256_cmpeq_epi16(s1, _mm256_set1_epi16((int16_t)fr_ref2));
-            active_frread = _mm256_blendv_epi8(_mm256_set1_epi16((int16_t)0x7FFF),
+            active_frread = _mm256_blendv_epi8(_mm256_set1_epi16((int16_t)FREED_INACTIVE16),
                                                _mm256_set1_epi16((int16_t)fr_read2), rowfreed2);
             active_frread = _mm256_blendv_epi8(active_frread,
                                                _mm256_set1_epi16((int16_t)fr_read), rowfreed);
@@ -2195,7 +2267,7 @@ int kswv::kswv256_16_impl(int16_t seq1SoA[],
             /* Rank-1 freed-cell override (issue 173 + TAPS neutral): force the
              * freed score where this column's read base equals the row's active
              * freed base (built once per row in active_frread above). One cmpeq +
-             * one blendv; sentinel (0x7FFF) lanes never match a real s2 so they
+             * one blendv; FREED_INACTIVE16 lanes never match a real s2 so they
              * pass through. cmpeq_epi16 gives whole-int16 masks, so the byte-wise
              * blendv is lane-correct. */
             if (HasFreed) {
@@ -2414,7 +2486,7 @@ void kswv::kswvBatchWrapper16_avx2(SeqPair *pairArray,
         for (int j = 0; j < SIMD_WIDTH16; j++) {
             SeqPair sp = pairArray[i + j];
             uint8_t *seq2 = seqBufQer + sp.idq;
-            int quanta = ((sp.len2 + 8 - 1) / 8) * 8;
+            int quanta = query_quantum16(sp.len2);
             for (int k = 0; k < sp.len2; k++)
                 mySeq2SoA[k * SIMD_WIDTH16 + j] = (seq2[k] == AMBIG_ ? AMBQ16 : seq2[k]);
             for (int k = sp.len2; k < quanta; k++)
@@ -2423,7 +2495,7 @@ void kswv::kswvBatchWrapper16_avx2(SeqPair *pairArray,
         }
         for (int j = 0; j < SIMD_WIDTH16; j++) {
             SeqPair sp = pairArray[i + j];
-            int quanta = ((sp.len2 + 8 - 1) / 8) * 8;
+            int quanta = query_quantum16(sp.len2);
             for (int k = quanta; k <= maxLen2; k++)
                 mySeq2SoA[k * SIMD_WIDTH16 + j] = 0xFFFF;
         }
@@ -2584,8 +2656,7 @@ void kswv::kswvBatchWrapper8(SeqPair *pairArray,
                 seq2 = seqBufQer + sp.idq;
 #endif
                 // assert(sp.len2 < this->maxQerLen);
-                int quanta = (sp.len2 + 16 - 1) / 16;  // based on SSE-8 bit lane
-                quanta *= 16;                          // for matching the output of bwa-mem
+                int quanta = query_quantum8(sp.len2);
                 for(k = 0; k < sp.len2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH8 + j] = (seq2[k]==AMBIG_? AMBQ:seq2[k]);
@@ -2600,8 +2671,7 @@ void kswv::kswvBatchWrapper8(SeqPair *pairArray,
             for(j = 0; j < SIMD_WIDTH8; j++)
             {
                 SeqPair sp = pairArray[i + j];
-                int quanta = (sp.len2 + 16 - 1) / 16;  // based on SSE2-8 bit lane
-                quanta *= 16;
+                int quanta = query_quantum8(sp.len2);
                 for(k = quanta; k <= maxLen2; k++)
                 {
                     mySeq2SoA[k * SIMD_WIDTH8 + j] = 0xFF;
@@ -2795,6 +2865,23 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
     _mm512_store_si512((__m512i *)(H0), zero512);
     _mm512_store_si512((__m512i *)(H1), zero512);
 
+    /* First column any lane pads with the 0xFF query sentinel, i.e.
+     * min(query_quantum8(len2)) over the group -- see the derivation in
+     * kswv_neon_u8_impl. Below it the boundary mask reduces to the per-row
+     * high_bit(s1); at and above it the full per-cell form is required. A
+     * uniform-length group gets jsplit == ncol and never runs the per-cell
+     * form -- common in phase 0, but see the phase-1 caveat on the NEON
+     * derivation: len2 = qe + 1 makes phase-1 groups ragged regardless of input
+     * lengths, so they do run it. (No minLen1 range here: unlike NEON's vbsl,
+     * the AVX-512 blend is a masked move that costs the same whether or not the
+     * mask is empty, so splitting the reference half out as well buys
+     * nothing.) */
+    int jsplit = ncol;
+    for (int l = 0; l < SIMD_WIDTH8; l++) {
+        const int quanta = query_quantum8(p[l].len2);
+        if (quanta < jsplit) jsplit = quanta;
+    }
+
     int i, limit = nrow;
     for (i=0; i < nrow; i++)
     {
@@ -2826,36 +2913,47 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
             __mmask64 rowfreed512  = _mm512_cmpeq_epi8_mask(s1, _mm512_set1_epi8((char)fr_ref));
             __mmask64 rowfreed2_512= _mm512_cmpeq_epi8_mask(s1, _mm512_set1_epi8((char)fr_ref2));
             /* One per-lane freed target: fr_read where ref==fr_ref, fr_read2 where
-             * ref==fr_ref2, else sentinel 0xFF (real s2 0-3/5/8 never equals it).
-             * The two ref tests are mutually exclusive; the macro then does a
-             * single per-cell cmpeq + blend. */
+             * ref==fr_ref2, else FREED_INACTIVE8 (no s2 value — 0-3/5/8 or the
+             * 0xFF pad — ever equals it). The two ref tests are mutually
+             * exclusive; the macro then does a single per-cell cmpeq + blend. */
             active_frread512 = _mm512_mask_blend_epi8(rowfreed2_512,
-                                   _mm512_set1_epi8((char)0xFF), _mm512_set1_epi8((char)fr_read2));
+                                   _mm512_set1_epi8((char)FREED_INACTIVE8), _mm512_set1_epi8((char)fr_read2));
             active_frread512 = _mm512_mask_blend_epi8(rowfreed512,
                                    active_frread512, _mm512_set1_epi8((char)fr_read));
         }
 
-        /* Boundary detection hoisted per-row: in u8, s2 only holds 0-3/5/8 (never
-         * the high bit), so high_bit(s1|s2) == high_bit(s1). Consumed by
-         * MAIN_SAM_CODE8_OPT only in the non-meth (!HasFreed) instantiation; the
-         * meth path keeps the per-cell form, so this is DCE'd there. The golden
-         * gate fails instantly if any s2 lane ever carried bit 7. */
-        __mmask64 rowboundary512 = _mm512_movepi8_mask(s1);
+        /* Reference-side half of the boundary mask; loop-invariant across j. */
+        const __mmask64 rowboundary512 = _mm512_movepi8_mask(s1);
+
+#define KSWV_AVX512_U8_CELL(BND)                                                    \
+        {                                                                           \
+            __m512i f11, s2, f21;                                                   \
+            h00 = _mm512_load_si512((__m512i *)(H0 + j * SIMD_WIDTH8));             \
+            s2  = _mm512_load_si512((__m512i *)(seq2SoA + (j) * SIMD_WIDTH8));      \
+            f11 = _mm512_load_si512((__m512i *)(F + (j+1) * SIMD_WIDTH8));          \
+                                                                                    \
+            MAIN_SAM_CODE8_OPT(s1, s2, h00, h11, e11, f11, f21, max512, sft512,     \
+                               (BND));                                              \
+                                                                                    \
+            _mm512_store_si512((__m512i *)(H1 + (j + 1) * SIMD_WIDTH8), h11);       \
+            _mm512_store_si512((__m512i *)(F + (j + 1)* SIMD_WIDTH8), f21);         \
+            l512 = _mm512_add_epi8(l512, one512);                                   \
+        }
 
         __m512i l512 = zero512;
-        for (j=0; j<ncol; j++)
-        {
-            __m512i f11, s2, f21;
-            h00 = _mm512_load_si512((__m512i *)(H0 + j * SIMD_WIDTH8));  // check for col "0"
-            s2  = _mm512_load_si512((__m512i *)(seq2SoA + (j) * SIMD_WIDTH8));
-            f11 = _mm512_load_si512((__m512i *)(F + (j+1) * SIMD_WIDTH8));
-
-            MAIN_SAM_CODE8_OPT(s1, s2, h00, h11, e11, f11, f21, max512, sft512);
-
-            _mm512_store_si512((__m512i *)(H1 + (j + 1) * SIMD_WIDTH8), h11);  // check for col "0"
-            _mm512_store_si512((__m512i *)(F + (j + 1)* SIMD_WIDTH8), f21);
-            l512 = _mm512_add_epi8(l512, one512);
-        }
+        /* Below jsplit the two forms are equal, so the meth (HasFreed)
+         * instantiation keeps the per-cell one: hoisting there pins a third
+         * live k-reg against the two freed masks and measured slightly slower.
+         * Above jsplit, OR the already-computed s1 half with the s2 half as
+         * masks rather than re-ORing the vectors -- a kord instead of a vpord,
+         * off the contended vector ports. */
+        for (j = 0; j < jsplit; j++)
+            KSWV_AVX512_U8_CELL(HasFreed
+                ? _mm512_movepi8_mask(_mm512_or_si512(s1, s2))
+                : rowboundary512)
+        for (; j < ncol; j++)
+            KSWV_AVX512_U8_CELL(rowboundary512 | _mm512_movepi8_mask(s2))
+#undef KSWV_AVX512_U8_CELL
 
         // Block I
         if (i > 0)
@@ -3194,8 +3292,7 @@ void kswv::kswvBatchWrapper16(SeqPair *pairArray,
 
 
                 // int quanta = 8 - sp.len2 % 8;  // based on SSE-16 bit lane
-                int quanta = (sp.len2 + 8 - 1)/8;  // based on SSE-16 bit lane
-                quanta *= 8;
+                int quanta = query_quantum16(sp.len2);
                 assert(sp.len2 < this->maxQerLen);
                 for(k = 0; k < sp.len2; k++)
                 {
@@ -3212,8 +3309,7 @@ void kswv::kswvBatchWrapper16(SeqPair *pairArray,
             for(j = 0; j < SIMD_WIDTH16; j++)
             {
                 SeqPair sp = pairArray[i + j];
-                int quanta = (sp.len2 + 8 - 1)/8;  // based on SSE2-16 bit lane
-                quanta *= 8;
+                int quanta = query_quantum16(sp.len2);
                 for(k = quanta; k <= maxLen2; k++)
                 {
                     // mySeq2SoA[k * SIMD_WIDTH16 + j] = DUMMY2_;
@@ -3409,7 +3505,7 @@ int kswv::kswv512_16_impl(int16_t seq1SoA[],
          * kswv512_u8_impl's active_frread (consumed by MAIN_SAM_CODE16_OPT).
          * fr_read where ref==fr_ref, fr_read2 where ref==fr_ref2 (mutually
          * exclusive), else a sentinel no real s2 equals: u16 s2 ∈ {0-3, AMBQ16=16,
-         * DUMMY3=26, 0xFFFF pad}, so 0x7FFF is safe. The 16-bit kernel has NO shift
+         * DUMMY3=26, 0xFFFF pad}, so FREED_INACTIVE16 is safe. The 16-bit kernel has NO shift
          * bias (m11 = h00 + sbt directly), so the freed value is just fr_val:
          * fr_val == w_match (GENOMIC/COLLAPSED) equals temp[0], while NEUTRAL
          * (fr_val==0) scores the conversion as 0. !HasFreed → this and the per-cell
@@ -3420,7 +3516,7 @@ int kswv::kswv512_16_impl(int16_t seq1SoA[],
             __mmask32 rowfreed512  = _mm512_cmpeq_epi16_mask(s1, _mm512_set1_epi16((int16_t)fr_ref));
             __mmask32 rowfreed2_512= _mm512_cmpeq_epi16_mask(s1, _mm512_set1_epi16((int16_t)fr_ref2));
             active_frread512 = _mm512_mask_blend_epi16(rowfreed2_512,
-                                   _mm512_set1_epi16((int16_t)0x7FFF), _mm512_set1_epi16((int16_t)fr_read2));
+                                   _mm512_set1_epi16((int16_t)FREED_INACTIVE16), _mm512_set1_epi16((int16_t)fr_read2));
             active_frread512 = _mm512_mask_blend_epi16(rowfreed512,
                                    active_frread512, _mm512_set1_epi16((int16_t)fr_read));
         }

--- a/test/framework/seqpair_batch.cpp
+++ b/test/framework/seqpair_batch.cpp
@@ -37,14 +37,15 @@ BatchBuffers::BatchBuffers(const std::vector<TestPair> &pairs, int xtra_flags)
         }
     }
     // SIMD tail padding: the kernel may read past the last pair when
-    // lane-filling.
-    ref_total += static_cast<size_t>(SIMD_WIDTH8) * maxRefLen;
-    qer_total += static_cast<size_t>(SIMD_WIDTH8) * maxQerLen;
+    // lane-filling. Sized for MAX_SIMD_WIDTH8, not this TU's SIMD_WIDTH8 --
+    // see the constant's comment in seqpair_batch.h.
+    ref_total += static_cast<size_t>(MAX_SIMD_WIDTH8) * maxRefLen;
+    qer_total += static_cast<size_t>(MAX_SIMD_WIDTH8) * maxQerLen;
 
     seqBufRef_.assign(ref_total, 0);
     seqBufQer_.assign(qer_total, 0);
-    pairs_.assign(n_ + SIMD_WIDTH8, SeqPair{});
-    aln_.assign(n_ + SIMD_WIDTH8, g_defr);
+    pairs_.assign(n_ + MAX_SIMD_WIDTH8, SeqPair{});
+    aln_.assign(n_ + MAX_SIMD_WIDTH8, g_defr);
 
     size_t ref_off = 0, qer_off = 0;
     for (int i = 0; i < n_; i++) {

--- a/test/framework/seqpair_batch.h
+++ b/test/framework/seqpair_batch.h
@@ -17,11 +17,24 @@
 
 namespace bwa_tests {
 
+// Tail padding is sized for the WIDEST 8-bit lane count of any tier (64, the
+// AVX-512BW SIMD_WIDTH8), not this translation unit's compile-time
+// SIMD_WIDTH8. The kernel rounds the batch up to a whole SIMD group and writes
+// those dummy lanes, so a test that reaches a kernel wider than the tier the
+// framework was compiled at -- which any test going through make_kswv() can
+// do, since that dispatches on the runtime tier and honors BWAMEM3_FORCE_TIER
+// -- would otherwise write past the end of these buffers.
+//
+// It backs getScores16 batches too: the widest SIMD_WIDTH16 is 32, so the
+// 8-bit bound covers both and there is no reason to carry two constants.
+constexpr int MAX_SIMD_WIDTH8 = 64;
+
 class BatchBuffers {
 public:
-    // Pack `pairs` into internal seqBufRef/seqBufQer with SIMD_WIDTH8 tail
-    // padding. After construction, pairs()/ref_buf()/qer_buf()/aln() are
-    // the correctly-shaped arguments for kswv::getScores8.
+    // Pack `pairs` into internal seqBufRef/seqBufQer with tail padding for the
+    // widest supported SIMD group. After construction,
+    // pairs()/ref_buf()/qer_buf()/aln() are the correctly-shaped arguments for
+    // kswv::getScores8.
     //
     // xtra_flags is written into every pair's h0 field — pass the exact
     // value production uses at bwamem_pair.cpp:1004 so that the minsc

--- a/test/framework/seqpair_gen.cpp
+++ b/test/framework/seqpair_gen.cpp
@@ -59,6 +59,36 @@ TestPair gen_sub_cluster_pair(std::mt19937 &rng, int qlen, int rlen,
     return p;
 }
 
+TestPair gen_tandem_repeat_pair(std::mt19937 &rng, int qlen, int rlen) {
+    assert(qlen > 0 && rlen > qlen &&
+           "gen_tandem_repeat_pair: rlen must exceed qlen");
+    std::uniform_int_distribution<int> base(0, 3);
+    std::uniform_int_distribution<int> pct(0, 99);
+    std::uniform_int_distribution<int> period_d(18, 31);
+
+    TestPair p;
+    p.ref.resize(rlen);
+    p.qry.resize(qlen);
+    p.tag = "tandem_repeat";
+
+    const int period = period_d(rng);
+    std::vector<uint8_t> motif(period);
+    for (int i = 0; i < period; i++) motif[i] = static_cast<uint8_t>(base(rng));
+
+    for (int i = 0; i < rlen; i++) {
+        p.ref[i] = (pct(rng) < 12) ? static_cast<uint8_t>(base(rng))
+                                   : motif[i % period];
+    }
+
+    std::uniform_int_distribution<int> start_d(0, rlen - qlen - 1);
+    const int start = start_d(rng);
+    for (int i = 0; i < qlen; i++) {
+        p.qry[i] = (pct(rng) < 18) ? static_cast<uint8_t>(base(rng))
+                                   : p.ref[start + i];
+    }
+    return p;
+}
+
 TestPair gen_with_n_bases_pair(std::mt19937 &rng, int qlen, int rlen,
                                int n_frac_pct) {
     TestPair p = gen_random_pair(rng, qlen, rlen);

--- a/test/framework/seqpair_gen.h
+++ b/test/framework/seqpair_gen.h
@@ -40,6 +40,18 @@ TestPair gen_sub_cluster_pair(std::mt19937 &rng, int qlen, int rlen,
 TestPair gen_with_n_bases_pair(std::mt19937 &rng, int qlen, int rlen,
                                int n_frac_pct);
 
+// Reference is a random motif of 18-31 bases tiled to `rlen` with scattered
+// substitutions (a tandem repeat); query is a mutated copy of a random window
+// of that reference. Unlike gen_random_pair -- whose ref and query are
+// independent, so the DP never rises far above zero -- this yields a high
+// primary score PLUS many near-threshold secondary maxima against the other
+// repeat copies. That plateau structure is what exercises the second-best
+// (KSW_XSUBO) machinery: score2/te2 and the b[]-collapse it depends on.
+// Asserts `qlen > 0 && rlen > qlen` — the query window is drawn from strictly
+// inside the reference — so a mis-parameterized call fails loudly instead of
+// sampling an empty window range. tag = "tandem_repeat".
+TestPair gen_tandem_repeat_pair(std::mt19937 &rng, int qlen, int rlen);
+
 } // namespace bwa_tests
 
 #endif

--- a/test/unit/test_kswv_mixed_qlen.cpp
+++ b/test/unit/test_kswv_mixed_qlen.cpp
@@ -1,0 +1,387 @@
+// test/unit/test_kswv_mixed_qlen.cpp
+//
+// kswv::getScores8 vs scalar ksw_align2 on MIXED-QUERY-LENGTH batches.
+//
+// kswvBatchWrapper8 pads each lane's query with DUMMY5 up to that lane's own
+// 16-base quantum, then fills every column from there to the group's widest
+// quantum with 0xFF -- the same high-bit sentinel used for reference rows past
+// len1. The kernel must therefore zero the DP diagonal term wherever bit 7 is
+// set in the reference base OR the query base.
+//
+// The NEON and AVX-512BW 8-bit kernels had hoisted that test to the reference
+// base alone, on the incorrect premise that a query byte never carries bit 7.
+// On a group whose queries straddle a quantum boundary the short lanes' 0xFF
+// columns were then left unmasked, carried a diagonal forward, and inflated
+// that lane's per-row maximum -- surfacing as a phantom second-best score,
+// which mem_matesw_batch_post stores as mem_alnreg_t::csub and the SAM writer
+// emits as XS.
+//
+// test_kswv_correctness.cpp already batches mixed query lengths (50-128), so
+// layout alone does not reproduce this: it takes content too. gen_random_pair
+// makes ref and query independent, so the DP never rises far enough for a
+// spurious row to clear minsc. The tandem-repeat generator used here produces
+// a high primary score plus many near-threshold secondary maxima, which is what
+// turns an unmasked padding column into an observable score2.
+//
+// A uniform-length batch cannot expose this IN PHASE 0 -- every lane's quantum
+// equals the group's, so no 0xFF query column exists. The lengths below
+// alternate per lane so that ANY group width (16, 32 or 64) sees both. Note
+// this does NOT make a fixed-length library safe: production phase 1 sets
+// len2 = qe + 1 per pair (bwamem_pair.cpp:875), so phase-1 groups have ragged
+// quanta whatever the input lengths were. Both phases are checked below.
+//
+// The --meth cases at the bottom cover the HasFreed=true instantiation, which
+// pre-fix was hit far harder than the symmetric one and only on NEON: that
+// kernel applied the hoisted rowboundary to BOTH instantiations, where
+// AVX-512BW gated it and so kept meth correct, and active_frread's old 0xFF
+// marker additionally aliased the 0xFF pad so the freed blend fired on every
+// padded column. Symmetric pre-fix loses only score2/te2; meth pre-fix loses
+// score, qe/te and phase 1's tb/qb as well.
+//
+// The pair count is deliberately odd, not a multiple of 64: being odd makes it
+// coprime to every 8-bit group width (16/32/64) and every 16-bit one (8/16/32),
+// so the final group is always partial. Only a partial group reaches the
+// kswvBatchWrapper* prologue that synthesizes len1=len2=0 dummy lanes out to
+// roundNumPairs -- exactly the writes BatchBuffers sizes its MAX_SIMD_WIDTH8
+// tail padding to absorb. A dummy lane also has query_quantum8(0) == 0, which
+// pulls the group's jsplit to 0 and forces the per-cell boundary mask across
+// every column, rather than the hoisted per-row form a uniform group takes.
+//
+// getScores16 carries the identical contract (0xFFFF past query_quantum16) and
+// is covered too, so the invariant is locked everywhere it can drift rather
+// than only in the two kernels that happened to be wrong. It needs match=14:
+// that puts min_seed_len*match = 266 >= 250, so default_xtra_flags drops
+// KSW_XBYTE and BOTH sides run word mode. Comparing the 16-bit kernel against
+// a byte-mode scalar oracle instead would report spurious score2 differences --
+// scalar ksw_u8 is striped and takes its row max before the lazy-F fix-up, so
+// the two precisions legitimately collect different b[] entries.
+
+#include <random>
+#include <vector>
+
+#include "doctest/doctest.h"
+
+#include "ksw_runner.h"
+#include "kswr_cmp.h"
+#include "kswv_runner.h"  // BWA_TESTS_HAVE_KSWV
+#include "scoring.h"
+#include "seqpair_batch.h"
+#include "seqpair_gen.h"
+
+#if BWA_TESTS_HAVE_KSWV
+
+#include "bwa.h"            // bwa_fill_scmat
+#include "bwamem.h"         // mem_opt_init, mem_opt_fill_meth_mat, MEM_METH_SCORING_*
+#include "kswv.h"
+#include "simd_dispatch.h"  // make_kswv
+
+namespace {
+
+// Typical mate-rescue reference window (mem_matesw fetches pes.high-ish bp).
+constexpr int kRefLen = 460;
+
+// Whether the RUNNING tier has a batched kswv kernel at all. Only AVX2,
+// AVX-512BW and NEON do; the sse41/sse42/avx classes are exit() stubs
+// (kswv.cpp:3749). These tests reach the kernel through make_kswv, which
+// honors BWAMEM3_FORCE_TIER, so a tier sweep down to SSE would otherwise
+// take the whole test binary down with it mid-suite rather than skip.
+bool batched_kswv_available() {
+    bwamem3_simd_init();
+    const int tier = bwamem3_simd_tier();
+    return tier == BWAMEM3_TIER_AVX2 || tier == BWAMEM3_TIER_AVX512BW ||
+           tier == BWAMEM3_TIER_NEON;
+}
+
+// Score one batch on the batched kernel and require every forward-pass kswr_t
+// field to match the scalar ksw_align2 oracle at the same matrix.
+//
+// `kernel_mat` is what make_kswv installs: nullptr selects the 9-arg overload
+// (symmetric, HasFreed=false); a bisulfite mat25 selects the mat-aware overload
+// and, with it, the HasFreed=true kernel instantiation. `mat` is the matrix the
+// scalar oracle uses and MUST be the same one, or the comparison is meaningless.
+//
+// Deliberately uses make_kswv() rather than the framework's run_kswv_batch():
+// run_kswv_batch constructs the concrete `kswv` class directly, which binds to
+// whichever tier this translation unit was compiled at (BASELINE_ARCH, i.e.
+// avx2 on x86). make_kswv dispatches on the RUNTIME tier and honors
+// BWAMEM3_FORCE_TIER, so this test reaches the AVX-512BW kernel -- one of the
+// two that regressed -- on a capable host, and can be swept across tiers.
+// Both phases run: phase 0 for score/score2/te/qe/te2, then phase 1 for tb/qb.
+// test_kswv_correctness.cpp also drives both, but only through run_kswv_batch's
+// compile-time-tier, symmetric-matrix, independent-ref-and-query configuration,
+// which is why neither phase's exposure to the padding contract showed up there.
+void compare_batch(uint64_t seed, const std::vector<bwa_tests::TestPair> &pairs,
+                   const bwa_tests::ScoringMatrix &mat, const int8_t *kernel_mat,
+                   bool use16, int max_qlen) {
+    const int xtra = bwa_tests::default_xtra_flags(static_cast<int>(mat[0]));
+
+    std::vector<kswr_t> scalar_aln;
+    scalar_aln.reserve(pairs.size());
+    for (const auto &p : pairs) {
+        scalar_aln.push_back(bwa_tests::run_scalar_ksw(p, mat));
+    }
+
+    bwa_tests::BatchBuffers bb(pairs, xtra);
+    auto pwsw = kernel_mat
+        ? make_kswv(bwa_tests::DEFAULT_GAP_OPEN, bwa_tests::DEFAULT_GAP_EXTEND,
+                    bwa_tests::DEFAULT_GAP_OPEN, bwa_tests::DEFAULT_GAP_EXTEND,
+                    mat[0], mat[1], 1, kRefLen, max_qlen, kernel_mat)
+        : make_kswv(bwa_tests::DEFAULT_GAP_OPEN, bwa_tests::DEFAULT_GAP_EXTEND,
+                    bwa_tests::DEFAULT_GAP_OPEN, bwa_tests::DEFAULT_GAP_EXTEND,
+                    mat[0], mat[1], 1, kRefLen, max_qlen);
+    REQUIRE(pwsw->needsScalar() == false);
+    if (use16) {
+        pwsw->getScores16(bb.pairs(), bb.ref_buf(), bb.qer_buf(), bb.aln(), bb.n(), 1, 0);
+    } else {
+        pwsw->getScores8(bb.pairs(), bb.ref_buf(), bb.qer_buf(), bb.aln(), bb.n(), 1, 0);
+    }
+
+    // Per-pair CHECKs only on mismatch: at 129 pairs x 5 fields the passing
+    // assertions would otherwise bury the signal (matching the convention in
+    // test_kswv_correctness.cpp).
+    for (int i = 0; i < bb.n(); i++) {
+        const kswr_t &want = scalar_aln[i];
+        const kswr_t &got  = bb.aln()[bb.pairs()[i].regid];
+        CAPTURE(seed);
+        CAPTURE(i);
+        CAPTURE(use16);
+        CAPTURE(bb.pairs()[i].len2);
+        if (!bwa_tests::kswr_score_eq(want, got))  CHECK(want.score  == got.score);
+        if (!bwa_tests::kswr_score2_eq(want, got)) CHECK(want.score2 == got.score2);
+        if (want.te != got.te)                     CHECK(want.te  == got.te);
+        if (want.qe != got.qe)                     CHECK(want.qe  == got.qe);
+        if (want.te2 != got.te2)                   CHECK(want.te2 == got.te2);
+    }
+
+    // Phase 1 (tb/qb recovery) has its own exposure to the padding contract,
+    // and a worse-behaved one: production sets len2 = qe + 1 per pair
+    // (bwamem_pair.cpp:875), so a phase-1 group's quanta are ragged even when
+    // every input read was the same length. A uniform-length library is
+    // therefore NOT immune -- phase 0 may be uniform while phase 1 never is.
+    //
+    // The failure mode differs too. kswv.cpp:887 only writes tb/qb when the
+    // phase-1 score reproduces the phase-0 score exactly; a padding-inflated
+    // score fails that equality, tb/qb keep the -1 the caller pre-seeded
+    // (bwamem_pair.cpp:942), and the `aln.qb >= 0` guard at bwamem_pair.cpp:281
+    // then discards the rescue outright. So here the symptom is a SILENTLY
+    // DROPPED mate rescue, not a mis-scored one.
+    // Guard against a vacuous phase-1 leg: prepare_phase1 keeps only pairs that
+    // clear the KSW_XSTART/KSW_XSUBO gate, and a batch that cleared none would
+    // run the loop below zero times and still report green.
+    const int survivors = bb.prepare_phase1();
+    REQUIRE(survivors > 0);
+    if (use16) {
+        pwsw->getScores16(bb.pairs(), bb.ref_buf(), bb.qer_buf(), bb.aln(), survivors, 1, 1);
+    } else {
+        pwsw->getScores8(bb.pairs(), bb.ref_buf(), bb.qer_buf(), bb.aln(), survivors, 1, 1);
+    }
+    for (int i = 0; i < survivors; i++) {
+        const int regid = bb.pairs()[i].regid;
+        const kswr_t &want = scalar_aln[regid];
+        const kswr_t &got  = bb.aln()[regid];
+        CAPTURE(seed);
+        CAPTURE(regid);
+        CAPTURE(use16);
+        CAPTURE(bb.pairs()[i].len2);
+        if (want.tb != got.tb) CHECK(want.tb == got.tb);
+        if (want.qb != got.qb) CHECK(want.qb == got.qb);
+    }
+}
+
+// Alternating-length tandem-repeat batch: the layout that puts a 0xFF query
+// column on the short lanes and the content that makes it observable.
+std::vector<bwa_tests::TestPair> mixed_len_batch(std::mt19937 &rng, int n_pairs,
+                                                 int len_a, int len_b) {
+    std::vector<bwa_tests::TestPair> pairs;
+    pairs.reserve(n_pairs);
+    for (int i = 0; i < n_pairs; i++) {
+        pairs.push_back(bwa_tests::gen_tandem_repeat_pair(
+            rng, (i % 2 == 0) ? len_a : len_b, kRefLen));
+    }
+    return pairs;
+}
+
+void check_batch_matches_scalar(uint64_t seed, int n_pairs, int len_a, int len_b,
+                                bool use16 = false) {
+    // match=1 keeps KSW_XBYTE set (byte mode, both sides); match=14 drops it
+    // (word mode, both sides). See the header note.
+    const bwa_tests::ScoringMatrix mat =
+        use16 ? bwa_tests::build_scoring_matrix(14, 8, 1)
+              : bwa_tests::default_scoring_matrix();
+    if (!batched_kswv_available()) {
+        MESSAGE("tier has no batched kswv kernel; skipping");
+        return;
+    }
+    std::mt19937 rng(static_cast<unsigned>(seed));
+    const auto pairs = mixed_len_batch(rng, n_pairs, len_a, len_b);
+    compare_batch(seed, pairs, mat, /*kernel_mat=*/nullptr, use16,
+                  len_a > len_b ? len_a : len_b);
+}
+
+// ---------------------------------------------------------------------------
+// Bisulfite (--meth) variants: the HasFreed=true kernel instantiations.
+// ---------------------------------------------------------------------------
+
+// Build the production OT/OB matrix for `scoring` at the given match/mismatch
+// via the SAME two calls the CLI makes -- bwa_fill_scmat (fastmap.cpp:1745)
+// then mem_opt_fill_meth_mat. Restating the freed-cell layout here instead
+// would stop testing mem_opt_fill_meth_mat and start testing a copy of it.
+bwa_tests::ScoringMatrix meth_matrix(int scoring, bool ot, int match, int mismatch) {
+    mem_opt_t *o = mem_opt_init();
+    o->a = match;
+    o->b = mismatch;
+    o->meth_scoring = scoring;
+    bwa_fill_scmat(o->a, o->b, o->mat);
+    mem_opt_fill_meth_mat(o);
+    const int8_t *src = ot ? o->mat_ot : o->mat_ob;
+    bwa_tests::ScoringMatrix mat;
+    for (int i = 0; i < 25; i++) mat[i] = src[i];
+    free(o);
+    return mat;
+}
+
+// Apply the read-side conversion the matrix frees, so the freed cell actually
+// fires: OT frees mat[ref C][read T], OB frees mat[ref G][read A]. Converting
+// most (not all) sites mimics a real bisulfite library and leaves both freed
+// and unfreed cells in the DP -- converting none would leave HasFreed nominally
+// on but never exercised, and converting all would erase the base from the read.
+void convert_query_bisulfite(std::mt19937 &rng, bwa_tests::TestPair &p, bool ot) {
+    std::uniform_int_distribution<int> pct(0, 99);
+    const uint8_t from = ot ? 1 : 2;   // nt4: C=1 (OT), G=2 (OB)
+    const uint8_t to   = ot ? 3 : 0;   //      T=3      , A=0
+    for (auto &b : p.qry) {
+        if (b == from && pct(rng) < 80) b = to;
+    }
+}
+
+// Returns false (and reports) when the running tier has no freed-cell kernel --
+// sse41/sse42/avx report needsScalar() for any freed matrix, and production
+// gates the batched meth path off the same property
+// (bwamem_pair.cpp: meth_freed_cell_tier_supported).
+bool freed_kernel_available(const bwa_tests::ScoringMatrix &mat) {
+    auto probe = make_kswv(bwa_tests::DEFAULT_GAP_OPEN, bwa_tests::DEFAULT_GAP_EXTEND,
+                           bwa_tests::DEFAULT_GAP_OPEN, bwa_tests::DEFAULT_GAP_EXTEND,
+                           mat[0], mat[1], 1, kRefLen, 256, mat.data());
+    return !probe->needsScalar();
+}
+
+void check_meth_batch_matches_scalar(uint64_t seed, int n_pairs, int len_a, int len_b,
+                                     int scoring, bool ot, bool use16 = false) {
+    // Same byte-vs-word split as the symmetric case: match=14 puts
+    // min_seed_len*match over 250 so default_xtra_flags drops KSW_XBYTE and
+    // both sides run word mode.
+    const bwa_tests::ScoringMatrix mat =
+        use16 ? meth_matrix(scoring, ot, 14, 8) : meth_matrix(scoring, ot, 1, 4);
+    // Guard against a vacuous meth leg. If mem_opt_fill_meth_mat ever stopped
+    // freeing the conversion cell, the matrix would be symmetric, the mat-aware
+    // make_kswv would select HasFreed=false, and every case below would quietly
+    // re-run the non-meth path while still reporting green. mat[0*5+1] (ref A x
+    // read C) is a real mismatch under both OT and OB, so the freed conversion
+    // cell must differ from it in all three scoring modes (+a, or 0 for NEUTRAL).
+    const int conv_idx = ot ? (1 * 5 + 3)   // OT: ref C x read T
+                            : (2 * 5 + 0);  // OB: ref G x read A
+    REQUIRE(mat[conv_idx] != mat[0 * 5 + 1]);
+
+    if (!batched_kswv_available()) {
+        MESSAGE("tier has no batched kswv kernel; skipping");
+        return;
+    }
+    if (!freed_kernel_available(mat)) {
+        MESSAGE("tier has no freed-cell kswv kernel (needsScalar); skipping");
+        return;
+    }
+
+    std::mt19937 rng(static_cast<unsigned>(seed));
+    auto pairs = mixed_len_batch(rng, n_pairs, len_a, len_b);
+    for (auto &p : pairs) convert_query_bisulfite(rng, p, ot);
+
+    compare_batch(seed, pairs, mat, mat.data(), use16,
+                  len_a > len_b ? len_a : len_b);
+}
+
+} // namespace
+
+// The regression itself. 143 -> quantum 144 and 151 -> quantum 160, so the
+// short lanes carry 16 padded query columns; 75 -> quantum 80 widens that to 80.
+TEST_CASE("kswv::getScores8 matches scalar on mixed-query-length batches"
+          * doctest::test_suite("unit/kswv")) {
+    for (uint64_t seed = 1; seed <= 32; ++seed) {
+        check_batch_matches_scalar(seed, 129, 143, 151);   // adjacent quanta
+        check_batch_matches_scalar(seed, 129, 75, 151);    // wide spread
+    }
+}
+
+// Same contract on the 16-bit kernels. These were never wrong, so this does not
+// fail on origin/main -- it exists so the hoist cannot be introduced there
+// later. 143/151 straddle a multiple of 8 as well as of 16.
+TEST_CASE("kswv::getScores16 matches scalar on mixed-query-length batches"
+          * doctest::test_suite("unit/kswv")) {
+    for (uint64_t seed = 1; seed <= 32; ++seed) {
+        check_batch_matches_scalar(seed, 129, 143, 151, /*use16=*/true);
+        check_batch_matches_scalar(seed, 129, 75, 151, /*use16=*/true);
+    }
+}
+
+// Control: uniform lengths leave no 0xFF query column on any lane whose result
+// is compared, so this passed even before the fix -- the tail group's dummy
+// lanes are padded to 0xFF from column 0, but their outputs are never read and
+// lanes do not interact. It guards the common production path against a
+// regression in the other direction.
+TEST_CASE("kswv matches scalar on uniform-query-length batches"
+          * doctest::test_suite("unit/kswv")) {
+    for (uint64_t seed = 101; seed <= 104; ++seed) {
+        check_batch_matches_scalar(seed, 129, 151, 151);
+        check_batch_matches_scalar(seed, 129, 151, 151, /*use16=*/true);
+    }
+}
+
+// The same contract under --meth, i.e. the HasFreed=true instantiation. This is
+// the production bisulfite mate-rescue path (bwamem_pair.cpp:963, default ON via
+// BWAMEM3_METH_BATCHED_RESCUE), and pre-fix it was worse off than the symmetric
+// one on NEON: that kernel applied the hoisted rowboundary to BOTH
+// instantiations, while AVX-512BW gated it (`cmp = HasFreed ? per-cell :
+// rowboundary512`) and so kept meth correct. On NEON the two defects compounded
+// -- active_frread's old 0xFF sentinel aliased the 0xFF query pad, so the freed
+// blend fired on every padded column AND the hoisted mask failed to zero it.
+// That is what FREED_INACTIVE8 and the restored per-cell test jointly fix, and
+// nothing in-repo covered it: every other asymmetric-matrix test targets
+// BandedPairWiseSW, not kswv.
+//
+// All three --meth-scoring modes, both strands: GENOMIC and NEUTRAL free one
+// cell (to +a and to 0 respectively), COLLAPSED frees the mirror pair too, and
+// the kernel folds all of them into one per-row active_frread target -- so each
+// mode is a different fr_val/fr_ref2 configuration through the same blend.
+TEST_CASE("kswv::getScores8 matches scalar on mixed-length --meth batches"
+          * doctest::test_suite("unit/kswv")) {
+    const int modes[] = {MEM_METH_SCORING_GENOMIC, MEM_METH_SCORING_NEUTRAL,
+                         MEM_METH_SCORING_COLLAPSED};
+    for (int scoring : modes) {
+        for (bool ot : {true, false}) {
+            for (uint64_t seed = 1; seed <= 8; ++seed) {
+                check_meth_batch_matches_scalar(seed, 129, 143, 151, scoring, ot);
+                check_meth_batch_matches_scalar(seed, 129, 75, 151, scoring, ot);
+            }
+        }
+    }
+}
+
+// 16-bit counterpart. Never wrong here either -- the u16 sentinel 0x7FFF never
+// aliased the 0xFFFF pad and all three 16-bit kernels kept the per-cell test --
+// so this locks the invariant rather than reproducing a failure.
+TEST_CASE("kswv::getScores16 matches scalar on mixed-length --meth batches"
+          * doctest::test_suite("unit/kswv")) {
+    const int modes[] = {MEM_METH_SCORING_GENOMIC, MEM_METH_SCORING_NEUTRAL,
+                         MEM_METH_SCORING_COLLAPSED};
+    for (int scoring : modes) {
+        for (bool ot : {true, false}) {
+            for (uint64_t seed = 1; seed <= 8; ++seed) {
+                check_meth_batch_matches_scalar(seed, 129, 143, 151, scoring, ot,
+                                                /*use16=*/true);
+                check_meth_batch_matches_scalar(seed, 129, 75, 151, scoring, ot,
+                                                /*use16=*/true);
+            }
+        }
+    }
+}
+
+#endif // BWA_TESTS_HAVE_KSWV


### PR DESCRIPTION
## Summary

One read in `panel-twist-5M` got `XS:i:21` from bwa-mem3's AVX-512 and NEON builds but `XS:i:0` from its AVX2 build and from upstream bwa-mem2. Root cause is a latent correctness bug in the **NEON and AVX-512BW 8-bit `kswv` mate-rescue kernels**, not a recent regression — v0.7.0 shows the same split.

`kswvBatchWrapper8` pads each lane's query with `DUMMY5` up to that lane's own 16-base quantum, then fills every column from there out to the group's widest quantum with `0xFF` — the same high-bit sentinel used for reference rows past `len1`. Kernels must zero the DP diagonal term wherever bit 7 is set in the reference base **or** the query base. Those two kernels had hoisted the test to the reference base alone, on the stated premise that a query byte never carries bit 7. It does.

On a group whose queries straddle a quantum boundary, the short lanes' `0xFF` columns went unmasked, carried a diagonal forward, and inflated that lane's per-row maximum. An inflated row could clear `minsc` and fall outside the primary region `[te-val, te+val]`, surfacing as a phantom second-best score — which `mem_matesw_batch_post` stores as `mem_alnreg_t::csub` and the SAM writer emits as `XS`. The best score was usually untouched, so the only visible symptom was a wrong `XS` on an occasional mate-rescued read.

AVX2 and both 16-bit kernels kept the correct per-cell test, which is exactly why the divergence was **AVX2-alone vs everything-else** rather than x86-vs-ARM. The read routes to the 8-bit kernel (`l_ms * a = 143 < 250` ⇒ `KSW_XBYTE`).

### Why it took 126.6M records to surface

It needs a mate-rescue SIMD group with mixed query lengths across a 16-base quantum, contamination exceeding the true row max, clearing `minsc`, landing outside the primary region, and surviving into `XS`.

## Evidence

Reduced from the 5M sample to **151 read pairs**, `-t 1`, deterministic. Instrumenting `mem_matesw_batch_post` to run scalar `ksw_align2` on the identical input:

```
[XSDBG-RESCUE] index=2090 path=kswv   score=37 score2=21 tb=196 te=252 te2=290 qb=53 qe=109
[XSDBG-SCALAR]                        score=37 score2=-1 tb=196 te=252 te2=-1  qb=53 qe=109
```

Every field matches except `score2`/`te2`. Per-row maxima against the scalar oracle isolate it to a single row — `row 290: scalar 18, kernel 21` — which clears `minsc=19` and sits just outside `high=289`. Group composition confirms the mechanism: the lane had `len2=143` (quantum 144) while the group contained `len2=151` lanes (quantum 160), so `ncol=160` left columns 144–159 filled with `0xFF` and unmasked.

## What changed

**`fix(kswv)`** — restore the per-cell `high_bit(s1|s2)` test, but only over the columns where it can fire. `jsplit = min(query_quantum8(len2))` over the group is the first column any lane pads, so below it the mask provably reduces to the hoisted per-row reference half. A uniform-length group — the common case — never runs the per-cell form. Also:
- `query_quantum8/16` gives the padding quantum one definition instead of thirteen open-coded copies across the six wrappers.
- The 8-bit `--meth` freed-cell blend gets its own inactive marker (`FREED_INACTIVE8`) instead of reusing `0xFF`. Aliasing the pad made the blend fire on every padded column, leaving correctness dependent on the boundary mask covering for it; the 16-bit kernels already pick `0x7FFF` on this reasoning.
- Deleted the "s2 never holds `0xFF`" claim from the comments carrying it — that sentence is what invited the bad hoist.

**`test(kswv)`** — `gen_tandem_repeat_pair` plus a test batching it at alternating query lengths, requiring every forward-pass `kswr_t` field to match the scalar oracle. Covers `getScores16` as well as `getScores8`, so the invariant is locked where it *can* drift, not only where it did.

It goes through `make_kswv` rather than the framework's `run_kswv_batch`: the latter constructs the concrete `kswv` class and so binds to the tier the test TU was compiled at, and can never reach the AVX-512BW kernel. Reaching a kernel wider than the framework's compile-time `SIMD_WIDTH8` also means `BatchBuffers` must size its tail padding for the widest tier, or the kernel's dummy-lane writes run past the end.

## Verification

Pre-fix = `origin/main` @ `e722ed0`. Measured on dedicated c7i.4xlarge (AVX-512BW/AVX2) and c8g.4xlarge (NEON) hosts.

### Correctness

| check | avx2 | avx512bw | neon |
|---|---|---|---|
| new unit test, pre-fix | pass | **fail** | **fail** |
| new unit test, post-fix | pass | pass | pass |
| e2e `XS` on reproducer, pre-fix | `XS:i:0` | **`XS:i:21`** | **`XS:i:21`** |
| e2e `XS` on reproducer, post-fix | `XS:i:0` | `XS:i:0` | `XS:i:0` |
| bwa-bsw-bench extend | PASS | PASS | PASS |
| bwa-bsw-bench rescue 8-bit | PASS | PASS | PASS |
| bwa-bsw-bench rescue 8-bit, 10% N | PASS | PASS | PASS |
| bwa-bsw-bench rescue 16-bit | — | — | PASS |
| bwa-bsw-bench `--meth-scoring` collapsed / genomic / neutral | PASS | PASS | PASS |

All golden gates byte-identical to pre-fix. The `--meth` gates specifically cover the `FREED_INACTIVE8` change. `make test` green on x86_64 and aarch64.

### Performance — `bwa-bsw-bench --mode rescue --force-width 8 --n 20000 --reps 7`, `mb3 Mc/s`

Run-to-run spread <0.5%; qlen 100 / 150.

| tier | pre-fix | post-fix | Δ |
|---|---|---|---|
| avx512bw (c7i) | 17628 / 18498 | 17600 / 18444 | −0.16% / −0.29% |
| neon (c8g) | 4927 / 5268 | 4917 / 5256 | −0.21% / −0.24% |
| avx2 (control, untouched) | 10146 / 10712 | 10143 / 10728 | ±0.0% |

The naive always-per-cell fix cost **−11%** on AVX-512BW and **−9.5%** on NEON; the `jsplit` split recovers essentially all of it.

## Follow-up

The strict 24-cell compare should be re-run against a build of this branch — the `panel-twist-5M` AVX-512 and NEON cells are expected to match the AVX2/bwa-mem2 baseline, giving 24/24 identical.

Not addressed here: `bandedSWA.cpp` carries the same *shape* of assumption (a kernel-local derivation about what the wrapper wrote, guarding a fast path), though via a different and more robust mechanism. Worth a separate look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect scoring for batches with queries of different lengths by aligning SIMD padding and boundary handling across implementations.
  * Prevented padded lanes from affecting freed-cell comparisons, eliminating false matches near padding boundaries.

* **Tests**
  * Added regression tests that compare batched SIMD results for mixed-length query lanes against a scalar alignment oracle across multiple modes.
  * Added tandem-repeat test generation and expanded coverage for both mixed and uniform query-length batches, including freed-cell scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->