### PR TITLE
fix(header): emit one default @HD on every output path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,14 @@ jobs:
           HEADER_PARITY_WORK_DIR=/tmp/header-parity \
           bash test/regression/header_parity.sh
 
+      - name: default @HD parity across output paths
+        if: matrix.canonical == true
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          HD_PARITY_PHIX_FA="$GITHUB_WORKSPACE/test/fixtures/phix.fa" \
+          HD_PARITY_WORK_DIR=/tmp/hd-parity \
+          bash test/regression/default_hd_parity.sh
+
       - name: SE alignment smoke (chr22)
         if: matrix.canonical == true
         run: |

--- a/docs/src/user-guide/output.md
+++ b/docs/src/user-guide/output.md
@@ -26,9 +26,16 @@ bwa-mem3 mem --bam=6 -t 16 ref.fa R1.fq.gz R2.fq.gz > out.bam
 
 ### `@HD`
 
-A default `@HD VN:1.6 SO:unsorted` line is emitted unless the user supplies
-one via `-H`. The sort order is `unsorted` because bwa-mem3 writes records in
-input read order; downstream sorting is always a separate step.
+A default `@HD VN:1.5 SO:unsorted GO:query` line is emitted unless the user
+supplies one via `-H` (or the index sidecar does). The sort order is `unsorted`
+because bwa-mem3 writes records in input read order; downstream sorting is
+always a separate step, and `GO:query` records that the records for one query
+are adjacent.
+
+The same line is emitted on every output path — SAM text, `--bam` and
+`--meth`. Through 0.7.1 the BAM writers emitted `@HD VN:1.6 SO:unsorted`
+instead, so the same run produced a different `@HD` depending on `--bam`; they
+now agree, on the string upstream bwa uses.
 
 ### `@SQ`
 

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -68,14 +68,12 @@ bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
     // @HD policy comes from the selected compat target; the evidence for each
     // row is in src/compat_target.cpp. DO NOT "fix" the missing @HD under a
     // compat target -- suppressing it is deliberate, not an oversight.
-    // compat->hd_line == NULL keeps this path's historical default, which
-    // differs from the SAM text path's (fg-labs/bwa-mem3#288).
-    if (!idx_has_hd && !user_has_hd && compat->emit_hd) {
-        int rc = compat->hd_line != NULL
-               ? sam_hdr_add_lines(hdr, compat->hd_line, 0)
-               : sam_hdr_add_line(hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL);
-        if (rc < 0) goto fail;
-    }
+    //
+    // sam_hdr_add_lines over the target's exact text, NOT sam_hdr_add_line with
+    // key/value pairs: the point of #288 is that all three writers emit ONE
+    // string, and a key/value call here would be a second place to spell it.
+    if (!idx_has_hd && !user_has_hd && compat->emit_hd &&
+        sam_hdr_add_lines(hdr, compat->hd_line, 0) < 0) goto fail;
     if (!idx_has_sq) {
         for (int i = 0; i < bns->n_seqs; ++i) {
             char len_buf[32];

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -766,13 +766,9 @@ static void print_sam_hdr(const bntseq_t *bns, const char *bns_hdr,
     }
     /* @HD policy comes from the selected compat target; the evidence for each
      * row is in src/compat_target.cpp. DO NOT "fix" the missing @HD under a
-     * compat target -- suppressing it is deliberate, not an oversight.
-     * compat->hd_line == NULL keeps this path's historical default, which
-     * differs from the BAM writer's (fg-labs/bwa-mem3#288). */
+     * compat target -- suppressing it is deliberate, not an oversight. */
     if (!user_HD && !idx_HD && compat->emit_hd) {
-        err_fputs(compat->hd_line != NULL ? compat->hd_line
-                                          : "@HD\tVN:1.5\tSO:unsorted\tGO:query",
-                  fp);
+        err_fputs(compat->hd_line, fp);
         err_fputc('\n', fp);
     }
 

--- a/src/compat_target.cpp
+++ b/src/compat_target.cpp
@@ -13,20 +13,15 @@
 
 /* --- `off`: bwa-mem3's native output -------------------------------------
  *
- * hd_line is NULL, meaning each output path keeps the default it already
- * emits. Those defaults DISAGREE -- SAM text writes
- * "@HD\tVN:1.5\tSO:unsorted\tGO:query" (bwa.cpp) while the BAM writer writes
- * "@HD\tVN:1.6\tSO:unsorted" (bam_writer.cpp). That is a real latent
- * inconsistency, tracked as fg-labs/bwa-mem3#288; reconciling it changes
- * default output on one of the two paths and so does not belong to --compat.
- * NULL here preserves both bytewise. A target that pins an exact string (see
- * bwa-mem) is what would force the question. */
+ * hd_line is the one canonical default (#288). It used to be NULL, meaning
+ * "whatever that output path emits" -- which was a different string on the
+ * SAM-text and BAM paths. */
 const compat_target_t COMPAT_TARGET_OFF = {
     /* .name               */ "off",
     /* .alias              */ NULL,
     /* .unavailable_reason */ NULL,
     /* .emit_hd            */ 1,
-    /* .hd_line            */ NULL,
+    /* .hd_line            */ BWAMEM3_DEFAULT_HD_LINE,
     /* .read_sidecar       */ 1,
     /* .emit_mq            */ 1,
     /* .emit_hn            */ 1,
@@ -74,7 +69,7 @@ static const compat_target_t COMPAT_TARGET_BWA_MEM = {
     /* .unavailable_reason */ "bwa-mem3 and bwa still differ on 224/63583 records "
                               "(53 above MAPQ 30), so byte-identity is not achievable",
     /* .emit_hd            */ 1,
-    /* .hd_line            */ "@HD\tVN:1.5\tSO:unsorted\tGO:query",
+    /* .hd_line            */ BWAMEM3_DEFAULT_HD_LINE,   /* == bwa.c:426 */
     /* .read_sidecar       */ 0,
     /* .emit_mq            */ 1,
     /* .emit_hn            */ 0,

--- a/src/compat_target.h
+++ b/src/compat_target.h
@@ -21,6 +21,14 @@
 extern "C" {
 #endif
 
+/* The default @HD record bwa-mem3 emits when neither -H nor the index sidecar
+ * supplies one. Byte-identical to upstream bwa (bwa.c:426, added in 0.7.18
+ * 6b18630). ONE definition on purpose: the SAM-text, BAM and --meth writers
+ * each used to hardcode their own, and the BAM ones had drifted to
+ * "VN:1.6 SO:unsorted" -- so the same run emitted a different @HD depending on
+ * --bam (fg-labs/bwa-mem3#288). Every emission site now spells it this way. */
+#define BWAMEM3_DEFAULT_HD_LINE "@HD\tVN:1.5\tSO:unsorted\tGO:query"
+
 typedef struct compat_target_t {
     /* Canonical spelling, as documented and as reported in diagnostics. */
     const char *name;
@@ -39,10 +47,9 @@ typedef struct compat_target_t {
     /* Emit a default @HD when neither -H nor the index sidecar supplies one. */
     int emit_hd;
 
-    /* Exact @HD text (no trailing newline) when emit_hd is set. NULL means
-     * "keep whatever default that output path already emits" -- the SAM text
-     * and BAM paths currently disagree (fg-labs/bwa-mem3#288), and only the
-     * `off` row tolerates that. */
+    /* Exact @HD text (no trailing newline). Always non-NULL when emit_hd is
+     * set, so an emitting site never has to fall back to a literal of its own
+     * -- that is exactly how the three writers drifted apart before #288. */
     const char *hd_line;
 
     /* Honor the bwa-mem3-only <prefix>.hdr / <baseprefix>.dict sidecar. Both

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -177,12 +177,12 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
      *
      * This writer does not consult a compat target, unlike bwa.cpp and
      * bam_writer.cpp: --compat with --meth is a hard error (rejected in
-     * main_mem's option validation), so only COMPAT_TARGET_OFF can reach here
-     * and OFF keeps each path's own default. A future target that relaxes the
-     * --meth exclusion must plumb compat->emit_hd/hd_line through here too.
-     * The string also differs from the SAM text path's -- fg-labs/bwa-mem3#288. */
+     * main_mem's option validation), so only COMPAT_TARGET_OFF can reach here,
+     * and OFF's hd_line IS BWAMEM3_DEFAULT_HD_LINE. A future target that
+     * relaxes the --meth exclusion must plumb compat->emit_hd/hd_line through
+     * here too. */
     if (!hdr_text_has_type(hdr_line, "@HD\t") &&
-        sam_hdr_add_line(w->hdr, "HD", "VN", "1.6", "SO", "unsorted", NULL) < 0) goto fail;
+        sam_hdr_add_lines(w->hdr, BWAMEM3_DEFAULT_HD_LINE, 0) < 0) goto fail;
 
     /* @SQ directly from the ORIGINAL (un-converted) bns contigs (D3 PR-5: no
      * f/r consolidation — alignments already carry original rids). Each @SQ is

--- a/test/meth_rg_header_test.sh
+++ b/test/meth_rg_header_test.sh
@@ -124,7 +124,8 @@ samtools view    "$tmp/meth.bam" >"$tmp/meth.recs" 2>/dev/null \
 assert_rg_consistent "--meth" "$tmp/meth.hdr" "$tmp/meth.recs"
 
 # --- --meth @HD de-dup: a user -H @HD must suppress the default @HD ---------
-# meth_bam_writer_open emits a default "@HD VN:1.6 SO:unsorted" UNLESS the
+# meth_bam_writer_open emits a default @HD (BWAMEM3_DEFAULT_HD_LINE,
+# "@HD VN:1.5 SO:unsorted GO:query") UNLESS the
 # user's -H already supplies an @HD (the hdr_text_has_type() guard). Without
 # that guard htslib would write two @HD lines (it does not de-dup @HD). Pass a
 # DISTINCT @HD (SO:coordinate) alongside -R and assert the output carries

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -16,6 +16,7 @@ matrix row; the rest run on the canonical AVX2 row only. Each script:
 | `supp_rep_hard_cap.sh`       | `--supp-rep-hard-cap` forces MAPQ=0 on repetitive-seed supps (#101)   | "--supp-rep-hard-cap repetitive-seed regression"    |
 | `compat_byte_identical.sh`   | `--compat=bwa-mem2` suppresses only MQ/HN/@HD; rest byte-identical    | "--compat byte-identical regression (phix)"         |
 | `header_parity.sh`           | `AH:*` on generated @SQ (#281); `--compat` skips the .hdr/.dict sidecar | "header parity regression (AH:*, --compat @HD/@SQ)" |
+| `default_hd_parity.sh`       | default `@HD` byte-identical across SAM/`--bam`/`--meth` (#288)        | "default @HD parity across output paths"            |
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
 
 Each script reads its inputs from environment variables — see the comment

--- a/test/regression/default_hd_parity.sh
+++ b/test/regression/default_hd_parity.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# test/regression/default_hd_parity.sh
+#
+# Regression: the DEFAULT `@HD` record must be byte-identical on every output
+# path — SAM text, `--bam`, and `--meth`.
+#
+# It was not. Each of the three writers hardcoded its own literal, and the two
+# BAM ones had drifted, so the same run emitted a different `@HD` depending on
+# `--bam` (fg-labs/bwa-mem3#288):
+#
+#   src/bwa.cpp        @HD VN:1.5 SO:unsorted GO:query
+#   src/bam_writer.cpp @HD VN:1.6 SO:unsorted
+#   src/meth_bam.cpp   @HD VN:1.6 SO:unsorted
+#
+# All three now emit BWAMEM3_DEFAULT_HD_LINE (src/compat_target.h), which is
+# byte-identical to upstream bwa's literal at bwa.c:426. This test pins that:
+# a fourth writer, or a "fix" to any one of the three, has to keep them equal.
+#
+# The assertion is equality ACROSS PATHS *and* against the expected string.
+# Equality alone would pass if all three drifted together; the literal alone
+# would not catch one path diverging on a value the test did not think to
+# check. Both are cheap, so assert both.
+#
+# `--compat` is out of scope here: it suppresses the default `@HD` entirely,
+# which compat_byte_identical.sh covers. This is about DEFAULT output.
+#
+# Inputs (env vars):
+#   BWA_MEM3        — path to the bwa-mem3 binary under test
+#   HD_PARITY_PHIX_FA — path to test/fixtures/phix.fa
+#   HD_PARITY_WORK_DIR — directory for fixture-private intermediates
+
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+: "${HD_PARITY_PHIX_FA:?HD_PARITY_PHIX_FA must be set}"
+: "${HD_PARITY_WORK_DIR:?HD_PARITY_WORK_DIR must be set}"
+
+# The one true default, duplicated here ON PURPOSE: a test that read the
+# constant from the source it is testing could not catch the constant changing.
+EXPECT=$'@HD\tVN:1.5\tSO:unsorted\tGO:query'
+
+mkdir -p "$HD_PARITY_WORK_DIR"
+cd "$HD_PARITY_WORK_DIR"
+# Remove only this script's own artifacts (never `rm -rf` a caller-supplied path).
+rm -f phix.fa phix.fa.* phix.dict phix.meth.* r1.fq r2.fq ./*.sam ./*.bam ./*.hdr ./*.log
+
+cp "$HD_PARITY_PHIX_FA" phix.fa
+ref=phix.fa
+
+# The reference must have NO sidecar: a <prefix>.hdr / <baseprefix>.dict @HD
+# takes precedence over the default and would make every assertion vacuous.
+rm -f "$ref.hdr" phix.dict
+"$BWA_MEM3" index "$ref" > index.log 2>&1
+
+# PE reads sliced from phix — deterministic, no PRNG.
+python3 - <<'PY'
+seq = "".join(l.strip() for l in open("phix.fa") if not l.startswith(">")).upper()
+comp = str.maketrans("ACGT", "TGCA")
+with open("r1.fq", "w") as a, open("r2.fq", "w") as b:
+    for i, off in enumerate([200, 900, 1600]):
+        x = seq[off:off+120]
+        y = seq[off+300:off+420][::-1].translate(comp)
+        a.write("@p%d/1\n%s\n+\n%s\n" % (i, x, "I"*120))
+        b.write("@p%d/2\n%s\n+\n%s\n" % (i, y, "I"*120))
+PY
+
+check() {   # <label> <actual-@HD>
+    if [ -z "$2" ]; then
+        echo "FAIL: $1 emitted no default @HD" >&2
+        exit 1
+    fi
+    if [ "$2" != "$EXPECT" ]; then
+        echo "FAIL: $1 default @HD differs from the expected default" >&2
+        printf '  expected: %s\n  actual:   %s\n' \
+            "$(printf '%s' "$EXPECT" | sed 's/\t/\\t/g')" \
+            "$(printf '%s' "$2"      | sed 's/\t/\\t/g')" >&2
+        exit 1
+    fi
+    printf '  %-12s %s\n' "$1" "$(printf '%s' "$2" | sed 's/\t/\\t/g')"
+}
+
+echo "default @HD by output path:"
+
+# --- SAM text ---
+"$BWA_MEM3" mem "$ref" r1.fq r2.fq > sam.sam 2>sam.err
+sam_hd=$(grep -m1 '^@HD' sam.sam || true)
+check "SAM text" "$sam_hd"
+
+if ! command -v samtools > /dev/null 2>&1; then
+    echo "SKIP: samtools not on PATH — --bam and --meth paths not checked"
+    echo "PASS: default @HD parity (SAM text only)"
+    exit 0
+fi
+
+# --- --bam ---
+"$BWA_MEM3" mem --bam "$ref" r1.fq r2.fq > bam.bam 2>bam.err
+bam_hd=$(samtools view -H --no-PG bam.bam | grep -m1 '^@HD' || true)
+check "--bam" "$bam_hd"
+
+# --- --meth (needs the D3 seed index) ---
+if [[ ! -s "$ref.meth.bwt.2bit.64" || ! -s "$ref.meth.amb" \
+      || ! -s "$ref.meth.ann"      || ! -s "$ref.meth.pac" ]]; then
+    "$BWA_MEM3" index --meth "$ref" > index-meth.log 2>&1 \
+        || { echo "FAIL: bwa-mem3 index --meth failed" >&2; cat index-meth.log >&2; exit 1; }
+fi
+"$BWA_MEM3" mem --meth "$ref" r1.fq > meth.bam 2>meth.err \
+    || { echo "FAIL: bwa-mem3 mem --meth exited non-zero" >&2; cat meth.err >&2; exit 1; }
+meth_hd=$(samtools view -H --no-PG meth.bam | grep -m1 '^@HD' || true)
+check "--meth" "$meth_hd"
+
+# Equality across paths is implied by all three matching EXPECT, but assert it
+# directly so a future change that relaxes EXPECT still cannot let them drift.
+if [ "$sam_hd" != "$bam_hd" ] || [ "$sam_hd" != "$meth_hd" ]; then
+    echo "FAIL: default @HD differs across output paths" >&2
+    exit 1
+fi
+
+echo "PASS: default @HD is byte-identical across SAM text, --bam and --meth"

--- a/test/unit/test_compat_target.cpp
+++ b/test/unit/test_compat_target.cpp
@@ -36,11 +36,11 @@ TEST_CASE("compat target `off` is bwa-mem3's native output") {
     CHECK(t->read_sidecar == 1);
     CHECK(t->emit_mq      == 1);
     CHECK(t->emit_hn      == 1);
-    // NULL, not a literal: each output path keeps the default it already
-    // emits. The SAM text and BAM paths disagree ("VN:1.5 ... GO:query" vs
-    // "VN:1.6 SO:unsorted"); pinning a string here would change default output
-    // on one of them, which --compat must never do.
-    CHECK(t->hd_line == nullptr);
+    // `off` pins the one canonical default. It used to be NULL, meaning "each
+    // path keeps whatever it emits" -- which was a different string on the SAM
+    // text and BAM paths until #288 unified them.
+    REQUIRE(t->hd_line != nullptr);
+    CHECK(std::string(t->hd_line) == "@HD\tVN:1.5\tSO:unsorted\tGO:query");
 }
 
 TEST_CASE("compat target `bwa-mem2` matches bwa-mem2 v2.2.1") {
@@ -71,10 +71,12 @@ TEST_CASE("compat target `bwa-mem` is fully specified but not selectable") {
     // evidence below; when the alignment work lands, this becomes nullptr.
     REQUIRE(t->unavailable_reason != nullptr);
     CHECK(std::string(t->unavailable_reason).find("byte-identity") != std::string::npos);
-    // bwa.c:426 — emitted unconditionally when -H supplies no @HD.
+    // bwa.c:426 — emitted unconditionally when -H supplies no @HD. bwa-mem3's
+    // own default is byte-identical to it, so this row shares the constant.
     REQUIRE(t->emit_hd == 1);
     REQUIRE(t->hd_line != nullptr);
     CHECK(std::string(t->hd_line) == "@HD\tVN:1.5\tSO:unsorted\tGO:query");
+    CHECK(std::string(t->hd_line) == std::string(BWAMEM3_DEFAULT_HD_LINE));
     // lh3/bwa#348 closed unmerged; bwa has no sidecar.
     CHECK(t->read_sidecar == 0);
     // THE field a single compat boolean could not express: bwa DOES emit MQ:i
@@ -137,10 +139,14 @@ TEST_CASE("every table row is reachable by name, and rows are self-consistent") 
         if (t->alias != nullptr)
             CHECK_MESSAGE(compat_target_from_name(t->alias) == t,
                           "row ", t->name, " is not reachable by its alias");
-        // A pinned @HD is meaningless unless the row emits one.
-        if (t->hd_line != nullptr)
-            CHECK_MESSAGE(t->emit_hd == 1,
-                          "row ", t->name, " pins hd_line but does not emit @HD");
+        // #288: a row that emits @HD must say exactly what, so no emission
+        // site ever needs a fallback literal of its own.
+        if (t->emit_hd)
+            CHECK_MESSAGE(t->hd_line != nullptr,
+                          "row ", t->name, " emits @HD but pins no hd_line");
+        else
+            CHECK_MESSAGE(t->hd_line == nullptr,
+                          "row ", t->name, " pins hd_line but emits no @HD");
     }
 }
 


### PR DESCRIPTION
Closes #288. Stacked on #277 — both touch the same `@HD` emission sites; review #277 first.

The three writers each hardcoded their own default `@HD`, and the two BAM ones had drifted, so the **same run emitted a different `@HD` depending on `--bam`**:

```console
$ bwa-mem3 mem       ref.fa r1.fq r2.fq | head -1
@HD	VN:1.5	SO:unsorted	GO:query
$ bwa-mem3 mem --bam ref.fa r1.fq r2.fq | samtools view -H -
@HD	VN:1.6	SO:unsorted
```

| writer | before | after |
|---|---|---|
| `src/bwa.cpp` (SAM text) | `VN:1.5 SO:unsorted GO:query` | `VN:1.5 SO:unsorted GO:query` |
| `src/bam_writer.cpp` (`--bam`) | `VN:1.6 SO:unsorted` | `VN:1.5 SO:unsorted GO:query` |
| `src/meth_bam.cpp` (`--meth`) | `VN:1.6 SO:unsorted` | `VN:1.5 SO:unsorted GO:query` |

All three now emit `BWAMEM3_DEFAULT_HD_LINE`, defined once in `src/compat_target.h` next to the rest of the `@HD` policy.

## Why the SAM-text string won

- It is **byte-identical to upstream bwa** (`bwa.c:426`, added in 0.7.18 `6b18630`) — the tie-breaker this project uses elsewhere.
- `GO:query` is true of our output (records for one query are adjacent) and is information the BAM path was silently dropping.
- `VN:1.5` vs `VN:1.6` is not load-bearing: neither path emits any SAM 1.6-only construct.

Changing the SAM path to `VN:1.6` instead would have diverged further from bwa for no gain.

**Only the default changes.** A user `@HD` from `-H`, or one from the index sidecar, still wins on every path and is emitted unchanged. Consumers of the BAM header will see `VN:1.5` where they saw `VN:1.6`, plus a new `GO:query`; no tool keys on either.

## A nice consequence

`compat_target_t::hd_line` is no longer `NULL` on the `off` row. It was `NULL` to mean *"keep whatever that path emits"* — a state that existed **only because the paths disagreed**, and which forced every emission site to carry a fallback literal of its own. That is precisely how they drifted.

Now `off` pins the canonical string, the fallbacks are deleted, and the invariant collapses to `emit_hd` ⟹ `hd_line`. The unit test asserts it per row, both directions.

The BAM writers also switch from `sam_hdr_add_line`’s key/value form to `sam_hdr_add_lines` over the target’s exact text, so the string is spelled in one place rather than reassembled per writer.

## Test

`test/regression/default_hd_parity.sh` (new, wired into CI) asserts the default `@HD` is byte-identical across **SAM text, `--bam` and `--meth`** *and* equal to the expected literal — equality alone would pass if all three drifted together, and the literal alone would miss one path diverging on a field the test did not think to check.

Mutation-verified: restoring the pre-fix BAM literal makes it fail as intended.

```
default @HD by output path:
  SAM text     @HD\tVN:1.5\tSO:unsorted\tGO:query
  --bam        @HD\tVN:1.5\tSO:unsorted\tGO:query
  --meth       @HD\tVN:1.5\tSO:unsorted\tGO:query
PASS: default @HD is byte-identical across SAM text, --bam and --meth
```

Full local suite: 128/128 unit tests, `default_hd_parity.sh`, `compat_byte_identical.sh`, `header_parity.sh`, `meth_rg_header_test.sh`, `meth_sidecar_enrich_test.sh`, mdbook + linkcheck.

## Doc drift fixed

`docs/src/user-guide/output.md` documented the BAM path’s `VN:1.6` as *the* default; a comment in `test/meth_rg_header_test.sh` said the same. Both corrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standardized the default SAM `@HD` header as `VN:1.5`, `SO:unsorted`, and `GO:query` when no custom header is provided.
  - Ensured the same default header is emitted consistently for SAM, BAM, and methylation BAM output.

- **Documentation**
  - Clarified default header behavior, output consistency, and compatibility changes in the user guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->