### PR TITLE
refactor(header): one generated-@SQ builder, one scanner, one record iterator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,25 @@ on:
     branches: [main]
   pull_request:
 
+# Least-privilege GITHUB_TOKEN. Without this block the token inherits the
+# repository default, which -- depending on the org/repo setting -- can be
+# read/write across contents, issues, pull requests and more, far beyond what
+# any job here needs. Nothing in this workflow uses the token except
+# actions/checkout, so `contents: read` is the whole requirement:
+#
+#   - actions/upload-artifact and actions/cache authenticate with
+#     ACTIONS_RUNTIME_TOKEN, which the runner injects independently of
+#     `permissions:` -- they need no grant here.
+#   - codecov-action uploads tokenless (no `token:`/`use_oidc:` below), so it
+#     needs neither `id-token: write` nor a secret.
+#
+# release.yml is the counterexample worth keeping in view: it starts from
+# `permissions: {}` and grants `contents`/`pull-requests` write per job,
+# because its jobs genuinely differ. Here all three jobs need exactly
+# `contents: read`, so it is declared once at the workflow level.
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     strategy:
@@ -78,6 +97,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          # Do not leave the GITHUB_TOKEN in .git/config after checkout. The
+          # steps that follow run the repository's own build scripts and the
+          # vendored submodules' configure/make, none of which does any git
+          # operation needing auth -- so a persisted credential is reachable
+          # by that code for no benefit. `submodules: recursive` is unaffected;
+          # checkout authenticates the submodule fetch inline. profiling-build
+          # below already set this; all four checkouts now agree.
+          persist-credentials: false
           submodules: recursive
 
       - name: Install dependencies (Linux)
@@ -493,6 +520,11 @@ jobs:
         if: matrix.canonical == true
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          # Most important of the four: this is a THIRD-PARTY tree, and the
+          # steps below copy fixtures out of it and run test/regression scripts
+          # against it. Persisting this repository's token inside a foreign
+          # checkout's .git/config has no use here at all.
+          persist-credentials: false
           repository: brentp/bwa-meth
           path: bwa-meth-oracle
 
@@ -552,6 +584,15 @@ jobs:
           CHR22_SIM_DIR=/tmp/chr22-sim-dense \
           PIXI_MANIFEST="$GITHUB_WORKSPACE/test/holodeck/pixi.toml" \
           bash test/regression/short_read_smoke.sh
+          # Re-run the header regression against the SAME asan binary. The
+          # header writers size buffers from header text, and a one-byte
+          # overrun there changes no output byte, so the non-asan run of this
+          # script earlier in the row cannot see it -- only asan can. Cheap
+          # (it builds its own 3-contig ALT fixture) and it needs the samtools
+          # apt package this row already installs for `samtools dict`.
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          HEADER_PARITY_WORK_DIR=/tmp/header-parity-asan \
+          bash test/regression/header_parity.sh
 
   coverage:
     name: Coverage (Linux AVX2, gcov → Codecov)
@@ -560,6 +601,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install dependencies

--- a/docs/src/user-guide/indexing.md
+++ b/docs/src/user-guide/indexing.md
@@ -33,6 +33,18 @@ expect roughly 11 GB total across all four files.
 >
 > See [Coming from bwa or bwa-mem2](../getting-started/migrating.md).
 
+<!-- Separates adjacent blockquotes: a bare blank line between two of them is
+     ambiguous (markdownlint MD028) and some renderers fuse them into one. -->
+
+> **Note — ALT-aware references**
+>
+> If the reference has a `<prefix>.alt` file *and* a `<prefix>.hdr` /
+> `<baseprefix>.dict` header sidecar, `index` warns when the sidecar's `@SQ`
+> records lack `AH:*` on the ALT contigs — a Picard/GATK `.dict` never has
+> them. See [`@SQ` in Output](output.md#sq) for why, and how to fix it.
+
+<!-- Separates adjacent blockquotes -- see above. -->
+
 > **Note — no `.0123` by default**
 >
 > Earlier releases (and bwa-mem2) also wrote `ref.fa.0123`, an *unpacked*

--- a/docs/src/user-guide/output.md
+++ b/docs/src/user-guide/output.md
@@ -40,9 +40,44 @@ now agree, on the string upstream bwa uses.
 ### `@SQ`
 
 One `@SQ` line is written per reference sequence, with the sequence name
-(`SN:`) and length (`LN:`) derived from the FM-index. If the index was built
-with a `.dict` or `.hdr` file that supplies `@SQ` records, those records are
-used instead of the auto-generated ones.
+(`SN:`) and length (`LN:`) derived from the FM-index. Contigs listed in
+`<prefix>.alt` additionally get `AH:*`, marking them as alternate loci.
+
+If a `<prefix>.hdr` or `<baseprefix>.dict` file sits next to the index and
+supplies `@SQ` records, those records are used **verbatim** instead of the
+auto-generated ones. This is deliberate: the sidecar is authoritative, so
+bwa-mem3 neither adds nor removes tags in it.
+
+> **Warning — a Picard/GATK `.dict` drops `AH:*`**
+>
+> `picard CreateSequenceDictionary` has no notion of a `.alt` file, so the
+> `.dict` it writes carries no `AH` tag. Because the sidecar is used verbatim,
+> **ALT contigs lose their `AH:*` in the output header** — which matters to
+> anything that keys on it, notably `bwa-postalt.js` and ALT-aware duplicate
+> marking and QC.
+>
+> This bites the standard Broad reference layout, because the discovery order
+> is `<prefix>.hdr` then `<baseprefix>.dict` — so
+> `Homo_sapiens_assembly38.fasta` resolves to `Homo_sapiens_assembly38.dict`,
+> exactly the file the GATK resource bundle ships.
+>
+> Both `index` and `mem` warn when the index has ALT contigs and the sidecar's
+> `@SQ` has no `AH`. Two paths do not, because on them there is nothing to lose:
+> `mem --meth` (the doubled reference's contigs are `f`/`r`-prefixed and have no
+> ALT status of their own — `index --meth` still checks the real reference), and
+> `--compat=bwa-mem2`, which ignores the sidecar entirely and generates `@SQ`
+> with `AH:*` from the index.
+>
+> The fix is to regenerate the sidecar with the ALT list — `samtools dict` reads
+> a bwa-style `.alt` and emits `AH:*` for you:
+>
+> ```bash
+> samtools dict --alt ref.fasta.alt -o ref.dict ref.fasta
+> ```
+>
+> Alternatively, delete the sidecar and let bwa-mem3 generate `@SQ` itself,
+> which always emits `AH:*` — at the cost of the `M5`/`UR`/`AS`/`SP` metadata
+> the `.dict` carries.
 
 In methylation mode (`--meth`), the doubled reference contains sequences with
 an `f` or `r` prefix in their names. The inline BAM post-processor collapses

--- a/docs/src/whats-different/equivalence.md
+++ b/docs/src/whats-different/equivalence.md
@@ -143,11 +143,13 @@ Caveats:
   --compat=bwa-mem2` would produce a diff-clean-looking stream over genuinely different
   alignments. `--compat` is meaningful only on the drop-in profile.
 - **The sidecar `@SQ` is skipped, not rewritten.** Outside `--compat` the
-  `<prefix>.hdr` / `<baseprefix>.dict` block remains authoritative and is emitted verbatim —
-  it is a port of [lh3/bwa#348](https://github.com/lh3/bwa/pull/348), designed for the block
-  to be produced complete by an external tool. If your index has a `.alt` file, generate the
-  sidecar with `samtools dict --alt <ref>.alt` so `AH:*` is carried; bwa-mem3 warns when it
-  sees ALT contigs and a sidecar `@SQ` without `AH`.
+  `<prefix>.hdr` / `<baseprefix>.dict` block remains authoritative and is emitted verbatim.
+  On those sidecar-honoring paths — the default profile, `--bam` and `--meth` — an index with
+  a `.alt` file needs that block to carry `AH:*` itself, because nothing re-derives it from
+  the index; see [`@SQ` in Output](../user-guide/output.md#sq) for why, which commands warn,
+  and how to regenerate the sidecar. Under `--compat=bwa-mem2` the requirement does not
+  apply: the sidecar is ignored entirely and `AH:*` is generated from the index (the table
+  row above), so a sidecar missing `AH` cannot affect that output.
 - **`--compat=bwa-mem` is recognized but rejected.** bwa-mem3 and bwa still differ on 224 of
   63,583 records (53 above MAPQ 30) in MAPQ, CIGAR, POS and TLEN, so no amount of output
   shaping makes them byte-identical. Tracked separately.

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -10,6 +10,7 @@
 #include "sam_encode.h"
 #include "utils.h"
 
+#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -42,21 +43,9 @@ bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
     // @HD records, so emitting both would produce two @HD lines. The
     // caller (fastmap.cpp) has already nulled `idx_hdr_lines` when the
     // user's -H supplies @SQ, so if we see @SQ here, they're authoritative.
-    int idx_has_sq = 0, idx_has_hd = 0;
-    if (idx_hdr_lines != NULL && idx_hdr_lines[0] != '\0') {
-        if (strncmp(idx_hdr_lines, "@SQ\t", 4) == 0 ||
-            strstr(idx_hdr_lines, "\n@SQ\t") != NULL)
-            idx_has_sq = 1;
-        if (strncmp(idx_hdr_lines, "@HD\t", 4) == 0 ||
-            strstr(idx_hdr_lines, "\n@HD\t") != NULL)
-            idx_has_hd = 1;
-    }
-    int user_has_hd = 0;
-    if (hdr_line != NULL && hdr_line[0] != '\0') {
-        if (strncmp(hdr_line, "@HD\t", 4) == 0 ||
-            strstr(hdr_line, "\n@HD\t") != NULL)
-            user_has_hd = 1;
-    }
+    const int idx_has_sq  = bwa_hdr_text_has_type(idx_hdr_lines, "@SQ\t");
+    const int idx_has_hd  = bwa_hdr_text_has_type(idx_hdr_lines, "@HD\t");
+    const int user_has_hd = bwa_hdr_text_has_type(hdr_line, "@HD\t");
 
     sam_hdr_t *hdr = sam_hdr_init();
     if (hdr == NULL) return NULL;
@@ -75,24 +64,20 @@ bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
     if (!idx_has_hd && !user_has_hd && compat->emit_hd &&
         sam_hdr_add_lines(hdr, compat->hd_line, 0) < 0) goto fail;
     if (!idx_has_sq) {
+        // One shared formatter (bwa.cpp) rather than sam_hdr_add_line varargs:
+        // the @SQ contents -- including AH:* on ALT contigs -- are identical on
+        // every path, and this writer having its own spelling is how it came to
+        // silently drop AH for every ALT-aware reference (#281, fixed per-copy;
+        // #289 consolidates them). Not gated on `compat`: both upstreams emit
+        // this block, so it is correct output, not a divergence.
+        kstring_t sq = {0, 0, NULL};
         for (int i = 0; i < bns->n_seqs; ++i) {
-            char len_buf[32];
-            snprintf(len_buf, sizeof(len_buf), "%lld", (long long)bns->anns[i].len);
-            // AH:* on ALT contigs. Both upstreams emit it on the generated
-            // @SQ block (bwa/bwa.c:432, bwa-mem2/src/bwa.cpp:538) and so does
-            // our SAM text path (bwa.cpp); this writer was ported as an
-            // SN+LN-only loop and silently dropped it for EVERY ALT-aware
-            // reference, sidecar or not. `is_alt` comes from <prefix>.alt via
-            // bwa_idx_load and has no representation in an htslib sam_hdr_t,
-            // so it must be re-applied here. Not gated on `compat`: it is what
-            // both upstreams do, so it is correct output, not a divergence.
-            int rc = bns->anns[i].is_alt
-                   ? sam_hdr_add_line(hdr, "SQ", "SN", bns->anns[i].name,
-                                      "LN", len_buf, "AH", "*", NULL)
-                   : sam_hdr_add_line(hdr, "SQ", "SN", bns->anns[i].name,
-                                      "LN", len_buf, NULL);
-            if (rc < 0) goto fail;
+            sq.l = 0;                      // reuse the buffer across contigs
+            if (bwa_format_sq_line(&sq, &bns->anns[i]) < 0) { free(sq.s); goto fail; }
+            int rc = sam_hdr_add_lines(hdr, sq.s, sq.l);
+            if (rc < 0) { free(sq.s); goto fail; }
         }
+        free(sq.s);
     }
     // Merge the index's .hdr/.dict records after the default @HD (and
     // auto-generated @SQ, when the index didn't supply its own) but before
@@ -108,22 +93,33 @@ bam_writer_t *bam_writer_open(const char *path, const bntseq_t *bns,
             const int keep_first_hd = !user_has_hd;
             int seen_hd = 0;
             // Copy idx_hdr_lines, dropping the losing @HD records.
+            //
+            // n + 2, not n + 1: the loop below writes a '\n' after EVERY record
+            // it keeps, but bwa_load_hdr_from_index strips the trailing newline
+            // from the text it returns, so `n` counts one separator fewer than
+            // the loop emits. Keeping every record of unterminated text
+            // therefore needs n + 1 bytes plus the NUL -- the exact case a
+            // sidecar with one @HD and no user -H produces, which overflowed
+            // this buffer by one byte on every such run.
             size_t n = strlen(idx_hdr_lines);
-            filtered = (char *)malloc(n + 1);
+            filtered = (char *)malloc(n + 2);
             if (filtered == NULL) goto fail;
             size_t w = 0;
-            const char *p = idx_hdr_lines;
-            while (*p) {
-                const char *eol = strchr(p, '\n');
-                size_t len = eol ? (size_t)(eol - p) : strlen(p);
-                int is_hd = (len >= 4 && strncmp(p, "@HD\t", 4) == 0);
+            const char *cur = idx_hdr_lines, *line; size_t len;
+            while (bwa_hdr_next_line(&cur, &line, &len)) {
+                int is_hd = (len >= 4 && strncmp(line, "@HD\t", 4) == 0);
                 if (len > 0 && (!is_hd || (keep_first_hd && !seen_hd))) {
-                    memcpy(filtered + w, p, len); w += len;
+                    memcpy(filtered + w, line, len); w += len;
                     filtered[w++] = '\n';
                 }
                 if (is_hd) seen_hd = 1;
-                p = eol ? eol + 1 : p + len;
             }
+            /* The n + 2 bound above is derived from bwa_hdr_next_line never
+             * yielding a phantom empty final record. Pin that derivation here:
+             * if the iterator's trailing-newline handling ever changes, this
+             * trips in a debug/ASAN build instead of silently overflowing the
+             * buffer by one byte again. */
+            assert(w <= n + 1);
             filtered[w] = '\0';
             to_add = filtered;
         }

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -591,46 +591,130 @@ static const char *hoist_line(const char *lines, FILE *fp)
 static void fputs_filtering_HD(const char *lines, int keep_first_HD, FILE *fp)
 {
     int seen_HD = 0;
-    for (const char *p = lines; *p != '\0'; ) {
-        const char *eol = strchr(p, '\n');
-        const size_t len = eol ? (size_t)(eol - p) : strlen(p);
-        const int is_HD = (len >= 4 && strncmp(p, "@HD\t", 4) == 0);
+    const char *cur = lines, *line; size_t len;
+    while (bwa_hdr_next_line(&cur, &line, &len)) {
+        const int is_HD = (len >= 4 && strncmp(line, "@HD\t", 4) == 0);
         if (len > 0 && (!is_HD || (keep_first_HD && !seen_HD))) {
-            err_fwrite(p, 1, len, fp);
+            err_fwrite(line, 1, len, fp);
             err_fputc('\n', fp);
         }
         if (is_HD) seen_HD = 1;
-        p = eol ? eol + 1 : p + len;
     }
+}
+
+/* Iterate the records of newline-separated SAM header text.
+ *
+ * Start with *p at the beginning of the text. Each call sets *line/*len to the
+ * next record (newline excluded), advances *p past it, and returns 1; returns 0
+ * at end of text. Text with or without a trailing newline both yield exactly
+ * the records present -- no phantom empty final record.
+ *
+ * Exists because this exact walk -- strchr('\n'), length, advance-or-stop --
+ * was hand-rolled in six places across three files (fg-labs/bwa-mem3#289),
+ * each subtly its own; all six now call here. Callers that care about empty
+ * records must still skip them; the iterator reports what is there.
+ *
+ *     const char *p = hdr_text, *line; size_t len;
+ *     while (bwa_hdr_next_line(&p, &line, &len)) { ... }
+ */
+int bwa_hdr_next_line(const char **p, const char **line, size_t *len)
+{
+    if (p == NULL || *p == NULL || **p == '\0') return 0;
+    const char *start = *p;
+    const char *eol = strchr(start, '\n');
+    *line = start;
+    *len  = eol ? (size_t)(eol - start) : strlen(start);
+    *p    = eol ? eol + 1 : start + *len;      /* lands on the NUL when no eol */
+    return 1;
+}
+
+/* Format the generated @SQ record for contig `ann` into `out` (appended, no
+ * trailing newline). Returns 0, or -1 if `out` could not be grown.
+ *
+ * ONE definition on purpose. This record used to be built independently in
+ * three writers -- snprintf+err_fputs here, sam_hdr_add_line varargs in
+ * bam_writer.cpp, ksprintf in meth_bam.cpp -- and they drifted: AH:* was
+ * correct only in this copy, so --bam and --meth lost ALT status for every
+ * ALT-aware reference until each copy was fixed separately
+ * (fg-labs/bwa-mem3#281); consolidating them so it cannot recur again is
+ * fg-labs/bwa-mem3#289. The three sinks all accept SAM header TEXT, so there
+ * is no reason for three spellings.
+ *
+ * Contents match what bwa (bwa.c:430-433) and bwa-mem2 (bwa.cpp:535-548) emit.
+ * The DECISION to emit is deliberately NOT here -- each writer gates it
+ * differently (-H precedence, sidecar precedence, --meth always-emit) and that
+ * is genuine per-path policy.
+ *
+ * Uses kstring rather than a fixed buffer: the old snprintf into char[512]
+ * truncated silently on a long contig name. The one cost of that is that the
+ * append can now fail, and ksprintf/kputs swallow their own failures -- so the
+ * worst case is reserved up front and the status returned, the same way the
+ * MC:Z and SA:Z builders in bam_writer.cpp handle it. Without this, a caller
+ * has no way to tell a failed append from a formatted record and would emit
+ * (or fputs) a NULL or truncated one. */
+int bwa_format_sq_line(kstring_t *out, const bntann1_t *ann)
+{
+    /* "@SQ\tSN:" + name + "\tLN:" + int + "\tAH:*" + NUL: 7 + 4 + 11 + 5 + 1,
+     * rounded up. Pre-sized, the appends below cannot need to grow `out`.
+     *
+     * The failure test is on `out` rather than a return value because this file
+     * uses bwa's kstring.h, whose ks_resize is void and leaves s->s NULL when
+     * the realloc fails -- not htslib's, which returns a status. (bam_writer.cpp
+     * gets htslib's and can check directly; see the MC:Z path there.) */
+    const size_t need = out->l + strlen(ann->name) + 32;
+    ks_resize(out, need);
+    if (out->s == NULL || out->m < need) return -1;
+    ksprintf(out, "@SQ\tSN:%s\tLN:%d", ann->name, ann->len);
+    /* AH:* marks an alternate locus. `is_alt` comes from <prefix>.alt via
+     * bwa_idx_load and has no representation in an htslib sam_hdr_t, so every
+     * writer must re-apply it from bns rather than expect it to survive. */
+    if (ann->is_alt) kputs("\tAH:*", out);
+    return 0;
+}
+
+/* True if the SAM header text `s` contains a record whose type is `tag` (e.g.
+ * "@HD\t"), either as the first line or following a newline. Hoisted out of
+ * meth_bam.cpp, where it was static, so the BAM writers stop open-coding it.
+ *
+ * `tag` is any NUL-terminated prefix, not specifically a 4-character "@XX\t" --
+ * hence the name, rather than the `tag4` this carried while it was static with
+ * two 4-character call sites.
+ *
+ * Implemented on the record iterator rather than as a strstr for "\n" + tag.
+ * The needle form needs a fixed buffer, and this is public now: a caller
+ * passing a longer type than the buffer holds would have its tag silently
+ * truncated and get a wrong answer instead of no match. Walking records has no
+ * length ceiling, and it keeps this file to one scanner. */
+int bwa_hdr_text_has_type(const char *s, const char *tag)
+{
+    if (s == NULL || tag == NULL) return 0;
+    const size_t n = strlen(tag);
+    if (n == 0) return 0;
+    const char *cur = s, *line; size_t len;
+    while (bwa_hdr_next_line(&cur, &line, &len))
+        if (len >= n && strncmp(line, tag, n) == 0) return 1;
+    return 0;
 }
 
 // Return 1 iff `lines` contains any @SQ header records.
 static int has_SQ(const char *lines)
 {
-    if (lines == NULL) return 0;
-    if (strncmp(lines, "@SQ\t", 4) == 0) return 1;
-    return strstr(lines, "\n@SQ\t") != NULL;
+    return bwa_hdr_text_has_type(lines, "@SQ\t");
 }
 
 // Return 1 iff `lines` contains an @HD record (first line, or after a newline).
 static int has_HD(const char *lines)
 {
-    if (lines == NULL) return 0;
-    if (strncmp(lines, "@HD\t", 4) == 0) return 1;
-    return strstr(lines, "\n@HD\t") != NULL;
+    return bwa_hdr_text_has_type(lines, "@HD\t");
 }
 
 // Count the number of @SQ header records in `lines`.
 static int count_SQ(const char *lines)
 {
     int n_SQ = 0;
-    if (lines) {
-        const char *p = lines;
-        while ((p = strstr(p, "@SQ\t")) != 0) {
-            if (p == lines || *(p - 1) == '\n') ++n_SQ;
-            p += 4;
-        }
-    }
+    const char *cur = lines, *line; size_t len;
+    while (bwa_hdr_next_line(&cur, &line, &len))
+        if (len >= 4 && strncmp(line, "@SQ\t", 4) == 0) ++n_SQ;
     return n_SQ;
 }
 
@@ -704,32 +788,43 @@ void bwa_warn_sidecar_missing_AH(const bntseq_t *bns, const char *idx_hdr_lines,
      * already reported by the @SQ-count mismatch warning in
      * bwa_print_sam_hdr2 ("N @SQ lines loaded from index; M sequences"). */
     int n_missing = 0, first_id = -1;
-    for (const char *line = idx_hdr_lines; *line != '\0'; ) {
-        const char *eol = strchr(line, '\n');
-        const size_t line_len = eol ? (size_t)(eol - line) : strlen(line);
+    const char *cur = idx_hdr_lines, *line; size_t line_len;
+    /* kh_get needs a NUL-terminated key and `sn` points into the header text, so
+     * each SN has to be copied out. One reusable buffer grown to the longest SN
+     * seen, NOT a fixed 256-byte stack array: contig names are strdup()ed from
+     * the FASTA/.ann name (bntseq.cpp) with no length bound, so a long-named ALT
+     * contig CAN exist in bns. Capping the copy silently skipped exactly those
+     * records, which is the case this check exists for -- an ALT contig whose
+     * sidecar @SQ lacks AH got no warning. It grows a handful of times at most
+     * (monotonically), so the single-pass cost the comment above is about is
+     * unchanged. */
+    char *name = NULL; size_t name_cap = 0;
+    while (bwa_hdr_next_line(&cur, &line, &line_len)) {
         const char *sn = NULL; size_t sn_len = 0; int has_ah = 0;
         if (sq_scan(line, line_len, &sn, &sn_len, &has_ah) && !has_ah) {
-            /* kh_get needs a NUL-terminated key and `sn` points into the
-             * header text. A name too long to fit cannot match a bns name
-             * either, so skipping it loses nothing -- but say so rather than
-             * dropping an @SQ record silently. */
-            char name[256];
-            if (sn_len >= sizeof(name)) {
-                if (bwa_verbose >= 3)
-                    fprintf(stderr, "[W::%s] sidecar @SQ has an SN of %zu bytes "
-                            "(max %zu); skipped in the ALT/AH check.\n",
-                            __func__, sn_len, sizeof(name) - 1);
-            } else {
-                memcpy(name, sn, sn_len);
-                name[sn_len] = '\0';
-                khiter_t k = kh_get(sqname, alt, name);
-                /* Report bns's copy of the name, not the stack buffer. */
-                if (k != kh_end(alt) && n_missing++ == 0) first_id = kh_val(alt, k);
+            if (sn_len + 1 > name_cap) {
+                char *tmp = (char *)realloc(name, sn_len + 1);
+                if (tmp == NULL) {
+                    /* Degrade rather than abort: this function only produces a
+                     * diagnostic, so failing the run over it would be worse than
+                     * losing it. Say that it was lost. */
+                    if (bwa_verbose >= 2)
+                        fprintf(stderr, "[W::%s] out of memory checking the "
+                                "sidecar for ALT/AH; check skipped.\n", __func__);
+                    free(name);
+                    kh_destroy(sqname, alt);
+                    return;
+                }
+                name = tmp; name_cap = sn_len + 1;
             }
+            memcpy(name, sn, sn_len);
+            name[sn_len] = '\0';
+            khiter_t k = kh_get(sqname, alt, name);
+            /* Report bns's copy of the name, not the scratch buffer. */
+            if (k != kh_end(alt) && n_missing++ == 0) first_id = kh_val(alt, k);
         }
-        if (eol == NULL) break;
-        line = eol + 1;
     }
+    free(name);
     kh_destroy(sqname, alt);
     if (n_missing == 0) return;
     const char *first = bns->anns[first_id].name;
@@ -793,14 +888,19 @@ static void print_sam_hdr(const bntseq_t *bns, const char *bns_hdr,
 
     // Generate @SQ from bns only when neither hdr_line nor bns_hdr supply any.
     if (n_SQ == 0 && !has_SQ(bns_hdr)) {
+        kstring_t sq = {0, 0, NULL};
         for (i = 0; i < bns->n_seqs; ++i) {
-            char buf[512];
-            snprintf(buf, sizeof(buf), "@SQ\tSN:%s\tLN:%d",
-                     bns->anns[i].name, bns->anns[i].len);
-            err_fputs(buf, fp);
-            if (bns->anns[i].is_alt) err_fputs("\tAH:*\n", fp);
-            else                     err_fputc('\n', fp);
+            sq.l = 0;                      /* reuse the buffer across contigs */
+            /* Fatal, like every other write failure on this path (err_fputs
+             * aborts): a header missing contigs is not a usable output, and
+             * this function has no way to report a partial one to its caller. */
+            if (bwa_format_sq_line(&sq, &bns->anns[i]) < 0)
+                err_fatal(__func__, "failed to allocate the @SQ record for contig %s",
+                          bns->anns[i].name);
+            err_fputs(sq.s, fp);
+            err_fputc('\n', fp);
         }
+        free(sq.s);
     }
 
     if (n_SQ != 0 && n_SQ != bns->n_seqs && bwa_verbose >= 2)

--- a/src/bwa.h
+++ b/src/bwa.h
@@ -38,6 +38,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "bwt.h"
 #include "macro.h"
 #include "compat_target.h"
+#include "kstring.h"
 #include "read_arena.h"
 
 #define BWA_IDX_BWT 0x1
@@ -158,6 +159,20 @@ extern "C" {
 	void bwa_print_sam_hdr2(const bntseq_t *bns, const char *idx_hdr_lines,
 	                        const char *hdr_line, FILE *fp,
 	                        const compat_target_t *compat);
+	/* Append the generated @SQ record for `ann` (SN, LN, and AH:* when the
+	 * contig is ALT) to `out`, without a trailing newline. The single
+	 * definition shared by the SAM-text, --bam and --meth writers. Returns 0,
+	 * or -1 if `out` could not be grown -- on -1 no record was appended and
+	 * `out->s` may be NULL, so callers must not emit `out`. */
+	int bwa_format_sq_line(kstring_t *out, const bntann1_t *ann);
+	/* True if SAM header text `s` contains a record whose type is `tag`
+	 * ("@HD\t", "@SQ\t", ...), as the first line or after a newline. The type
+	 * may be any length; an empty one matches nothing. */
+	int bwa_hdr_text_has_type(const char *s, const char *tag);
+	/* Iterate newline-separated SAM header records. Start with *p at the text;
+	 * sets *line/*len to the next record (no newline) and advances *p, returning
+	 * 1, or returns 0 at end of text. */
+	int bwa_hdr_next_line(const char **p, const char **line, size_t *len);
 	char *bwa_load_hdr_from_index(const char *prefix);
 	/* Warn (at bwa_verbose >= 2) when the index marks contigs ALT but the
 	 * sidecar's @SQ block carries no AH for them. The sidecar is authoritative

--- a/src/bwtindex.cpp
+++ b/src/bwtindex.cpp
@@ -273,6 +273,34 @@ static void index_usage(void)
 	        "  -h, --help         print this help message and exit\n");
 }
 
+/* Report, at index time, the ALT/AH gap `mem` also reports -- see
+ * bwa_warn_sidecar_missing_AH (bwa.cpp) for why a sidecar's @SQ is emitted
+ * verbatim rather than enriched. Worth saying here as well: this is when the
+ * reference layout is in front of the user and regenerating the sidecar still
+ * costs nothing, whereas `mem` reports it only once an alignment is running.
+ *
+ * `mem` remains the authoritative check -- the .alt and the sidecar are both
+ * optional and either may be dropped in after indexing, so a quiet `index` is
+ * not a guarantee.
+ *
+ * The .alt existence test is what makes this cheap: with no .alt no contig can
+ * be ALT, so the check is provably a no-op, and skipping it avoids reading the
+ * sidecar and the .ann/.amb (~1 MB on hg38) to reach that conclusion. */
+static void warn_if_sidecar_hides_alt(const char *prefix)
+{
+	char alt_path[PATH_MAX];
+	int n = snprintf(alt_path, sizeof(alt_path), "%s.alt", prefix);
+	if (n <= 0 || (size_t)n >= sizeof(alt_path)) return;
+	if (access(alt_path, F_OK) != 0) return;
+
+	char *idx_hdr = bwa_load_hdr_from_index(prefix);   /* NULL when no sidecar */
+	if (idx_hdr == NULL) return;
+	bntseq_t *bns = bns_restore(prefix);               /* applies .alt -> is_alt */
+	bwa_warn_sidecar_missing_AH(bns, idx_hdr, prefix); /* no-ops on a NULL bns */
+	bns_destroy(bns);                                  /* NULL-safe */
+	free(idx_hdr);
+}
+
 int bwa_index(int argc, char *argv[]) // the "index" command
 {
 	int c;
@@ -383,11 +411,20 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 			fprintf(stderr, "ERROR: --meth does not accept -p (outputs <in.fasta>.* and <in.fasta>.meth.*)\n");
 			return 1;
 		}
-		return meth_index_build(argv[optind], emit_unpacked_ref,
-		                       resolved_mem, user_max_memory > 0);
+		int rc = meth_index_build(argv[optind], emit_unpacked_ref,
+		                         resolved_mem, user_max_memory > 0);
+		/* The real reference only. The `.meth` seed index has no .alt of its own
+		 * and its contigs are f/r-prefixed, so it can never have ALT status to
+		 * lose -- the same reason `mem` skips this check in meth mode
+		 * (fastmap.cpp). Stating it here beats relying on the seed prefix
+		 * happening not to resolve a sidecar. */
+		if (rc == 0) warn_if_sidecar_hides_alt(argv[optind]);
+		return rc;
 	}
 	if (prefix == 0) prefix = argv[optind];
-	return bwa_idx_build(argv[optind], prefix, emit_unpacked_ref);
+	int rc = bwa_idx_build(argv[optind], prefix, emit_unpacked_ref);
+	if (rc == 0) warn_if_sidecar_hides_alt(prefix);
+	return rc;
 }
 
 int bwa_idx_build(const char *fa, const char *prefix, int emit_unpacked_ref)

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -2277,12 +2277,8 @@ int main_mem(int argc, char *argv[])
         extern char *bwa_pg;
         /* Suppress idx .hdr/.dict records entirely when the user's -H
          * supplies any @SQ, matching bwa_print_sam_hdr2's SAM precedence. */
-        const char *bam_idx_hdr = idx_hdr_lines;
-        if (hdr_line != NULL) {
-            if (strncmp(hdr_line, "@SQ\t", 4) == 0 ||
-                strstr(hdr_line, "\n@SQ\t") != NULL)
-                bam_idx_hdr = NULL;
-        }
+        const char *bam_idx_hdr = bwa_hdr_text_has_type(hdr_line, "@SQ\t")
+                                ? NULL : idx_hdr_lines;
         bam_writer = bam_writer_open(bam_path, aux.fmi->idx->bns,
                                      bam_idx_hdr, hdr_line,
                                      bwa_pg, opt->bam_level, opt->compat);

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -37,22 +37,6 @@ static void sanitize_cl(char *s)
     for (; *s; ++s) if (*s == '\t') *s = ' ';
 }
 
-/* True if the SAM header text `s` contains a line whose type is `tag4`
- * (e.g. "@HD\t"): either as the first line or following a newline. Used to
- * avoid emitting a default @HD when the user's -H already supplies one —
- * htslib's sam_hdr_add_lines does not de-dup @HD records, so two would be
- * written. Mirrors the same guard in bam_writer.cpp's default path. */
-static int hdr_text_has_type(const char *s, const char *tag4)
-{
-    if (s == NULL || s[0] == '\0') return 0;
-    size_t n = strlen(tag4);
-    if (strncmp(s, tag4, n) == 0) return 1;
-    char needle[8] = "\n";
-    /* tag4 is always 4 chars ("@XX\t"); "\n" + tag4 fits in 8. */
-    strncpy(needle + 1, tag4, sizeof(needle) - 2);
-    return strstr(s, needle) != NULL;
-}
-
 /* True if the tab-delimited @SQ `line` (length `line_len`) carries a token
  * exactly equal to `key``val` (whole token, not a prefix) — e.g. key="SN:"
  * val="<name>", or key="LN:" val="<decimal>". */
@@ -84,27 +68,29 @@ static int sq_line_has_kv(const char *line, size_t line_len,
  * whose M5/UR would misidentify the sequence, so nothing is appended in that
  * case. Appends nothing if `hdr_text` is NULL/empty or has no matching @SQ.
  * SN is unique in a valid header, so the first match wins. */
-static void meth_append_sq_extra_tags(const char *hdr_text, const char *sn,
-                                      int64_t expected_len, kstring_t *out)
+/* Returns 0 on success (including "nothing to append"), -1 if a kstring append
+ * failed. The caller must not add the @SQ line on -1: `out` would be a
+ * truncated record, and emitting a header line missing half its identity tags
+ * is worse than failing the open. */
+static int meth_append_sq_extra_tags(const char *hdr_text, const char *sn,
+                                     int64_t expected_len, kstring_t *out)
 {
-    if (hdr_text == NULL || hdr_text[0] == '\0' || sn == NULL) return;
+    if (hdr_text == NULL || hdr_text[0] == '\0' || sn == NULL) return 0;
     static const char *const WANT[] = { "M5:", "UR:", "AS:", "SP:" };
     const int n_want = (int)(sizeof(WANT) / sizeof(WANT[0]));
     const size_t sn_len = strlen(sn);
     char ln_buf[32];
     int ln_len = snprintf(ln_buf, sizeof(ln_buf), "%lld", (long long)expected_len);
-    if (ln_len <= 0 || (size_t)ln_len >= sizeof(ln_buf)) return;
+    if (ln_len <= 0 || (size_t)ln_len >= sizeof(ln_buf)) return 0;
 
-    const char *line = hdr_text;
-    while (*line != '\0') {
-        const char *eol = strchr(line, '\n');
-        size_t line_len = eol ? (size_t)(eol - line) : strlen(line);
+    const char *cur = hdr_text, *line; size_t line_len;
+    while (bwa_hdr_next_line(&cur, &line, &line_len)) {
         if (line_len >= 4 && strncmp(line, "@SQ\t", 4) == 0 &&
             sq_line_has_kv(line, line_len, "SN:", 3, sn, sn_len)) {
             /* SN matched: only enrich when LN agrees, else the sidecar is
              * stale/foreign and its identity tags can't be trusted. */
             if (!sq_line_has_kv(line, line_len, "LN:", 3, ln_buf, (size_t)ln_len))
-                return;
+                return 0;
             const char *end = line + line_len;
             const char *p = line + 3;
             while (p < end) {
@@ -113,41 +99,42 @@ static void meth_append_sq_extra_tags(const char *hdr_text, const char *sn,
                 if (tok_end == NULL) tok_end = end;
                 for (int i = 0; i < n_want; ++i) {
                     if ((size_t)(tok_end - tok) > 3 && strncmp(tok, WANT[i], 3) == 0) {
-                        kputc('\t', out);
-                        kputsn(tok, (int)(tok_end - tok), out);
+                        if (kputc('\t', out) < 0 ||
+                            kputsn(tok, (int)(tok_end - tok), out) < 0)
+                            return -1;
                         break;
                     }
                 }
                 p = tok_end;
             }
-            return;                           /* SN is unique; first match wins */
+            return 0;                         /* SN is unique; first match wins */
         }
-        if (eol == NULL) break;
-        line = eol + 1;
     }
+    return 0;
 }
 
 /* Append to `out` every record line of `hdr_text` that is NOT @HD or @SQ
  * (i.e. @CO/@PG/@RG and any others), each terminated by '\n'. @SQ is skipped
  * because the consolidated @SQ block is authoritative (its identity tags are
  * merged separately by meth_append_sq_extra_tags); @HD is skipped because the
- * writer emits its own. */
-static void meth_append_passthrough_records(const char *hdr_text, kstring_t *out)
+ * writer emits its own.
+ *
+ * Returns 0 on success, -1 if a kstring append failed -- the same contract as
+ * meth_append_sq_extra_tags above, and for the same reason: on -1 `out` holds a
+ * truncated record set, so the caller must not pass it to sam_hdr_add_lines. */
+static int meth_append_passthrough_records(const char *hdr_text, kstring_t *out)
 {
-    if (hdr_text == NULL) return;
-    const char *line = hdr_text;
-    while (*line != '\0') {
-        const char *eol = strchr(line, '\n');
-        size_t line_len = eol ? (size_t)(eol - line) : strlen(line);
+    if (hdr_text == NULL) return 0;
+    const char *cur = hdr_text, *line; size_t line_len;
+    while (bwa_hdr_next_line(&cur, &line, &line_len)) {
         int skip = (line_len >= 4 && (strncmp(line, "@HD\t", 4) == 0 ||
                                       strncmp(line, "@SQ\t", 4) == 0));
         if (!skip && line_len > 0) {
-            kputsn(line, (int)line_len, out);
-            kputc('\n', out);
+            if (kputsn(line, (int)line_len, out) < 0 || kputc('\n', out) < 0)
+                return -1;
         }
-        if (eol == NULL) break;
-        line = eol + 1;
     }
+    return 0;
 }
 
 meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
@@ -181,7 +168,7 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
      * and OFF's hd_line IS BWAMEM3_DEFAULT_HD_LINE. A future target that
      * relaxes the --meth exclusion must plumb compat->emit_hd/hd_line through
      * here too. */
-    if (!hdr_text_has_type(hdr_line, "@HD\t") &&
+    if (!bwa_hdr_text_has_type(hdr_line, "@HD\t") &&
         sam_hdr_add_lines(w->hdr, BWAMEM3_DEFAULT_HD_LINE, 0) < 0) goto fail;
 
     /* @SQ directly from the ORIGINAL (un-converted) bns contigs (D3 PR-5: no
@@ -197,16 +184,25 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
      * the sidecar enrichment: meth_append_sq_extra_tags copies only
      * M5/UR/AS/SP, never AH. Appended BEFORE those tags so the line reads
      * SN, LN, AH, then identity tags -- the order bwa emits. */
-    for (int i = 0; i < bns->n_seqs; ++i) {
+    {
         kstring_t sq = {0, 0, NULL};
-        ksprintf(&sq, "@SQ\tSN:%s\tLN:%lld",
-                 bns->anns[i].name, (long long)bns->anns[i].len);
-        if (bns->anns[i].is_alt) kputs("\tAH:*", &sq);
-        meth_append_sq_extra_tags(orig_idx_hdr_lines, bns->anns[i].name,
-                                  bns->anns[i].len, &sq);
-        int rc = (sq.s != NULL) ? sam_hdr_add_lines(w->hdr, sq.s, sq.l) : -1;
+        for (int i = 0; i < bns->n_seqs; ++i) {
+            sq.l = 0;                    /* reuse the buffer across contigs */
+            if (bwa_format_sq_line(&sq, &bns->anns[i]) < 0) { free(sq.s); goto fail; }
+            if (meth_append_sq_extra_tags(orig_idx_hdr_lines, bns->anns[i].name,
+                                          bns->anns[i].len, &sq) < 0) {
+                free(sq.s);
+                goto fail;
+            }
+            /* No `sq.s != NULL` guard: that check existed because the old
+             * inline ksprintf could leave sq.s NULL with no way to say so.
+             * bwa_format_sq_line reports that as -1 above, and a failed
+             * enrichment append is reported as -1 too -- so by here sq holds a
+             * complete record. bam_writer.cpp's copy of this loop never had it. */
+            int rc = sam_hdr_add_lines(w->hdr, sq.s, sq.l);
+            if (rc < 0) { free(sq.s); goto fail; }
+        }
         free(sq.s);
-        if (rc < 0) goto fail;
     }
 
     /* Original reference's non-@HD/@SQ sidecar records (@CO/@PG/@RG),
@@ -219,7 +215,10 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
      * contigs) is never consulted. */
     if (orig_idx_hdr_lines != NULL && orig_idx_hdr_lines[0] != '\0') {
         kstring_t pt = {0, 0, NULL};
-        meth_append_passthrough_records(orig_idx_hdr_lines, &pt);
+        if (meth_append_passthrough_records(orig_idx_hdr_lines, &pt) < 0) {
+            free(pt.s);
+            goto fail;
+        }
         int rc = (pt.l > 0) ? sam_hdr_add_lines(w->hdr, pt.s, pt.l) : 0;
         free(pt.s);
         if (rc < 0) goto fail;

--- a/test/index_alt_sidecar_warn_test.sh
+++ b/test/index_alt_sidecar_warn_test.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# test/index_alt_sidecar_warn_test.sh
+#
+# Asserts that `bwa-mem3 index` reports the ALT/AH gap: the reference has ALT
+# contigs (via <prefix>.alt) but the header sidecar (<baseprefix>.dict /
+# <prefix>.hdr) supplies @SQ records with no AH tag.
+#
+# Why this matters: the sidecar's @SQ is authoritative by design (a port of
+# lh3/bwa#348), so bwa-mem3 emits it verbatim and does NOT inject AH:*. A
+# Picard/GATK-style .dict carries no AH -- Picard has no notion of a .alt file
+# -- so the standard Broad reference layout silently loses ALT status from every
+# output header. `mem` reports this too; indexing is the earlier place to hear
+# it, when the remedy (`samtools dict --alt`) still costs nothing.
+#
+# Scope: this covers the `index` call site -- that it is reached, and that it
+# stays quiet in each of the three ways it should (no sidecar, no ALT contig,
+# sidecar already carrying AH). Every case that reads a sidecar runs against
+# both names bwa_load_hdr_from_index accepts (<prefix>.hdr and
+# <baseprefix>.dict), plus one case pinning that .hdr wins when both exist.
+# The remaining gating inside bwa_warn_sidecar_missing_AH (--compat, the --bam
+# path) is covered at `mem` level by test/regression/header_parity.sh, which
+# uses a real `samtools dict --alt` sidecar rather than a hand-written one.
+# This script deliberately needs no samtools, so it runs on every CI leg.
+#
+# Usage: test/index_alt_sidecar_warn_test.sh <bwa-mem3-binary>
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <bwa-mem3-binary>" >&2
+    exit 2
+fi
+
+bin="$1"
+[[ -x "$bin" ]] || { echo "FAIL: bwa-mem3 binary not executable at $bin" >&2; exit 1; }
+
+fail () {  # $1 = stderr file to dump, $2... = message
+    local err="$1"; shift
+    echo "FAIL [index alt sidecar warn]: $*" >&2
+    echo "--- index stderr:" >&2
+    cat "$err" >&2
+    exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+ALT_SN="chrX_KI000001v1_alt"
+# The warning is emitted by bwa_warn_sidecar_missing_AH (src/bwa.cpp); match its
+# text, not a bare "ALT", so the assertion cannot pass on unrelated output.
+WARN_RE="sidecar supplies @SQ without an AH tag"
+
+# One line per sequence: `fold` drops the final newline when the length is not a
+# multiple of the width, gluing the next '>' onto the sequence -- silently, and
+# the index then builds with a single contig.
+emit_contig () {  # $1 = name, $2 = length
+    printf '>%s\n' "$1"
+    head -c "$2" /dev/zero | tr '\0' 'A'
+    printf '\n'
+}
+
+make_ref () {  # $1 = destination fasta
+    {
+        emit_contig chr1      2000
+        emit_contig chr2      1500
+        emit_contig "$ALT_SN" 1000
+    } > "$1"
+}
+
+# Picard/GATK-style sequence dictionary (SN/LN/M5/AS/UR/SP) -- what
+# CreateSequenceDictionary emits and what the Broad bundle ships as
+# <basename>.dict. $2 appends tags to the ALT record: '' for Picard (no AH).
+write_dict () {  # $1 = destination sidecar, $2 = extra tags on the ALT record
+    {
+        printf '@HD\tVN:1.5\tSO:unsorted\n'
+        printf '@SQ\tSN:chr1\tLN:2000\tM5:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tAS:test\tUR:file:/refs/ref.fa\tSP:synthetic\n'
+        printf '@SQ\tSN:chr2\tLN:1500\tM5:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\tAS:test\tUR:file:/refs/ref.fa\tSP:synthetic\n'
+        printf '@SQ\tSN:%s\tLN:1000\tM5:cccccccccccccccccccccccccccccccc\tAS:test\tUR:file:/refs/ref.fa\tSP:synthetic%s\n' \
+            "$ALT_SN" "${2-}"
+    } > "$1"
+}
+
+# bwa_load_hdr_from_index (src/bwa.cpp) resolves <prefix>.hdr FIRST and only
+# falls back to <baseprefix>.dict. Both names must therefore be exercised: a
+# regression in either lookup leaves the other passing. For `index ref.fa` the
+# prefix is `ref.fa`, so the two names are `ref.fa.hdr` and `ref.dict`.
+SIDECAR_KINDS=(dict hdr)
+
+# Assigns the path to the global SIDECAR rather than printing it: a `$(...)`
+# substitution runs in a subshell, where the unknown-kind `exit` below would
+# kill only that subshell and leave the script running with an empty path.
+set_sidecar () {  # $1 = case dir, $2 = kind (dict|hdr)
+    case "$2" in
+        dict) SIDECAR="$1/ref.dict"   ;;   # <baseprefix>.dict, the fallback
+        hdr)  SIDECAR="$1/ref.fa.hdr" ;;   # <prefix>.hdr, tried first
+        *)    echo "internal error: unknown sidecar kind '$2'" >&2; exit 2 ;;
+    esac
+}
+
+write_alt () {  # $1 = destination .alt
+    printf '%s\t0\tchr1\t1\t60\t1000M\t*\t0\t0\t*\t*\n' "$ALT_SN" > "$1"
+}
+
+# --------------------------------------------------------------------------
+# Case A: .alt present, sidecar present without AH -> MUST warn
+# --------------------------------------------------------------------------
+case_A () {  # $1 = sidecar kind
+    local kind="$1"
+    local a="$tmp/a-$kind"; mkdir -p "$a"
+    make_ref   "$a/ref.fa"
+    write_alt  "$a/ref.fa.alt"                 # .alt is <prefix>.alt
+    set_sidecar "$a" "$kind"
+    write_dict "$SIDECAR"                      # no AH on the ALT record
+    "$bin" index "$a/ref.fa" > /dev/null 2> "$a/err.txt" \
+        || fail "$a/err.txt" "case A[$kind]: index exited non-zero"
+
+    grep -q "$WARN_RE" "$a/err.txt" \
+        || fail "$a/err.txt" "case A[$kind]: expected the missing-AH warning at index time"
+    grep -q "samtools dict" "$a/err.txt" \
+        || fail "$a/err.txt" "case A[$kind]: warning must name the \`samtools dict --alt\` remedy"
+    grep -q "$ALT_SN" "$a/err.txt" \
+        || fail "$a/err.txt" "case A[$kind]: warning should name the offending contig ($ALT_SN)"
+}
+
+for kind in "${SIDECAR_KINDS[@]}"; do case_A "$kind"; done
+
+# --------------------------------------------------------------------------
+# Case B: .alt present, NO sidecar -> must NOT warn. bwa-mem3 generates its own
+# @SQ with AH:*, so nothing is lost. Exercises the no-sidecar early return.
+#
+# Not parameterized over SIDECAR_KINDS: the case is defined by the absence of
+# every sidecar name, so there is only one variant of it to run.
+# --------------------------------------------------------------------------
+b="$tmp/b"; mkdir -p "$b"
+make_ref  "$b/ref.fa"
+write_alt "$b/ref.fa.alt"
+"$bin" index "$b/ref.fa" > /dev/null 2> "$b/err.txt" \
+    || fail "$b/err.txt" "case B: index exited non-zero"
+
+! grep -q "$WARN_RE" "$b/err.txt" \
+    || fail "$b/err.txt" "case B: no sidecar present; must not warn"
+
+# --------------------------------------------------------------------------
+# Case C: sidecar without AH but NO .alt -> must NOT warn. No contig is ALT, so
+# a missing AH is correct rather than a loss. This is the common case for most
+# references, where a spurious warning would be pure noise.
+# --------------------------------------------------------------------------
+case_C () {  # $1 = sidecar kind
+    local kind="$1"
+    local c="$tmp/c-$kind"; mkdir -p "$c"
+    make_ref   "$c/ref.fa"
+    set_sidecar "$c" "$kind"
+    write_dict "$SIDECAR"
+    "$bin" index "$c/ref.fa" > /dev/null 2> "$c/err.txt" \
+        || fail "$c/err.txt" "case C[$kind]: index exited non-zero"
+
+    ! grep -q "$WARN_RE" "$c/err.txt" \
+        || fail "$c/err.txt" "case C[$kind]: reference has no ALT contigs; must not warn"
+}
+
+for kind in "${SIDECAR_KINDS[@]}"; do case_C "$kind"; done
+
+# --------------------------------------------------------------------------
+# Case D: .alt present AND the sidecar's ALT @SQ already carries AH:* -> must
+# NOT warn. This is the state case A tells the user to reach, so it is the one
+# case where a false positive would train them to ignore the warning. It is
+# also the only negative case that exercises the AH-detection itself rather
+# than an early return: cases B and C bail before any @SQ is scanned.
+# --------------------------------------------------------------------------
+case_D () {  # $1 = sidecar kind
+    local kind="$1"
+    local d="$tmp/d-$kind"; mkdir -p "$d"
+    set_sidecar "$d" "$kind"
+    make_ref   "$d/ref.fa"
+    write_alt  "$d/ref.fa.alt"
+    # $'...' rather than '\tAH:*': write_dict passes the extra tags through a
+    # printf %s, which does NOT expand escapes, so a plain '\tAH:*' would leave a
+    # literal backslash-t in the record. The AH token would not be tab-delimited,
+    # the sidecar would still be AH-less as far as the scanner is concerned, and the
+    # case would "fail" on a fixture bug rather than on the code.
+    write_dict "$SIDECAR" $'\tAH:*'   # what `samtools dict --alt` produces
+    # Verify the fixture is what the case claims: AH:* must be a whole tab-delimited
+    # field on the ALT record, which is the only form bwa_warn_sidecar_missing_AH
+    # recognizes.
+    awk -F'\t' -v sn="SN:$ALT_SN" '
+        $1 == "@SQ" {
+            for (i = 2; i <= NF; ++i) if ($i == sn) alt = 1
+            if (alt) { for (i = 2; i <= NF; ++i) if ($i == "AH:*") ok = 1; alt = 0 }
+        }
+        END { exit !ok }' "$SIDECAR" \
+        || fail "$SIDECAR" "case D[$kind]: fixture bug -- AH:* is not a tab-delimited field on the ALT @SQ"
+    "$bin" index "$d/ref.fa" > /dev/null 2> "$d/err.txt" \
+        || fail "$d/err.txt" "case D[$kind]: index exited non-zero"
+
+    ! grep -q "$WARN_RE" "$d/err.txt" \
+        || fail "$d/err.txt" "case D[$kind]: sidecar already carries AH:* on the ALT contig; must not warn"
+}
+
+for kind in "${SIDECAR_KINDS[@]}"; do case_D "$kind"; done
+
+# --------------------------------------------------------------------------
+# Case E: .alt present, an AH-less <prefix>.hdr AND an AH-carrying
+# <baseprefix>.dict -> MUST warn. Pins the resolution ORDER rather than either
+# lookup in isolation: the cases above pass whichever name wins, so only a
+# disagreeing pair proves .hdr is consulted first. If the precedence ever
+# flipped to .dict, the AH-carrying .dict would silence the warning here.
+# --------------------------------------------------------------------------
+e="$tmp/e"; mkdir -p "$e"
+make_ref   "$e/ref.fa"
+write_alt  "$e/ref.fa.alt"
+write_dict "$e/ref.fa.hdr"            # no AH -- the winner, so this must warn
+write_dict "$e/ref.dict" $'\tAH:*'    # has AH -- must be ignored
+"$bin" index "$e/ref.fa" > /dev/null 2> "$e/err.txt" \
+    || fail "$e/err.txt" "case E: index exited non-zero"
+
+grep -q "$WARN_RE" "$e/err.txt" \
+    || fail "$e/err.txt" "case E: <prefix>.hdr outranks <baseprefix>.dict; the AH-less .hdr must warn"
+
+# --------------------------------------------------------------------------
+# Case F: an AH-less sidecar whose ALT contig has a LONG name (>= 256 bytes)
+# -> MUST still warn. bwa_warn_sidecar_missing_AH has to copy each sidecar SN
+# out of the header text to get a NUL-terminated hash key; when that copy went
+# into a fixed 256-byte stack buffer, any longer SN was skipped outright. That
+# silently disabled this very check for exactly the contigs it is about --
+# contig names are strdup()ed from the FASTA name with no length bound
+# (bntseq.cpp), so a long-named ALT contig is representable in bns.
+#
+# `local ALT_SN` rather than a subshell: make_ref / write_alt / write_dict read
+# $ALT_SN at call time, so bash's dynamic scoping makes them all use the long
+# name here, while `fail`'s exit still terminates the script (it would only
+# leave a subshell).
+# --------------------------------------------------------------------------
+case_F () {
+    local ALT_SN="chrX_$(printf 'L%.0s' $(seq 1 300))_alt"   # ~306 bytes
+    [[ ${#ALT_SN} -ge 256 ]] \
+        || { echo "FAIL [index alt sidecar warn]: case F fixture bug -- ALT_SN is only ${#ALT_SN} bytes, need >= 256" >&2; exit 1; }
+    local f="$tmp/f"; mkdir -p "$f"
+    make_ref   "$f/ref.fa"
+    write_alt  "$f/ref.fa.alt"
+    write_dict "$f/ref.dict"          # no AH on the long-named ALT record
+    "$bin" index "$f/ref.fa" > /dev/null 2> "$f/err.txt" \
+        || fail "$f/err.txt" "case F: index exited non-zero"
+
+    grep -q "$WARN_RE" "$f/err.txt" \
+        || fail "$f/err.txt" "case F: a ${#ALT_SN}-byte ALT contig name must not be skipped by the ALT/AH check"
+    grep -q "$ALT_SN" "$f/err.txt" \
+        || fail "$f/err.txt" "case F: warning should name the offending contig"
+}
+
+case_F
+
+echo "PASS: index reports an AH-less sidecar only when the reference has ALT contigs and the sidecar omits AH (both .dict and .hdr, .hdr first; long contig names included)"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -111,6 +111,16 @@ ok "meth_rg_header_test"
 "$HERE/meth_sidecar_enrich_test.sh" "$BWAMEM3" "$FIXTURES" || fail "meth_sidecar_enrich_test failed"
 ok "meth_sidecar_enrich_test"
 
+# --- index_alt_sidecar_warn_test ------------------------------------------
+# `index` must warn when the reference has ALT contigs (<prefix>.alt) but the
+# header sidecar supplies @SQ with no AH tag -- the Picard/GATK .dict case,
+# where ALT status is silently lost from every output header. It must stay quiet
+# with no sidecar, with no ALT contig, and when the sidecar already carries
+# AH:*. The remaining --compat and --bam gating is covered at `mem` level by
+# regression/header_parity.sh.
+"$HERE/index_alt_sidecar_warn_test.sh" "$BWAMEM3" || fail "index_alt_sidecar_warn_test failed"
+ok "index_alt_sidecar_warn_test"
+
 # --- help_prescan_test ----------------------------------------------------
 # `mem --help` pre-scan must not match `--help` when it is the value of
 # an option that takes an argument (-R, -o, --set-as-failed, ...).

--- a/test/unit/test_sam_hdr_emit.cpp
+++ b/test/unit/test_sam_hdr_emit.cpp
@@ -62,6 +62,10 @@ std::string render(const char *idx_hdr_lines, const char *hdr_line,
     return out;
 }
 
+// Number of lines starting with `prefix`. Pass the record type WITH its
+// terminating tab ("@SQ\t", not "@SQ"): the production predicates all match
+// "@XX\t", so a bare type would let a malformed "@SQX" line satisfy a count
+// that the aligner itself would not have counted.
 int count_lines_starting(const std::string &s, const char *prefix) {
     int n = 0;
     size_t pos = 0;
@@ -76,7 +80,8 @@ int count_lines_starting(const std::string &s, const char *prefix) {
     return n;
 }
 
-// Index of the first line starting with `prefix`, or -1.
+// Index of the first line starting with `prefix`, or -1. Same convention as
+// count_lines_starting: the prefix carries the record type's tab.
 int line_index_of(const std::string &s, const char *prefix) {
     int idx = 0;
     size_t pos = 0;
@@ -106,7 +111,7 @@ TEST_CASE("@HD: exactly one is emitted, in every -H shape") {
     };
     for (const Case &c : cases) {
         const std::string out = render(NULL, c.hdr_line, &COMPAT_TARGET_OFF);
-        CHECK_MESSAGE(count_lines_starting(out, "@HD") == 1,
+        CHECK_MESSAGE(count_lines_starting(out, "@HD\t") == 1,
                       "case: ", c.desc, "\n----\n", out, "----");
     }
 }
@@ -115,9 +120,9 @@ TEST_CASE("@HD: a leading user @HD wins and is hoisted above @SQ") {
     // Hoisting is what makes the header spec-valid (@HD must come first). It
     // is bwa-mem3-only -- bwa emits -H records after @SQ (bwa.c:438).
     const std::string out = render(NULL, "@HD\tVN:1.6\tSO:coordinate", &COMPAT_TARGET_OFF);
-    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(count_lines_starting(out, "@HD\t") == 1);
     CHECK(out.rfind("@HD\tVN:1.6\tSO:coordinate", 0) == 0);   // literally first
-    CHECK(line_index_of(out, "@HD") < line_index_of(out, "@SQ"));
+    CHECK(line_index_of(out, "@HD\t") < line_index_of(out, "@SQ\t"));
     CHECK(out.find("VN:1.5") == std::string::npos);           // default suppressed
 }
 
@@ -127,17 +132,17 @@ TEST_CASE("@HD: a non-leading user @HD suppresses the default but stays inline")
     // anyway. What it MUST do is suppress the default; failing to was the bug.
     const std::string out =
         render(NULL, "@RG\tID:x\tSM:y\n@HD\tVN:1.6\tSO:coordinate", &COMPAT_TARGET_OFF);
-    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(count_lines_starting(out, "@HD\t") == 1);
     CHECK(out.find("VN:1.5") == std::string::npos);           // default suppressed
     CHECK(out.find("VN:1.6") != std::string::npos);           // the user's survives
-    CHECK(line_index_of(out, "@SQ") < line_index_of(out, "@HD"));   // inline, after @SQ
-    CHECK(count_lines_starting(out, "@RG") == 1);             // and @RG is not lost
+    CHECK(line_index_of(out, "@SQ\t") < line_index_of(out, "@HD\t"));   // inline, after @SQ
+    CHECK(count_lines_starting(out, "@RG\t") == 1);             // and @RG is not lost
 }
 
 TEST_CASE("@HD: the index sidecar supplies one when -H does not") {
     const std::string out =
         render("@HD\tVN:1.4\tSO:queryname\n@CO\tfrom the sidecar", NULL, &COMPAT_TARGET_OFF);
-    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(count_lines_starting(out, "@HD\t") == 1);
     CHECK(out.find("VN:1.4") != std::string::npos);
     CHECK(out.find("VN:1.5") == std::string::npos);           // default suppressed
     CHECK(out.find("@CO\tfrom the sidecar") != std::string::npos);
@@ -148,7 +153,7 @@ TEST_CASE("@HD: the user's -H beats the sidecar's, and only one survives") {
     // loser is consumed off the front of the sidecar and simply not printed.
     const std::string out = render("@HD\tVN:1.4\tSO:queryname",
                                    "@HD\tVN:1.6\tSO:coordinate", &COMPAT_TARGET_OFF);
-    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(count_lines_starting(out, "@HD\t") == 1);
     CHECK(out.find("VN:1.6") != std::string::npos);           // user's
     CHECK(out.find("VN:1.4") == std::string::npos);           // sidecar's dropped
 }
@@ -174,7 +179,7 @@ TEST_CASE("@HD: a LOSING sidecar @HD is dropped wherever it sits in the sidecar"
     };
     for (const Case &c : cases) {
         const std::string out = render(c.idx, c.usr, &COMPAT_TARGET_OFF);
-        CHECK_MESSAGE(count_lines_starting(out, "@HD") == 1,
+        CHECK_MESSAGE(count_lines_starting(out, "@HD\t") == 1,
                       "case: ", c.desc, "\n----\n", out, "----");
         CHECK_MESSAGE(out.find("VN:1.6") != std::string::npos,   // the user's wins
                       "case: ", c.desc, "\n----\n", out, "----");
@@ -193,7 +198,7 @@ TEST_CASE("@HD: only the first of several sidecar @HD records survives") {
     const std::string out =
         render("@HD\tVN:1.4\tSO:queryname\n@RG\tID:z\n@HD\tVN:1.3\tSO:unsorted",
                NULL, &COMPAT_TARGET_OFF);
-    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(count_lines_starting(out, "@HD\t") == 1);
     CHECK(out.find("VN:1.4") != std::string::npos);           // first wins
     CHECK(out.find("VN:1.3") == std::string::npos);
     CHECK(count_lines_starting(out, "@RG\tID:z") == 1);
@@ -205,17 +210,17 @@ TEST_CASE("@HD: a compat target that emits none emits none, but -H still wins") 
     REQUIRE(mem2->emit_hd == 0);
 
     // No user or sidecar @HD -> nothing at all. bwa-mem2 emits no @HD.
-    CHECK(count_lines_starting(render(NULL, NULL, mem2), "@HD") == 0);
+    CHECK(count_lines_starting(render(NULL, NULL, mem2), "@HD\t") == 0);
 
     // A user @HD is still honored -- the target suppresses only the DEFAULT.
     const std::string out = render(NULL, "@HD\tVN:1.6\tSO:coordinate", mem2);
-    CHECK(count_lines_starting(out, "@HD") == 1);
+    CHECK(count_lines_starting(out, "@HD\t") == 1);
     CHECK(out.find("VN:1.6") != std::string::npos);
 }
 
 TEST_CASE("@SQ: generated from bns, carrying AH:* on ALT contigs") {
     const std::string out = render(NULL, NULL, &COMPAT_TARGET_OFF);
-    CHECK(count_lines_starting(out, "@SQ") == 2);
+    CHECK(count_lines_starting(out, "@SQ\t") == 2);
     CHECK(out.find("@SQ\tSN:chr1\tLN:1000\n") != std::string::npos);
     CHECK(out.find("@SQ\tSN:chr1_alt\tLN:500\tAH:*\n") != std::string::npos);
 }
@@ -225,8 +230,62 @@ TEST_CASE("@SQ: a user -H @SQ block is authoritative and suppresses generation")
     // any @SQ, it is used alone -- no generation, and the sidecar is ignored.
     const std::string out = render("@SQ\tSN:from_sidecar\tLN:7",
                                    "@SQ\tSN:from_user\tLN:9", &COMPAT_TARGET_OFF);
-    CHECK(count_lines_starting(out, "@SQ") == 1);
+    CHECK(count_lines_starting(out, "@SQ\t") == 1);
     CHECK(out.find("SN:from_user") != std::string::npos);
     CHECK(out.find("SN:from_sidecar") == std::string::npos);
     CHECK(out.find("SN:chr1") == std::string::npos);          // nothing generated
+}
+
+TEST_CASE("@SQ: '@SQ' named inside another record does not count as one") {
+    // The -H @SQ count decides whether the bns block is generated at all, so a
+    // false positive silently drops every contig from the header. Only records
+    // that BEGIN with "@SQ\t" count -- a @CO that merely mentions the tag, and a
+    // line whose text contains it after the first field, must not.
+    const std::string co = render(NULL, "@CO\tsee @SQ\tfor details",
+                                  &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(co, "@SQ\t") == 2);      // still generated from bns
+    CHECK(co.find("SN:chr1_alt") != std::string::npos);
+
+    // ... and a real @SQ record that also mentions the tag later on its own
+    // line counts exactly once, so generation is still suppressed.
+    const std::string one = render(NULL, "@SQ\tSN:from_user\tLN:9\tXX:@SQ\t",
+                                   &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(one, "@SQ\t") == 1);
+    CHECK(one.find("SN:chr1") == std::string::npos);
+}
+
+TEST_CASE("@SQ: a record type that merely EXTENDS @SQ is not an @SQ") {
+    // The record type ends at the tab, so "@SQX" is its own (unknown) type, not
+    // an @SQ with a typo. count_SQ requires "@SQ\t", so generation still fires
+    // and the malformed record is passed through as an ordinary -H line.
+    //
+    // This is also what makes the tab mandatory in the assertions above: with a
+    // bare "@SQ" prefix, this header counts THREE and the case cannot tell an
+    // exact-prefix implementation from a loose one.
+    const std::string out = render(NULL, "@SQX\tSN:bogus\tLN:1", &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(out, "@SQ\t") == 2);       // generated from bns
+    CHECK(count_lines_starting(out, "@SQ") == 3);         // ... plus the @SQX line
+    CHECK(count_lines_starting(out, "@SQX\t") == 1);      // preserved, not dropped
+    CHECK(out.find("SN:chr1_alt") != std::string::npos);
+}
+
+TEST_CASE("@SQ: -H text without a trailing newline is still counted and emitted") {
+    // -H text arrives unterminated from bwa_insert_header and newline-terminated
+    // from a sidecar file; both must yield the same record count. If the final
+    // record were dropped, generation would fire and the header would carry the
+    // user's @SQ plus all of bns.
+    const std::string out = render(NULL, "@SQ\tSN:only\tLN:5", &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(out, "@SQ\t") == 1);
+    CHECK(out.find("SN:only") != std::string::npos);
+    CHECK(out.find("SN:chr1") == std::string::npos);
+}
+
+TEST_CASE("@HD/@SQ: blank records in -H text are dropped, not emitted") {
+    // Header text can carry empty lines (a sidecar with a stray newline). They
+    // are not valid records; the emitter drops them rather than writing bare
+    // newlines into the header.
+    const std::string out = render(NULL, "@RG\tID:a\n\n@RG\tID:b",
+                                   &COMPAT_TARGET_OFF);
+    CHECK(count_lines_starting(out, "@RG\t") == 2);
+    CHECK(out.find("\n\n") == std::string::npos);
 }

--- a/test/unit/test_sq_line_format.cpp
+++ b/test/unit/test_sq_line_format.cpp
@@ -1,0 +1,201 @@
+// test/unit/test_sq_line_format.cpp — the shared generated-@SQ formatter and
+// the shared header-text type predicate (src/bwa.cpp).
+//
+// bwa_format_sq_line is the one definition of "what a generated @SQ record
+// contains", shared by the SAM-text, --bam and --meth writers. It exists
+// because those three used to build the record independently and drifted:
+// AH:* was correct in only one of them, so --bam and --meth silently dropped
+// ALT status for every ALT-aware reference until each copy was fixed
+// separately (fg-labs/bwa-mem3#281). Collapsing them to one definition, so
+// that class of drift cannot recur, is fg-labs/bwa-mem3#289.
+//
+// Contents must match what bwa (bwa.c:430-433) and bwa-mem2 (bwa.cpp:535-548)
+// emit, so these assertions are against the upstream layout, not against
+// whatever the current implementation happens to produce.
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+#include "doctest/doctest.h"
+#include "bwa.h"
+
+namespace {
+// A bntann1_t carrying just the fields the formatter reads. `name` is not
+// owned by the struct in bwa, so pointing it at a literal is correct here.
+bntann1_t ann(const char *name, int64_t len, int is_alt) {
+    bntann1_t a{};
+    a.name   = const_cast<char *>(name);
+    a.len    = (int32_t)len;
+    a.is_alt = is_alt;
+    return a;
+}
+
+std::string format(const bntann1_t &a) {
+    kstring_t s = {0, 0, NULL};
+    REQUIRE(bwa_format_sq_line(&s, &a) == 0);
+    std::string out = s.s ? s.s : "";
+    free(s.s);
+    return out;
+}
+} // namespace
+
+TEST_CASE("bwa_format_sq_line: primary contig is SN + LN, no AH") {
+    bntann1_t a = ann("chr1", 248956422, 0);
+    CHECK(format(a) == "@SQ\tSN:chr1\tLN:248956422");
+}
+
+TEST_CASE("bwa_format_sq_line: ALT contig gains AH:* after LN") {
+    // Field ORDER matters, not just presence: bwa appends AH immediately after
+    // LN, and --meth appends its M5/UR/AS/SP after that. Asserting the exact
+    // string pins the layout the sidecar-enrichment path builds on.
+    bntann1_t a = ann("chr1_alt", 5000, 1);
+    CHECK(format(a) == "@SQ\tSN:chr1_alt\tLN:5000\tAH:*");
+}
+
+TEST_CASE("bwa_format_sq_line: no trailing newline") {
+    // Callers add their own terminator -- err_fputc('\n') on the SAM path,
+    // sam_hdr_add_lines' length argument on the BAM paths -- and --meth
+    // appends more tags after this. A newline here would corrupt all three.
+    bntann1_t a = ann("chr2", 100, 0);
+    const std::string s = format(a);
+    REQUIRE(!s.empty());
+    CHECK(s.back() != '\n');
+    CHECK(s.find('\n') == std::string::npos);
+}
+
+TEST_CASE("bwa_format_sq_line: appends, so a buffer can be reused") {
+    // Every caller reuses one kstring across contigs by resetting l to 0.
+    // Appending (not overwriting) is what makes --meth's tag enrichment work.
+    kstring_t s = {0, 0, NULL};
+    bntann1_t a = ann("chr1", 10, 0);
+    CHECK(bwa_format_sq_line(&s, &a) == 0);
+    const size_t after_first = s.l;
+    bntann1_t b = ann("chr2", 20, 0);
+    CHECK(bwa_format_sq_line(&s, &b) == 0);
+    CHECK(s.l > after_first);
+    CHECK(std::string(s.s) == "@SQ\tSN:chr1\tLN:10@SQ\tSN:chr2\tLN:20");
+    s.l = 0;                       // the reset every caller performs
+    CHECK(bwa_format_sq_line(&s, &b) == 0);
+    CHECK(std::string(s.s, s.l) == "@SQ\tSN:chr2\tLN:20");
+    free(s.s);
+}
+
+TEST_CASE("bwa_format_sq_line: reports success so a caller can refuse to emit") {
+    // The formatter reserves the record's worst case up front and returns a
+    // status, because ksprintf/kputs swallow their own failures: without it, a
+    // caller cannot distinguish a formatted record from a failed append and
+    // would fputs a NULL or hand a truncated line to sam_hdr_add_lines. Only
+    // the success half is assertable without an allocator hook -- pin it, since
+    // all three callers now branch on it.
+    kstring_t s = {0, 0, NULL};
+    bntann1_t a = ann("chr1_alt", 5000, 1);
+    CHECK(bwa_format_sq_line(&s, &a) == 0);
+    REQUIRE(s.s != NULL);                     // what the callers rely on
+    CHECK(s.l == strlen("@SQ\tSN:chr1_alt\tLN:5000\tAH:*"));
+    // The reservation must cover the AH:* branch too, so the record is whole
+    // and NUL-terminated within the capacity that was reserved.
+    CHECK(s.m > s.l);
+    CHECK(s.s[s.l] == '\0');
+    free(s.s);
+}
+
+TEST_CASE("bwa_format_sq_line: a long contig name is not truncated") {
+    // The SAM-text path used to snprintf into char[512] and would silently
+    // truncate. kstring grows instead.
+    const std::string name(600, 'x');
+    bntann1_t a = ann(name.c_str(), 1234, 0);
+    CHECK(format(a) == "@SQ\tSN:" + name + "\tLN:1234");
+}
+
+TEST_CASE("bwa_hdr_text_has_type matches whole records only") {
+    const char *hdr =
+        "@HD\tVN:1.5\tSO:unsorted\n"
+        "@SQ\tSN:chr1\tLN:100\n"
+        "@CO\tSQ is mentioned in this comment\n";
+    CHECK(bwa_hdr_text_has_type(hdr, "@HD\t") == 1);   // first line
+    CHECK(bwa_hdr_text_has_type(hdr, "@SQ\t") == 1);   // after a newline
+    CHECK(bwa_hdr_text_has_type(hdr, "@CO\t") == 1);
+    CHECK(bwa_hdr_text_has_type(hdr, "@RG\t") == 0);   // absent
+
+    // A record type named only INSIDE another line must not match -- the
+    // comment above says "SQ" but carries no @SQ record of its own.
+    CHECK(bwa_hdr_text_has_type("@CO\tmentions @SQ\there\n", "@SQ\t") == 0);
+
+    // A leading match must be at position 0, not merely present.
+    CHECK(bwa_hdr_text_has_type("x@HD\tVN:1.5\n", "@HD\t") == 0);
+
+    CHECK(bwa_hdr_text_has_type(NULL, "@HD\t") == 0);
+    CHECK(bwa_hdr_text_has_type("", "@HD\t") == 0);
+    CHECK(bwa_hdr_text_has_type("@HD\tVN:1.5\n", NULL) == 0);
+
+    // An empty type matches nothing. Returning 1 (every record "starts with"
+    // the empty string) would make a caller that built its tag from an empty
+    // variable see records that are not there.
+    CHECK(bwa_hdr_text_has_type(hdr, "") == 0);
+
+    // A record on the LAST line of unterminated text still matches -- header
+    // text arrives without a trailing newline from bwa_insert_header.
+    CHECK(bwa_hdr_text_has_type("@SQ\tSN:chr1\tLN:1\n@RG\tID:a", "@RG\t") == 1);
+}
+
+TEST_CASE("bwa_hdr_text_has_type has no tag-length ceiling") {
+    // This is public API, so the type is whatever the caller passes -- not
+    // necessarily a 4-char "@XX\t". A length-capped implementation would
+    // truncate a longer type and then match on the truncation, reporting a
+    // record that is not present.
+    const char *hdr = "@HD\tVN:1.5\n@COMMENTARY\tx\n";
+    CHECK(bwa_hdr_text_has_type(hdr, "@COMMENTARY\t") == 1);
+    // "@COMMENTX\t" shares its first 8 characters with the record above, so a
+    // truncating implementation would wrongly report a match.
+    CHECK(bwa_hdr_text_has_type(hdr, "@COMMENTX\t") == 0);
+    // A type longer than any record cannot match.
+    CHECK(bwa_hdr_text_has_type(hdr, "@COMMENTARY\tx\ty\n") == 0);
+}
+
+TEST_CASE("bwa_hdr_next_line iterates records, with or without a trailing newline") {
+    auto records = [](const char *text) {
+        std::vector<std::string> out;
+        const char *p = text, *line; size_t len;
+        while (bwa_hdr_next_line(&p, &line, &len)) out.emplace_back(line, len);
+        return out;
+    };
+
+    // Trailing newline must NOT yield a phantom empty final record -- the
+    // sidecar loader returns text without one, htslib emits it with one, and
+    // the six call sites this replaced disagreed on which they handled.
+    const std::vector<std::string> want{"@HD\tVN:1.5", "@SQ\tSN:chr1\tLN:100"};
+    CHECK(records("@HD\tVN:1.5\n@SQ\tSN:chr1\tLN:100\n") == want);
+    CHECK(records("@HD\tVN:1.5\n@SQ\tSN:chr1\tLN:100")   == want);
+
+    // A single record, either way.
+    CHECK(records("@HD\tVN:1.5")   == std::vector<std::string>{"@HD\tVN:1.5"});
+    CHECK(records("@HD\tVN:1.5\n") == std::vector<std::string>{"@HD\tVN:1.5"});
+
+    // Empty records ARE reported; callers that care skip them (both meth_bam
+    // helpers do, via `len > 0`). The iterator does not silently drop data.
+    CHECK(records("a\n\nb") == std::vector<std::string>({"a", "", "b"}));
+
+    // Degenerate inputs terminate rather than loop or deref.
+    CHECK(records("").empty());
+    const char *nul = NULL, *line; size_t len;
+    CHECK(bwa_hdr_next_line(&nul, &line, &len) == 0);
+    CHECK(bwa_hdr_next_line(NULL, &line, &len) == 0);
+}
+
+TEST_CASE("bwa_hdr_next_line advances exactly past each record") {
+    // The cursor must land on the next record's first byte, so a caller can
+    // stop early and resume -- meth_append_sq_extra_tags returns mid-iteration.
+    const char *text = "one\ntwo\nthree";
+    const char *p = text, *line; size_t len;
+    REQUIRE(bwa_hdr_next_line(&p, &line, &len) == 1);
+    CHECK(std::string(line, len) == "one");
+    CHECK(std::string(p) == "two\nthree");
+    REQUIRE(bwa_hdr_next_line(&p, &line, &len) == 1);
+    CHECK(std::string(line, len) == "two");
+    CHECK(std::string(p) == "three");
+    REQUIRE(bwa_hdr_next_line(&p, &line, &len) == 1);
+    CHECK(std::string(line, len) == "three");
+    CHECK(*p == '\0');
+    CHECK(bwa_hdr_next_line(&p, &line, &len) == 0);
+}


### PR DESCRIPTION
Closes #289. Stacked on #291 (which stacks on #277) — review those first.

Pure refactor. **No output change**, measured on the path this actually rewrites.

## The duplication

The rule *"a generated `@SQ` record is `SN`, `LN`, and `AH:*` iff the contig is ALT"* was written three times, in three notations:

| file | mechanism |
|---|---|
| `src/bwa.cpp` | `snprintf` into `char[512]` + `err_fputs` |
| `src/bam_writer.cpp` | `sam_hdr_add_line` varargs |
| `src/meth_bam.cpp` | `ksprintf` into a `kstring_t` + `sam_hdr_add_lines` |

That is not hypothetical drift — **#281 was exactly this bug.** `AH:*` was correct in the first copy and silently absent from the other two, so `--bam` and `--meth` lost ALT status for every ALT-aware reference, and fixing it took three independent edits. Consolidating the copies so that class of drift cannot recur is #289, which this PR closes. (An earlier revision of this description swapped those two the other way; #281 is the bug that was filed and fixed, #289 is the consolidation.)

The three sinks do not justify three spellings: all of them accept SAM header *text*. `meth_bam.cpp` already formatted into a kstring and handed it to `sam_hdr_add_lines`; `bwa.cpp` writes text to a `FILE*`; `bam_writer.cpp`’s varargs call becomes `sam_hdr_add_lines` over the same text with no semantic change.

`bwa_format_sq_line(kstring_t *, const bntann1_t *)` is now the single definition. It also retires `bwa.cpp`’s fixed `char[512]`, which truncated silently on a long contig name.

**What is deliberately NOT unified** is the *decision* to emit — `bwa.cpp` gates on `n_SQ == 0 && !has_SQ(bns_hdr)`, `bam_writer.cpp` on `!idx_has_sq`, `meth_bam.cpp` always emits then enriches. That is genuine per-path precedence policy.

## The header-text scanners

*"Does this text contain a record of type X"* existed as the parameterized `hdr_text_has_type()` in `meth_bam.cpp` — the narrowest module, and `static`, so nobody else could reach it — while the general modules open-coded it: `has_SQ()` in `bwa.cpp` was a byte-for-byte specialization, `bam_writer.cpp` had three copies, `fastmap.cpp` a fourth.

Now `bwa_hdr_text_has_type()` in `bwa.cpp`; those six sites call it.

## Evidence

Produced by running the **pre-refactor** binary (this PR’s base, #291) and the **post-refactor** binary against identical inputs.

### The generated `@SQ` path — what this refactor rewrites

hg38 with its `.dict` sidecar hidden behind a symlink farm, so `@SQ` is generated for all 3366 contigs:

```
  SAM before #289 : 34dabb50dd7a704866e841d3e5a7f68d (3366 lines)
  SAM after  #289 : 34dabb50dd7a704866e841d3e5a7f68d (3366 lines)
  BAM before #289 : 34dabb50dd7a704866e841d3e5a7f68d (3366 lines)
  BAM after  #289 : 34dabb50dd7a704866e841d3e5a7f68d (3366 lines)
```

That md5 is also the bwa-mem2 v2.2.1 golden header’s, which is the expected identity rather than a coincidence: bwa-mem2 emits no `@HD` and a bare `SN`/`LN` `@SQ` block — precisely what the generated block is.

### The `AH:*` path

A 3-contig ALT fixture (`chr1` / `chr2` / `chr1_alt` plus a matching `.alt`), no sidecar, across **all three writers**:

```
  sam   before=475d3ea32410b8a7ccae54c8455f122c after=475d3ea32410b8a7ccae54c8455f122c  IDENTICAL
  bam   before=475d3ea32410b8a7ccae54c8455f122c after=475d3ea32410b8a7ccae54c8455f122c  IDENTICAL
  meth  before=475d3ea32410b8a7ccae54c8455f122c after=475d3ea32410b8a7ccae54c8455f122c  IDENTICAL

  @SQ	SN:chr1_alt	LN:5000	AH:*
```

All three writers now emit the **same** `@SQ` block — the property whose absence *was* #281.

### The sidecar path — unaffected, as expected

On unmodified hg38: `--compat=bwa-mem2` header parity still holds (md5 `34dabb50…`), and the DEFAULT `@SQ` block is byte-identical before and after (md5 `deeee9c202eeabe6933e290eafd2e237`).

## Test

`test/unit/test_sq_line_format.cpp` (new) covers both entry points:

- field **order** (`AH` immediately after `LN` — the `--meth` enrichment appends behind it);
- no trailing newline (each caller adds its own terminator, and `--meth` appends more tags);
- **appends** rather than overwrites, so callers can reuse one buffer across contigs;
- no truncation on a 600-char contig name (the old `char[512]` would have truncated);
- whole-record matching for the type predicate — a `@SQ` mentioned *inside* a `@CO` comment must not match, and a leading match must be at position 0.

Full local suite, clean build: 134/134 unit tests, `default_hd_parity.sh`, `compat_byte_identical.sh`, `header_parity.sh`, `meth_rg_header_test.sh`, `meth_sidecar_enrich_test.sh`, `help_prescan_test.sh`, mdbook + linkcheck.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SAM header record detection and precedence for user-provided `-H` text using stricter whole-record matching.
  * Standardized `@SQ` formatting and suppression rules, including correct `AH:*` insertion for alternate contigs from the appropriate source.
  * Improved ALT-sidecar warnings during indexing when required `AH:*` tags are missing, including support for very long contig names.

* **Tests**
  * Added unit tests for `@SQ` formatting, header record iteration, and header type detection.
  * Added/extended regression coverage for ALT-sidecar warning behavior.

* **Documentation**
  * Updated guidance on ALT-aware `@SQ`/`AH:*`, warning causes, and remediation.

* **Chores**
  * Tightened CI token permissions and added ASAN header-parity reruns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
