### PR TITLE
perf(io): pool per-read string fields in a per-chunk arena

### DIFF
--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -58,8 +58,8 @@ static inline void trim_readno(kstring_t *s)
         s->l -= 2, s->s[s->l] = 0;
 }
 
-static inline void kseq2bseq1(const kseq_t *ks, bseq1_t *s)
-{ // TODO: it would be better to allocate one chunk of memory, but probably it does not matter in practice
+static inline void kseq2bseq1(const kseq_t *ks, bseq1_t *s, read_arena_t *arena)
+{
     // bseq_read/bseq_read_orig grow `seqs` with realloc, which leaves the
     // new entries uninitialized. Zero first so sam/bams/n_bams/cap_bams
     // start well-defined — the output loop at fastmap.cpp free()s them
@@ -69,21 +69,29 @@ static inline void kseq2bseq1(const kseq_t *ks, bseq1_t *s)
      * memset above would otherwise leave it 0, which the seed-chemistry filter
      * reads as OB. --meth ingest overwrites it with the read-number 0/1. */
     s->meth_base_ot = -1;
-    s->name = strdup(ks->name.s);
+    /* PIPE-F6: name/seq/qual are carved from the per-chunk bump arena instead
+     * of individually strdup'd. Byte-identical to strdup — read_arena_dup does
+     * malloc-then-memcpy-then-NUL, and kseq kstrings are NUL-terminated so
+     * ks->name.l/seq.l/qual.l are the exact strlen()s strdup would have copied.
+     * `comment` stays heap-owned: --meth (fastmap step 0) frees and reassigns
+     * it to a fresh heap string, and the non-copy_comment path frees it early,
+     * so its ownership is not uniform enough to live in the arena. */
+    s->name = read_arena_dup(arena, ks->name.s, ks->name.l);
     s->comment = ks->comment.l? strdup(ks->comment.s) : 0;
-    s->seq = strdup(ks->seq.s);
-    s->qual = ks->qual.l? strdup(ks->qual.s) : 0;
+    s->seq = read_arena_dup(arena, ks->seq.s, ks->seq.l);
+    s->qual = ks->qual.l? read_arena_dup(arena, ks->qual.s, ks->qual.l) : 0;
     s->l_seq = strlen(s->seq);
 }
 
 /* Customized for MPI processing */
 bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_, void *ks2_,
-                   FILE* fpp, int len, int64_t *s)
+                   FILE* fpp, int len, int64_t *s, read_arena_t **arena_out)
 {
     kseq_t *ks = (kseq_t*)ks1_, *ks2 = (kseq_t*)ks2_;
     int64_t size = 0, m, n, size2 = 0;
     bseq1_t *seqs;
     m = n = 0; seqs = 0;
+    read_arena_t *arena = read_arena_create();
     char buf[len];
     
     while (kseq_read(ks) >= 0)
@@ -97,7 +105,7 @@ bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_, void *ks2_,
             seqs = (bseq1_t*) realloc(seqs, m * sizeof(bseq1_t));
         }
         trim_readno(&ks->name);
-        kseq2bseq1(ks, &seqs[n]);
+        kseq2bseq1(ks, &seqs[n], arena);
         seqs[n].id = n;
         {
             //kseq_t *ksd = ks;
@@ -150,7 +158,7 @@ bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_, void *ks2_,
         
         if (ks2) {
             trim_readno(&ks2->name);
-            kseq2bseq1(ks2, &seqs[n]);
+            kseq2bseq1(ks2, &seqs[n], arena);
             seqs[n].id = n;
             n++;
             // size += seqs[n++].l_seq;
@@ -164,17 +172,24 @@ bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_, void *ks2_,
         if (ks2 && kseq_read(ks2) >= 0)
             fprintf(stderr, "[W::%s] the 1st file has fewer sequences.\n", __func__);
     }
+    /* PIPE-F6: hand the arena to the caller, or destroy it if this batch
+     * carved nothing (n == 0 → seqs stays NULL and the pipeline treats it as
+     * clean EOF, freeing nothing). */
+    if (n == 0) { read_arena_destroy(arena); arena = NULL; }
+    *arena_out = arena;
     *n_ = n;
     *s = size;
     return seqs;
 }
 
-bseq1_t *bseq_read_orig(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s)
+bseq1_t *bseq_read_orig(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s,
+                        read_arena_t **arena_out)
 {
     kseq_t *ks = (kseq_t*)ks1_, *ks2 = (kseq_t*)ks2_;
     int64_t size = 0, m, n;
     bseq1_t *seqs;
     m = n = 0; seqs = 0;
+    read_arena_t *arena = read_arena_create();
     while (kseq_read(ks) >= 0)
     {
         if (ks2 && kseq_read(ks2) < 0) { // the 2nd file has fewer reads
@@ -186,7 +201,7 @@ bseq1_t *bseq_read_orig(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
             seqs = (bseq1_t*) realloc(seqs, m * sizeof(bseq1_t));
         }
         trim_readno(&ks->name);
-        kseq2bseq1(ks, &seqs[n]);
+        kseq2bseq1(ks, &seqs[n], arena);
         seqs[n].id = n;
         //{
         //  size += strlen(seqs[n].name);
@@ -199,7 +214,7 @@ bseq1_t *bseq_read_orig(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
 
         if (ks2) {
             trim_readno(&ks2->name);
-            kseq2bseq1(ks2, &seqs[n]);
+            kseq2bseq1(ks2, &seqs[n], arena);
             seqs[n].id = n;
             size += seqs[n++].l_seq;
         }
@@ -212,15 +227,19 @@ bseq1_t *bseq_read_orig(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
         if (ks2 && kseq_read(ks2) >= 0)
             fprintf(stderr, "[W::%s] the 1st file has fewer sequences.\n", __func__);
     }
+    /* PIPE-F6: see bseq_read above — hand off, or free the empty arena at EOF. */
+    if (n == 0) { read_arena_destroy(arena); arena = NULL; }
+    *arena_out = arena;
     *n_ = n;
     *s = size;
     return seqs;
 }
 
-bseq1_t *bseq_read_one_fasta_file(int64_t chunk_size, int *n_, gzFile fp, int64_t *s)
+bseq1_t *bseq_read_one_fasta_file(int64_t chunk_size, int *n_, gzFile fp, int64_t *s,
+                                  read_arena_t **arena_out)
 {
     kseq_t *ks = kseq_init(fp);
-    bseq1_t *seq = bseq_read_orig(chunk_size, n_, ks, NULL, s);
+    bseq1_t *seq = bseq_read_orig(chunk_size, n_, ks, NULL, s, arena_out);
     kseq_destroy(ks);
     return seq;
 }

--- a/src/bwa.h
+++ b/src/bwa.h
@@ -38,6 +38,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "bwt.h"
 #include "macro.h"
 #include "compat_target.h"
+#include "read_arena.h"
 
 #define BWA_IDX_BWT 0x1
 #define BWA_IDX_BNS 0x2
@@ -98,13 +99,20 @@ extern char bwa_rg_id[256];
 #ifdef __cplusplus
 extern "C" {
 #endif
-    bseq1_t *bseq_read_orig(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s);
+    /* On success (return != NULL) *arena_out receives the per-chunk bump arena
+     * that backs the returned reads' name/seq/qual fields; the caller owns it
+     * and must read_arena_destroy() it after the chunk is fully consumed. At
+     * EOF (return NULL) *arena_out is set to NULL and there is nothing to free.
+     * See read_arena.h and the PIPE-F6 note for the ownership contract. */
+    bseq1_t *bseq_read_orig(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s,
+                            read_arena_t **arena_out);
 
     bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_,
                        void *ks2_, FILE* fpp, int len,
-                       int64_t *sz);
-    
-    bseq1_t *bseq_read_one_fasta_file(int64_t chunk_size, int *n_, gzFile fp, int64_t *s);
+                       int64_t *sz, read_arena_t **arena_out);
+
+    bseq1_t *bseq_read_one_fasta_file(int64_t chunk_size, int *n_, gzFile fp, int64_t *s,
+                                      read_arena_t **arena_out);
     
     void bseq_classify(int n, bseq1_t *seqs, int m[2], bseq1_t *sep[2]);
     

--- a/src/fast_reader_bseq.c
+++ b/src/fast_reader_bseq.c
@@ -8,6 +8,7 @@
 #include "fr_fastq.h"
 #include "utils.h"   /* err_fatal */
 #include "stage_prof.h"
+#include "read_arena.h"
 
 /* This adapter turns fr_fastq record slices into the bseq1_t array the pipeline
  * consumes. fr_fastq replaced the kseq layer (see fr_fastq.c): records are now
@@ -49,7 +50,7 @@ static inline char *fr_dup_field(const char *src, size_t len)
  * well-defined. Zeroing the whole struct (rather than hand-listing
  * sam/bams/n_bams/cap_bams) stays correct if a field is ever added to bseq1_t.
  * id is overwritten by the caller. */
-static inline void fr_rec_to_bseq1(const fr_fastq_rec_t *r, bseq1_t *s)
+static inline void fr_rec_to_bseq1(const fr_fastq_rec_t *r, bseq1_t *s, read_arena_t *arena)
 {
     memset(s, 0, sizeof(*s));
     /* Honor the bseq1_t.meth_base_ot -1 sentinel ("non-meth") from bwa.h: the
@@ -57,10 +58,17 @@ static inline void fr_rec_to_bseq1(const fr_fastq_rec_t *r, bseq1_t *s)
      * reads as OB. --meth ingest overwrites it with the read-number 0/1. */
     s->meth_base_ot = -1;
     size_t name_l = fr_trim_readno_len(r->name, r->name_l);
-    s->name    = fr_dup_field(r->name, name_l);
+    /* PIPE-F6: name/seq/qual are carved from the per-chunk bump arena instead
+     * of individually malloc'd. read_arena_dup does the same length-known
+     * malloc+memcpy+NUL as fr_dup_field, so the bytes, lengths, and NUL
+     * termination are identical — only the backing allocation changes. comment
+     * stays heap-owned (fr_dup_field): --meth (fastmap step 0) frees and
+     * reassigns it, and the non-copy_comment path frees it early, so its
+     * ownership is not uniform enough to live in the arena. */
+    s->name    = read_arena_dup(arena, r->name, name_l);
     s->comment = r->comment_l ? fr_dup_field(r->comment, r->comment_l) : 0;
-    s->seq     = fr_dup_field(r->seq, r->seq_l);
-    s->qual    = r->qual_l ? fr_dup_field(r->qual, r->qual_l) : 0;
+    s->seq     = read_arena_dup(arena, r->seq, r->seq_l);
+    s->qual    = r->qual_l ? read_arena_dup(arena, r->qual, r->qual_l) : 0;
     s->l_seq   = (int)r->seq_l;
 }
 
@@ -68,12 +76,14 @@ void *fast_kseq_init(fast_reader_t *fr) { return fr_fastq_init(fr); }
 
 void fast_kseq_destroy(void *p) { fr_fastq_destroy((fr_fastq_t *)p); }
 
-bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s)
+bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s,
+                        read_arena_t **arena_out)
 {
     fr_fastq_t *p1 = (fr_fastq_t *)ks1_, *p2 = (fr_fastq_t *)ks2_;
     int64_t size = 0, m, n;
     bseq1_t *seqs;
     m = n = 0; seqs = 0;
+    read_arena_t *arena = read_arena_create();
     for (;;) {
         /* Tokenize the next record(s). fr_fastq_next scans record boundaries and
          * pulls bytes through the codec layer, which charges its read()/inflate
@@ -109,11 +119,11 @@ bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
             seqs = tmp;
         }
         double _tp = sp_enabled() ? sp_wall() : 0.0;
-        fr_rec_to_bseq1(&r1, &seqs[n]);
+        fr_rec_to_bseq1(&r1, &seqs[n], arena);
         seqs[n].id = n;
         size += seqs[n++].l_seq;
         if (p2) {
-            fr_rec_to_bseq1(&r2, &seqs[n]);
+            fr_rec_to_bseq1(&r2, &seqs[n], arena);
             seqs[n].id = n;
             size += seqs[n++].l_seq;
         }
@@ -125,6 +135,12 @@ bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
         if (p2 && fr_fastq_next(p2, &rr) == 1)
             fprintf(stderr, "[W::%s] the 1st file has fewer sequences.\n", __func__);
     }
+    /* PIPE-F6: hand the per-chunk arena (backing every read's name/seq/qual) to
+     * the caller, which destroys it in the write stage once the chunk is fully
+     * consumed. An empty batch (n == 0 → seqs == NULL, read as clean EOF by the
+     * pipeline) carved nothing, so free the arena here and report none. */
+    if (n == 0) { read_arena_destroy(arena); arena = NULL; }
+    *arena_out = arena;
     *n_ = n;
     *s = size;
     return seqs;

--- a/src/fast_reader_bseq.h
+++ b/src/fast_reader_bseq.h
@@ -31,8 +31,14 @@ void  fast_kseq_destroy(void *p);
  * required; `ks2_` is the second mate handle and may be NULL for single-end /
  * interleaved input. At EOF the function sets *n_ = 0 and *s = 0; the returned
  * pointer is then NULL (no records were allocated). Mismatched record counts
- * between the two files are reported to stderr and truncate the batch. */
-bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s);
+ * between the two files are reported to stderr and truncate the batch.
+ *
+ * On success *arena_out receives the per-chunk bump arena backing the returned
+ * reads' name/seq/qual fields; the caller owns it and must read_arena_destroy()
+ * it after the chunk is fully consumed. At EOF (*n_ == 0, return NULL)
+ * *arena_out is set to NULL. See read_arena.h for the ownership contract. */
+bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int64_t *s,
+                        read_arena_t **arena_out);
 
 #ifdef __cplusplus
 }

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -382,8 +382,8 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         /* Read "reads" from input file (fread) */
         int64_t sz = 0;
         ret->seqs = aux->legacy_reader
-            ? bseq_read_orig(aux->task_size, &ret->n_seqs, aux->ks, aux->ks2, &sz)
-            : bseq_read_fast(aux->task_size, &ret->n_seqs, aux->frks, aux->frks2, &sz);
+            ? bseq_read_orig(aux->task_size, &ret->n_seqs, aux->ks, aux->ks2, &sz, &ret->read_arena)
+            : bseq_read_fast(aux->task_size, &ret->n_seqs, aux->frks, aux->frks2, &sz, &ret->read_arena);
 
         tprof[READ_IO][0] += __rdtsc() - tim;
 
@@ -672,13 +672,16 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
 
             for (int k = 0; k < group_size; ++k) {
                 if (sp_enabled() && ret->seqs[i+k].sam) sp_wbytes += (long)strlen(ret->seqs[i+k].sam);
-                free(ret->seqs[i+k].name);
+                /* PIPE-F6: name/seq/qual are carved from ret->read_arena, which
+                 * is freed once below — do NOT free them individually here.
+                 * comment stays heap-owned (see the reader / --meth notes), and
+                 * sam/bams are allocated during processing; those still free
+                 * per-read. meth_orig_seq is a step-0 heap strdup (NULL outside
+                 * --meth; free() is NULL-safe). */
                 free(ret->seqs[i+k].comment);
-                free(ret->seqs[i+k].seq);
-                free(ret->seqs[i+k].qual);
                 free(ret->seqs[i+k].sam);
                 free(ret->seqs[i+k].bams);
-                free(ret->seqs[i+k].meth_orig_seq); /* NULL outside --meth; free() is NULL-safe */
+                free(ret->seqs[i+k].meth_orig_seq);
             }
             i += group_size;
         }
@@ -695,6 +698,11 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
             ret->prof.chunk = __sync_fetch_and_add(&g_sp_chunk, 1);
             sp_add_chunk(&ret->prof);
         }
+        /* PIPE-F6: every name/seq/qual freed above by the former per-field loop
+         * now lives in this one arena; release it once for the whole chunk.
+         * All uses are done: output was written above and the seq/qual bytes
+         * are never read after the SAM/BAM string was built. NULL-safe. */
+        read_arena_destroy(ret->read_arena);
         free(ret->seqs);
         free(ret);
         tprof[SAM_IO][0] += __rdtsc() - tim;

--- a/src/fastmap.h
+++ b/src/fastmap.h
@@ -101,6 +101,10 @@ typedef struct {
 	ktp_aux_t *aux;
 	int n_seqs;
 	bseq1_t *seqs;
+	/* PIPE-F6: per-chunk bump arena backing every read's name/seq/qual fields.
+	 * Set by the reader in step 0; destroyed once in step 2 after the chunk's
+	 * output is written. NULL when the chunk carried no reads (clean EOF). */
+	read_arena_t *read_arena;
 	prof_chunk_t prof;   /* stage_prof: per-chunk read/process/write timing (--profile) */
 } ktp_data_t;
 

--- a/src/read_arena.h
+++ b/src/read_arena.h
@@ -1,0 +1,137 @@
+/* Per-chunk bump arena for immutable per-read string fields (PIPE-F6).
+ *
+ * Motivation: the FASTQ readers used to malloc() every per-read string field
+ * (name/seq/qual) individually at ingest, and the output stage free()d each one
+ * individually — frequently on a DIFFERENT thread than the one that allocated
+ * it (the klib kt_pipeline reads a chunk on one thread and writes it on
+ * another). That is ~3 mallocs/read + ~3 frees/read of small buffers, with the
+ * frees crossing threads, which stresses the allocator's cross-thread free
+ * path across the ~100M reads of a typical run.
+ *
+ * This arena replaces that with one growable, per-chunk bump allocator: the
+ * reader carves each read's name/seq/qual out of the arena, and the output
+ * stage frees the WHOLE arena once per chunk instead of per field. Only the
+ * allocation strategy changes — field contents, lengths, and NUL-termination
+ * are byte-identical to the former per-field malloc/strdup path.
+ *
+ * Ownership / lifetime contract:
+ *   - Exactly one arena is created per read-chunk, by the reader, and returned
+ *     to the pipeline alongside the bseq1_t array. It is stored on the chunk
+ *     (ktp_data_t.read_arena) and destroyed exactly once, in the write stage,
+ *     after every field it backs has been consumed.
+ *   - The arena is owned by a single chunk and never shared mutably between the
+ *     threads processing different chunks (each chunk carries its own).
+ *   - Only allocation grows the arena, and that happens solely on the read
+ *     thread during ingest; the process/write stages only READ the fields (the
+ *     in-place 2-bit sequence encoding and --meth C->T/G->A projection mutate
+ *     the seq bytes in place, same length, which is fine — arena memory is
+ *     mutable and those never reallocate the field).
+ *
+ * Pointer stability: the arena is SEGMENTED (a linked list of blocks). A new
+ * allocation that does not fit the current block gets a fresh block; existing
+ * blocks are never realloc()'d or moved, so every pointer previously handed out
+ * stays valid for the arena's lifetime. This is the property that lets the
+ * reader carve many fields and hand out stable char* into the same arena. */
+#ifndef READ_ARENA_H
+#define READ_ARENA_H
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "utils.h" /* err_fatal — abort loudly on OOM, matching house style */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Default block size. Read fields are small (tens–hundreds of bytes) and a
+ * chunk holds up to ~task_size bytes of sequence, so 1 MiB blocks keep the
+ * block count (and thus the malloc/free count) tiny while wasting at most the
+ * unused tail of one block per fill. */
+#define READ_ARENA_BLOCK_SIZE ((size_t)(1u << 20))
+
+typedef struct read_arena_block_s {
+	struct read_arena_block_s *next; /* previous (older) block; NULL terminates */
+	char  *data;                     /* block storage */
+	size_t cap;                      /* bytes allocated for `data` */
+	size_t used;                     /* bytes handed out from this block */
+} read_arena_block_t;
+
+typedef struct read_arena_s {
+	read_arena_block_t *head; /* current (newest) block; NULL until first alloc */
+} read_arena_t;
+
+/* Create an empty arena. Aborts on OOM. */
+static inline read_arena_t *read_arena_create(void)
+{
+	read_arena_t *a = (read_arena_t *)malloc(sizeof(read_arena_t));
+	if (a == NULL)
+		err_fatal(__func__, "failed to allocate read arena");
+	a->head = NULL;
+	return a;
+}
+
+/* Push a fresh block large enough for at least `need` bytes to the front. */
+static inline void read_arena_grow(read_arena_t *a, size_t need)
+{
+	size_t cap = READ_ARENA_BLOCK_SIZE;
+	if (need > cap) cap = need;
+	read_arena_block_t *b = (read_arena_block_t *)malloc(sizeof(read_arena_block_t));
+	if (b == NULL)
+		err_fatal(__func__, "failed to allocate read arena block header");
+	b->data = (char *)malloc(cap);
+	if (b->data == NULL)
+		err_fatal(__func__, "failed to allocate %zu-byte read arena block", cap);
+	b->cap = cap;
+	b->used = 0;
+	b->next = a->head;
+	a->head = b;
+}
+
+/* Carve `n` bytes from the arena. Returned pointer is stable for the arena's
+ * lifetime. Byte alignment is sufficient here — the only callers store NUL-
+ * terminated char strings (name/seq/qual), which have no alignment
+ * requirement. Aborts on OOM. n == 0 is legal and returns a valid pointer. */
+static inline void *read_arena_alloc(read_arena_t *a, size_t n)
+{
+	read_arena_block_t *b = a->head;
+	if (b == NULL || b->used + n > b->cap) {
+		read_arena_grow(a, n);
+		b = a->head;
+	}
+	void *p = b->data + b->used;
+	b->used += n;
+	return p;
+}
+
+/* Copy a length-known field into the arena and NUL-terminate it, returning the
+ * arena-owned copy. The source need not be NUL-terminated; dst[len] is set
+ * explicitly. Produces a byte-identical result to malloc(len+1)+memcpy. */
+static inline char *read_arena_dup(read_arena_t *a, const char *src, size_t len)
+{
+	char *dst = (char *)read_arena_alloc(a, len + 1);
+	memcpy(dst, src, len);
+	dst[len] = '\0';
+	return dst;
+}
+
+/* Free the arena and every block it owns. NULL is a no-op. */
+static inline void read_arena_destroy(read_arena_t *a)
+{
+	if (a == NULL) return;
+	read_arena_block_t *b = a->head;
+	while (b != NULL) {
+		read_arena_block_t *prev = b->next;
+		free(b->data);
+		free(b);
+		b = prev;
+	}
+	free(a);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* READ_ARENA_H */

--- a/test/integration/bwt_seed_strategy_test.cpp
+++ b/test/integration/bwt_seed_strategy_test.cpp
@@ -63,7 +63,13 @@ int main(int argc, char **argv) {
 	}
     
     printf("before reading sequences\n");
-    bseq1_t *seqs = bseq_read_one_fasta_file(QUERY_DB_SIZE, &numReads, fp, &total_size);
+    /* The per-read name/seq/qual strings are carved from this arena rather than
+     * malloc'd individually, so the reader hands it back for the caller to
+     * release once for the whole chunk — see read_arena_destroy() below. The
+     * seqs[] fields point into it and must not outlive it. */
+    read_arena_t *read_arena = NULL;
+    bseq1_t *seqs = bseq_read_one_fasta_file(QUERY_DB_SIZE, &numReads, fp,
+                                            &total_size, &read_arena);
 
     if(seqs == NULL)
     {
@@ -215,6 +221,10 @@ int main(int argc, char **argv) {
     _mm_free(matchArray);
     _mm_free(max_intv_array);
     delete fmiSearch;
+    /* Releases every name/seq/qual string in seqs[] in one call; nothing reads
+     * them after this point. free() on the seqs[] array itself is NULL-safe. */
+    read_arena_destroy(read_arena);
+    free(seqs);
     return 0;
 }
 

--- a/test/integration/fmi_test.cpp
+++ b/test/integration/fmi_test.cpp
@@ -64,7 +64,13 @@ int main(int argc, char **argv) {
 	}
     
     printf("before reading sequences\n");
-    bseq1_t *seqs = bseq_read_one_fasta_file(QUERY_DB_SIZE, &numReads, fp, &total_size);
+    /* The per-read name/seq/qual strings are carved from this arena rather than
+     * malloc'd individually, so the reader hands it back for the caller to
+     * release once for the whole chunk — see read_arena_destroy() below. The
+     * seqs[] fields point into it and must not outlive it. */
+    read_arena_t *read_arena = NULL;
+    bseq1_t *seqs = bseq_read_one_fasta_file(QUERY_DB_SIZE, &numReads, fp,
+                                            &total_size, &read_arena);
 
     if(seqs == NULL)
     {
@@ -320,6 +326,10 @@ int main(int argc, char **argv) {
     _mm_free(batchTid);
     _mm_free(batchOffset);
     delete fmiSearch;
+    /* Releases every name/seq/qual string in seqs[] in one call; nothing reads
+     * them after this point. free() on the seqs[] array itself is NULL-safe. */
+    read_arena_destroy(read_arena);
+    free(seqs);
     return 0;
 }
 


### PR DESCRIPTION
## What

Pool the per-read string fields (`name`/`seq`/`qual`) in a **per-chunk bump arena** instead of `malloc`-ing each field individually at ingest and `free`-ing each individually at output.

The klib `kt_pipeline` reads a chunk on one thread and writes it on another, so the old path did ~3 `malloc` + ~3 `free` per read with the **frees crossing threads** — across the ~100M reads of a typical run, exactly the workload a per-thread-arena allocator handles worst. The new `read_arena_t` (segmented bump allocator, `src/read_arena.h`) is created once per chunk by the reader, carries the chunk's fields, and is destroyed once in the write stage after every field it backs is consumed.

## Byte-identity

Only the allocation strategy changes — field contents, lengths, and NUL-termination are identical to the former per-field `strdup` path. Full-output records are byte-identical (records + headers excl. the build-dependent `@PG`), macOS arm64 / NEON, `-t 8`, vs `origin/main`:

| sample | workload | output lines | result |
|--------|----------|--------------|--------|
| wgs-5M (HG00096) | WGS paired-end | 10,033,925 | ✅ byte-identical |
| sim-wgs-place (~10M) | simulated placement PE | 10,728,019 | ✅ byte-identical |

(bwa-mem3 output is thread-count-dependent via per-chunk insert-size estimation, so byte-identity is gated at a fixed `-t`, as with the other cleanup PRs.)

## Performance — allocator-dependent

The win only materializes where cross-thread frees are expensive:

| allocator | -t64 Δ (sim-place, Graviton4) |
|-----------|-------------------------------|
| **glibc malloc** (`USE_MIMALLOC=0`) | **−8.24%** |
| mimalloc (default) | −0.21% (neutral) |

mimalloc's per-thread arenas already make the per-field churn ~free, so the default build is unaffected in both output and speed. This strictly helps allocation-bound builds (e.g. glibc / platforms without mimalloc); it does not regress the default. RSS is neutral.

## Notes
`src/read_arena.h` documents the full ownership/lifetime contract (one arena per chunk, grown only on the read thread during ingest, freed once in the write stage) and pointer-stability guarantees (segmented blocks; in-place 2-bit encode and `--meth` C→T/G→A projection mutate seq bytes in place at the same length, never reallocating).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved read processing efficiency by consolidating per-chunk memory management for sequence names, sequences, and quality data.
  - Reduced individual allocation and cleanup overhead during FASTA/FASTQ ingestion.

- **API Updates**
  - Read-ingestion interfaces now provide chunk-level memory ownership information.
  - Empty or end-of-input batches are handled without retaining unused memory.

- **Bug Fixes**
  - Improved cleanup reliability for read data after output processing and integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->