### PR TITLE
feat(index): warn when an AH-less sidecar hides ALT contigs, and document the remedy

### DIFF
--- a/docs/src/user-guide/indexing.md
+++ b/docs/src/user-guide/indexing.md
@@ -33,6 +33,18 @@ expect roughly 11 GB total across all four files.
 >
 > See [Coming from bwa or bwa-mem2](../getting-started/migrating.md).
 
+<!-- Separates adjacent blockquotes: a bare blank line between two of them is
+     ambiguous (markdownlint MD028) and some renderers fuse them into one. -->
+
+> **Note — ALT-aware references**
+>
+> If the reference has a `<prefix>.alt` file *and* a `<prefix>.hdr` /
+> `<baseprefix>.dict` header sidecar, `index` warns when the sidecar's `@SQ`
+> records lack `AH:*` on the ALT contigs — a Picard/GATK `.dict` never has
+> them. See [`@SQ` in Output](output.md#sq) for why, and how to fix it.
+
+<!-- Separates adjacent blockquotes -- see above. -->
+
 > **Note — no `.0123` by default**
 >
 > Earlier releases (and bwa-mem2) also wrote `ref.fa.0123`, an *unpacked*

--- a/docs/src/user-guide/output.md
+++ b/docs/src/user-guide/output.md
@@ -40,9 +40,44 @@ now agree, on the string upstream bwa uses.
 ### `@SQ`
 
 One `@SQ` line is written per reference sequence, with the sequence name
-(`SN:`) and length (`LN:`) derived from the FM-index. If the index was built
-with a `.dict` or `.hdr` file that supplies `@SQ` records, those records are
-used instead of the auto-generated ones.
+(`SN:`) and length (`LN:`) derived from the FM-index. Contigs listed in
+`<prefix>.alt` additionally get `AH:*`, marking them as alternate loci.
+
+If a `<prefix>.hdr` or `<baseprefix>.dict` file sits next to the index and
+supplies `@SQ` records, those records are used **verbatim** instead of the
+auto-generated ones. This is deliberate: the sidecar is authoritative, so
+bwa-mem3 neither adds nor removes tags in it.
+
+> **Warning — a Picard/GATK `.dict` drops `AH:*`**
+>
+> `picard CreateSequenceDictionary` has no notion of a `.alt` file, so the
+> `.dict` it writes carries no `AH` tag. Because the sidecar is used verbatim,
+> **ALT contigs lose their `AH:*` in the output header** — which matters to
+> anything that keys on it, notably `bwa-postalt.js` and ALT-aware duplicate
+> marking and QC.
+>
+> This bites the standard Broad reference layout, because the discovery order
+> is `<prefix>.hdr` then `<baseprefix>.dict` — so
+> `Homo_sapiens_assembly38.fasta` resolves to `Homo_sapiens_assembly38.dict`,
+> exactly the file the GATK resource bundle ships.
+>
+> Both `index` and `mem` warn when the index has ALT contigs and the sidecar's
+> `@SQ` has no `AH`. Two paths do not, because on them there is nothing to lose:
+> `mem --meth` (the doubled reference's contigs are `f`/`r`-prefixed and have no
+> ALT status of their own — `index --meth` still checks the real reference), and
+> `--compat=bwa-mem2`, which ignores the sidecar entirely and generates `@SQ`
+> with `AH:*` from the index.
+>
+> The fix is to regenerate the sidecar with the ALT list — `samtools dict` reads
+> a bwa-style `.alt` and emits `AH:*` for you:
+>
+> ```bash
+> samtools dict --alt ref.fasta.alt -o ref.dict ref.fasta
+> ```
+>
+> Alternatively, delete the sidecar and let bwa-mem3 generate `@SQ` itself,
+> which always emits `AH:*` — at the cost of the `M5`/`UR`/`AS`/`SP` metadata
+> the `.dict` carries.
 
 In methylation mode (`--meth`), the doubled reference contains sequences with
 an `f` or `r` prefix in their names. The inline BAM post-processor collapses

--- a/docs/src/whats-different/equivalence.md
+++ b/docs/src/whats-different/equivalence.md
@@ -143,11 +143,13 @@ Caveats:
   --compat=bwa-mem2` would produce a diff-clean-looking stream over genuinely different
   alignments. `--compat` is meaningful only on the drop-in profile.
 - **The sidecar `@SQ` is skipped, not rewritten.** Outside `--compat` the
-  `<prefix>.hdr` / `<baseprefix>.dict` block remains authoritative and is emitted verbatim —
-  it is a port of [lh3/bwa#348](https://github.com/lh3/bwa/pull/348), designed for the block
-  to be produced complete by an external tool. If your index has a `.alt` file, generate the
-  sidecar with `samtools dict --alt <ref>.alt` so `AH:*` is carried; bwa-mem3 warns when it
-  sees ALT contigs and a sidecar `@SQ` without `AH`.
+  `<prefix>.hdr` / `<baseprefix>.dict` block remains authoritative and is emitted verbatim.
+  On those sidecar-honoring paths — the default profile, `--bam` and `--meth` — an index with
+  a `.alt` file needs that block to carry `AH:*` itself, because nothing re-derives it from
+  the index; see [`@SQ` in Output](../user-guide/output.md#sq) for why, which commands warn,
+  and how to regenerate the sidecar. Under `--compat=bwa-mem2` the requirement does not
+  apply: the sidecar is ignored entirely and `AH:*` is generated from the index (the table
+  row above), so a sidecar missing `AH` cannot affect that output.
 - **`--compat=bwa-mem` is recognized but rejected.** bwa-mem3 and bwa still differ on 224 of
   63,583 records (53 above MAPQ 30) in MAPQ, CIGAR, POS and TLEN, so no amount of output
   shaping makes them byte-identical. Tracked separately.

--- a/src/bwtindex.cpp
+++ b/src/bwtindex.cpp
@@ -224,6 +224,34 @@ static void index_usage(void)
 	        "  -h, --help         print this help message and exit\n");
 }
 
+/* Report, at index time, the ALT/AH gap `mem` also reports -- see
+ * bwa_warn_sidecar_missing_AH (bwa.cpp) for why a sidecar's @SQ is emitted
+ * verbatim rather than enriched. Worth saying here as well: this is when the
+ * reference layout is in front of the user and regenerating the sidecar still
+ * costs nothing, whereas `mem` reports it only once an alignment is running.
+ *
+ * `mem` remains the authoritative check -- the .alt and the sidecar are both
+ * optional and either may be dropped in after indexing, so a quiet `index` is
+ * not a guarantee.
+ *
+ * The .alt existence test is what makes this cheap: with no .alt no contig can
+ * be ALT, so the check is provably a no-op, and skipping it avoids reading the
+ * sidecar and the .ann/.amb (~1 MB on hg38) to reach that conclusion. */
+static void warn_if_sidecar_hides_alt(const char *prefix)
+{
+	char alt_path[PATH_MAX];
+	int n = snprintf(alt_path, sizeof(alt_path), "%s.alt", prefix);
+	if (n <= 0 || (size_t)n >= sizeof(alt_path)) return;
+	if (access(alt_path, F_OK) != 0) return;
+
+	char *idx_hdr = bwa_load_hdr_from_index(prefix);   /* NULL when no sidecar */
+	if (idx_hdr == NULL) return;
+	bntseq_t *bns = bns_restore(prefix);               /* applies .alt -> is_alt */
+	bwa_warn_sidecar_missing_AH(bns, idx_hdr, prefix); /* no-ops on a NULL bns */
+	bns_destroy(bns);                                  /* NULL-safe */
+	free(idx_hdr);
+}
+
 int bwa_index(int argc, char *argv[]) // the "index" command
 {
 	int c;
@@ -328,10 +356,19 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 			fprintf(stderr, "ERROR: --meth does not accept -p (outputs <in.fasta>.* and <in.fasta>.meth.*)\n");
 			return 1;
 		}
-		return meth_index_build(argv[optind], emit_unpacked_ref);
+		int rc = meth_index_build(argv[optind], emit_unpacked_ref);
+		/* The real reference only. The `.meth` seed index has no .alt of its own
+		 * and its contigs are f/r-prefixed, so it can never have ALT status to
+		 * lose -- the same reason `mem` skips this check in meth mode
+		 * (fastmap.cpp). Stating it here beats relying on the seed prefix
+		 * happening not to resolve a sidecar. */
+		if (rc == 0) warn_if_sidecar_hides_alt(argv[optind]);
+		return rc;
 	}
 	if (prefix == 0) prefix = argv[optind];
-	return bwa_idx_build(argv[optind], prefix, emit_unpacked_ref);
+	int rc = bwa_idx_build(argv[optind], prefix, emit_unpacked_ref);
+	if (rc == 0) warn_if_sidecar_hides_alt(prefix);
+	return rc;
 }
 
 int bwa_idx_build(const char *fa, const char *prefix, int emit_unpacked_ref)

--- a/test/index_alt_sidecar_warn_test.sh
+++ b/test/index_alt_sidecar_warn_test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# test/index_alt_sidecar_warn_test.sh
+#
+# Asserts that `bwa-mem3 index` reports the ALT/AH gap: the reference has ALT
+# contigs (via <prefix>.alt) but the header sidecar (<baseprefix>.dict /
+# <prefix>.hdr) supplies @SQ records with no AH tag.
+#
+# Why this matters: the sidecar's @SQ is authoritative by design (a port of
+# lh3/bwa#348), so bwa-mem3 emits it verbatim and does NOT inject AH:*. A
+# Picard/GATK-style .dict carries no AH -- Picard has no notion of a .alt file
+# -- so the standard Broad reference layout silently loses ALT status from every
+# output header. `mem` reports this too; indexing is the earlier place to hear
+# it, when the remedy (`samtools dict --alt`) still costs nothing.
+#
+# Scope: this covers the `index` call site -- that it is reached, and that it
+# stays quiet in each of the three ways it should (no sidecar, no ALT contig,
+# sidecar already carrying AH). The remaining gating inside
+# bwa_warn_sidecar_missing_AH (--compat, the --bam path) is covered at `mem`
+# level by test/regression/header_parity.sh, which uses a real
+# `samtools dict --alt` sidecar rather than a hand-written one. This script
+# deliberately needs no samtools, so it runs on every CI leg.
+#
+# Usage: test/index_alt_sidecar_warn_test.sh <bwa-mem3-binary>
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <bwa-mem3-binary>" >&2
+    exit 2
+fi
+
+bin="$1"
+[[ -x "$bin" ]] || { echo "FAIL: bwa-mem3 binary not executable at $bin" >&2; exit 1; }
+
+fail () {  # $1 = stderr file to dump, $2... = message
+    local err="$1"; shift
+    echo "FAIL [index alt sidecar warn]: $*" >&2
+    echo "--- index stderr:" >&2
+    cat "$err" >&2
+    exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+ALT_SN="chrX_KI000001v1_alt"
+# The warning is emitted by bwa_warn_sidecar_missing_AH (src/bwa.cpp); match its
+# text, not a bare "ALT", so the assertion cannot pass on unrelated output.
+WARN_RE="sidecar supplies @SQ without an AH tag"
+
+# One line per sequence: `fold` drops the final newline when the length is not a
+# multiple of the width, gluing the next '>' onto the sequence -- silently, and
+# the index then builds with a single contig.
+emit_contig () {  # $1 = name, $2 = length
+    printf '>%s\n' "$1"
+    head -c "$2" /dev/zero | tr '\0' 'A'
+    printf '\n'
+}
+
+make_ref () {  # $1 = destination fasta
+    {
+        emit_contig chr1      2000
+        emit_contig chr2      1500
+        emit_contig "$ALT_SN" 1000
+    } > "$1"
+}
+
+# Picard/GATK-style sequence dictionary (SN/LN/M5/AS/UR/SP) -- what
+# CreateSequenceDictionary emits and what the Broad bundle ships as
+# <basename>.dict. $2 appends tags to the ALT record: '' for Picard (no AH).
+write_dict () {  # $1 = destination .dict, $2 = extra tags on the ALT record
+    {
+        printf '@HD\tVN:1.5\tSO:unsorted\n'
+        printf '@SQ\tSN:chr1\tLN:2000\tM5:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tAS:test\tUR:file:/refs/ref.fa\tSP:synthetic\n'
+        printf '@SQ\tSN:chr2\tLN:1500\tM5:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\tAS:test\tUR:file:/refs/ref.fa\tSP:synthetic\n'
+        printf '@SQ\tSN:%s\tLN:1000\tM5:cccccccccccccccccccccccccccccccc\tAS:test\tUR:file:/refs/ref.fa\tSP:synthetic%s\n' \
+            "$ALT_SN" "${2-}"
+    } > "$1"
+}
+
+write_alt () {  # $1 = destination .alt
+    printf '%s\t0\tchr1\t1\t60\t1000M\t*\t0\t0\t*\t*\n' "$ALT_SN" > "$1"
+}
+
+# --------------------------------------------------------------------------
+# Case A: .alt present, sidecar present without AH -> MUST warn
+# --------------------------------------------------------------------------
+a="$tmp/a"; mkdir -p "$a"
+make_ref   "$a/ref.fa"
+write_alt  "$a/ref.fa.alt"   # .alt is <prefix>.alt
+write_dict "$a/ref.dict"     # .dict is <baseprefix>.dict
+"$bin" index "$a/ref.fa" > /dev/null 2> "$a/err.txt" \
+    || fail "$a/err.txt" "case A: index exited non-zero"
+
+grep -q "$WARN_RE" "$a/err.txt" \
+    || fail "$a/err.txt" "case A: expected the missing-AH warning at index time"
+grep -q "samtools dict" "$a/err.txt" \
+    || fail "$a/err.txt" "case A: warning must name the \`samtools dict --alt\` remedy"
+grep -q "$ALT_SN" "$a/err.txt" \
+    || fail "$a/err.txt" "case A: warning should name the offending contig ($ALT_SN)"
+
+# --------------------------------------------------------------------------
+# Case B: .alt present, NO sidecar -> must NOT warn. bwa-mem3 generates its own
+# @SQ with AH:*, so nothing is lost. Exercises the no-sidecar early return.
+# --------------------------------------------------------------------------
+b="$tmp/b"; mkdir -p "$b"
+make_ref  "$b/ref.fa"
+write_alt "$b/ref.fa.alt"
+"$bin" index "$b/ref.fa" > /dev/null 2> "$b/err.txt" \
+    || fail "$b/err.txt" "case B: index exited non-zero"
+
+! grep -q "$WARN_RE" "$b/err.txt" \
+    || fail "$b/err.txt" "case B: no sidecar present; must not warn"
+
+# --------------------------------------------------------------------------
+# Case C: sidecar without AH but NO .alt -> must NOT warn. No contig is ALT, so
+# a missing AH is correct rather than a loss. This is the common case for most
+# references, where a spurious warning would be pure noise.
+# --------------------------------------------------------------------------
+c="$tmp/c"; mkdir -p "$c"
+make_ref   "$c/ref.fa"
+write_dict "$c/ref.dict"
+"$bin" index "$c/ref.fa" > /dev/null 2> "$c/err.txt" \
+    || fail "$c/err.txt" "case C: index exited non-zero"
+
+! grep -q "$WARN_RE" "$c/err.txt" \
+    || fail "$c/err.txt" "case C: reference has no ALT contigs; must not warn"
+
+# --------------------------------------------------------------------------
+# Case D: .alt present AND the sidecar's ALT @SQ already carries AH:* -> must
+# NOT warn. This is the state case A tells the user to reach, so it is the one
+# case where a false positive would train them to ignore the warning. It is
+# also the only negative case that exercises the AH-detection itself rather
+# than an early return: cases B and C bail before any @SQ is scanned.
+# --------------------------------------------------------------------------
+d="$tmp/d"; mkdir -p "$d"
+make_ref   "$d/ref.fa"
+write_alt  "$d/ref.fa.alt"
+# $'...' rather than '\tAH:*': write_dict passes the extra tags through a
+# printf %s, which does NOT expand escapes, so a plain '\tAH:*' would leave a
+# literal backslash-t in the record. The AH token would not be tab-delimited,
+# the sidecar would still be AH-less as far as the scanner is concerned, and the
+# case would "fail" on a fixture bug rather than on the code.
+write_dict "$d/ref.dict" $'\tAH:*'   # what `samtools dict --alt` produces
+# Verify the fixture is what the case claims: AH:* must be a whole tab-delimited
+# field on the ALT record, which is the only form bwa_warn_sidecar_missing_AH
+# recognizes.
+awk -F'\t' -v sn="SN:$ALT_SN" '
+    $1 == "@SQ" {
+        for (i = 2; i <= NF; ++i) if ($i == sn) alt = 1
+        if (alt) { for (i = 2; i <= NF; ++i) if ($i == "AH:*") ok = 1; alt = 0 }
+    }
+    END { exit !ok }' "$d/ref.dict" \
+    || fail "$d/ref.dict" "case D: fixture bug -- AH:* is not a tab-delimited field on the ALT @SQ"
+"$bin" index "$d/ref.fa" > /dev/null 2> "$d/err.txt" \
+    || fail "$d/err.txt" "case D: index exited non-zero"
+
+! grep -q "$WARN_RE" "$d/err.txt" \
+    || fail "$d/err.txt" "case D: sidecar already carries AH:* on the ALT contig; must not warn"
+
+echo "PASS: index reports an AH-less sidecar only when the reference has ALT contigs and the sidecar omits AH"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -111,6 +111,16 @@ ok "meth_rg_header_test"
 "$HERE/meth_sidecar_enrich_test.sh" "$BWAMEM3" "$FIXTURES" || fail "meth_sidecar_enrich_test failed"
 ok "meth_sidecar_enrich_test"
 
+# --- index_alt_sidecar_warn_test ------------------------------------------
+# `index` must warn when the reference has ALT contigs (<prefix>.alt) but the
+# header sidecar supplies @SQ with no AH tag -- the Picard/GATK .dict case,
+# where ALT status is silently lost from every output header. It must stay quiet
+# with no sidecar, with no ALT contig, and when the sidecar already carries
+# AH:*. The remaining --compat and --bam gating is covered at `mem` level by
+# regression/header_parity.sh.
+"$HERE/index_alt_sidecar_warn_test.sh" "$BWAMEM3" || fail "index_alt_sidecar_warn_test failed"
+ok "index_alt_sidecar_warn_test"
+
 # --- help_prescan_test ----------------------------------------------------
 # `mem --help` pre-scan must not match `--help` when it is the value of
 # an option that takes an argument (-R, -o, --set-as-failed, ...).


### PR DESCRIPTION
Closes #281. Stacked on #292 (which stacks on #291 → #277 → #276) — review those first.

## Why this, and not the fix #281 proposed

#281's body suggested merging `AH:*` into the sidecar-derived `@SQ` by `SN`. That was investigated and deliberately rejected while building #277, so this PR does *not* enrich the sidecar. The reasoning, recorded here so it does not get relitigated:

The `<prefix>.hdr` / `<baseprefix>.dict` feature is a port of [lh3/bwa#348](https://github.com/lh3/bwa/pull/348), whose author intended the block to be produced complete by an external dict tool. Asked in 2022 how anyone would add `AH` by hand, jmarshall replied that a `samtools dict` option was coming to read the `.alt` and emit `AH` — and [samtools/samtools#1676](https://github.com/samtools/samtools/pull/1676) shipped it (`samtools dict -l/--alt`, merged 2022-07-19, present in samtools 1.23.1). So the sidecar is authoritative *including* `AH`, and the sanctioned generator exists.

Enriching also drags in three problems that warning does not:

- **The enrich/strip asymmetry.** If we add `AH` where the index says ALT, do we strip it where the index says not-ALT? Adding restores index truth our own sidecar feature destroyed; stripping overrides user data.
- **A concrete failure case:** unconditional stripping deletes correct `AH` from a hand-made `.hdr`.
- **An `LN`-disagreement gate:** what to do when the sidecar's `LN` contradicts the index.

Neither bwa nor bwa-mem2 has sidecar support at all, so there is no upstream behaviour to match here; the nearest analogue is `-H`, which both upstreams pass through verbatim. Verbatim is the upstream-*consistent* choice.

## What this adds

`mem` already warns (`bwa_warn_sidecar_missing_AH`, landed in #277). This runs the same check at the end of a successful `index` build, reusing that function rather than restating the policy.

Indexing is the earlier and better place to hear it: it is when the reference layout is in front of the user, and regenerating the sidecar still costs nothing. Hearing it first from `mem` means discovering it after an alignment run — or not at all, since the consequence (`bwa-postalt.js` and ALT-aware dedup/QC silently losing ALT status) surfaces far downstream.

Advisory by construction: the `.alt` and the sidecar are both optional and either may be added after indexing, so the check cannot fail a build. It calls `bns_restore` to apply `<prefix>.alt`, because `bwa_idx_build` never populates `is_alt` itself.

## Docs

`output.md` previously said only that sidecar `@SQ` records "are used instead of the auto-generated ones" — omitting the consequence. It now covers why the sidecar is verbatim, that a Picard/GATK `.dict` carries no `AH`, that this hits the **standard Broad layout** (`Homo_sapiens_assembly38.fasta` → `Homo_sapiens_assembly38.dict`, exactly what the GATK bundle ships), and both ways out. `indexing.md` gets a pointer where someone setting up a reference is actually reading.

## Test

`test/index_alt_sidecar_warn_test.sh`, registered in `run_unit_tests.sh`. Four cases on a programmatically generated 3-contig reference — no committed fixtures:

| case | `.alt` | sidecar | expected |
|---|---|---|---|
| A | yes | no `AH` | **warns**, names the contig and the remedy |
| B | yes | has `AH` | silent |
| C | yes | none | silent (bwa-mem3 generates `@SQ` with `AH:*` itself) |
| D | no | no `AH` | silent (no contig is ALT, so no `AH` is correct) |

Verified failing before the fix (case A, exit 1) and passing after. Full suite: 53 OK, 0 failures, 2 pre-existing SKIPs for the chr22/hg38 fixtures absent locally.

The remedy in the docs is verified end to end, not asserted:

```
$ samtools dict --alt ref.fa.alt -o ref.dict ref.fa
$ bwa-mem3 index ref.fa            # no warning
$ bwa-mem3 mem ref.fa r.fq | grep _alt
@SQ  SN:chrX_KI000001v1_alt  LN:1000  M5:8b2f8e56…  AH:*  UR:file:///…/ref.fa
```

`AH:*` present *and* the dict's `M5`/`UR` retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added warnings when ALT-aware references use sidecar headers missing required `AH:*` tags.
  - Warning messages identify affected ALT contigs and recommend regenerating sidecars with ALT metadata or removing them.

- **Documentation**
  - Expanded guidance on ALT-aware indexing, header generation, sidecar precedence, compatibility behavior, and corrective steps.

- **Bug Fixes**
  - Improved detection across standard and methylation indexing workflows.

- **Tests**
  - Added regression coverage for missing, present, and irrelevant `AH:*` metadata scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->