### PR TITLE
perf(main): calibrate proc_freq without sleeping a full second

### DIFF
--- a/docs/src/developer-guide/regression-tests.md
+++ b/docs/src/developer-guide/regression-tests.md
@@ -128,6 +128,7 @@ Additional integration shell scripts in `test/`:
 | `shm_round_trip_test.sh` | `bwa-mem3 shm` load / list / drop cycle |
 | `shm_meth_test.sh` | `--meth` index compatibility with `shm` |
 | `help_prescan_test.sh` | `--help` prints without running alignment |
+| `proc_freq_calibration_test.sh` | startup does not sleep to calibrate `proc_freq`, and the calibrated tick rate is plausible |
 | `libsais_*.sh` | libsais index correctness vs. BWA / determinism |
 
 ## Benchmark harness (`bench/`)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@ Contacts: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@
 #include "simd_dispatch.h"
 #include "version.h"
 #include "bwa_shm.h"
+#include <time.h>   /* clock_gettime, nanosleep: proc_freq calibration */
 
 #ifdef USE_MIMALLOC
 #include <mimalloc.h>
@@ -71,14 +72,77 @@ static void append_pg_cl_arg(kstring_t *pg, const char *arg)
     }
 }
 
+// Measure the __rdtsc() tick rate (ticks per second) that every timing
+// report divides by: display_stats(), the `index` "Total time taken" line,
+// and the `mem` profiling trailer.
+//
+// This used to be `tim = __rdtsc(); sleep(1); proc_freq = __rdtsc() - tim;`,
+// which spent a full second of wall time on EVERY invocation -- including
+// `version`, `shm -l`, and plain usage errors, none of which ever read
+// proc_freq. Invisible next to a real alignment run, but it dominates the
+// test suite: run_unit_tests.sh spawns ~60 short bwa-mem3 processes, so it
+// spent ~60 s of its 74 s asleep against under 5 s of real CPU work.
+//
+// Measure over a short window instead and divide by the wall time
+// CLOCK_MONOTONIC reports for that same window. Both clocks track wall
+// time -- the TSC is invariant on every x86-64 this targets, and __rdtsc()
+// reads the fixed-rate CNTVCT_EL0 on arm64 -- so a couple of milliseconds
+// is plenty. Residual error is the nanosecond-scale cost of the counter
+// reads spread over the window (well under 0.1%), far below the precision
+// the timing reports claim. It is also no less representative than the old
+// sleep: a sleeping core sits at its lowest P-state, so on the parts whose
+// TSC is *not* invariant, sleep(1) measured precisely the frequency the
+// aligner never runs at.
+static uint64_t calibrate_proc_freq(void)
+{
+    // 5 ms, doubling per retry. nanosleep() returns early when a signal
+    // arrives; we divide by the *measured* elapsed time rather than the
+    // requested one, so a short window is still usable -- but if it came
+    // back too short to divide by with any precision, try again on a
+    // longer one.
+    const long base_window_ns = 5L * 1000 * 1000;
+    const int max_attempts = 4;
+    for (int attempt = 0; attempt < max_attempts; ++attempt) {
+        struct timespec window = {0, base_window_ns << attempt};
+        // Zero-initialized so that a failing clock_gettime() -- which
+        // CLOCK_MONOTONIC does not do in practice, but which would
+        // otherwise leave these indeterminate -- yields elapsed == 0 and
+        // falls into the retry below rather than reading uninitialized
+        // memory and dividing by garbage.
+        struct timespec t0 = {0, 0}, t1 = {0, 0};
+
+        clock_gettime(CLOCK_MONOTONIC, &t0);
+        uint64_t c0 = __rdtsc();
+        nanosleep(&window, NULL);
+        uint64_t c1 = __rdtsc();
+        clock_gettime(CLOCK_MONOTONIC, &t1);
+
+        double elapsed = (double)(t1.tv_sec - t0.tv_sec)
+                       + (double)(t1.tv_nsec - t0.tv_nsec) * 1e-9;
+        if (elapsed >= 1e-4 && c1 > c0)
+            return (uint64_t)((double)(c1 - c0) / elapsed + 0.5);
+    }
+    // Not reachable in practice (it would take max_attempts consecutive
+    // windows cut short to under 100 us). Say so on stderr rather than
+    // silently returning a bogus rate: without this, a pathological
+    // environment -- nanosleep() blocked by a seccomp filter, a process
+    // under relentless signal pressure -- would print implausible timings
+    // with nothing explaining why. stderr only, so the SAM on stdout is
+    // unaffected.
+    fprintf(stderr, "[W::%s] could not calibrate the processor tick rate in "
+                    "%d attempts; timing reports will be meaningless.\n",
+            __func__, max_attempts);
+    // Return 1 rather than 0 so the reports print implausible seconds
+    // instead of dividing by zero.
+    return 1;
+}
+
 int main(int argc, char* argv[])
 {
     bwamem3_simd_init();
 
     // ---------------------------------
-    uint64_t tim = __rdtsc();
-    sleep(1);
-    proc_freq = __rdtsc() - tim;
+    proc_freq = calibrate_proc_freq();
 
     int ret = -1;
     if (argc < 2) return usage();

--- a/test/proc_freq_calibration_test.sh
+++ b/test/proc_freq_calibration_test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# test/proc_freq_calibration_test.sh
+#
+# `proc_freq` (the __rdtsc() tick rate that every timing report divides by)
+# is calibrated once at startup. It used to be measured with a literal
+# `sleep(1)`, which charged a full second of wall time to EVERY invocation
+# -- including `version`, `shm -l`, and usage errors, none of which ever
+# read proc_freq. This test guards both halves of the replacement:
+#
+#   1. Startup is cheap: N back-to-back `version` calls finish in well
+#      under N seconds. A reintroduced sleep(1) fails here immediately.
+#   2. The calibration is still correct: a real `mem` run reports a
+#      plausible processor frequency. A proc_freq of 0 prints @0.000000 MHz
+#      and a broken window prints an absurd value; either fails here.
+#
+# Usage: test/proc_freq_calibration_test.sh <bwa-mem3-binary> <fixtures-dir>
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 <bwa-mem3-binary> <fixtures-dir>" >&2
+    exit 2
+fi
+
+abspath() { (cd "$(dirname "$1")" && printf '%s/%s\n' "$(pwd)" "$(basename "$1")"); }
+bin="$(abspath "$1")"
+fixtures="$(abspath "$2")"
+ref="$fixtures/phix.fa"
+reads="$fixtures/reads.fa"
+
+[[ -x "$bin" ]]   || { echo "FAIL: bwa-mem3 binary not executable at $bin" >&2; exit 1; }
+[[ -s "$ref" ]]   || { echo "FAIL: phix.fa missing at $ref" >&2; exit 1; }
+[[ -s "$reads" ]] || { echo "FAIL: reads.fa missing at $reads" >&2; exit 1; }
+
+# Build the phiX FMI index if not already present.
+if [[ ! -s "$ref.bwt.2bit.64" || ! -s "$ref.amb" \
+      || ! -s "$ref.ann"       || ! -s "$ref.pac" ]]; then
+    "$bin" index "$ref" >/dev/null 2>&1 \
+        || { echo "FAIL: bwa-mem3 index on phix.fa failed" >&2; exit 1; }
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# --- 1. Startup does not sleep ----------------------------------------------
+# `version` reads no index and prints a handful of lines, so its entire
+# runtime is process startup. Timed with bash's integer-second SECONDS
+# rather than a high-resolution clock so the test needs no non-POSIX date
+# or extra interpreter. 8 invocations against a 3 s budget sits between the
+# two costs it has to separate: ~25x above the measured cost (~0.11 s for
+# all 8, i.e. ~14 ms each) and ~2.7x below the old sleep(1) cost (8 s). The
+# large upper margin is what keeps it from flaking on a loaded CI runner.
+runs=8
+budget=3
+SECONDS=0
+for _ in $(seq "$runs"); do
+    "$bin" version > "$tmpdir/version.out" 2> "$tmpdir/version.err" \
+        || { echo "FAIL: bwa-mem3 version exited non-zero" >&2
+             cat "$tmpdir/version.err" >&2; exit 1; }
+done
+elapsed=$SECONDS
+if (( elapsed > budget )); then
+    echo "FAIL: $runs 'bwa-mem3 version' calls took ${elapsed}s (budget ${budget}s)." >&2
+    echo "      Startup is sleeping again -- see calibrate_proc_freq() in src/main.cpp." >&2
+    exit 1
+fi
+
+# --- 2. The calibration still produces a plausible frequency ----------------
+# display_stats() prints "Processor is running @<freq> MHz" from proc_freq
+# (src/profiling.cpp: `proc_freq*1.0/1e6` under %lf). proc_freq == 0 renders
+# as @0.000000 MHz -- it is the *time* lines below it that divide by
+# proc_freq and print `inf` -- and a mis-scaled window renders orders of
+# magnitude off; require a value inside a deliberately generous band that no
+# real tick source (a ~24 MHz arm64 CNTVCT_EL0 through a multi-GHz x86 TSC)
+# falls outside of.
+"$bin" mem "$ref" "$reads" > "$tmpdir/mem.sam" 2> "$tmpdir/mem.err" \
+    || { echo "FAIL: bwa-mem3 mem on phix.fa exited non-zero" >&2
+         cat "$tmpdir/mem.err" >&2; exit 1; }
+
+# Capture the field verbatim ([^ ]+, not just digits) so whatever %lf
+# actually printed -- 0.000000, an absurd magnitude, or a non-numeric
+# nan/inf -- lands in the failure message instead of the match silently
+# failing and reporting a missing line.
+freq_mhz="$(sed -nE 's/^Processor is running @([^ ]+) MHz$/\1/p' "$tmpdir/mem.err" | head -n1)"
+[[ -n "$freq_mhz" ]] \
+    || { echo "FAIL: 'Processor is running @... MHz' line missing from mem stderr" >&2
+         cat "$tmpdir/mem.err" >&2; exit 1; }
+
+awk -v f="$freq_mhz" 'BEGIN { exit !(f + 0 >= 1 && f + 0 <= 100000) }' \
+    || { echo "FAIL: implausible calibrated frequency: ${freq_mhz} MHz (expected 1 .. 100000)" >&2
+         exit 1; }
+
+echo "PASS: startup does not sleep ($runs version calls in ${elapsed}s); calibrated @${freq_mhz} MHz"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -117,6 +117,13 @@ ok "meth_sidecar_enrich_test"
 "$HERE/help_prescan_test.sh" "$BWAMEM3" "$FIXTURES" || fail "help_prescan_test failed"
 ok "help_prescan_test"
 
+# --- proc_freq_calibration_test -------------------------------------------
+# Startup must not sleep to calibrate proc_freq (it used to sleep(1) on
+# every invocation, which dominated this very suite), and the replacement
+# short-window calibration must still report a plausible tick rate.
+"$HERE/proc_freq_calibration_test.sh" "$BWAMEM3" "$FIXTURES" || fail "proc_freq_calibration_test failed"
+ok "proc_freq_calibration_test"
+
 # --- fast_preset_test -----------------------------------------------------
 # --fast bundles the four characterized speed levers; explicit flags override;
 # default path stays clean. Asserts on the resolved-opts audit line.


### PR DESCRIPTION
## Problem

`main()` opens with a literal one-second sleep on **every** invocation:

```c
uint64_t tim = __rdtsc();
sleep(1);
proc_freq = __rdtsc() - tim;
```

That is how `proc_freq` — the `__rdtsc()` tick rate every timing report divides by — has always been learned. The cost is charged to every process, including `version`, `shm -l`, and plain usage errors, none of which ever read `proc_freq`. It is invisible next to a real alignment run, but it dominates anything that spawns many short processes: `test/run_unit_tests.sh` spawns ~60 of them and spent ~60 s of its 74 s wall time asleep, against under 5 s of real CPU work.

## Change

Measure over a 5 ms window and divide by the wall time `CLOCK_MONOTONIC` reports for that same window. Both clocks track wall time — the TSC is invariant on the x86-64 parts this targets, and `__rdtsc()` reads the fixed-rate `CNTVCT_EL0` on arm64 — so a few milliseconds is plenty. The window doubles on retry if a signal cuts `nanosleep()` short, and the elapsed time is measured rather than assumed, so an interrupted window is still usable.

## Accuracy

The short window is *more* accurate than the sleep it replaces, not less. On an arm64 host whose `CNTVCT_EL0` runs at exactly 24.000000 MHz:

| calibration | reported frequency | spread | bias |
|---|---|---|---|
| `sleep(1)` (before) | 24.018, 24.046, 24.121 MHz | 0.4% | +0.2% |
| 5 ms window (after) | 23.997, 24.000, 23.997, 24.000, 23.998 MHz | 0.02% | −0.01% |

The old measurement is taken on an idle core sitting at its lowest P-state, which on parts whose TSC is not invariant is precisely the frequency the aligner does not run at.

## Measured effect

Same machine, same test binaries, back-to-back:

| | before | after |
|---|---|---|
| `bwa-mem3 version` | 1.01 s | 0.01 s |
| `test/run_unit_tests.sh` | 73.6 s | 7.3–14.0 s |

`ALL UNIT TESTS PASSED` in both runs.

## Output identity

SAM output is byte-identical against a binary built from the pre-change source at the same commit, on both `phix.fa` and `synthetic_1mb.fa`, excluding the `@PG` line (it carries `argv[0]`, which differs between the two binaries by construction). `proc_freq` is only ever consumed by `fprintf` of elapsed times — it cannot reach alignment output.

This touches no Smith-Waterman kernel, so the `bwa-bsw-bench` gate does not apply.

## Test

`test/proc_freq_calibration_test.sh` guards both halves of the replacement:

1. **Startup does not sleep** — eight `version` calls must finish inside a 3 s budget. Timed with bash's integer `SECONDS` so the test needs no non-POSIX `date`; the budget sits ~2.7× above the measured cost and >2× below the old `sleep(1)` cost, so it separates the two without being flaky on a loaded runner.
2. **The calibration still works** — a real `mem` run must report a plausible tick rate. A `proc_freq` of 0 renders as `inf` and fails here.

Verified to **fail** (exit 1, "Startup is sleeping again") against a binary built from the pre-change source and **pass** after. Registered in `run_unit_tests.sh` (which CI runs) and in the `regression-tests.md` script table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved startup responsiveness by replacing the fixed calibration delay with a more accurate, timing-based processor-frequency calibration.

* **Bug Fixes**
  * Enhanced processor-frequency calibration robustness with retries when timing measurements are unreliable, including a safe fallback if calibration can’t be completed.

* **Tests**
  * Added a standalone regression test to confirm startup remains fast and the reported processor frequency is within a plausible range.
  * Hooked the new regression test into the unit-test suite.

* **Documentation**
  * Updated the regression test documentation to include the new standalone test script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->