### PR TITLE
perf(mem): size chaining scratch per thread instead of per read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,13 @@ jobs:
           CHR22_SIM_DIR=/tmp/chr22-sim \
           bash test/regression/thread_determinism.sh
 
+      - name: Chaining scratch is per-thread, not per-read
+        if: matrix.canonical == true
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          CHR22_FA=/tmp/chr22/chr22.fa \
+          bash test/regression/chain_scratch_per_thread.sh
+
       - name: --supp-rep-hard-cap repetitive-seed regression
         if: matrix.canonical == true
         run: |

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -2294,6 +2294,17 @@ int mem_kernel2_core(FMI_search *fmi,
                 free(chn.seeds);
         }
         free(chain_ar[l].a);
+
+        /* mem_chain2aln_across_reads_V2 parks a back-pointer to the originating
+         * chain on every alnreg (a->c) and walks a->c->seeds to compute
+         * a->seedcov. Every one of those reads happens above, inside that
+         * function; nothing downstream of this point touches a->c. The chain it
+         * points at has just been freed, and its seeds lived in this thread's
+         * seed_scratch window -- which the very next work item on this thread
+         * will overwrite. Clear the pointer so a future reader gets a null
+         * dereference instead of silently-recycled seeds. */
+        for (int i2 = 0; i2 < (int) regs[l].n; ++i2)
+            regs[l].a[i2].c = NULL;
     }
 
     int m = 0;
@@ -2371,7 +2382,10 @@ static void worker_aln(void *data, int seq_id, int batch_size, int tid)
                      w->seqs + seq_id,
                      w->regs + seq_id,
                      batch_size,
-                     w->chain_ar + seq_id,
+                     /* This thread's chain window -- the SAME one worker_bwt
+                      * just filled for this work item. Per-tid, not per-seq_id;
+                      * see worker_alloc. */
+                     w->chain_scratch + (size_t) tid * BATCH_SIZE,
                      &w->mmc,
                      mem_aln_ref_string(w),
                      tid,
@@ -2386,19 +2400,28 @@ static void worker_bwt(void *data, int seq_id, int batch_size, int tid)
 {
     worker_t *w = (worker_t*) data;
     printf_(VER, "4. Calling mem_kernel1_core..%d %d\n", seq_id, tid);
-    int seedBufSz = w->seedBufSize;
 
-    int memSize = w->nreads;
-    if (batch_size < BATCH_SIZE) {
-        seedBufSz = (memSize - seq_id) * AVG_SEEDS_PER_READ;
-        // fprintf(stderr, "[%0.4d] Info: adjusted seedBufSz %d\n", tid, seedBufSz);
-    }
+    /* One fixed-size window per thread. The old code additionally granted the
+     * final (ragged) work item the whole unused remainder of a global,
+     * nreads-sized arena via `(w->nreads - seq_id) * AVG_SEEDS_PER_READ` --
+     * which, because nreads is a deliberate over-estimate of the read count
+     * (chunk_bases / NREADS_ESTIMATE_AVG_BASES + 10), handed that item millions
+     * of extra seed slots. With per-thread windows there is no remainder to
+     * grant, so that adjustment is gone.
+     *
+     * Dropping it only moves where a chain's seeds are allocated: on overflow
+     * chain_add_one_seed falls back to calloc and marks the chain with
+     * m == SEEDS_PER_CHAIN + 1. That flag is output-dead -- it is read only by
+     * the capacity-growth ladder in test_and_merge (which preserves
+     * seeds[0..n-1] either way) and by the `m > SEEDS_PER_CHAIN` free sites --
+     * so a chain's contents, and therefore every alignment, are unchanged. */
+    int seedBufSz = w->seed_scratch_size;
 
     mem_kernel1_core(w->fmi, w->opt,
                      w->seqs + seq_id,
                      batch_size,
-                     w->chain_ar + seq_id,
-                     w->seedBuf + seq_id * AVG_SEEDS_PER_READ,
+                     w->chain_scratch + (size_t) tid * BATCH_SIZE,
+                     w->seed_scratch + (size_t) tid * BATCH_SIZE * AVG_SEEDS_PER_READ,
                      seedBufSz,
                      &(w->mmc),
                      tid,

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -382,10 +382,15 @@ typedef struct worker_t {
     bseq1_t          *seqs;
     mem_alnreg_v     *regs;
     int64_t           n_processed;
-    mem_chain_v      *chain_ar;
+    /* Per-THREAD chaining scratch: nthreads * BATCH_SIZE entries, indexed by
+     * tid (see worker_alloc). Renamed from chain_ar/seedBuf when they stopped
+     * being nreads-sized seq_id-indexed arrays, so that any out-of-tree code
+     * still doing `w.chain_ar + seq_id` fails to compile rather than silently
+     * running off the end of a much smaller allocation. */
+    mem_chain_v      *chain_scratch;
     mem_cache         mmc;
-    mem_seed_t       *seedBuf;
-    int64_t           seedBufSize;
+    mem_seed_t       *seed_scratch;
+    int64_t           seed_scratch_size;   /* one thread's window, in seeds */
     mem_seed_t       *auxSeedBuf;
     int64_t           auxSeedBufSize;
     uint8_t          *ref_string;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -195,6 +195,13 @@ void worker_alloc(const mem_opt_t *opt, worker_t &w, int32_t nreads, int32_t nth
     assert(opt != NULL);
     assert(nreads >= 0);
     assert(nthreads > 0);
+    /* The assert above compiles out under NDEBUG, and the chaining scratch is
+     * now sized FROM nthreads rather than from nreads -- so a release build
+     * given nthreads <= 0 would allocate a zero-entry scratch that kt_for then
+     * writes into, because kt_for makes the same input safe by clamping
+     * (`if (n_threads < 1) n_threads = 1`, kthread.cpp) instead of refusing.
+     * Clamp identically so the two agree on how many windows exist. */
+    if (nthreads < 1) nthreads = 1;
 
     // Record the thread count on the worker so worker_free can validate the
     // paired call and the per-thread loops can never walk past the slots
@@ -203,38 +210,76 @@ void worker_alloc(const mem_opt_t *opt, worker_t &w, int32_t nreads, int32_t nth
 
     int32_t memSize = nreads;
 
-    /* Mem allocation section for core kernels.
-     *
-     * PIPE-F24: regs/chain_ar/seedBuf are the only nreads-sized scratch here,
-     * and seedBuf alone is memSize*AVG_SEEDS_PER_READ*sizeof(mem_seed_t) —
-     * multiple GB for a capped (~256M-base) chunk. When memSize == 0 the caller
-     * is deferring this sizing to the grow-on-demand path in kt_pipeline
-     * (step 1), which allocates the trio EXACTLY from the parsed read count
-     * (ret->n_seqs) and reuses it across chunks. Leaving the pointers NULL here
-     * is a valid state: that path free()s them (free(NULL) is a no-op) before
-     * its own calloc/malloc, and worker_free is NULL-safe too. For memSize > 0
-     * (e.g. language-binding consumers that size the trio themselves) the
-     * behavior is byte-identical to before. */
-    w.regs = NULL; w.chain_ar = NULL; w.seedBuf = NULL;
+    /* Mem allocation section for core kernels */
+    w.regs = NULL; w.chain_scratch = NULL; w.seed_scratch = NULL;
 
+    /* regs is genuinely chunk-lifetime, and the only nreads-sized allocation
+     * left here: it is filled by the align pass, read by mem_pestat, and
+     * consumed (and freed per read) by worker_sam.
+     *
+     * PIPE-F24: when memSize == 0 the caller is deferring that sizing to the
+     * grow-on-demand path in kt_pipeline (step 1), which allocates regs EXACTLY
+     * from the parsed read count (ret->n_seqs) and reuses it across chunks.
+     * Leaving the pointer NULL here is a valid state: that path free()s it
+     * (free(NULL) is a no-op) before its own calloc, and worker_free is
+     * NULL-safe too. For memSize > 0 (e.g. language-binding consumers that size
+     * regs themselves) the behavior is byte-identical to before. */
     if (memSize > 0) {
         w.regs = (mem_alnreg_v *) calloc(memSize, sizeof(mem_alnreg_v));
-        w.chain_ar = (mem_chain_v*) malloc (memSize * sizeof(mem_chain_v));
-        w.seedBuf = (mem_seed_t *) calloc(sizeof(mem_seed_t),  memSize * AVG_SEEDS_PER_READ);
-
-        assert(w.seedBuf  != NULL);
-        assert(w.regs     != NULL);
-        assert(w.chain_ar != NULL);
+        assert(w.regs != NULL);
     }
 
-    w.seedBufSize = BATCH_SIZE * AVG_SEEDS_PER_READ;
+    /* chain_scratch / seed_scratch are PER-THREAD scratch, not per-read arrays.
+     * They used to be sized by nreads and indexed by seq_id, because worker_bwt
+     * and worker_aln were two separate kt_for passes and the chains + their
+     * seeds had to survive the barrier between them. The fused worker_bwt_aln
+     * removed that requirement: mem_kernel2_core frees chain->a for every read
+     * in the item before returning, so both buffers are dead the moment a work
+     * item ends and a thread can reuse its own window for the next item.
+     *
+     * kt_for dispatches items of at most BATCH_SIZE reads and never hands the
+     * same tid to two concurrent invocations, so nthreads windows of BATCH_SIZE
+     * entries each is exactly sufficient.
+     *
+     * At -t 64 and the default -K this takes seed_scratch from 13.1 GB to 67 MB
+     * and chain_scratch from 204.8 MB to 1.0 MB. The old sizing came off the
+     * read-count estimate (chunk_bases / NREADS_ESTIMATE_AVG_BASES, and
+     * chunk_bases is -K * -t), so it grew in BOTH -t and -K -- 39.3 GB of
+     * seed_scratch alone at -t 192. The new sizing drops the -K dependence
+     * entirely and leaves a per-thread constant.
+     *
+     * Those new figures are for BATCH_SIZE 512; arm64 uses 1024, so double them
+     * there (134 MB / 2.1 MB). The old figures do not depend on BATCH_SIZE.
+     *
+     * Both are sized from nthreads, so PIPE-F24's memSize == 0 deferral does not
+     * apply to them: that exists so an nreads-shaped buffer is not sized before
+     * the read count is known, and neither of these is nreads-shaped any more.
+     * They are allocated unconditionally, and the reallocation in kt_pipeline
+     * step 1 correspondingly regrows only regs. */
+    const int64_t scratch_reads = (int64_t) nthreads * BATCH_SIZE;
+    w.chain_scratch = (mem_chain_v*) malloc (scratch_reads * sizeof(mem_chain_v));
+    w.seed_scratch  = (mem_seed_t *) calloc(scratch_reads * AVG_SEEDS_PER_READ,
+                                            sizeof(mem_seed_t));
+
+    assert(w.seed_scratch  != NULL);
+    assert(w.chain_scratch != NULL);
+
+    /* Size of ONE thread's seed window. */
+    w.seed_scratch_size = BATCH_SIZE * AVG_SEEDS_PER_READ;
 
     /*** printing ***/
-    int64_t allocMem = memSize * sizeof(mem_alnreg_v) +
-        memSize * sizeof(mem_chain_v) +
-        sizeof(mem_seed_t) * memSize * AVG_SEEDS_PER_READ;
+    int64_t scratchMem = scratch_reads * sizeof(mem_chain_v) +
+        sizeof(mem_seed_t) * scratch_reads * AVG_SEEDS_PER_READ;
+    int64_t allocMem = memSize * sizeof(mem_alnreg_v) + scratchMem;
     fprintf(stderr, "------------------------------------------\n");
     fprintf(stderr, "1. Memory pre-allocation for Chaining: %0.4lf MB\n", allocMem/1e6);
+    /* Reported separately from the total because the two scale differently and
+     * conflating them hides regressions: regs is legitimately per-read (it
+     * tracks -K), whereas the chaining scratch must depend only on the thread
+     * count. test/regression/chain_scratch_per_thread.sh asserts this figure is
+     * invariant across -K. */
+    fprintf(stderr, "   per-thread chaining scratch: %0.4lf MB (%d threads)\n",
+            scratchMem/1e6, nthreads);
 
 
     /* SWA mem allocation */
@@ -320,9 +365,9 @@ void worker_free(worker_t &w, int32_t nthreads)
     // Catch mismatched alloc/free pairs before they drive out-of-bounds frees.
     assert(w.nthreads == nthreads);
 
-    free(w.chain_ar);
+    free(w.chain_scratch);
     free(w.regs);
-    free(w.seedBuf);
+    free(w.seed_scratch);
 
     for(int l=0; l<nthreads; l++) {
         _mm_free(w.mmc.seqBufLeftRef[l*CACHE_LINE]);
@@ -504,12 +549,35 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         if (w.nreads < ret->n_seqs)
         {
             fprintf(stderr, "[0000] Reallocating initial memory allocations!!\n");
-            free(w.regs); free(w.chain_ar); free(w.seedBuf);
+            /* Only regs is sized by the read count. chain_scratch/seed_scratch
+             * are per-thread windows sized by nthreads * BATCH_SIZE and are
+             * unaffected by how many reads a chunk turns out to hold. */
+            free(w.regs);
             w.nreads = ret->n_seqs;
             w.regs = (mem_alnreg_v *) calloc(w.nreads, sizeof(mem_alnreg_v));
-            w.chain_ar = (mem_chain_v*) malloc (w.nreads * sizeof(mem_chain_v));
-            w.seedBuf = (mem_seed_t *) calloc(sizeof(mem_seed_t), w.nreads * AVG_SEEDS_PER_READ);
-            assert(w.regs != NULL); assert(w.chain_ar != NULL); assert(w.seedBuf != NULL);
+            assert(w.regs != NULL);
+        }
+
+        /* The per-thread chaining scratch must never be resized per chunk: it is
+         * sized from nthreads * BATCH_SIZE in worker_alloc and indexed by tid, so
+         * an nreads-shaped reallocation here would give back the memory this
+         * sizing reclaimed, and a SMALLER one would hand two threads overlapping
+         * windows.
+         *
+         * Enforced rather than merely commented because the mistake is invisible
+         * downstream: the alignments are byte-identical either way, so every
+         * parity and determinism test in the suite would still pass. Deliberately
+         * not an assert -- this has to survive NDEBUG, which is exactly the build
+         * a memory regression would be noticed in. Costs one comparison per
+         * chunk. */
+        if (w.seed_scratch_size != (int64_t) BATCH_SIZE * AVG_SEEDS_PER_READ) {
+            fprintf(stderr,
+                    "ERROR: per-thread seed scratch was resized per chunk "
+                    "(%lld seeds, expected %lld); the chaining scratch must be "
+                    "sized only in worker_alloc (src/fastmap.cpp).\n",
+                    (long long) w.seed_scratch_size,
+                    (long long) BATCH_SIZE * AVG_SEEDS_PER_READ);
+            exit(EXIT_FAILURE);
         }
 
         fprintf(stderr, "[0000] Calling mem_process_seqs.., task: %d\n", task++);
@@ -852,16 +920,20 @@ static int process(void *shared, gzFile gfp, gzFile gfp2, int pipe_threads)
     }
 #endif
 
-    /* PIPE-F24: do NOT pre-size the per-read chaining scratch (regs/chain_ar/
-     * seedBuf) from a bytes/NREADS_ESTIMATE_AVG_BASES heuristic. That estimate
-     * (chunk_bytes/100 + 10) is right only for ~100 bp reads: it OVER-allocates
-     * a multi-GB seedBuf for longer reads (pure waste — the pool is never
-     * shrunk) and UNDER-allocates for shorter reads, forcing a free() + multi-GB
-     * calloc() on the first chunk. Start at 0 and let the grow-on-demand path in
-     * kt_pipeline (step 1) size the trio EXACTLY from the actual parsed read
-     * count (ret->n_seqs) and reuse it across chunks. Correctness is unchanged:
-     * that path runs BEFORE any read indexes these buffers and guarantees
-     * w.nreads >= n_seqs, with identical calloc zero-init. */
+    /* PIPE-F24: do NOT pre-size the read-count-sized scratch from a
+     * bytes/NREADS_ESTIMATE_AVG_BASES heuristic. That estimate (chunk_bytes/100
+     * + 10) is right only for ~100 bp reads: it OVER-allocates for longer reads
+     * (pure waste — the pool is never shrunk) and UNDER-allocates for shorter
+     * ones, forcing a free() + large calloc() on the first chunk. Start at 0 and
+     * let the grow-on-demand path in kt_pipeline (step 1) size it EXACTLY from
+     * the actual parsed read count (ret->n_seqs) and reuse it across chunks.
+     * Correctness is unchanged: that path runs BEFORE any read indexes the
+     * buffer and guarantees w.nreads >= n_seqs, with identical calloc zero-init.
+     *
+     * `regs` is the only such buffer now — chain_scratch/seed_scratch are sized
+     * from nthreads * BATCH_SIZE in worker_alloc and never depend on nreads, so
+     * a 0 here costs them nothing. That is also what retires the worst case this
+     * comment was written about: the multi-GB overshoot was seed_scratch's. */
     int32_t nreads = 0;
 
     /* All memory allocation */

--- a/src/fastmap.h
+++ b/src/fastmap.h
@@ -121,6 +121,19 @@ int main_mem(int argc, char *argv[]);
 // `w.nthreads` so the matching worker_free can validate the pairing. Prints
 // a small summary to stderr. Asserts on allocation failure (matching the
 // rest of bwa-mem3).
+//
+// Buffer lifetimes, which callers driving the kernels themselves MUST respect:
+//   * `w.regs` is sized by `nreads` and indexed by the read's position in the
+//     chunk (`seq_id`). It must stay live from the align pass through pairing
+//     and SAM emission.
+//   * `w.chain_scratch` and `w.seed_scratch` are PER-THREAD scratch, sized by
+//     `nthreads * BATCH_SIZE` and indexed by `tid`, NOT by `seq_id`. Thread
+//     `tid` owns `chain_scratch[tid * BATCH_SIZE ..]` and
+//     `seed_scratch[tid * BATCH_SIZE * AVG_SEEDS_PER_READ ..]` and may reuse
+//     that window for every work item it runs, because mem_kernel2_core frees
+//     every chain in the item before returning. Indexing either by `seq_id`
+//     (as bwa-mem3 did before these buffers were shrunk) now runs off the end
+//     of the allocation and corrupts other threads' windows.
 void worker_alloc(const mem_opt_t *opt, worker_t &w, int32_t nreads, int32_t nthreads);
 
 // Release all per-worker scratch buffers previously allocated by

--- a/src/macro.h
+++ b/src/macro.h
@@ -60,9 +60,10 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #define AVG_SEEDS_PER_READ 64        /* Used for storing seeds in chains*/
 
 // Average bases per read, used as a coarse upper-bound estimate (#reads
-// per chunk) for per-run regs/chain_ar/seedBuf allocation. Not a
-// correctness bound — the SMEM and related per-thread buffers are sized
-// at batch time from the observed maximum read length and grown on demand.
+// per chunk) for per-run `regs` allocation. Not a correctness bound — the
+// SMEM and related per-thread buffers are sized at batch time from the
+// observed maximum read length and grown on demand, and the chaining
+// scratch (chain_scratch/seed_scratch) is sized from the thread count.
 #define NREADS_ESTIMATE_AVG_BASES 100
 
 /* BWAMEM_BATCHED_MATESW:

--- a/test/regression/chain_scratch_per_thread.sh
+++ b/test/regression/chain_scratch_per_thread.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# test/regression/chain_scratch_per_thread.sh
+#
+# Regression: the chaining scratch buffers (worker_t::chain_scratch and
+# worker_t::seed_scratch) must be sized PER THREAD, i.e. by
+# nthreads * BATCH_SIZE, and must NOT scale with the batch size (-K) or with
+# the read count of a chunk.
+#
+# Why this needs its own test. These buffers were originally sized by
+# `nreads = chunk_bases / NREADS_ESTIMATE_AVG_BASES + 10` and indexed by
+# seq_id, left over from when worker_bwt and worker_aln were two separate
+# kt_for passes and the chains plus their seeds had to survive the barrier
+# between them. Fusing them into worker_bwt_aln made that unnecessary, but the
+# allocation was not shrunk, so seed_scratch reached 13.1 GB at -t 64 and
+# 39.3 GB at -t 192 -- growth linear in -t that made a large -t untenable.
+#
+# The crucial point for testing: re-introducing the nreads sizing is
+# COMPLETELY INVISIBLE to output. The alignments are byte-identical either
+# way, so every parity/determinism test in this suite would still pass while
+# the memory regression silently returned. Nothing else guards this, which is
+# why the assertion is on the allocation report rather than on the SAM.
+#
+# Method: worker_alloc reports the scratch allocation separately from the
+# per-read `regs` array:
+#   "   per-thread chaining scratch: <N> MB (<T> threads)"
+# Because that figure depends only on nthreads and BATCH_SIZE, three things must
+# hold, and the test checks all three:
+#
+#   1. It is EXACTLY equal across a 16x change in -K. Asserting equality rather
+#      than a ratio matters: the combined "Memory pre-allocation for Chaining"
+#      total also contains `regs`, which legitimately tracks -K, so any ratio
+#      test against the total needs a fudge factor whose safe range shifts with
+#      the chosen -K values. Exact equality on the isolated figure has none of
+#      that fragility.
+#   2. It is EXACTLY linear in -t. Without this, a sizing that mixed in a
+#      constant, or scaled with something other than the thread count, would
+#      still pass (1).
+#   3. The scratch is never resized per chunk. This one cannot be checked from
+#      the figures at all: worker_alloc prints them before the first chunk is
+#      parsed, so a reallocation in kt_pipeline step 1 -- which is exactly where
+#      the old code sized chain_ar/seedBuf from ret->n_seqs -- would leave both
+#      figures untouched and this test green. It is instead enforced in the code
+#      (a hard size check in that step, surviving NDEBUG) and observed here via
+#      the exit status plus the absence of its error message.
+#
+# Inputs (env vars):
+#   BWA_MEM3  -- path to the bwa-mem3 binary under test
+#   CHR22_FA  -- path to chr22.fa, pre-indexed with bwa-mem3 by the caller
+#   TMPDIR    -- optional; scratch location (must be disk-backed, not tmpfs)
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+: "${CHR22_FA:?CHR22_FA must be set}"
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/chain_scratch.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+# A tiny read set: the assertion is about ALLOCATION, not alignment, so the
+# reads only need to be real enough to get through worker_alloc. Generated
+# here rather than committed, per the project's no-test-data-files rule.
+python3 - "$WORK" <<'PY'
+import gzip, random, sys
+out = sys.argv[1]
+random.seed(20260725)          # fixed seed: fixture must be reproducible
+bases = "ACGT"
+with gzip.open(f"{out}/r1.fq.gz", "wt") as f1, gzip.open(f"{out}/r2.fq.gz", "wt") as f2:
+    for i in range(2000):
+        s1 = "".join(random.choice(bases) for _ in range(100))
+        s2 = "".join(random.choice(bases) for _ in range(100))
+        f1.write(f"@read{i}/1\n{s1}\n+\n{'I'*100}\n")
+        f2.write(f"@read{i}/2\n{s2}\n+\n{'I'*100}\n")
+PY
+
+# Report the isolated per-thread scratch allocation, in MB, for a given -t / -K.
+scratch_mb_for() {
+    local t="$1" k="$2" err="$WORK/t$1k$2.err"
+    local rc mb
+
+    # The exit status is asserted, not assumed, for two reasons. worker_alloc
+    # reports the scratch line early, so a run that printed it and then died
+    # would otherwise yield a perfectly comparable number from a failed run. And
+    # the per-chunk resize guard in kt_pipeline step 1 reports a violation by
+    # exiting non-zero -- see the note below on why that guard exists.
+    set +e
+    "$BWA_MEM3" mem -t "$t" -K "$k" "$CHR22_FA" \
+        "$WORK/r1.fq.gz" "$WORK/r2.fq.gz" > /dev/null 2> "$err"
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+        echo "FAIL: 'bwa-mem3 mem -t $t -K $k' exited $rc" >&2
+        tail -20 "$err" >&2
+        exit 1
+    fi
+
+    # grep exits 1 when the line is absent, which under `set -e` (plus pipefail)
+    # would abort the script on the assignment itself and never reach the
+    # diagnostic below -- so the failure is caught explicitly instead.
+    set +e
+    mb=$(grep -m1 "per-thread chaining scratch" "$err" | sed 's/.*scratch: *//; s/ MB.*//')
+    set -e
+    if [ -z "$mb" ]; then
+        echo "FAIL: could not find the per-thread scratch line in $err" >&2
+        echo "      (worker_alloc must report it; see src/fastmap.cpp)" >&2
+        tail -20 "$err" >&2
+        exit 1
+    fi
+    echo "$mb"
+}
+
+# --- 1. Invariant across -K -------------------------------------------------
+SMALL=$(scratch_mb_for 4 4000000)      #   4 Mbase
+LARGE=$(scratch_mb_for 4 64000000)     #  64 Mbase, 16x
+
+echo "per-thread chaining scratch:  -K 4M => ${SMALL} MB    -K 64M => ${LARGE} MB"
+
+if [ "$SMALL" != "$LARGE" ]; then
+    echo "FAIL: chaining scratch changed with -K (${SMALL} MB -> ${LARGE} MB)." >&2
+    echo "      It must depend only on nthreads * BATCH_SIZE, never on the read" >&2
+    echo "      count or batch size. See worker_alloc() in src/fastmap.cpp." >&2
+    exit 1
+fi
+
+# --- 2. Exactly linear in -t ------------------------------------------------
+# -K invariance alone does not pin the formula: a sizing that mixed in any
+# constant, or that scaled with something other than the thread count, could
+# still be -K-invariant. Doubling -t must double the figure exactly.
+T8=$(scratch_mb_for 8 4000000)
+
+echo "per-thread chaining scratch:  -t 4 => ${SMALL} MB    -t 8 => ${T8} MB"
+
+awk -v a="$SMALL" -v b="$T8" 'BEGIN {
+    # Both come from the same %0.4lf format, so an exact ratio is safe to
+    # demand; the tolerance only absorbs that 4-decimal rounding.
+    exit !(a > 0 && b > 0 && (b / a) > 1.9995 && (b / a) < 2.0005)
+}' || {
+    echo "FAIL: chaining scratch is not linear in -t (${SMALL} MB at -t 4," >&2
+    echo "      ${T8} MB at -t 8; expected exactly 2x). The sizing must be" >&2
+    echo "      nthreads * BATCH_SIZE. See worker_alloc() in src/fastmap.cpp." >&2
+    exit 1
+}
+
+# --- 3. The per-chunk resize guard never fired ------------------------------
+# kt_pipeline step 1 exits non-zero if the scratch was resized per chunk, which
+# the exit-status check in scratch_mb_for already turns into a failure. Assert
+# the message is absent as well, so this stays a failure even if that guard is
+# ever softened to a warning: a reallocation at THAT site is invisible to the
+# figures above, because worker_alloc reports them before the first chunk is
+# read.
+if grep -l "per-thread seed scratch was resized" "$WORK"/*.err >/dev/null 2>&1; then
+    echo "FAIL: the per-chunk scratch resize guard fired:" >&2
+    grep -h "per-thread seed scratch was resized" "$WORK"/*.err >&2
+    exit 1
+fi
+
+echo "PASS: chaining scratch is per-thread ($SMALL MB at -t 4), invariant across a 16x -K change, exactly linear in -t, and never resized per chunk."


### PR DESCRIPTION
The chaining scratch buffers `chain_ar` and `seedBuf` were allocated with one slot per read in the chunk (`nreads = chunk_bases / NREADS_ESTIMATE_AVG_BASES + 10`) and indexed by `seq_id`. They only ever need one slot per *thread*.

That sizing is vestigial. It dates from when `worker_bwt` and `worker_aln` were two separate `kt_for` passes, so a read's chains and their seeds had to survive the barrier between them. Fusing the two into `worker_bwt_aln` removed that requirement — `mem_kernel2_core` frees every chain in a work item before it returns — but the allocation was never shrunk.

`kt_for` dispatches items of at most `BATCH_SIZE` reads and never hands the same `tid` to two concurrent invocations, so `nthreads` windows of `BATCH_SIZE` entries is exactly sufficient. This indexes both buffers by `tid` and renames them to `chain_scratch` / `seed_scratch`, so that any out-of-tree code still doing `w.chain_ar + seq_id` fails to compile rather than silently running off the end of a much smaller allocation.

## Measured

c8g.16xlarge (arm64, `BATCH_SIZE` 1024), wgs-5M, 3 reps, interleaved, warm page cache:

| `-t` | chaining pre-alloc | peak RSS | main_mem wall |
|---:|---|---|---|
| 16 | 3366.42 → **72.48 MB** | 16.54 → **14.50 GB** (−12.3%) | −0.16% |
| 64 | 5386.26 → **197.76 MB** | 21.93 → **18.72 GB** (−14.6%) | −0.31% |

Wall does not regress — slightly faster at both thread counts, and the patched binary was never slower in any of the 12 runs, but the magnitude sits at the edge of the 0.02–0.10% rep-to-rep CV, so this is best read as neutral rather than as a speedup. Peak RSS was measured two independent ways (`getrusage` via `/usr/bin/time -v`, and tricorder's `/proc` sampling) which agreed within 0.2%.

RSS falls by less than the allocation does because `seed_scratch` is `calloc`'d, so only touched pages were ever resident.

These batches are still subject to the current 256 Mbase chunk cap, so `-t 64` allocates for 2.56M reads rather than the 6.4M that `chunk_size * n_threads` implies. With the cap lifted — i.e. matching bwa and bwa-mem2's uncapped batching — the saving grows proportionally: `seed_scratch` alone would be 13.1 GB on x86 (`BATCH_SIZE` 512) against 67 MB after, and 39.3 GB at `-t 192`. Removing growth that is linear in `-t` is the point; the table above is the capped, conservative case.

## Byte-identity

Verified two ways, each with a repeat-run determinism control:

- against a pristine build at the same commit, `-t 8 -K 40M`: 10,030,561 records, md5 `920a6535ba48f8a0fa8bfee49f208984`
- on c8g at the default batch: `-t 16` md5 `5774c6ef428a3bb3a9eef35d454826a2`, `-t 64` md5 `0809620696bf6cb842f5f7e6bfa0ccf1`

## Two things worth a reviewer's attention

**The ragged-tail `seedBufSz` adjustment is deleted, not preserved.** It granted the final work item the entire unused remainder of the global arena, and because `nreads` deliberately over-estimates the read count, that remainder was millions of seed slots — carrying it into a per-thread window would overflow into the neighbouring thread's buffer. Dropping it only moves where a chain's seeds are allocated (arena vs `calloc`), which is recorded in `mem_chain_t::m`. That field is output-dead: it is read only by the capacity-growth ladder in `test_and_merge`, which preserves `seeds[0..n-1]` either way, and by the three `m > SEEDS_PER_CHAIN` free sites.

**`mem_alnreg_t::c` is now cleared once the chains are freed.** It is a back-pointer to the originating chain, read in nine places inside `mem_chain2aln_across_reads_V2` to compute `a->seedcov`. All of those reads happen before the free, so reuse is safe — but leaving the pointer set would now dangle into a window the *next* work item overwrites, rather than into an untouched arena.

## Test

`test/regression/chain_scratch_per_thread.sh`, wired into CI.

A return to per-read sizing would be invisible to every existing parity and determinism test, since the alignments are byte-identical either way. So `worker_alloc` now reports the scratch allocation separately from the per-read `regs` array, and the test asserts that figure is exactly unchanged across a 16× `-K` change. Confirmed to fail against a pre-change binary.

## Cross-architecture stack measurement

All three PRs in the stack were re-measured together on **two 64-vCPU hosts**, wgs-5M, 3 reps, interleaved, warm page cache, so each commit's contribution is separable and the whole is checked against `main`:

| `-t 64` | c8g.16xlarge (NEON) | c6a.16xlarge (AVX2) |
|---|---:|---:|
| `main` (8dbf218) | 24.81 s | 30.58 s |
| `+A` (#297) | 24.77 s (−0.15%) | 30.47 s (−0.35%) |
| `+uncap` (#298) | 26.10 s (+5.23%) | 32.02 s (+4.72%) |
| `+B` (#305) | **24.15 s (−2.63%)** | **30.27 s (−1.01%)** |

Rep-to-rep CV 0.02–0.7%. Peak RSS at `-t 64`: `main` 21.92 / 22.05 GB, `+A` 18.73 / 18.77, full stack 24.62 / 24.50.

**Net: the stack is faster than `main` at `-t 64` on both architectures while restoring byte-identity with bwa/bwa-mem2, which `main` does not have at `-t >= 26`.** It costs ~2.8 GB of peak RSS at `-t 64` (uncapping adds ~6.1 GB, #297 gives back ~3.2); at `-t 16` and `-t 32` the stack is a net memory win of ~2 GB.

Output digests were identical on both hosts at every thread count:

```
-t 16  main=5774c6ef  A=5774c6ef  uncap=5774c6ef  B_off=5774c6ef  B_on=5774c6ef
-t 32  main=08096206  A=08096206  uncap=9465e564  B_off=9465e564  B_on=9465e564
-t 64  main=08096206  A=08096206  uncap=b9c1e797  B_off=b9c1e797  B_on=b9c1e797
```

Four things follow. #297 is byte-neutral (`main == A` everywhere). #305 is byte-neutral (`uncap == B_off == B_on` everywhere). The cap is the *only* thing that changes output, and only at `-t >= 26`. And `main` produces the same digest at `-t 32` and `-t 64` because the cap pins both batches to 256 Mbase — a direct demonstration of the mechanism #298 fixes. The digests also match between NEON and AVX2, so cross-architecture byte-identity holds through the whole stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alignment memory safety by avoiding later dereferences of freed data.
  - Made per-thread chaining/seed scratch sizing consistent in multi-threaded runs (now tied to thread count rather than batch size settings).

- **Tests**
  - Added a regression test ensuring per-thread scratch memory stays constant when changing batch sizing options, scales correctly with threads, and that resize guards don’t trigger unexpectedly.
  - Enabled the regression step in canonical continuous integration runs.

- **Documentation**
  - Clarified scratch-buffer lifetimes and correct indexing/sizing expectations for reliable parallel behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->