### PR TITLE
fix(mem): make the batch-size cap opt-in so default batching matches bwa-mem2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,16 @@ jobs:
           CHR22_FA=/tmp/chr22/chr22.fa \
           bash test/regression/chain_scratch_per_thread.sh
 
+      - name: Chunk cap stays opt-in (batching matches bwa-mem2 at every -t)
+        if: matrix.canonical == true
+        # bwa and bwa-mem2 both use an uncapped `chunk_size * n_threads` batch.
+        # A default cap re-partitions the input, which changes each batch's
+        # mem_pestat cohort and therefore the output, for every -t >= 26.
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          FIXTURES="$GITHUB_WORKSPACE/test/fixtures" \
+          bash test/regression/chunk_cap_optin.sh
+
       - name: --supp-rep-hard-cap repetitive-seed regression
         if: matrix.canonical == true
         run: |

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -31,7 +31,7 @@ Options:
                   total order (faster, but resolves equal-end-position ties
                   differently from bwa-mem2, which the default reproduces).
                   NOT byte-identical to the default (divergence confined to the
-                  low-confidence tail).
+                  low-confidence tail). Also implies --chunk-cap 256000000.
     --compat STR  shape output to be byte-identical to another aligner.
                   Targets: bwa-mem2 (alias mem2), off
                   bwa-mem2: suppress the MQ:i and HN:i tags and the default @HD,
@@ -57,6 +57,12 @@ Input/output options:
    -5            for split alignment, take the alignment with the smallest coordinate as primary
    -q            don't modify mapQ of supplementary alignments
    -K INT        process INT input bases in each batch regardless of nThreads (for reproducibility) []
+   --chunk-cap INT
+                 upper bound (bases) on the default nThreads-scaled batch size;
+                 0 = off. Off by default so batching matches bwa/bwa-mem2 exactly
+                 at any -t. Capping re-partitions the input and is NOT
+                 byte-identical. Prefer -K if you want a fixed batch size AND
+                 reproducibility [0]
    -v INT        verbose level: 1=error, 2=warning, 3=message, 4+=debugging [3]
    -T INT        minimum score to output [30]
    -h INT[,INT]  if there are <INT hits with score >80.00% of the max score, output all in XA [5,200]

--- a/docs/src/best-practices/optimization-checklist.md
+++ b/docs/src/best-practices/optimization-checklist.md
@@ -158,6 +158,8 @@ locus. All uniquely-mapped reads are unaffected.
 | Multi-threaded sort | `samtools sort -@` with appropriate thread split | [User Guide — Threading](../user-guide/threading.md) |
 | Reorder seeds longest-first | `--seed-order local-longest` | [Equivalence](../whats-different/equivalence.md) |
 | SMEM deduplication | `--smem-dedup`; ~10 % fewer SA lookups; opt-in, not byte-identical | [Features → --smem-dedup](../whats-different/features.md#--smem-dedup-smem-deduplication) |
+| Reproducible output | `-K INT`; pins the batch size so output does not move with `-t` | [Aligning → `-K`](../user-guide/aligning.md) |
+| Pipeline overlap at very high `-t` | `--chunk-cap INT`; off by default, opt-in, not byte-identical | [`mem` → `--chunk-cap`](../cli/mem.md) |
 
 ---
 

--- a/docs/src/best-practices/settings-profiles.md
+++ b/docs/src/best-practices/settings-profiles.md
@@ -53,6 +53,20 @@ No extra flags. Use this when you are:
 - migrating an existing bwa-mem2 pipeline and want to change one variable (the aligner binary) at a
   time before tuning anything else.
 
+> **Add `-K` if you are comparing against bwa/bwa-mem2, or need reproducible output.**
+> The default batch size is `chunk_size × -t`, so it moves with the thread count, and batch
+> boundaries determine each batch's `mem_pestat` insert-size cohort — which feeds pairing, mate
+> rescue and MAPQ. `bwa` and `bwa-mem2` use the identical formula, so this is inherited behaviour,
+> not a bwa-mem3 difference; but it does mean a drop-in comparison is only apples-to-apples when
+> both sides see the same batching. Pass the **same `-K` to both binaries** (or match the `-t`):
+>
+> ```bash
+> bwa-mem3 mem -t <N> -K 100000000 ref.fa R1.fq R2.fq > mem3.sam
+> bwa-mem2 mem -t <M> -K 100000000 ref.fa R1.fq R2.fq > mem2.sam   # any -t; -K pins the batching
+> ```
+>
+> See [Aligning → `-K`](../user-guide/aligning.md) for the full explanation.
+
 ## Recommended profile
 
 ```bash

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -191,10 +191,59 @@ By default, bwa-mem3 may downgrade the MAPQ of supplementary alignments.
 
 #### `-K INT` — fixed batch size
 
-Forces each thread batch to process exactly `INT` input bases regardless of
-the number of threads. Useful when you need bit-for-bit reproducible output
-across runs with different `-t` values: fix `-K` to the same value and the
-output is deterministic.
+Forces each batch to process exactly `INT` input bases regardless of the number
+of threads. **Recommended whenever reproducibility or bwa/bwa-mem2 comparison
+matters.**
+
+Without `-K` the batch size is `chunk_size × -t` (10,000,000 × `-t` by default),
+so it moves with the thread count. That is not merely a scheduling detail:
+`mem_pestat` estimates the paired-end insert-size distribution from whichever
+reads land in a batch, and the resulting bounds feed pairing, mate rescue and
+MAPQ. Two runs over the same input at different `-t` can therefore disagree on a
+small number of records. `bwa` and `bwa-mem2` compute the batch size with the
+same formula and have the same property — `-K` exists in all three to pin it.
+
+Fix `-K` to the same value on both sides and the output becomes independent of
+`-t`. `-K` always wins: it is never overridden by `--chunk-cap` or `--fast`.
+
+#### `--chunk-cap INT` — upper bound on the auto-scaled batch size
+
+Caps the default `chunk_size × -t` batch at `INT` bases. `0` (the default)
+disables it, so out of the box bwa-mem3 batches **exactly** like `bwa` and
+`bwa-mem2` at any `-t`.
+
+Capping keeps the read/compute/write pipeline overlapped at very high `-t`,
+where a single batch would otherwise be enormous (10M × 192 ≈ 1.9 Gbase) and the
+input would be only three or four batches — the first batch's read and the last
+batch's write then overlap nothing. On a 64-core host that fill/drain costs
+roughly 1.6 s of a 26 s alignment.
+
+It is **opt-in because it re-partitions the input**, and by the `mem_pestat`
+mechanism described under `-K` that changes output. A capped run is not
+byte-identical to `bwa`/`bwa-mem2` at the same `-t`, and bwa-mem3 prints a
+warning to stderr when the cap actually engages. `--fast` implies
+`--chunk-cap 256000000` (`--fast` already does not promise byte-identical
+output). If you want a bounded batch *and* reproducibility, use `-K` instead.
+
+The value must be a plain non-negative base count — no `K`/`M`/`G` suffix.
+`--chunk-cap 100M` is rejected with an error rather than accepted and silently
+read as `0` (that is, as no cap at all).
+
+For cap sweeps, `BWA_MEM3_CHUNK_CAP` overrides all of the above, including
+`--fast`'s implied cap; setting it to `0` switches an explicit `--chunk-cap`
+back off. An empty value is ignored, and a malformed one is reported on stderr
+and ignored rather than being read as `0`. `-K` still wins over it — a fixed
+batch size is never capped.
+
+Precedence, highest first:
+
+| Setting | Effect |
+|---|---|
+| `-K INT` | pins the batch size exactly; never capped |
+| `BWA_MEM3_CHUNK_CAP` | overrides the cap from either source below (`0` = off) |
+| `--chunk-cap INT` | caps the auto-scaled batch (`0` = off) |
+| `--fast` | implies `--chunk-cap 256000000` |
+| *(default)* | no cap — identical batching to `bwa`/`bwa-mem2` |
 
 #### `-v INT` — verbosity
 

--- a/docs/src/getting-started/migrating.md
+++ b/docs/src/getting-started/migrating.md
@@ -50,6 +50,18 @@ If you validate against a previous bwa/bwa-mem2 release, expect (and audit)
 these differences — see [Equivalence with bwa-mem2](../whats-different/equivalence.md)
 for the field-by-field comparison and a per-PR trail.
 
+**Use `-K` on both sides when you validate.** The default batch size is
+`chunk_size × -t` in all three tools, and each batch's `mem_pestat` insert-size
+estimate comes from the reads in that batch — so a run at `-t 16` and a run at
+`-t 32` can legitimately differ on a few records, in bwa-mem2 as much as in
+bwa-mem3. Pinning `-K` to the same value on both binaries removes that variable
+and makes the diff attributable to the aligner:
+
+```bash
+bwa-mem2 mem -t 16 -K 100000000 ref.fa R1.fq.gz R2.fq.gz > mem2.sam
+bwa-mem3 mem -t 16 -K 100000000 ref.fa R1.fq.gz R2.fq.gz > mem3.sam
+```
+
 ## Recommended migration sequence
 
 1. **Install** bwa-mem3 — see [Installation](installation.md).

--- a/docs/src/user-guide/aligning.md
+++ b/docs/src/user-guide/aligning.md
@@ -65,11 +65,36 @@ string is embedded as an `RG:Z:` tag on every output record.
 ### Chunk size: `-K`
 
 ```text
--K INT   process INT input bases in each batch [10000000]
+-K INT   process INT input bases in each batch, regardless of -t []
 ```
 
 Larger `-K` values increase memory use but can improve throughput on very deep
-or very wide batches. The default is appropriate for most workloads.
+or very wide batches.
+
+**`-K` is strongly recommended whenever reproducibility matters.** Without it,
+the batch size is `chunk_size × -t` (10,000,000 × `-t` by default), so it
+*changes with the thread count* — and the batch boundaries are not cosmetic.
+`mem_pestat` infers the paired-end insert-size distribution from whatever reads
+land in a batch, and those bounds feed pairing, mate rescue and MAPQ. Two runs
+of the same input at different `-t` can therefore differ in a small number of
+records. This is inherited behaviour, not a bwa-mem3 quirk: `bwa` and
+`bwa-mem2` compute the batch size with exactly the same formula, and `-K` exists
+in all three precisely to pin it.
+
+Passing `-K` makes output **independent of `-t`**, which is what you want for:
+
+- byte-for-byte comparison against `bwa` or `bwa-mem2` (pass the same `-K` to both),
+- regression tests and release gating,
+- any pipeline where the thread count varies with the machine it lands on.
+
+```bash
+# reproducible regardless of how many threads the host gives us
+bwa-mem3 mem -t "$(nproc)" -K 100000000 ref.fa R1.fq R2.fq > out.sam
+```
+
+A good starting value is `10000000 × <the -t you would normally use>`, which
+reproduces the batching you already get today. `-K` is never overridden by
+`--chunk-cap` or `--fast`.
 
 ### SAM output control: `-S`, `-P`
 

--- a/docs/src/user-guide/threading.md
+++ b/docs/src/user-guide/threading.md
@@ -68,6 +68,14 @@ and [Best Practices: multi-sample workflows](../best-practices/multi-sample.md).
 
 ## Memory use
 
+> **`-t` changes the output, not just the speed.** The default batch size is
+> `chunk_size × -t`, and each batch's `mem_pestat` insert-size estimate is drawn
+> from the reads in that batch — so the same input aligned at different thread
+> counts can differ on a small number of records. `bwa` and `bwa-mem2` behave
+> identically here. Pass **`-K INT`** to pin the batch size and make output
+> independent of `-t`; do this for regression tests, release gating, and any
+> comparison against `bwa`/`bwa-mem2`. See [Aligning → `-K`](aligning.md).
+
 Peak RAM is the resident index (~15 GB for hg38, ~22 GB under `--meth`) plus a
 per-batch working set that scales with the *effective* batch size
 (`chunk_size × n_threads`), and is fixed with respect to `-t`. The per-batch term

--- a/docs/src/whats-different/equivalence.md
+++ b/docs/src/whats-different/equivalence.md
@@ -273,6 +273,17 @@ The following changes can move alignments, scores, or MAPQ relative to upstream,
 
 (The resolve→order→chain seeding refactor that backs `--seed-order` is byte-identical in its default `off` mode; it is described in the dedicated section below rather than listed here, since only its non-`off` modes are divergent.)
 
+### Batch size, `-t`, and why comparisons need `-K`
+
+Any equivalence claim on this page is implicitly a claim **at a fixed batch size**, and the default batch size is `chunk_size × -t`. That is inherited: `bwa`, `bwa-mem2` and bwa-mem3 all compute it the same way. It matters because batch boundaries are not purely a scheduling concern — `mem_pestat` estimates the paired-end insert-size distribution from whatever reads happen to land in a batch, and those percentile bounds feed pairing, mate rescue and MAPQ. Change the partition and a small number of records can change with it.
+
+Two consequences:
+
+- **`bwa-mem3 -t N` must be compared against `bwa-mem2 -t N`**, not against `bwa-mem2 -t M`. Comparing across thread counts measures the batching, not the aligner.
+- **Pass `-K` to both sides** if you want the comparison to be independent of `-t` altogether. `-K` pins the batch size exactly, is never capped, and is the reason it exists in all three tools.
+
+`--chunk-cap` (off by default) bounds the auto-scaled batch and therefore re-partitions the input; it is opt-in for exactly this reason, warns on stderr when it engages, and is implied by `--fast`. A run with `--chunk-cap` in effect is **not** byte-identical to `bwa`/`bwa-mem2` at the same `-t`. See [`mem` → `--chunk-cap`](../cli/mem.md) and [Aligning → `-K`](../user-guide/aligning.md).
+
 ### Seed ordering (`--seed-order`, opt-in)
 
 `--seed-order off` (the default) preserves byte-identical output. The internal resolve→order→chain refactor that enables it was verified to be bit-for-bit identical to the previous code path across single-end, paired-end, and threaded runs.

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -38,6 +38,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #endif
 #include <sstream>
 #include <getopt.h>
+#include <errno.h>    /* errno/ERANGE: strtoll validation of the INT options */
 #include <unistd.h>   /* access(): --compat's "you passed a file" diagnostic */
 #include "fastmap.h"
 #include "FMI_search.h"
@@ -1068,7 +1069,7 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                  total order (faster, but resolves equal-end-position ties\n");
     fprintf(stderr, "                  differently from bwa-mem2, which the default reproduces).\n");
     fprintf(stderr, "                  NOT byte-identical to the default (divergence confined to the\n");
-    fprintf(stderr, "                  low-confidence tail).\n");
+    fprintf(stderr, "                  low-confidence tail). Also implies --chunk-cap 256000000.\n");
     fprintf(stderr, "    --compat STR  shape output to be byte-identical to another aligner.\n");
     fprintf(stderr, "                  Targets: %s\n", compat_target_selectable_list());
     fprintf(stderr, "                  bwa-mem2: suppress the MQ:i and HN:i tags and the default @HD,\n");
@@ -1098,6 +1099,12 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "   -5            for split alignment, take the alignment with the smallest coordinate as primary\n");
     fprintf(stderr, "   -q            don't modify mapQ of supplementary alignments\n");
     fprintf(stderr, "   -K INT        process INT input bases in each batch regardless of nThreads (for reproducibility) []\n");
+    fprintf(stderr, "   --chunk-cap INT\n");
+    fprintf(stderr, "                 upper bound (bases) on the default nThreads-scaled batch size;\n");
+    fprintf(stderr, "                 0 = off. Off by default so batching matches bwa/bwa-mem2 exactly\n");
+    fprintf(stderr, "                 at any -t. Capping re-partitions the input and is NOT\n");
+    fprintf(stderr, "                 byte-identical. Prefer -K if you want a fixed batch size AND\n");
+    fprintf(stderr, "                 reproducibility [0]\n");
     fprintf(stderr, "   -v INT        verbose level: 1=error, 2=warning, 3=message, 4+=debugging [%d]\n", bwa_verbose);
     fprintf(stderr, "   -T INT        minimum score to output [%d]\n", opt->T);
     fprintf(stderr, "   -h INT[,INT]  if there are <INT hits with score >%.2f%% of the max score, output all in XA [%d,%d]\n",
@@ -1227,6 +1234,14 @@ int main_mem(int argc, char *argv[])
     char        *p, *rg_line               = 0, *hdr_line = 0;
     const char  *mode                      = 0;
     int          fast                      = 0;
+    /* --chunk-cap: upper bound (bases) on the default `chunk_size * n_threads`
+     * batch size. 0 = off, which is the DEFAULT and matches bwa and bwa-mem2
+     * exactly (both compute `chunk_size * n_threads` with no cap). Capping
+     * re-partitions the input, which changes each batch's mem_pestat cohort and
+     * therefore the output, so it must never be on by default -- see the
+     * task_size block below. */
+    int64_t      chunk_cap                 = 0;
+    int          chunk_cap_set             = 0;
 
     mem_opt_t    *opt, opt0;
     gzFile        fp = 0, fp2 = 0;
@@ -1274,6 +1289,7 @@ int main_mem(int argc, char *argv[])
         OPT_ADAPTIVE_BAND,
         OPT_EXTEND_MATE_CONCORDANT,
         OPT_COMPAT,
+        OPT_CHUNK_CAP,
 #ifdef STAGE_PROF
         OPT_PROFILE,
 #endif
@@ -1288,6 +1304,7 @@ int main_mem(int argc, char *argv[])
         {"skip-contained-ext",       no_argument,       0, OPT_SKIP_CONTAINED_EXT},
         {"adaptive-band",            no_argument,       0, OPT_ADAPTIVE_BAND},
         {"extend-mate-concordant",   optional_argument, 0, OPT_EXTEND_MATE_CONCORDANT},
+        {"chunk-cap",                required_argument, 0, OPT_CHUNK_CAP},
         {"meth",                     optional_argument, 0, OPT_METH},
         {"meth-scoring",             required_argument, 0, OPT_METH_SCORING},
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
@@ -1548,6 +1565,26 @@ int main_mem(int argc, char *argv[])
         }
         else if (c == OPT_SMEM_DEDUP) opt->smem_dedup = 1;
         else if (c == OPT_FAST) fast = 1;
+        else if (c == OPT_CHUNK_CAP) {
+            /* Validated the same way as --supp-rep-hard-cap below rather than via
+             * a bare atoll, which maps every unparseable value to 0 -- and 0 here
+             * means "no cap". A typo would therefore silently change the batch
+             * size, which is the exact class of invisible batching change this
+             * option exists to make explicit. */
+            char *end = NULL;
+            errno = 0;
+            long long v = strtoll(optarg, &end, 10);
+            if (end == optarg || end == NULL || *end != '\0' ||
+                errno == ERANGE || v < 0) {
+                fprintf(stderr, "ERROR: --chunk-cap requires a non-negative "
+                                "integer number of bases (0 = off), got '%s'\n", optarg);
+                free(opt);
+                if (out_opened) fclose(aux.fp);
+                return 1;
+            }
+            chunk_cap = (int64_t)v;
+            chunk_cap_set = 1;
+        }
         else if (c == OPT_SKIP_CONTAINED_EXT) opt->skip_contained_ext = 1;
         else if (c == OPT_ADAPTIVE_BAND) opt->band_start = ADAPTIVE_BAND_START;
         else if (c == OPT_EXTEND_MATE_CONCORDANT) {
@@ -1939,6 +1976,11 @@ int main_mem(int argc, char *argv[])
         else
             fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d --adaptive-band --extend-mate-concordant alnreg-sort=fast\n",
                     __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains);
+        /* --fast also caps the batch size, which keeps the read/compute/write
+         * pipeline overlapped at high -t. It re-partitions the input and so is not
+         * byte-identical -- which --fast already is not -- hence it rides here
+         * rather than in the default path. An explicit --chunk-cap still wins. */
+        if (!chunk_cap_set) chunk_cap = 256000000;
     }
 
     /* Load bwt2/FMI index */
@@ -2273,23 +2315,68 @@ int main_mem(int argc, char *argv[])
          * exactly, never cap. */
         aux.task_size = fixed_chunk_size;
     } else {
-        /* Default batch size is chunk_size (~10M bases) per thread. That keeps
-         * each thread well-fed, but at very high -t it makes a single chunk
-         * enormous (10M * 192 ~= 1.9G bases), so the input is only ~3-4 chunks
-         * and the pipeline starves: the first chunk's read and the last chunk's
-         * write don't overlap anything, leaving cores idle (fill/drain). Cap the
-         * default so high -t still produces enough chunks to keep read/compute/
-         * write overlapped, while keeping each chunk far above the ~33k-pairs
-         * floor below which per-chunk overhead (pestat/barriers) starts to bite.
-         * Output stays identical for -t small enough that the cap doesn't engage
-         * (scaled <= cap); above that, batch composition changes exactly as -K
-         * would (validated to leave proper-pair rate unchanged). The cap is
-         * overridable via BWA_MEM3_CHUNK_CAP (bases; <=0 disables, for sweeps). */
-        int64_t cap = 256000000;
+        /* Default batch size is chunk_size (~10M bases) per thread -- byte-for-byte
+         * the same formula as bwa (fastmap.c: `opt->chunk_size * opt->n_threads`)
+         * and bwa-mem2 v2.2.1 (fastmap.cpp: same), with NO cap.
+         *
+         * A cap is tempting: at very high -t a single chunk becomes enormous
+         * (10M * 192 ~= 1.9G bases), so the input is only ~3-4 chunks and the
+         * pipeline starves -- the first chunk's read and the last chunk's write
+         * overlap nothing (fill/drain). Measured on c8g.16xlarge / wgs-5M, that
+         * costs ~1.6s of a 25.8s PROCESS() at -t 64.
+         *
+         * But capping RE-PARTITIONS THE INPUT, and the partition is not an
+         * implementation detail: mem_pestat() infers the insert-size distribution
+         * from whatever reads land in a batch (bwamem.cpp), and those percentile
+         * bounds feed pairing, mate rescue and MAPQ. Different batches => different
+         * pes => different output. Everything else in the aligner is batch-invariant
+         * (read ids come from the global n_processed counter, so the hash_64 tie
+         * breaks are stable), which makes mem_pestat the single reason a cap is
+         * observable at all -- and it is enough.
+         *
+         * A default cap of 256M therefore silently broke byte-identity with
+         * bwa/bwa-mem2 for every -t >= 26 (10M * 26 > 256M) -- ordinary production
+         * settings -- while looking safe because the benchmark aligns at -t 16,
+         * where the cap never engaged. So the cap is now OPT-IN:
+         *
+         *   default            no cap; identical batching to bwa/bwa-mem2 at any -t
+         *   --chunk-cap N      cap at N bases (0 = off)
+         *   --fast             implies --chunk-cap 256000000 (--fast already does
+         *                      not promise byte-identical output)
+         *   BWA_MEM3_CHUNK_CAP env override, for sweeps; wins over both
+         *
+         * If you want a specific batch size AND reproducibility, use -K: it pins
+         * the size exactly and is never capped (see the branch above), which also
+         * makes output independent of -t. */
+        int64_t cap = chunk_cap;
+        /* An unset or EMPTY value leaves the CLI/--fast cap alone -- atoll("") is
+         * 0, which would otherwise read as "no cap" and silently switch an
+         * explicit --chunk-cap off. A malformed value is reported rather than
+         * silently treated as 0 for the same reason: this variable changes how
+         * the input is partitioned, so a typo in it must not quietly change the
+         * output. Reported, not fatal -- unlike the --chunk-cap flag, the index
+         * is already loaded here, and an unusable sweep value should not throw
+         * that work away when the documented default is still correct. */
         const char *cap_env = getenv("BWA_MEM3_CHUNK_CAP");
-        if (cap_env && *cap_env) cap = (int64_t)atoll(cap_env);
+        if (cap_env && *cap_env) {
+            char *cap_end = NULL;
+            errno = 0;
+            long long env_v = strtoll(cap_env, &cap_end, 10);
+            if (cap_end == cap_env || cap_end == NULL || *cap_end != '\0' ||
+                errno == ERANGE || env_v < 0) {
+                fprintf(stderr, "WARNING: BWA_MEM3_CHUNK_CAP='%s' is not a "
+                                "non-negative integer; ignoring it and using "
+                                "chunk cap %lld\n", cap_env, (long long)cap);
+            } else {
+                cap = (int64_t)env_v;
+            }
+        }
         int64_t scaled = (int64_t)opt->chunk_size * (int64_t)opt->n_threads;
         aux.task_size = (cap > 0 && scaled > cap) ? cap : scaled;
+        if (cap > 0 && scaled > cap)
+            fprintf(stderr, "[M::%s] chunk cap engaged: batch %lld -> %lld bases; "
+                    "output is NOT byte-identical to bwa/bwa-mem2 at this -t\n",
+                    __func__, (long long)scaled, (long long)cap);
     }
     tprof[MISC][1] = opt->chunk_size = aux.actual_chunk_size = aux.task_size;
 

--- a/test/regression/chunk_cap_optin.sh
+++ b/test/regression/chunk_cap_optin.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# test/regression/chunk_cap_optin.sh
+#
+# Regression: the batch-size cap must stay OFF by default.
+#
+# bwa (fastmap.c) and bwa-mem2 v2.2.1 (fastmap.cpp) both compute the default
+# batch as `opt->chunk_size * opt->n_threads` with no upper bound. bwa-mem3
+# briefly capped that default at 256M bases, which silently re-partitioned the
+# input for every `-t >= 26` (10M * 26 > 256M). The partition is not cosmetic:
+# mem_pestat() infers the insert-size distribution from whatever reads land in a
+# batch, and those bounds feed pairing, mate rescue and MAPQ — so a capped run
+# is not byte-identical to bwa/bwa-mem2 at the same -t. The regression hid
+# because the benchmark aligns at -t 16, where the cap never engaged.
+#
+# This test pins the contract:
+#   * default              -> never capped, at any -t (identical batching to bwa-mem2)
+#   * --chunk-cap N        -> caps at N (opt-in)
+#   * --fast               -> implies the cap (--fast already is not byte-identical)
+#   * BWA_MEM3_CHUNK_CAP   -> wins over both --chunk-cap and --fast's implied cap,
+#                             including setting 0 to switch an explicit cap back off;
+#                             an empty value is ignored
+#   * -K                   -> always wins, is never capped, and does not consult
+#                             the env var at all (it takes a different branch)
+#
+# Inputs:
+#   BWA_MEM3 — path to bwa-mem3 binary
+#   FIXTURES — directory containing phix.fa and reads.fa (default: test/fixtures)
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+FIXTURES="${FIXTURES:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)}"
+
+src_ref="$FIXTURES/phix.fa"
+reads="$FIXTURES/reads.fa"
+[[ -x "$BWA_MEM3" ]] || { echo "FAIL: binary not executable: $BWA_MEM3" >&2; exit 1; }
+[[ -s "$src_ref" ]]  || { echo "FAIL: phix.fa missing: $src_ref" >&2; exit 1; }
+[[ -s "$reads" ]]    || { echo "FAIL: reads.fa missing: $reads" >&2; exit 1; }
+
+# Index a private copy so the test never writes into the fixtures tree.
+mdir="$(mktemp -d)"; err="$mdir/err.log"
+trap 'rm -rf "$mdir"' EXIT
+ref="$mdir/phix.fa"
+cp "$src_ref" "$ref"
+"$BWA_MEM3" index "$ref" >/dev/null 2>&1 || { echo "FAIL: index phix.fa" >&2; exit 1; }
+
+fails=0
+
+# The effective batch size is reported by the reader as `read_chunk: <bases>`.
+# Note the args must be passed as separate words: under zsh an unquoted "$1"
+# holding "-t 32 -K 100" is ONE argv entry and atoi() silently eats the rest.
+batch_size() {
+    "$BWA_MEM3" mem "$@" "$ref" "$reads" >/dev/null 2>"$err" \
+        || { echo "FAIL: mem exited nonzero (args: $*)" >&2; cat "$err" >&2; exit 1; }
+    grep -m1 -oE 'read_chunk: [0-9]+' "$err" | grep -oE '[0-9]+$'
+}
+
+expect() {  # $1 = expected batch size, rest = mem args
+    local want="$1"; shift
+    local got; got="$(batch_size "$@")"
+    if [[ "$got" != "$want" ]]; then
+        echo "FAIL: 'mem $*' batch=$got, expected $want"
+        fails=$((fails + 1))
+    else
+        echo "  ok: 'mem $*' batch=$got"
+    fi
+}
+
+# As expect(), but with BWA_MEM3_CHUNK_CAP set for just this invocation.
+#
+# Written as an explicit helper rather than as a `BWA_MEM3_CHUNK_CAP=N expect ...`
+# prefix for two reasons. The prefix form works on a bash function (the value
+# reaches the binary and does not leak into later calls -- verified) but POSIX
+# leaves that unspecified for functions, so it is not something to rely on. And
+# the failure message from expect() prints only the mem args, so a prefixed
+# assignment would be invisible in exactly the output someone reads to debug it.
+#
+# $1 = env value (may be empty), $2 = expected batch size, rest = mem args
+expect_env() {
+    local envval="$1" want="$2"; shift 2
+    local got
+    got="$(BWA_MEM3_CHUNK_CAP="$envval" batch_size "$@")"
+    if [[ "$got" != "$want" ]]; then
+        echo "FAIL: 'BWA_MEM3_CHUNK_CAP=$envval mem $*' batch=$got, expected $want"
+        fails=$((fails + 1))
+    else
+        echo "  ok: 'BWA_MEM3_CHUNK_CAP=$envval mem $*' batch=$got"
+    fi
+}
+
+# --- the actual regression: default must never cap, at any -t ---------------
+expect 320000000 -t 32
+expect 640000000 -t 64
+expect 160000000 -t 16
+
+# --- opt-in cap -------------------------------------------------------------
+expect 256000000 -t 32 --chunk-cap 256000000
+expect 160000000 -t 16 --chunk-cap 256000000   # below the cap: untouched
+expect 320000000 -t 32 --chunk-cap 0           # 0 disables
+
+# --- --fast implies the cap; explicit flags still win -----------------------
+expect 256000000 -t 32 --fast
+expect  64000000 -t 32 --fast --chunk-cap 64000000
+
+# --- BWA_MEM3_CHUNK_CAP wins over everything except -K ----------------------
+# The env override exists for cap sweeps, so it has to beat both the CLI flag and
+# --fast's implied cap, and be able to switch a cap back OFF.
+expect_env 128000000 128000000 -t 32                          # enables a cap the default lacks
+expect_env 128000000 128000000 -t 32 --chunk-cap 256000000     # beats an explicit cap
+expect_env 128000000 128000000 -t 32 --fast                    # beats --fast's implied cap
+expect_env 0         320000000 -t 32 --chunk-cap 256000000     # 0 switches an explicit cap off
+expect_env 0         320000000 -t 32 --fast                    # ... and --fast's implied one
+expect_env 512000000 320000000 -t 32                           # cap above scaled: untouched
+
+# An EMPTY value is ignored rather than parsed as 0 -- `cap_env && *cap_env` in
+# main_mem. Without this case, dropping the `*cap_env` check would go unnoticed:
+# atoll("") is 0, which would silently disable an explicit cap.
+expect_env "" 256000000 -t 32 --chunk-cap 256000000
+
+# A MALFORMED value is reported and ignored, not parsed as 0. Parsing it as 0
+# would silently switch an explicit cap off -- a typo in a sweep variable
+# quietly changing how the input is partitioned is the failure mode this whole
+# option exists to prevent.
+expect_env abc 320000000 -t 32                          # falls back to no cap
+expect_env xyz 256000000 -t 32 --chunk-cap 256000000    # falls back to the CLI cap
+BWA_MEM3_CHUNK_CAP=abc batch_size -t 32 >/dev/null
+grep -q "BWA_MEM3_CHUNK_CAP='abc' is not a non-negative integer" "$err" \
+    || { echo "FAIL: a malformed BWA_MEM3_CHUNK_CAP must be reported, not silently ignored"
+         fails=$((fails + 1)); }
+
+# --- -K always wins and is never capped ------------------------------------
+expect 100000000 -t 32 -K 100000000
+expect 100000000 -t 32 --fast -K 100000000
+# -K takes the fixed_chunk_size branch, which never reads BWA_MEM3_CHUNK_CAP, so
+# even an env cap far below -K must not clip it.
+expect_env 1000000 100000000 -t 32 -K 100000000
+
+# --- the warning fires only when the cap actually engages -------------------
+# Three cases, because the warning is gated on `scaled > cap`, not on "a cap is
+# configured": an implementation that warns whenever --chunk-cap is present
+# would pass the first and third checks and still be wrong.
+batch_size -t 32 --chunk-cap 256000000 >/dev/null   # 320M > 256M: clipped
+grep -q 'chunk cap engaged' "$err" || { echo "FAIL: expected 'chunk cap engaged' warning"; fails=$((fails + 1)); }
+batch_size -t 16 --chunk-cap 256000000 >/dev/null   # 160M < 256M: configured but inert
+if grep -q 'chunk cap engaged' "$err"; then
+    echo "FAIL: an unengaged chunk cap must not report a warning"
+    fails=$((fails + 1))
+fi
+batch_size -t 32 >/dev/null                          # no cap at all
+if grep -q 'chunk cap engaged' "$err"; then
+    echo "FAIL: default run must not report a chunk cap"
+    fails=$((fails + 1))
+fi
+
+# --- an unparseable --chunk-cap is rejected, not silently read as 0 ---------
+# atoll() maps every unparseable value to 0, and 0 means "no cap" -- so without
+# validation `--chunk-cap 100M` would look accepted and quietly leave batching
+# uncapped. Uses `=` form so a leading '-' is not taken for another option.
+reject() {  # $1 = the --chunk-cap value that must be refused
+    local rc
+    set +e
+    "$BWA_MEM3" mem "--chunk-cap=$1" "$ref" "$reads" >/dev/null 2>"$err"
+    rc=$?
+    set -e
+    if [[ "$rc" -eq 0 ]]; then
+        echo "FAIL: '--chunk-cap=$1' was accepted; expected a non-zero exit"
+        fails=$((fails + 1))
+    elif ! grep -q 'ERROR: --chunk-cap requires a non-negative integer' "$err"; then
+        echo "FAIL: '--chunk-cap=$1' exited $rc but without the expected diagnostic"
+        fails=$((fails + 1))
+    else
+        echo "  ok: '--chunk-cap=$1' rejected"
+    fi
+}
+reject abc      # not a number at all
+reject 100M     # trailing suffix: the option takes plain bases, not 100M
+reject -5       # negative
+
+if [[ "$fails" -ne 0 ]]; then
+    echo "FAIL: chunk-cap opt-in regression ($fails failure(s))"
+    exit 1
+fi
+echo "PASS: chunk-cap is opt-in; default batching matches bwa/bwa-mem2 at every -t"


### PR DESCRIPTION
> **Stacked on #297.** Review that first; this PR's diff is against it. The ordering is deliberate — see "Why this is stacked" below.

`bwa` and `bwa-mem2` both batch reads as an **uncapped** `chunk_size * n_threads` bases. bwa-mem3 additionally capped that at 256 Mbase:

| tool | site | batch | capped? |
|---|---|---|---|
| `bwa` | `fastmap.c:394` | `opt->chunk_size * opt->n_threads` | no |
| `bwa-mem2` v2.2.1 | `fastmap.cpp:944` | `opt->chunk_size * opt->n_threads` | no |
| bwa-mem3 (before) | `fastmap.cpp` | `min(chunk_size * n_threads, 256000000)` | **yes** |

With the default `chunk_size` of 10,000,000 the cap engages at `10M * n > 256M`, i.e. **`-t >= 26`**. `-t 32` and `-t 64` are ordinary production settings.

A different batch is a different `mem_pestat` cohort, which changes the inferred insert-size distribution, which feeds pairing, mate rescue and MAPQ. So the cap silently changes alignments relative to bwa/bwa-mem2 on any run with `-t >= 26`.

This went unnoticed because our benchmark aligns at `-t 16`, where `10M * 16 = 160M` never reaches the cap.

## Measured

`c8g.16xlarge`, wgs-5M, `-t 64`. Digests exclude `@PG` (it embeds the command line, so any run with an extra flag differs trivially — an earlier attempt at this comparison was invalid for exactly that reason). A repeat run is included as a determinism control.

| configuration | digest | |
|---|---|---|
| uncapped (= bwa/bwa-mem2 batching) | `d0005b6822c4d5b1` | |
| uncapped, repeat | `d0005b6822c4d5b1` | deterministic ✅ |
| `--chunk-cap 256000000` | `f7ce74d6d0b689df` | **differs** ⚠️ |
| `-K 100000000` | `cb9a9b6d505ed2cc` | |
| `-K 100000000 --chunk-cap 256000000` | `cb9a9b6d505ed2cc` | identical ✅ |

Two conclusions: the cap really does change output, and `-K` neutralises it entirely — which is direct empirical support for recommending `-K` as the reproducibility knob.

## The fix

The cap becomes opt-in:

```
default            no cap; identical batching to bwa/bwa-mem2 at any -t
--chunk-cap N      cap at N bases (0 = off)
--fast             implies --chunk-cap 256000000
-K N               pins the batch exactly, never capped, always wins
BWA_MEM3_CHUNK_CAP env override, for sweeps; wins over all
```

`--fast` is the natural home for the cap because it already promises non-identical output. `-K` beating everything matters because it is the documented reproducibility knob in all three tools; a cap silently overriding it would be indefensible.

A stderr warning fires when the cap actually engages, so a capped run cannot be mistaken for a drop-in one.

## Cost, and why this is stacked on #297

Removing the cap costs **+4.1% wall and +11.1 GB peak RSS at `-t 64`**, because the batch grows from 256 Mbase to `10M * -t` and the per-chunk allocations grow with it.

That memory cost is why this is stacked on #297 rather than landing alone. #297 makes the chaining scratch per-thread rather than per-read, so the dominant term — `seed_scratch`, which would otherwise be **13.1 GB** at an uncapped `-t 64` — becomes 67 MB (x86) / 136 MB (arm64) and stops growing with `-t` at all. Landing this PR without #297 would take `-t 64` peak RSS to roughly 33.6 GB.

The remaining wall cost is fill/drain: the first batch's read and the last batch's write overlap nothing, and both grow with the batch. Recovering that byte-identically is the follow-up (decoupling the `mem_pestat` cohort from the scheduling batch), which will be stacked on this PR.

Interim mitigation for anyone memory-constrained today: use `-K`, which is now recommended throughout the docs.

## Test

`test/regression/chunk_cap_optin.sh`, wired into CI, pins the whole matrix including precedence. Verified to have teeth: forcing the cap back on via `BWA_MEM3_CHUNK_CAP=256000000` produces 5 failures.

## Docs

`-K` is now recommended wherever settings and equivalence are discussed: `user-guide/aligning.md` (which also had the wrong default documented for `-K` — it claimed `10000000` when `-K` is actually unset), `user-guide/threading.md`, `cli/mem.md`, `best-practices/settings-profiles.md`, `best-practices/optimization-checklist.md`, `getting-started/migrating.md`, `whats-different/equivalence.md`.

## Cross-architecture stack measurement

All three PRs in the stack were re-measured together on **two 64-vCPU hosts**, wgs-5M, 3 reps, interleaved, warm page cache, so each commit's contribution is separable and the whole is checked against `main`:

| `-t 64` | c8g.16xlarge (NEON) | c6a.16xlarge (AVX2) |
|---|---:|---:|
| `main` (8dbf218) | 24.81 s | 30.58 s |
| `+A` (#297) | 24.77 s (−0.15%) | 30.47 s (−0.35%) |
| `+uncap` (#298) | 26.10 s (+5.23%) | 32.02 s (+4.72%) |
| `+B` (#305) | **24.15 s (−2.63%)** | **30.27 s (−1.01%)** |

Rep-to-rep CV 0.02–0.7%. Peak RSS at `-t 64`: `main` 21.92 / 22.05 GB, `+A` 18.73 / 18.77, full stack 24.62 / 24.50.

**Net: the stack is faster than `main` at `-t 64` on both architectures while restoring byte-identity with bwa/bwa-mem2, which `main` does not have at `-t >= 26`.** It costs ~2.8 GB of peak RSS at `-t 64` (uncapping adds ~6.1 GB, #297 gives back ~3.2); at `-t 16` and `-t 32` the stack is a net memory win of ~2 GB.

Output digests were identical on both hosts at every thread count:

```
-t 16  main=5774c6ef  A=5774c6ef  uncap=5774c6ef  B_off=5774c6ef  B_on=5774c6ef
-t 32  main=08096206  A=08096206  uncap=9465e564  B_off=9465e564  B_on=9465e564
-t 64  main=08096206  A=08096206  uncap=b9c1e797  B_off=b9c1e797  B_on=b9c1e797
```

Four things follow. #297 is byte-neutral (`main == A` everywhere). #305 is byte-neutral (`uncap == B_off == B_on` everywhere). The cap is the *only* thing that changes output, and only at `-t >= 26`. And `main` produces the same digest at `-t 32` and `-t 64` because the cap pins both batches to 256 Mbase — a direct demonstration of the mechanism #298 fixes. The digests also match between NEON and AVX2, so cross-architecture byte-identity holds through the whole stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--chunk-cap INT` to optionally cap auto-sized input batch sizes for high-thread workloads.
  * `--fast` now implies `--chunk-cap 256000000` unless `--chunk-cap` is explicitly set.
  * When chunk capping is active, output partitioning may change and a diagnostic warning is shown.

* **Documentation**
  * Expanded `-K` guidance and clarified how fixed batching impacts pairing/MAPQ and equivalence checks.
  * Documented `--chunk-cap` behavior, precedence, and related settings-profile notes.

* **Tests / CI**
  * Added regression coverage for default uncapped behavior, opt-in semantics (including `0`), precedence, and warning presence; ran as a canonical-only CI step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->