### PR TITLE
fix(index): resolve the auto memory budget from the host, not a 32 GiB cap

### DIFF
--- a/docs/_generated/cli/index.txt
+++ b/docs/_generated/cli/index.txt
@@ -4,7 +4,8 @@ Usage: bwa-mem3 index [-p prefix] [-t N] [--max-memory SIZE] [--tmp-dir PATH] [-
   -t INT             worker threads [auto: detected cores, cgroup-aware]
   --max-memory SIZE  peak memory budget; SIZE accepts a G/M/K suffix
                      (case-insensitive) or bare bytes
-                     [auto: min(50% of RAM, 32G), cgroup-aware]
+                     [auto: RAM less a reserve of min(max(2G, 5%), 50%),
+                     cgroup-aware]
   --tmp-dir PATH     scratch directory [$TMPDIR]
   --meth             build a BS-aware dual index. Writes the original-alphabet
                      index at <in.fasta>.* plus a converted seed FM-index at

--- a/docs/src/cli/index-cmd.md
+++ b/docs/src/cli/index-cmd.md
@@ -68,7 +68,8 @@ precondition that is checked before the build starts, not a target the builder
 spills to meet. A reference whose estimated requirement exceeds the budget is
 rejected with exit code 3 and a message naming both the `--max-memory` value
 that would clear it and the host RAM that would clear it automatically. Human
-genomes need roughly 12 bytes per base of doubled text — about 72 GB for hg38 —
+genomes need roughly 12 bytes per base of doubled text (8 below ~1.07 Gbp, where
+the suffix array still fits 32-bit entries) — about 72 GB for hg38 —
 so plan on a host with ~76 GB of RAM or more.
 
 ### `--tmp-dir PATH` — scratch directory

--- a/docs/src/cli/index-cmd.md
+++ b/docs/src/cli/index-cmd.md
@@ -56,18 +56,26 @@ cap CPU usage.
 ### `--max-memory SIZE` — peak memory budget
 
 Limits how much RAM the indexer may use at once. `SIZE` accepts a `G`, `M`, or
-`K` suffix (case-insensitive) or a bare byte count. The default is
-`min(50% of RAM, 32 GB)`, computed in a cgroup-aware manner.
+`K` suffix (case-insensitive) or a bare byte count. The default is the memory
+available to the process less a reserve of `min(max(2 GB, 5%), 50%)`, computed in
+a cgroup-aware manner — index construction is a one-shot batch job, so the
+default lets it use the host it was given. The reserve is the larger of 2 GB and
+5% of total, except that it never exceeds half of total, so a host below 4 GB
+still resolves to a usable budget (a 1 GB host budgets 512 MB) instead of zero.
 
-For large references (hg38 and above) on machines with limited RAM, setting
-this to a value lower than the reference size causes the indexer to partition
-work and use `--tmp-dir` for intermediate files, at the cost of extra I/O.
+Suffix-array construction is **not** currently bounded-memory: the budget is a
+precondition that is checked before the build starts, not a target the builder
+spills to meet. A reference whose estimated requirement exceeds the budget is
+rejected with exit code 3 and a message naming both the `--max-memory` value
+that would clear it and the host RAM that would clear it automatically. Human
+genomes need roughly 12 bytes per base of doubled text — about 72 GB for hg38 —
+so plan on a host with ~76 GB of RAM or more.
 
 ### `--tmp-dir PATH` — scratch directory
 
-Scratch directory for intermediate files when memory is partitioned. Defaults
-to `$TMPDIR`. Point this at a fast local disk (NVMe or ramdisk) to minimize
-wall-clock time when `--max-memory` forces partitioned construction.
+Scratch directory for intermediate files. Defaults to `$TMPDIR`. The builder
+stages a doubled `.pac` here during construction, so point this at a fast local
+disk (NVMe or ramdisk) with room for ~2 bits per base of doubled text.
 
 ### `--emit-unpacked-ref` — also write `<prefix>.0123`
 

--- a/docs/src/user-guide/indexing.md
+++ b/docs/src/user-guide/indexing.md
@@ -112,17 +112,27 @@ bwa-mem3 index /data/indexes/hg38/hg38.fa
 
 ## Time and memory
 
-Index construction is **multi-threaded and memory-bounded**. `index -t` defaults
-to the detected core count (cgroup-aware), and `--max-memory` caps peak RAM at
-`min(50% of RAM, 32 GB)` by default — raise or lower it to trade memory against
-spill I/O. On a typical multi-core host, indexing hg38 takes a few minutes
-(longer if pinned to a single core).
+Index construction is **multi-threaded**. `index -t` defaults to the detected
+core count (cgroup-aware), and `--max-memory` defaults to the memory available
+to the process less a reserve of `min(max(2 GB, 5%), 50%)` — a batch build is
+allowed to use the host it was given. The reserve never exceeds half of total, so
+a host below 4 GB still gets a usable budget (a 1 GB host budgets 512 MB). On a
+typical multi-core host, indexing hg38 takes a few minutes (longer if pinned to a
+single core).
+
+Peak memory is roughly **12 bytes per base of doubled text**, i.e. ~72 GB for
+hg38. `--max-memory` is a precondition checked before the build starts, not a
+spill target: a reference that does not fit the budget is rejected up front
+(exit code 3) rather than built more slowly. Budget hg38 on a host with ~76 GB
+of RAM or more; the rejection message names both the `--max-memory` override
+and the host size that would work without one.
 
 bwa-mem3 builds the suffix array with
-[libsais](https://github.com/IlyaGrebnov/libsais), whose OpenMP-parallel,
-memory-bounded construction is faster and leaner than the original bwa-mem2
-approach. See [Performance improvements](../whats-different/performance.md) for
-benchmark numbers.
+[libsais](https://github.com/IlyaGrebnov/libsais), whose OpenMP-parallel
+construction is faster and leaner than the original bwa-mem2 approach. It is not
+a bounded-memory construction — see the per-base cost above. See
+[Performance improvements](../whats-different/performance.md) for benchmark
+numbers.
 
 > **Warning — Do not index over a live shared-memory segment**
 >

--- a/docs/src/user-guide/indexing.md
+++ b/docs/src/user-guide/indexing.md
@@ -121,11 +121,18 @@ typical multi-core host, indexing hg38 takes a few minutes (longer if pinned to 
 single core).
 
 Peak memory is roughly **12 bytes per base of doubled text**, i.e. ~72 GB for
-hg38. `--max-memory` is a precondition checked before the build starts, not a
-spill target: a reference that does not fit the budget is rejected up front
-(exit code 3) rather than built more slowly. Budget hg38 on a host with ~76 GB
-of RAM or more; the rejection message names both the `--max-memory` override
-and the host size that would work without one.
+hg38. Below ~1.07 Gbp the suffix array still fits 32-bit entries and the cost
+drops to ~8 bytes per base. `--max-memory` is a precondition checked before the
+build starts, not a spill target: a reference that does not fit the budget is
+rejected up front (exit code 3) rather than built more slowly. Budget hg38 on a
+host with ~76 GB of RAM or more; the rejection message names both the
+`--max-memory` override and the host size that would work without one.
+
+`--meth` needs about **twice** that, because it builds a second index over a
+per-strand-converted reference whose text is twice as long: ~144 GB estimated for
+hg38, so budget a host with ~152 GB of RAM or more. Both builds run in one
+process and the first does not fully release its memory before the second starts,
+so the per-base figures above already account for that overlap.
 
 bwa-mem3 builds the suffix array with
 [libsais](https://github.com/IlyaGrebnov/libsais), whose OpenMP-parallel

--- a/scripts/bench_index.sh
+++ b/scripts/bench_index.sh
@@ -21,8 +21,9 @@
 #   BWA_TEST_HG38_FASTA / BWA_TEST_HG38_MET_C2T - source FASTA paths
 #   BWA_INDEX_THREADS    - passed to `bwa-mem3 index -t`. Unset = auto-detect.
 #   BWA_INDEX_MAX_MEMORY - passed to `bwa-mem3 index --max-memory`. Unset =
-#       auto-detect (min(50% RAM, 32G)). The 32G cap rejects hg38 (~58 GiB
-#       peak) and hg38_meth, so override here to reproduce the PR's numbers
+#       auto-detect (RAM less a min(max(2G, 5%), 50%) reserve), which accepts hg38
+#       (~58 GiB peak) on any host with >= ~76 GiB of RAM. Set an explicit
+#       budget to make wall-time / peak-RSS comparable across hosts
 #       (e.g. BWA_INDEX_MAX_MEMORY=128G on a 256 GiB host).
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"

--- a/src/FMI_search.cpp
+++ b/src/FMI_search.cpp
@@ -388,6 +388,8 @@ int FMI_search::build_index(bool emit_unpacked_ref) {
         opts.max_memory_bytes = parse_ll(mm, "BWA_INDEX_MAX_MEMORY");
     if (const char* td = getenv("BWA_INDEX_TMPDIR"))
         opts.tmpdir           = td;
+    if (const char* mu = getenv("BWA_INDEX_MAX_MEMORY_USER"))
+        opts.max_memory_user_specified = (mu[0] == '1');
     opts.emit_unpacked_ref = emit_unpacked_ref;
     return libsais_build_fm_index(prefix, pac_len, opts);
 }

--- a/src/bwtindex.cpp
+++ b/src/bwtindex.cpp
@@ -40,8 +40,6 @@
 #include <sys/stat.h>
 #include <zlib.h>
 
-#include <algorithm>
-
 #include "bntseq.h"
 #include "bwa.h"
 #include "bwt.h"
@@ -212,7 +210,8 @@ static void index_usage(void)
 	        "  -t INT             worker threads [auto: detected cores, cgroup-aware]\n"
 	        "  --max-memory SIZE  peak memory budget; SIZE accepts a G/M/K suffix\n"
 	        "                     (case-insensitive) or bare bytes\n"
-	        "                     [auto: min(50%% of RAM, 32G), cgroup-aware]\n"
+	        "                     [auto: RAM less a reserve of min(max(2G, 5%%), 50%%),\n"
+	        "                     cgroup-aware]\n"
 	        "  --tmp-dir PATH     scratch directory [$TMPDIR]\n"
 	        "  --meth             build a BS-aware dual index. Writes the original-alphabet\n"
 	        "                     index at <in.fasta>.* plus a converted seed FM-index at\n"
@@ -293,8 +292,11 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 			fprintf(stderr, "[bwa_index] --max-memory = %.1f GiB (user-specified)\n",
 			        (double)resolved_mem / (double)(1LL << 30));
 		} else if (detected_mem > 0) {
-			resolved_mem = std::min<int64_t>(detected_mem / 2, 32LL << 30);
-			fprintf(stderr, "[bwa_index] --max-memory = %.1f GiB (auto: 50%% of %.1f GiB detected, capped at 32 GiB)\n",
+			// Index construction is a one-shot batch job: give it the host less
+			// a reserve, not a fraction. A fractional default refuses hg38 on
+			// every machine below ~144 GiB even though the build fits in ~58 GiB.
+			resolved_mem = bwa::resolve_batch_memory_budget(detected_mem);
+			fprintf(stderr, "[bwa_index] --max-memory = %.1f GiB (auto: %.1f GiB detected less a reserve, cgroup-aware)\n",
 			        (double)resolved_mem  / (double)(1LL << 30),
 			        (double)detected_mem  / (double)(1LL << 30));
 		} else {

--- a/src/bwtindex.cpp
+++ b/src/bwtindex.cpp
@@ -46,6 +46,7 @@
 #include "utils.h"
 #include "FMI_search.h"
 #include "kseq.h"
+#include "libsais_build.h"
 #include "system.h"
 
 KSEQ_DECLARE(gzFile)
@@ -96,8 +97,57 @@ static int meth_c2t_is_fresh(const char *in_fa, const char *out_fa)
  *      SA-intervals, which are then remapped to original coordinates for chaining and
  *      extension. The `.meth` separation is by file PREFIX (not by changing the global
  *      CP_FILENAME_SUFFIX, which serves every index). */
-static int meth_index_build(const char *fa, int emit_unpacked_ref)
+/* Sum the reference length the way bns_fasta2bntseq will pack it, so the seed
+ * index's cost can be estimated before any index is built. Costs one extra
+ * sequential pass over the reference on every --meth run, including the ones
+ * that go on to succeed: ~10 s for an uncompressed hg38, longer for a gzipped
+ * one where the pass is decompression-bound. That is under 1% of the two SA
+ * constructions it guards, and it buys a refusal that leaves no partial index
+ * behind. Returns -1 on read error. */
+static int64_t fasta_count_bases(const char *fa)
 {
+    gzFile in = gzopen(fa, "r");
+    if (in == NULL) return -1;
+    kseq_t *seq = kseq_init(in);
+    int64_t total = 0;
+    int kr = 0;
+    while ((kr = kseq_read(seq)) >= 0) total += (int64_t)seq->seq.l;
+    kseq_destroy(seq);
+    gzclose(in);
+    return kr < -1 ? -1 : total;
+}
+
+static int meth_index_build(const char *fa, int emit_unpacked_ref,
+                            int64_t max_memory_bytes, int max_memory_user_specified)
+{
+    /* 0. Preflight the DOMINANT build before writing anything. --meth builds two
+     * indexes sequentially in one process: the original over N = 2*l_pac, then a
+     * seed over a per-strand-converted FASTA whose text is twice as long again
+     * (4*l_pac). The seed therefore costs ~2x the original and is what decides
+     * whether the invocation can run at all -- but the per-build check inside
+     * libsais_build_fm_index only fires once that build starts, i.e. after the
+     * original index has already been built and written. On hg38 that wastes an
+     * hour and leaves a half-populated index directory. The seed's size is known
+     * from the reference length alone, so refuse up front instead. */
+    if (max_memory_bytes > 0) {
+        int64_t l_pac = fasta_count_bases(fa);
+        if (l_pac < 0) {
+            fprintf(stderr, "ERROR: cannot read %s to estimate index memory\n", fa);
+            return 2;
+        }
+        int64_t seed_need = libsais_estimate_peak_bytes(4 * l_pac);
+        if (seed_need > max_memory_bytes) {
+            fprintf(stderr, "[bwa_index:--meth] the seed index dominates: ~%s vs ~%s for "
+                            "the original, because its per-strand-converted text is "
+                            "twice as long\n",
+                    bwa::fmt_bytes(seed_need).c_str(),
+                    bwa::fmt_bytes(libsais_estimate_peak_bytes(2 * l_pac)).c_str());
+            libsais_report_budget_shortfall("index --meth", seed_need, max_memory_bytes,
+                                            max_memory_user_specified != 0, 2 * l_pac);
+            return 3;
+        }
+    }
+
     /* 1. Original-alphabet index (extension reference). emit_unpacked_ref applies
      * to the original only (its `.0123` is the legacy bwa-mem2 extension target);
      * the seed index never needs an unpacked ref (step 2b passes false). */
@@ -282,23 +332,23 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 
 	// Resolve --max-memory and -t: user value wins; otherwise auto from
 	// cgroup-aware host detection. Emit a one-line audit per flag.
+	int64_t resolved_mem = 0;
 	{
 		int64_t detected_mem = bwa::detect_total_memory_bytes();
 		int     detected_cpu = bwa::detect_cpu_count();
 
-		int64_t resolved_mem;
 		if (user_max_memory > 0) {
 			resolved_mem = user_max_memory;
-			fprintf(stderr, "[bwa_index] --max-memory = %.1f GiB (user-specified)\n",
-			        (double)resolved_mem / (double)(1LL << 30));
+			fprintf(stderr, "[bwa_index] --max-memory = %s (user-specified)\n",
+			        bwa::fmt_bytes(resolved_mem).c_str());
 		} else if (detected_mem > 0) {
 			// Index construction is a one-shot batch job: give it the host less
 			// a reserve, not a fraction. A fractional default refuses hg38 on
 			// every machine below ~144 GiB even though the build fits in ~58 GiB.
 			resolved_mem = bwa::resolve_batch_memory_budget(detected_mem);
-			fprintf(stderr, "[bwa_index] --max-memory = %.1f GiB (auto: %.1f GiB detected less a reserve, cgroup-aware)\n",
-			        (double)resolved_mem  / (double)(1LL << 30),
-			        (double)detected_mem  / (double)(1LL << 30));
+			fprintf(stderr, "[bwa_index] --max-memory = %s (auto: %s detected less a reserve, cgroup-aware)\n",
+			        bwa::fmt_bytes(resolved_mem).c_str(),
+			        bwa::fmt_bytes(detected_mem).c_str());
 		} else {
 			resolved_mem = 4LL << 30;
 			fprintf(stderr, "[bwa_index] --max-memory = 4.0 GiB (fallback: host detection failed; "
@@ -323,6 +373,9 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 		setenv("BWA_INDEX_MAX_MEMORY", buf, 1);
 		snprintf(buf, sizeof(buf), "%d", resolved_cpu);
 		setenv("BWA_INDEX_THREADS", buf, 1);
+		// Diagnostics only: lets the preflight suppress a "retry on a bigger
+		// host" hint when the budget came from the command line.
+		setenv("BWA_INDEX_MAX_MEMORY_USER", user_max_memory > 0 ? "1" : "0", 1);
 	}
 
 	if (meth) {
@@ -330,7 +383,8 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 			fprintf(stderr, "ERROR: --meth does not accept -p (outputs <in.fasta>.* and <in.fasta>.meth.*)\n");
 			return 1;
 		}
-		return meth_index_build(argv[optind], emit_unpacked_ref);
+		return meth_index_build(argv[optind], emit_unpacked_ref,
+		                       resolved_mem, user_max_memory > 0);
 	}
 	if (prefix == 0) prefix = argv[optind];
 	return bwa_idx_build(argv[optind], prefix, emit_unpacked_ref);

--- a/src/libsais_build.cpp
+++ b/src/libsais_build.cpp
@@ -48,13 +48,17 @@ double elapsed_since(clock_t_::time_point t) {
 }
 
 
-std::string fmt_bytes(int64_t b) {
+// Reference length in the unit a user thinks in, so a small fixture does not
+// report "0.00 Gbp".
+std::string fmt_bases(int64_t bp) {
     char out[32];
-    if      (b >= (1LL << 30)) std::snprintf(out, sizeof(out), "%.1f GiB", (double)b / (double)(1LL << 30));
-    else if (b >= (1LL << 20)) std::snprintf(out, sizeof(out), "%.1f MiB", (double)b / (double)(1LL << 20));
-    else                        std::snprintf(out, sizeof(out), "%lld B",   (long long)b);
+    if      (bp >= 1000000000LL) std::snprintf(out, sizeof(out), "%.2f Gbp", (double)bp / 1e9);
+    else if (bp >= 1000000LL)    std::snprintf(out, sizeof(out), "%.1f Mbp", (double)bp / 1e6);
+    else                         std::snprintf(out, sizeof(out), "%lld bp",  (long long)bp);
     return std::string(out);
 }
+
+using bwa::fmt_bytes;
 
 // Pack the forward-only .pac (l_pac bases) plus its reverse-complement into
 // a doubled .pac on disk. The sais-lite path built this doubled text in
@@ -124,6 +128,55 @@ std::string resolve_tmpdir(const LibsaisBuildOpts& opts) {
 
 } // anonymous namespace
 
+bool libsais_sa_is_64bit(int64_t N) {
+    const int64_t kSais32Threshold = (int64_t)INT32_MAX - 10000;
+    return (N + 1) >= kSais32Threshold;
+}
+
+int64_t libsais_estimate_peak_bytes(int64_t N) {
+    // Per-base preflight headroom: 6 B/base (int32) / 12 B/base (int64) covers
+    // measured peaks on chr22 and chr1-6 with margin for libsais aux arrays and
+    // OMP/mimalloc overhead on small inputs.
+    return (N + 1) * (libsais_sa_is_64bit(N) ? 12 : 6);
+}
+
+void libsais_report_budget_shortfall(const char* what, int64_t need_bytes,
+                                     int64_t budget_bytes, bool budget_user_specified,
+                                     int64_t ref_bases) {
+    const bool use_int64_sa = libsais_sa_is_64bit(2 * ref_bases);
+    // Round the --max-memory suggestion up to a whole unit the flag accepts, in
+    // the unit the requirement actually lands in: ceil-to-GiB overshoots ~44x on
+    // a 23 MiB requirement.
+    const bool      suggest_g   = need_bytes >= (1LL << 30);
+    const int64_t   unit        = suggest_g ? (1LL << 30) : (1LL << 20);
+    const long long suggest_n   = (long long)((need_bytes + unit - 1) / unit);
+    const char      suggest_sfx = suggest_g ? 'G' : 'M';
+
+    std::fprintf(stderr,
+            "ERROR: %s needs ~%s (%d-bit SA) to index a %s reference; "
+            "--max-memory is %s.\n",
+            what, fmt_bytes(need_bytes).c_str(), use_int64_sa ? 64 : 32,
+            fmt_bases(ref_bases).c_str(), fmt_bytes(budget_bytes).c_str());
+
+    // A host-size hint is noise when the user pinned the budget themselves: the
+    // binding constraint is their flag, not the machine. "Use a smaller
+    // reference" is never an option for a whole-genome aligner, so it is gone.
+    const int64_t required_total = budget_user_specified
+                                 ? -1
+                                 : bwa::required_total_for_batch_budget(need_bytes);
+    if (required_total > 0)
+        std::fprintf(stderr,
+                "       Retry on a host with >= %s of RAM, or pass --max-memory %lld%c\n"
+                "       to build within a smaller budget (which may swap). Bounded-memory\n"
+                "       SA construction is not yet implemented.\n",
+                fmt_bytes(required_total).c_str(), suggest_n, suggest_sfx);
+    else
+        std::fprintf(stderr,
+                "       Raise --max-memory to at least %lld%c. Bounded-memory SA "
+                "construction is not yet implemented.\n",
+                suggest_n, suggest_sfx);
+}
+
 int libsais_build_fm_index(const char* prefix, int64_t pac_len,
                            const LibsaisBuildOpts& opts)
 {
@@ -142,40 +195,11 @@ int libsais_build_fm_index(const char* prefix, int64_t pac_len,
     std::fprintf(stderr, "[libsais_build] N=%lld threads=%d (user-requested=%d)\n",
             (long long)N, T, T_user);
 
-    // Per-base preflight headroom: 6 B/base (int32) / 12 B/base (int64)
-    // covers measured peaks on chr22 and chr1-6 with ~20% margin for
-    // libsais aux arrays and OMP/mimalloc overhead on small inputs.
-    const int64_t kSais32Threshold = (int64_t)INT32_MAX - 10000;
-    const bool    use_int64_sa     = (N + 1) >= kSais32Threshold;
-    const int64_t per_base_bytes   = use_int64_sa ? 12 : 6;
-    const int64_t est_bytes        = (N + 1) * per_base_bytes;
+    const bool    use_int64_sa = libsais_sa_is_64bit(N);
+    const int64_t est_bytes    = libsais_estimate_peak_bytes(N);
     if (opts.max_memory_bytes > 0 && est_bytes > opts.max_memory_bytes) {
-        // Name both remedies in the units the user has to act in: the exact
-        // --max-memory value that clears the estimate, and the host size whose
-        // auto-resolved budget would clear it without an override. "Use a
-        // smaller reference" is not an option for a whole-genome aligner.
-        const int64_t gib             = 1LL << 30;
-        const int64_t suggest_gib     = (est_bytes + gib - 1) / gib;
-        const int64_t required_total  = bwa::required_total_for_batch_budget(est_bytes);
-        std::fprintf(stderr,
-                "ERROR: libsais needs ~%s (%d-bit SA) to index a %.2f Gbp reference; "
-                "--max-memory is %s.\n",
-                fmt_bytes(est_bytes).c_str(),
-                use_int64_sa ? 64 : 32,
-                (double)l_pac / 1e9,
-                fmt_bytes(opts.max_memory_bytes).c_str());
-        if (required_total > 0)
-            std::fprintf(stderr,
-                    "       Retry on a host with >= %s of RAM, or pass "
-                    "--max-memory %lldG to build within a smaller budget\n"
-                    "       (which may swap). Bounded-memory SA construction is "
-                    "not yet implemented.\n",
-                    fmt_bytes(required_total).c_str(), (long long)suggest_gib);
-        else
-            std::fprintf(stderr,
-                    "       Pass --max-memory %lldG to proceed. Bounded-memory SA "
-                    "construction is not yet implemented.\n",
-                    (long long)suggest_gib);
+        libsais_report_budget_shortfall("libsais", est_bytes, opts.max_memory_bytes,
+                                        opts.max_memory_user_specified, l_pac);
         return 3;
     }
     std::fprintf(stderr, "[libsais_build] estimate ~%s (budget %s)\n",

--- a/src/libsais_build.cpp
+++ b/src/libsais_build.cpp
@@ -134,10 +134,31 @@ bool libsais_sa_is_64bit(int64_t N) {
 }
 
 int64_t libsais_estimate_peak_bytes(int64_t N) {
-    // Per-base preflight headroom: 6 B/base (int32) / 12 B/base (int64) covers
-    // measured peaks on chr22 and chr1-6 with margin for libsais aux arrays and
-    // OMP/mimalloc overhead on small inputs.
-    return (N + 1) * (libsais_sa_is_64bit(N) ? 12 : 6);
+    // Per-base cost, calibrated against measured peak RSS rather than derived
+    // from the buffer arithmetic alone (buf is 1 B/base, the SA 4 or 8, and
+    // libsais's aux arrays plus the OMP/allocator arenas add the rest).
+    //
+    // Two properties have to hold, and the second is the binding one because
+    // `index --meth` runs two builds in one process -- the original over
+    // N = 2*l_pac, then a seed over 4*l_pac -- and does not return the first
+    // build's memory before the second starts. So the estimate for a build must
+    // also cover a --meth invocation whose *dominant* build is that size.
+    //
+    // Worst measured cost per base of N, over a size ladder from chr17 (0.08
+    // Gbp) to chr1-9 (1.67 Gbp) on a 64 GiB 12-core host:
+    //
+    //             single build   --meth process   estimate   margins
+    //   int32 SA      5.90 B         7.07 B          8         1.36 / 1.13
+    //   int64 SA      9.84 B        10.04 B         12         1.22 / 1.20
+    //
+    // The int32 constant was 6, i.e. only 1.02x over a single build's own peak
+    // and *below* the --meth process peak -- so a small-reference `--meth` build
+    // could exceed its budget by ~17% while every individual estimate cleared
+    // it. int64's 1.22x margin already absorbed the same carry-over, which is
+    // why the defect was confined to the int32 path. 8 restores a comparable
+    // margin; no --meth-specific term is needed, and none is wanted, since the
+    // carry-over measures as bounded rather than proportional.
+    return (N + 1) * (libsais_sa_is_64bit(N) ? 12 : 8);
 }
 
 void libsais_report_budget_shortfall(const char* what, int64_t need_bytes,

--- a/src/libsais_build.cpp
+++ b/src/libsais_build.cpp
@@ -5,6 +5,7 @@
 #include "io_utils.h"
 #include "macro.h"
 #include "packed_text.h"
+#include "system.h"
 #include "utils.h"
 
 #include <atomic>
@@ -149,14 +150,32 @@ int libsais_build_fm_index(const char* prefix, int64_t pac_len,
     const int64_t per_base_bytes   = use_int64_sa ? 12 : 6;
     const int64_t est_bytes        = (N + 1) * per_base_bytes;
     if (opts.max_memory_bytes > 0 && est_bytes > opts.max_memory_bytes) {
+        // Name both remedies in the units the user has to act in: the exact
+        // --max-memory value that clears the estimate, and the host size whose
+        // auto-resolved budget would clear it without an override. "Use a
+        // smaller reference" is not an option for a whole-genome aligner.
+        const int64_t gib             = 1LL << 30;
+        const int64_t suggest_gib     = (est_bytes + gib - 1) / gib;
+        const int64_t required_total  = bwa::required_total_for_batch_budget(est_bytes);
         std::fprintf(stderr,
-                "ERROR: libsais build would use ~%s (%d-bit SA); --max-memory is %s.\n",
+                "ERROR: libsais needs ~%s (%d-bit SA) to index a %.2f Gbp reference; "
+                "--max-memory is %s.\n",
                 fmt_bytes(est_bytes).c_str(),
                 use_int64_sa ? 64 : 32,
+                (double)l_pac / 1e9,
                 fmt_bytes(opts.max_memory_bytes).c_str());
-        std::fprintf(stderr,
-                "       Raise --max-memory or use a smaller reference. "
-                "(Bounded-memory SA construction is not yet implemented.)\n");
+        if (required_total > 0)
+            std::fprintf(stderr,
+                    "       Retry on a host with >= %s of RAM, or pass "
+                    "--max-memory %lldG to build within a smaller budget\n"
+                    "       (which may swap). Bounded-memory SA construction is "
+                    "not yet implemented.\n",
+                    fmt_bytes(required_total).c_str(), (long long)suggest_gib);
+        else
+            std::fprintf(stderr,
+                    "       Pass --max-memory %lldG to proceed. Bounded-memory SA "
+                    "construction is not yet implemented.\n",
+                    (long long)suggest_gib);
         return 3;
     }
     std::fprintf(stderr, "[libsais_build] estimate ~%s (budget %s)\n",

--- a/src/libsais_build.h
+++ b/src/libsais_build.h
@@ -14,7 +14,29 @@ struct LibsaisBuildOpts {
      * doubled --meth seed). The FM build itself never consumes the `.0123`.
      * Set true only to emit it for an external consumer (e.g. bwa-mem2). */
     bool        emit_unpacked_ref = false;
+    /* True when --max-memory came from the command line rather than from
+     * host detection. Only affects diagnostics: a "retry on a bigger host"
+     * hint is noise when the binding constraint is the user's own flag. */
+    bool        max_memory_user_specified = false;
 };
+
+// True when a doubled text of length `N` forces libsais's 64-bit SA path,
+// which doubles the per-suffix cost.
+bool libsais_sa_is_64bit(int64_t N);
+
+// Estimated peak bytes for a libsais build over a doubled text of length `N`
+// (= 2 * l_pac). 6 B/base on the int32 SA path, 12 B/base once `N` forces the
+// int64 SA; both cover measured peaks with margin for libsais aux arrays and
+// OMP/allocator overhead. Exposed so callers can preflight a build they have
+// not started yet.
+int64_t libsais_estimate_peak_bytes(int64_t N);
+
+// Report a memory-budget shortfall on stderr in one standard form, naming what
+// is needed, the budget, and the remedies. `what` labels the build being
+// refused (e.g. "libsais"); `ref_bases` is the reference length in bp.
+void libsais_report_budget_shortfall(const char* what, int64_t need_bytes,
+                                     int64_t budget_bytes, bool budget_user_specified,
+                                     int64_t ref_bases);
 
 // Build the bwa-mem3 FM index via libsais's generalized-suffix-array
 // construction. Precondition: `<prefix>.pac` and `<prefix>.ann` already

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -18,6 +18,14 @@
 
 namespace bwa {
 
+std::string fmt_bytes(int64_t b) {
+    char out[32];
+    if      (b >= (1LL << 30)) std::snprintf(out, sizeof(out), "%.1f GiB", (double)b / (double)(1LL << 30));
+    else if (b >= (1LL << 20)) std::snprintf(out, sizeof(out), "%.1f MiB", (double)b / (double)(1LL << 20));
+    else                       std::snprintf(out, sizeof(out), "%lld B",   (long long)b);
+    return std::string(out);
+}
+
 namespace {
 
 // Slurp up to 4 KiB from `path` into `out`; returns true on success.

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -194,4 +194,47 @@ int detect_cpu_count() {
     return r < 1 ? 1 : r;
 }
 
+namespace {
+
+// Headroom left to the OS and to whatever else shares the host: the larger of
+// an absolute floor and a proportional share.
+constexpr int64_t kBatchReserveFloorBytes = 2LL << 30;   // 2 GiB
+constexpr int64_t kBatchReserveDivisor    = 20;          // 5% of total
+
+} // namespace
+
+int64_t resolve_batch_memory_budget(int64_t total_bytes) {
+    if (total_bytes <= 0) return -1;
+    int64_t reserve = std::max(kBatchReserveFloorBytes,
+                               total_bytes / kBatchReserveDivisor);
+    // Never reserve more than half: on a host smaller than 2x the floor the
+    // proportional rule would otherwise resolve to a zero or negative budget.
+    reserve = std::min(reserve, total_bytes / 2);
+    return total_bytes - reserve;
+}
+
+int64_t required_total_for_batch_budget(int64_t budget_bytes) {
+    if (budget_bytes <= 0) return -1;
+    // The reserve has three regimes -- half of total below 4 GiB, a flat 2 GiB
+    // up to 40 GiB, then 5% -- so a closed-form inverse needs three branches
+    // plus their boundary cases, and any of them can silently disagree with the
+    // forward policy. Binary search the forward function instead: it is
+    // monotonic non-decreasing, so the smallest sufficient total is well
+    // defined, the answer is exact in every regime by construction, and the
+    // inverse cannot drift if the policy above is ever retuned. ~63 iterations,
+    // evaluated at most once per refused build.
+    int64_t lo = 1, hi = INT64_MAX, best = -1;
+    while (lo <= hi) {
+        int64_t mid = lo + (hi - lo) / 2;          // no overflow
+        if (resolve_batch_memory_budget(mid) >= budget_bytes) {
+            best = mid;
+            hi = mid - 1;                          // mid >= lo >= 1, so no underflow
+        } else {
+            if (mid == INT64_MAX) break;           // infeasible: nothing suffices
+            lo = mid + 1;
+        }
+    }
+    return best;
+}
+
 } // namespace bwa

--- a/src/system.h
+++ b/src/system.h
@@ -2,8 +2,13 @@
 #define BWA_SYSTEM_H
 
 #include <cstdint>
+#include <string>
 
 namespace bwa {
+
+// Format a byte count for human-facing output: "N.N GiB", "N.N MiB", or "N B".
+// Sized so a --max-memory of 15M reads as "15.0 MiB" rather than "0.0 GiB".
+std::string fmt_bytes(int64_t bytes);
 
 // Total memory available to the process in bytes. On Linux returns
 // min(cgroup v2 memory.max, cgroup v1 memory.limit_in_bytes, physical RAM).

--- a/src/system.h
+++ b/src/system.h
@@ -18,6 +18,25 @@ int64_t detect_total_memory_bytes();
 // Always returns >= 1.
 int detect_cpu_count();
 
+// Peak-memory budget for a one-shot batch job, given the total memory
+// available to the process (i.e. detect_total_memory_bytes()).
+//
+// The policy is "the machine, less a headroom reserve" rather than a fixed
+// fraction: a batch build exists to consume the host it was given, and a
+// fractional split refuses work that the host can plainly do. The reserve is
+// max(2 GiB, 5% of total), itself clamped to half of total so that small hosts
+// still resolve to a usable budget instead of zero.
+//
+// Returns -1 when total_bytes <= 0; callers must supply their own fallback.
+int64_t resolve_batch_memory_budget(int64_t total_bytes);
+
+// The SMALLEST total memory for which resolve_batch_memory_budget() yields at
+// least `budget_bytes` -- exact in every reserve regime, so the "retry on a host
+// with >= N" hint it feeds never overstates what a host needs. Returns -1 when
+// `budget_bytes` is non-positive, or when no total is sufficient (the reserve is
+// always positive, so budgets within ~5% of INT64_MAX are unreachable).
+int64_t required_total_for_batch_budget(int64_t budget_bytes);
+
 namespace system_detail {
 
 // Parse cgroup v2 memory.max content. Returns -1 for "max" or unparseable

--- a/test/libsais_memory_budget_test.sh
+++ b/test/libsais_memory_budget_test.sh
@@ -66,6 +66,46 @@ for budget_mib in 128 512 2048; do
     trap - EXIT
 done
 
+# `--meth` builds two indexes sequentially in one process: the original over
+# N = 2*l_pac, then a seed over a per-strand-converted text twice as long
+# (4*l_pac), so the seed costs ~2x the original and decides whether the
+# invocation can run. Pick a budget between the two estimates: the original
+# would fit, the seed cannot. The preflight must refuse UP FRONT and leave no
+# index behind -- previously the seed's own check fired only once that build
+# started, i.e. after the original index had been built and written (an hour
+# into an hg38 run, leaving a half-populated index directory).
+TD="$(mktemp -d)"
+trap 'rm -rf "$TD"' EXIT
+cp "$FA_SRC" "$TD/m.fa"
+# The fixture is ~1 Mbp -> original est ~11.4 MiB, seed est ~22.9 MiB.
+if "$BWAMEM3" index --meth --max-memory 16M "$TD/m.fa" >"$TD/out" 2>"$TD/err"; then
+    echo "FAIL: --meth --max-memory 16M should have been refused (seed needs ~23 MiB)"
+    FAIL=1
+else
+    rc=$?
+    if [[ "$rc" -ne 3 ]]; then
+        echo "FAIL: --meth budget refusal exited $rc, expected 3"
+        cat "$TD/err"
+        FAIL=1
+    elif ! grep -q 'seed index dominates' "$TD/err"; then
+        echo "FAIL: --meth refusal did not explain that the seed dominates"
+        cat "$TD/err"
+        FAIL=1
+    else
+        # The point of the up-front check: nothing was built before refusing.
+        leaked="$(find "$TD" -name 'm.fa.*' -not -name '*.fai' | head -5)"
+        if [[ -n "$leaked" ]]; then
+            echo "FAIL: --meth refusal left index artifacts behind:"
+            echo "$leaked"
+            FAIL=1
+        else
+            echo "OK:   --meth --max-memory 16M refused up front (exit 3, nothing written)"
+        fi
+    fi
+fi
+rm -rf "$TD"
+trap - EXIT
+
 if [[ $FAIL -ne 0 ]]; then
     echo "libsais_memory_budget_test: FAILED"
     exit 1

--- a/test/system_test.cpp
+++ b/test/system_test.cpp
@@ -143,6 +143,17 @@ int main() {
 
     CHECK(required_total_for_batch_budget(kHg38Need) < 80 * kGiB);
 
+    // fmt_bytes: a --max-memory of 15M must not read as "0.0 GiB" (it did).
+    CHECK(bwa::fmt_bytes(15 * 1024 * 1024) == "15.0 MiB");
+    CHECK(bwa::fmt_bytes(1200 * 1024 * 1024) == "1.2 GiB");
+    CHECK(bwa::fmt_bytes(64 * kGiB) == "64.0 GiB");
+    CHECK(bwa::fmt_bytes(512) == "512 B");
+    CHECK(bwa::fmt_bytes(0) == "0 B");
+    // Boundaries: exactly 1 MiB / 1 GiB step up to the larger unit.
+    CHECK(bwa::fmt_bytes(1024 * 1024) == "1.0 MiB");
+    CHECK(bwa::fmt_bytes(1024 * 1024 - 1) == "1048575 B");
+    CHECK(bwa::fmt_bytes(kGiB) == "1.0 GiB");
+
     int cpu = bwa::detect_cpu_count();
     CHECK(cpu >= 1);
     // 4096 was too tight for HPC / cloud nodes: AWS u-7i.metal-224xl already

--- a/test/system_test.cpp
+++ b/test/system_test.cpp
@@ -72,6 +72,77 @@ int main() {
     // big memory-optimised cloud / HPC instances.
     CHECK(mem <= (int64_t)1 << 50);
 
+    // Batch memory budget policy. The regression this guards: an hg38 build
+    // needs ~72 GiB, and the previous `min(50% of RAM, 32 GiB)` default
+    // refused it on every host — including a 256 GiB server.
+    const int64_t kGiB      = 1LL << 30;
+    const int64_t kHg38Need = 77216326020LL;   // (2 * 3217346917 + 1) * 12 B
+    using bwa::resolve_batch_memory_budget;
+    using bwa::required_total_for_batch_budget;
+
+    CHECK(resolve_batch_memory_budget(0) == -1);
+    CHECK(resolve_batch_memory_budget(-1) == -1);
+
+    // Reserve floor dominates below 40 GiB: budget = total - 2 GiB.
+    CHECK(resolve_batch_memory_budget(8 * kGiB) == 6 * kGiB);
+    CHECK(resolve_batch_memory_budget(32 * kGiB) == 30 * kGiB);
+    // Proportional reserve (5%) takes over above 40 GiB.
+    CHECK(resolve_batch_memory_budget(40 * kGiB) == 38 * kGiB);
+    CHECK(resolve_batch_memory_budget(80 * kGiB) == 76 * kGiB);
+    CHECK(resolve_batch_memory_budget(256 * kGiB) == 256 * kGiB - 256 * kGiB / 20);
+    // Small hosts still resolve to something usable, never <= 0.
+    CHECK(resolve_batch_memory_budget(1 * kGiB) == 512 * 1024 * 1024);
+    CHECK(resolve_batch_memory_budget(1) > 0);
+    // Monotonic: more RAM never yields a smaller budget.
+    for (int64_t t = 1; t <= 512 * kGiB; t = t * 3 / 2 + 1)
+        CHECK(resolve_batch_memory_budget(t) <= resolve_batch_memory_budget(t * 3 / 2 + 1));
+
+    // hg38 must build on hosts that can plainly hold it, and must not be
+    // promised on hosts that cannot.
+    CHECK(resolve_batch_memory_budget(96 * kGiB) >= kHg38Need);
+    CHECK(resolve_batch_memory_budget(128 * kGiB) >= kHg38Need);
+    CHECK(resolve_batch_memory_budget(256 * kGiB) >= kHg38Need);
+    CHECK(resolve_batch_memory_budget(64 * kGiB) < kHg38Need);
+
+    // The inverse is what the error message quotes, so it must be both
+    // sufficient AND minimal: quoting a host size larger than necessary sends
+    // someone shopping for RAM they do not need.
+    CHECK(required_total_for_batch_budget(0) == -1);
+    CHECK(required_total_for_batch_budget(-1) == -1);
+
+    // Sufficiency and minimality across all three reserve regimes.
+    for (int64_t b = 1; b <= 512 * kGiB; b = b * 3 / 2 + 1) {
+        int64_t total = required_total_for_batch_budget(b);
+        CHECK(total > 0);
+        CHECK(resolve_batch_memory_budget(total) >= b);
+        // Minimal: one byte less must not suffice.
+        if (total > 1) CHECK(resolve_batch_memory_budget(total - 1) < b);
+    }
+
+    // Half-reserve regime (total <= 4 GiB): budget = ceil(total/2), so the
+    // smallest sufficient total is 2b-1 -- NOT b + 2 GiB. A 1-byte host
+    // resolves to a 1-byte budget.
+    CHECK(required_total_for_batch_budget(1) == 1);
+    CHECK(required_total_for_batch_budget(2) == 3);
+    CHECK(required_total_for_batch_budget(2 * kGiB) == 4 * kGiB - 1);
+
+    // Transition into the fixed 2 GiB reserve, then into the 5% reserve.
+    CHECK(required_total_for_batch_budget(2 * kGiB + 1) == 4 * kGiB + 1);
+    CHECK(required_total_for_batch_budget(38 * kGiB - 1) == 40 * kGiB - 1);
+    CHECK(required_total_for_batch_budget(38 * kGiB) == 40 * kGiB);
+
+    // Large budgets whose required total still fits int64_t must be answered,
+    // not rejected: the answer is only ~1.053x the budget.
+    const int64_t huge = INT64_MAX / 2;
+    const int64_t huge_total = required_total_for_batch_budget(huge);
+    CHECK(huge_total > 0);
+    CHECK(resolve_batch_memory_budget(huge_total) >= huge);
+    // Genuinely infeasible: no total resolves to a budget of INT64_MAX, since
+    // the reserve is always positive at that scale.
+    CHECK(required_total_for_batch_budget(INT64_MAX) == -1);
+
+    CHECK(required_total_for_batch_budget(kHg38Need) < 80 * kGiB);
+
     int cpu = bwa::detect_cpu_count();
     CHECK(cpu >= 1);
     // 4096 was too tight for HPC / cloud nodes: AWS u-7i.metal-224xl already

--- a/test/unit/test_index_memory_estimate.cpp
+++ b/test/unit/test_index_memory_estimate.cpp
@@ -1,0 +1,90 @@
+// test/unit/test_index_memory_estimate.cpp — the index memory preflight arithmetic.
+//
+// `bwa-mem3 index` refuses a build whose estimated peak exceeds --max-memory.
+// Two properties decide whether that refusal is correct, and both used to be
+// inline arithmetic no test could reach:
+//
+//   libsais_sa_is_64bit(N)        — which SA width libsais will pick, since the
+//                                   int64 path doubles the per-suffix cost.
+//   libsais_estimate_peak_bytes(N)— the estimate compared against the budget.
+//
+// The regression these pin: a `min(50% of RAM, 32 GiB)` default meant hg38's
+// estimate (12 B/base over a doubled 6.43 Gbase text = 71.9 GiB) lost to a
+// 32 GiB budget on every host, including a 256 GiB server. The thresholds below
+// are derived from the constants themselves — INT32_MAX - 10000 for the SA-width
+// switch, 6/12 B/base for the cost — not recorded from a run.
+//
+// `N` throughout is the DOUBLED text length (2 * l_pac), which is what libsais
+// is handed; a `--meth` seed index doubles it again (4 * l_pac).
+
+#include "doctest/doctest.h"
+
+#include "libsais_build.h"
+
+#include <cstdint>
+
+namespace {
+
+constexpr int64_t kGiB          = 1LL << 30;
+constexpr int64_t kSwitchPoint  = (int64_t)INT32_MAX - 10000;   // N + 1 >= this => int64 SA
+
+// Reference lengths (l_pac) of the genomes this preflight actually gates.
+constexpr int64_t kHg38Lpac   = 3217346917LL;
+constexpr int64_t kChr17Lpac   = 83257441LL;
+
+} // namespace
+
+TEST_CASE("libsais_sa_is_64bit: switches exactly at INT32_MAX - 10000") {
+    CHECK(libsais_sa_is_64bit(kSwitchPoint - 2) == false);
+    CHECK(libsais_sa_is_64bit(kSwitchPoint - 1) == true);   // N + 1 == threshold
+    CHECK(libsais_sa_is_64bit(kSwitchPoint) == true);
+    CHECK(libsais_sa_is_64bit(0) == false);
+}
+
+TEST_CASE("libsais_estimate_peak_bytes: 6 B/base int32, 12 B/base int64") {
+    CHECK(libsais_estimate_peak_bytes(1000) == 1001 * 6);
+    CHECK(libsais_estimate_peak_bytes(kSwitchPoint) == (kSwitchPoint + 1) * 12);
+    // Crossing the width switch makes the estimate jump, not grow smoothly.
+    const int64_t below = libsais_estimate_peak_bytes(kSwitchPoint - 2);
+    const int64_t above = libsais_estimate_peak_bytes(kSwitchPoint - 1);
+    CHECK(above > below);
+    CHECK(above >= below * 2);
+}
+
+TEST_CASE("libsais_estimate_peak_bytes: hg38 needs ~72 GiB, well past the old 32 GiB cap") {
+    const int64_t hg38 = libsais_estimate_peak_bytes(2 * kHg38Lpac);
+    CHECK(libsais_sa_is_64bit(2 * kHg38Lpac) == true);
+    // ~71.9 GiB. Bracketed rather than pinned so a deliberate recalibration of
+    // the per-base margin does not fail this test spuriously.
+    CHECK(hg38 > 71 * kGiB);
+    CHECK(hg38 < 73 * kGiB);
+    // The defect: the removed default could never clear it, on any host.
+    CHECK(hg38 > 32 * kGiB);
+}
+
+TEST_CASE("libsais_estimate_peak_bytes: a --meth seed costs ~2x its original") {
+    // --meth builds the original over 2 * l_pac, then a seed over 4 * l_pac
+    // (an f... C->T and an r... G->A contig per chromosome). Both hg38 halves
+    // take the int64 path, so the ratio is exactly the text-length ratio.
+    const int64_t orig = libsais_estimate_peak_bytes(2 * kHg38Lpac);
+    const int64_t seed = libsais_estimate_peak_bytes(4 * kHg38Lpac);
+    CHECK(libsais_sa_is_64bit(4 * kHg38Lpac) == true);
+    CHECK(seed > orig);
+    CHECK(seed == doctest::Approx((double)orig * 2).epsilon(0.001));
+    CHECK(seed > 143 * kGiB);
+    CHECK(seed < 145 * kGiB);
+
+    // chr17 stays on the int32 path for BOTH halves, so the 2x holds there too
+    // — this is the fixture the shell test exercises.
+    const int64_t c_orig = libsais_estimate_peak_bytes(2 * kChr17Lpac);
+    const int64_t c_seed = libsais_estimate_peak_bytes(4 * kChr17Lpac);
+    CHECK(libsais_sa_is_64bit(4 * kChr17Lpac) == false);
+    CHECK(c_seed == doctest::Approx((double)c_orig * 2).epsilon(0.001));
+
+    // And the gap the up-front --meth preflight closes: a budget can clear the
+    // original while the seed cannot fit, which used to be discovered only
+    // after the original index had already been built and written.
+    const int64_t budget = (c_orig + c_seed) / 2;
+    CHECK(c_orig <= budget);
+    CHECK(c_seed > budget);
+}

--- a/test/unit/test_index_memory_estimate.cpp
+++ b/test/unit/test_index_memory_estimate.cpp
@@ -12,7 +12,8 @@
 // estimate (12 B/base over a doubled 6.43 Gbase text = 71.9 GiB) lost to a
 // 32 GiB budget on every host, including a 256 GiB server. The thresholds below
 // are derived from the constants themselves — INT32_MAX - 10000 for the SA-width
-// switch, 6/12 B/base for the cost — not recorded from a run.
+// switch, 8/12 B/base for the cost — plus, in the last two cases, peak-RSS
+// figures recorded from real builds.
 //
 // `N` throughout is the DOUBLED text length (2 * l_pac), which is what libsais
 // is handed; a `--meth` seed index doubles it again (4 * l_pac).
@@ -41,14 +42,15 @@ TEST_CASE("libsais_sa_is_64bit: switches exactly at INT32_MAX - 10000") {
     CHECK(libsais_sa_is_64bit(0) == false);
 }
 
-TEST_CASE("libsais_estimate_peak_bytes: 6 B/base int32, 12 B/base int64") {
-    CHECK(libsais_estimate_peak_bytes(1000) == 1001 * 6);
+TEST_CASE("libsais_estimate_peak_bytes: 8 B/base int32, 12 B/base int64") {
+    CHECK(libsais_estimate_peak_bytes(1000) == 1001 * 8);
     CHECK(libsais_estimate_peak_bytes(kSwitchPoint) == (kSwitchPoint + 1) * 12);
-    // Crossing the width switch makes the estimate jump, not grow smoothly.
+    // Crossing the width switch makes the estimate jump, not grow smoothly:
+    // 8 -> 12 B/base, so a one-base increase costs 1.5x.
     const int64_t below = libsais_estimate_peak_bytes(kSwitchPoint - 2);
     const int64_t above = libsais_estimate_peak_bytes(kSwitchPoint - 1);
     CHECK(above > below);
-    CHECK(above >= below * 2);
+    CHECK(above == doctest::Approx((double)below * 1.5).epsilon(0.001));
 }
 
 TEST_CASE("libsais_estimate_peak_bytes: hg38 needs ~72 GiB, well past the old 32 GiB cap") {
@@ -87,4 +89,71 @@ TEST_CASE("libsais_estimate_peak_bytes: a --meth seed costs ~2x its original") {
     const int64_t budget = (c_orig + c_seed) / 2;
     CHECK(c_orig <= budget);
     CHECK(c_seed > budget);
+}
+
+// The estimate is a promise: the build it gates must not exceed it. These are
+// peak-RSS figures MEASURED with /usr/bin/time -l and RSS sampling on one
+// 64 GiB 12-core arm64 host, so they are a floor on the required margin rather
+// than a universal bound -- another host's allocator or thread count can peak
+// higher. They exist to stop the per-base constants being lowered back to a
+// value that real builds overrun, which is exactly what the int32 constant did
+// at 6 B/base.
+namespace {
+
+struct MeasuredPeak {
+    const char* label;
+    int64_t     N;            // doubled text length handed to libsais
+    int64_t     peak_bytes;   // observed peak RSS
+};
+
+// Single builds: `index` on cumulative hg38 slices (and each --meth run's
+// first build, which is an ordinary build of the original reference).
+const MeasuredPeak kSingleBuildPeaks[] = {
+    {"chr17       (int32)",   166514882,   902348800LL},
+    {"chr17 seed  (int32)",   333029764,  1776664576LL},
+    {"chr1        (int32)",   497912844,  2812051456LL},
+    {"chr1-2      (int32)",   982299902,  5185159168LL},
+    {"chr1-3      (int32)",  1378891020,  8129052672LL},
+    {"chr1-4      (int32)",  1759320130, 10151133184LL},
+    {"chr1-5      (int32)",  2122396648, 12057460736LL},
+    {"chr1-6      (int64)",  2464008606, 24248434688LL},
+    {"chr1-7      (int64)",  2782700552, 27249328128LL},
+    {"chr1-8      (int64)",  3072977824, 29934387200LL},
+    {"chr1-9      (int64)",  3349767258, 30999101440LL},
+};
+
+// `index --meth` whole-process peaks, keyed by the SEED build's N (= 4*l_pac),
+// which is the dominant build and therefore what the preflight checks.
+const MeasuredPeak kMethProcessPeaks[] = {
+    {"chr17 --meth  (int32)",  333029764,  2311536640LL},
+    {"chr1 --meth   (int32)",  995825688,  7044399104LL},
+    {"chr1-2 --meth (int32)", 1964599804, 11325145088LL},
+    {"chr1-3 --meth (int64)", 2757782040, 26843906048LL},
+    {"chr1-4 --meth (int64)", 3518640260, 35315105792LL},
+    {"chr1-5 --meth (int64)", 4244793296, 38338084864LL},
+};
+
+} // namespace
+
+TEST_CASE("libsais_estimate_peak_bytes: covers every measured single-build peak") {
+    for (const MeasuredPeak& m : kSingleBuildPeaks) {
+        const int64_t est = libsais_estimate_peak_bytes(m.N);
+        CAPTURE(m.label);
+        CAPTURE(est);
+        CAPTURE(m.peak_bytes);
+        CHECK(est > m.peak_bytes);
+    }
+}
+
+TEST_CASE("libsais_estimate_peak_bytes: covers every measured --meth process peak") {
+    // This is the property the old int32 constant broke: the seed build's
+    // estimate has to cover the whole invocation, because the original build's
+    // memory is still resident when the seed build runs.
+    for (const MeasuredPeak& m : kMethProcessPeaks) {
+        const int64_t est = libsais_estimate_peak_bytes(m.N);
+        CAPTURE(m.label);
+        CAPTURE(est);
+        CAPTURE(m.peak_bytes);
+        CHECK(est > m.peak_bytes);
+    }
 }


### PR DESCRIPTION
## Problem

`bwa-mem3 index` cannot index any reference larger than ~1.43 Gbp at default settings, **on any host**. It is not host-specific — it follows from two constants that were introduced together and never checked against each other:

| | code | value |
|---|---|---|
| Budget | `src/bwtindex.cpp:296` | `resolved_mem = min(detected_mem / 2, 32 GiB)` |
| Demand | `src/libsais_build.cpp:147-150` | `(N+1) x 12 B/base` for the int64 SA, where `N = 2 x l_pac` |

Any reference past ~1.07 Gbp forces the int64 SA, so the abort threshold is `l_pac > 32 GiB / 24 ~= 1.43 Gbp`. hg38 estimates at 71.9 GiB against a 32 GiB budget and exits 3.

Two things make this worse than it looks:

- **It is a regression against upstream bwa-mem2, not an inherited limit.** `--max-memory`, the 32 GiB cap, and the preflight abort all arrived in `79b90ce` (#57, 2026-04-26) along with the `ext/libsais` submodule; the last upstream commit touching `src/bwtindex.cpp` is `26f54dd` (2020-07-09). Before #57, `FMI_search::build_index` allocated ~60 GiB of explicit buffers for hg38 with no check at all — so a large host simply built the index. #57 actually *reduced* the requirement (dropped one N-byte copy; ~54 GiB of explicit buffers today) but added a hard refusal at a default that is unconditionally below it. **A 256 GiB server resolves `min(128 GiB, 32 GiB)` = 32 GiB and fails at a build it could do four times over.**
- **Removing only the cap does not fix it.** `detected_mem / 2` on a 128 GiB host is 64 GiB, still short of 71.9 GiB. Under the old policy hg38 needs a >= 144 GiB host. The 50% split double-margins an estimate that already carries ~33% headroom over the real buffers.

Every tagged release is affected (`git tag --contains 79b90ce` lists v0.1.0-pre through v0.7.0 and v2.0). Nobody hit it because the bench fleet consumes prebuilt indexes — though `scripts/bench_index.sh` had already quietly documented "The 32G cap rejects hg38 (~58 GiB peak)".

## Changes

1. **Budget policy** — new `bwa::resolve_batch_memory_budget()` replaces `min(detected/2, 32 GiB)`: the memory available to the process less a reserve of `min(max(2 GiB, 5%), 50%)`, i.e. the larger of 2 GiB and 5%, never more than half of total so small hosts still resolve to a usable budget. Index construction is a one-shot batch job; it should be allowed to use the host it was given, which is what upstream did. Detection stays cgroup-aware, so in a container this reads the container's limit.

2. **Actionable rejection** — the preflight message now names both remedies in the units the user acts in: the exact `--max-memory` value that clears the estimate, and (via `bwa::required_total_for_batch_budget()`) the host RAM that clears it with no override. It also reports the reference size. `"use a smaller reference"` is gone — it was never an option for a whole-genome aligner.

3. **Docs, help text, and bench script** — corrected to the new default. This also removes a **false claim**: `docs/src/cli/index-cmd.md` and `docs/src/user-guide/indexing.md` both stated that a budget below the reference size makes the indexer "partition work and use `--tmp-dir` for intermediate files" / trade "memory against spill I/O". No such path exists — the code says so itself ("Bounded-memory SA construction is not yet implemented") and hard-aborts. That fiction is plausibly why the cap survived three months of releases.

## Effect

Budget resolved on a bare host, vs hg38's 71.9 GiB requirement:

| host RAM | before | after |
|---|---|---|
| 64 GiB | 32 GiB, reject | 60.8 GiB, reject *(correct: real peak ~58 GiB would swap)* |
| 96 GiB | 32 GiB, reject | 91.2 GiB, **build** |
| 128 GiB | 32 GiB, reject | 121.6 GiB, **build** |
| 256 GiB | 32 GiB, reject | 243.2 GiB, **build** |

## Validation

All runs on one host (arm64 macOS, **64 GiB RAM**, 12 cores), pre-fix binary = `0.7.0-e722ed0` (the 32 GiB cap is unchanged between it and `origin/main`).

**The decisive A/B: same input, same machine, opposite outcomes.** A 9-contig hg38 slice (chr1–chr9, 1,674,883,629 bp, `N` = 3,349,767,258) was chosen so its 37.4 GiB estimate lands *between* the old 32 GiB cap and the new 60.8 GiB budget:

| binary | resolved budget | estimate | result |
|---|---|---|---|
| pre-fix `e722ed0` | 32.0 GiB (`50% of 64.0 GiB, capped`) | 37.4 GiB | **exit 3, rejected** |
| this PR | 60.8 GiB (`64.0 GiB less a reserve`) | 37.4 GiB | **exit 0** in 344.85 s, peak RSS **28.87 GiB** |

Note the peak: **28.87 GiB is below the pre-fix binary's own 32 GiB budget.** The old default rejected a build that would have fit inside it, because the preflight compares a deliberately conservative 12 B/base estimate (measured margin here: 37.4 est vs 28.9 actual, ~1.30x) rather than the ~9 B/base the builder actually touches.

The resulting index is functional, not merely present — 20k HG002 WGS read pairs aligned against it: 79.46% primary mapped, 72.6% of primaries at MAPQ >= 30, alignments confined to exactly the 9 expected contigs.

**Full hg38 still refuses, with an actionable message** (the correct outcome on a 64 GiB host — the real peak of ~58 GiB would swap):

```
[bwa_index] --max-memory = 60.8 GiB (auto: 64.0 GiB detected less a reserve, cgroup-aware)
[libsais_build] N=6434693834 threads=12 (user-requested=12)
ERROR: libsais needs ~71.9 GiB (64-bit SA) to index a 3.22 Gbp reference; --max-memory is 60.8 GiB.
       Retry on a host with >= 75.7 GiB of RAM, or pass --max-memory 72G to build within a smaller budget
       (which may swap). Bounded-memory SA construction is not yet implemented.
```

**Index output is unchanged.** chr17 (83.3 Mbp) built with both binaries under their respective auto budgets (32.0 vs 60.8 GiB) is byte-identical across every index file — `.bwt.2bit.64` (270,586,805 B), `.pac`, `.ann`, `.amb`. The change is budget resolution only; it cannot alter index bytes.

**Tests and gates:**
- `test/system_test` — extended with the policy table, monotonicity, the hg38 accept/reject thresholds, `fmt_bytes` formatting including its unit boundaries, and for the inverse both sufficiency **and minimality** (`resolve(required(b)-1) < b`) across all three reserve regimes plus a near-`INT64_MAX` budget. Passes.
- `test/libsais_memory_budget_test.sh` — the three existing single-build cases pass unchanged; they always pass `--max-memory` explicitly, so the enforced peak-RSS bound they guard is untouched by the policy change. A new `--meth` case asserts the up-front refusal (exit 3, nothing written).
- `test/unit/test_index_memory_estimate.cpp` (new) — the SA-width switch at `INT32_MAX - 10000`, the 6/12 B-per-base cost, hg38's ~72 GiB vs the removed 32 GiB cap, and the 2x `--meth` seed ratio.
- `make docs-cli` re-run and `docs/_generated/cli/index.txt` committed, so the `docs.yml` staleness check stays green.
- `mdbook build` exits 0; no new link warnings.


## Added after first review

**The `--meth` seed budget is now preflighted up front.** `--meth` builds two indexes sequentially in one process — the original over `N = 2*l_pac`, then a seed over a per-strand-converted text twice as long again (`4*l_pac`, an `f…` C→T and an `r…` G→A contig per chromosome). The seed therefore costs **~2x** the original: 143.83 GiB vs 71.91 GiB on hg38, so `--meth` needs a ~160 GiB host where plain indexing needs ~76 GiB.

The budget itself is unchanged by `--meth`, and should be — it is a ceiling on what the host permits, not a statement of requirement, and a host does not gain RAM because you passed a flag. What was wrong is that the check lived inside `libsais_build_fm_index`, so it fired only once each build *started*: a budget that cleared the original and not the seed was discovered after the original index had already been built and written. On hg38 that is an hour wasted and a half-populated index directory. Measured on chr17 with a budget between the two estimates, the refusal is now immediate (exit 3 in 0.06 s) and leaves nothing on disk.

`--meth` output is byte-identical to the pre-change binary across all nine files (original + seed) on chr17.

**Measured while validating this — filed separately, not addressed here.** A `--meth` run's process peak *exceeds* its largest single build, because the first build's memory is essentially never released. On chr17: original alone 0.84 GiB, seed alone 1.65 GiB, `--meth` 2.15 GiB — and an RSS trace shows the dip between builds is only 0.84 → 0.80 GiB. It is not mimalloc purge delay (`MIMALLOC_PURGE_DELAY=0` changes nothing). Consequence: per-build estimates can each clear a budget that the process then exceeds. I deliberately did **not** fold a carry-over margin into this preflight — with one data point, a summed bound (`est(2N) + est(N)` = 2.79 GiB vs 2.15 GiB measured) would demand a ~227 GiB host for `--meth` hg38 where the real peak is ~140 GiB, re-creating the very false-refusal bug this PR fixes. The cause needs characterising first; it may be a fixable leak worth more than modelling it.

**Review fixes.** All four CodeRabbit findings were valid and are applied: the documented default now includes the small-host reserve clamp (`min(max(2G, 5%), 50%)`) in the help text and all three doc sites; the leftover "memory-bounded" description of libsais is gone; and `required_total_for_batch_budget` is corrected. That last one was a real bug of mine — the inverse over-reported in the half-reserve regime (`required(1)` returned 2 GiB + 1 where a 1-byte total suffices) and its overflow guard rejected representable budgets. My original test only asserted sufficiency, never minimality, so it passed a wrong answer. It now binary-searches the forward policy, which is exact in every regime and cannot drift if the policy is retuned, and the tests assert minimality, both regime transitions, and a near-`INT64_MAX` budget.

## Not applicable

No Smith-Waterman kernel is touched (`bandedSWA.cpp`, `kswv.cpp`, `ksw.cpp`, `neon_utils.h`, `simd_compat.h` all unchanged), so the `bwa-bsw-bench` byte-identity gate does not apply to this change.

## Follow-up

The ceiling is *moved*, not removed: the requirement is inherent to a full suffix array over the doubled text, and the `--meth` doubled seed index (N ~= 12.9 Gbase) still needs ~144 GiB. The long-term fix is compressed-space incremental BWT construction (ropebwt3-style rope + SA samples recovered by an LF walk), which would put hg38 in single-digit GiB. Prototype to follow separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated `bwa-mem3 index --max-memory` default to be cgroup-aware and computed as available memory minus a reserved buffer.
  * Added pre-build memory precondition: builds that exceed the budget are rejected (exit code `3`) with clearer remediation guidance.
  * Enhanced `--meth` memory/budget behavior guidance (seed dominates when applicable).
* **Documentation**
  * Refreshed CLI help and user-guide “Time and memory” with the new budget model, hg38 sizing examples, and clarified tmp scratch usage.
* **Tests**
  * Added regression coverage for the new memory budgeting/estimation behavior and `--meth` preflight refusals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->