### PR TITLE
ci(kswv): key the ccache by the resolved -march=native ISA

### DIFF
--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -448,27 +448,81 @@ jobs:
         if: matrix.arch == 'arm'
         run: echo "MAKE_ARCH=arm64" >> "$GITHUB_ENV"
 
+      # Fingerprint what `-march=native` actually resolves to on THIS runner.
+      #
+      # Several targets in this job compile src/kswv.cpp and src/bandedSWA.cpp
+      # at -march=native (Makefile: src/kswv.native.o, src/bandedSWA.native.o,
+      # consumed by kswv_nrow_zero_test, kswv_freed_cell_test,
+      # bandedswa_padding_test, bandedswa_highzdrop_seed_test and
+      # bandedswa_high_h0_zdrop_test). ccache hashes the literal command line
+      # and the compiler binary -- NOT the host CPU -- so on two runners with
+      # the same gcc the string "-march=native" hashes identically while the
+      # emitted code does not. A newer-microarch object then gets served to an
+      # older-microarch runner and the test dies with SIGILL (exit 132) before
+      # its first assertion.
+      #
+      # MAKE_ARCH alone does not separate them: it has three values
+      # (avx2 / avx512bw / arm64) while -march=native encodes the exact
+      # microarch, so Ice Lake, Sapphire Rapids and Granite Rapids all share
+      # the avx512bw bucket and collide. Observed on PR #290 -- a
+      # bandedSWA.native.o built by the previous run SIGILL'd on the next one.
+      #
+      # `-Q --help=target` prints the target options AS RESOLVED for the
+      # selected -march, so it is the authoritative answer to "what will the
+      # compiler emit here", and it tracks the compiler version too.
+      - name: Fingerprint native ISA
+        run: |
+          set -euo pipefail
+          # Preferred source: the resolved target options themselves.
+          if dump=$(g++ -march=native -Q --help=target 2>/dev/null) && [ -n "$dump" ]; then
+            src="gcc -Q --help=target"
+          else
+            # Coarser, but still varies with both host CPU and compiler. Only
+            # here so an environment where -Q --help=target is unavailable
+            # degrades the key's precision instead of failing the whole job.
+            dump=$(g++ -v 2>&1; grep -E '^(model name|flags|Features)' /proc/cpuinfo | sort -u)
+            src="compiler version + cpuinfo (fallback)"
+          fi
+          # A constant hash would silently re-merge every microarch into one
+          # bucket -- the exact bug this guards -- so refuse to emit one.
+          if [ -z "$dump" ]; then
+            echo "::error::could not fingerprint the native ISA"
+            exit 1
+          fi
+          echo "fingerprint source: $src"
+          printf '%s\n' "$dump" > /tmp/native-isa.txt
+          isa=$(sha256sum < /tmp/native-isa.txt | cut -c1-16)
+          echo "NATIVE_ISA=$isa" >> "$GITHUB_ENV"
+          # Belt and braces: feed the same dump into ccache's own hash, so a
+          # false hit is impossible even if two microarchs ever do land in one
+          # cache entry (e.g. a future job that forgets the key component).
+          echo "CCACHE_EXTRAFILES=/tmp/native-isa.txt" >> "$GITHUB_ENV"
+          # Breadcrumbs for triaging a future SIGILL.
+          echo "native ISA fingerprint: $isa"
+          grep -m1 'model name' /proc/cpuinfo || true
+
       - name: Cache ccache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ env.CCACHE_DIR }}
-          # Include MAKE_ARCH in the key/restore-keys so cache entries
-          # don't leak across x86 microarch boundaries. The
-          # `kswv_nrow_zero_test` target compiles src/kswv.cpp at
-          # -march=native to exercise the host's native-ISA kswv class
-          # (see parent Makefile's src/kswv.native.o rule). ccache hashes
-          # the literal command line, NOT host CPUID -- so an
-          # AVX-512-built kswv.native.o was previously served to runners
-          # that lacked AVX-512 (via the `ccache-${{ runner.arch }}-`
-          # prefix matching across microarchs) and the test would SIGILL
-          # on its first kswv operation. Partitioning by MAKE_ARCH
-          # (avx2 / avx512bw / arm64) keeps the cache microarch-aware.
-          # This drops the historical sharing with run-mem-${arch} jobs,
-          # which is fine -- run-mem-x86 builds with explicit -m flags
-          # tied to MAKE_ARCH anyway, not -march=native.
-          key: ccache-${{ runner.arch }}-${{ env.MAKE_ARCH }}-kswv-${{ github.sha }}
+          # Partitioned by NATIVE_ISA -- the hash of what `-march=native`
+          # resolves to on this runner (see "Fingerprint native ISA" above for
+          # why, and for the SIGILL it prevents). MAKE_ARCH stays in the key so
+          # the entries remain readable at a glance, but NATIVE_ISA is the part
+          # that makes them correct: it is strictly finer, since every
+          # avx512bw-class microarch shares one MAKE_ARCH value.
+          #
+          # Both key and restore-keys carry it. A restore-key prefix that
+          # stopped at MAKE_ARCH would re-admit exactly the cross-microarch
+          # match this is meant to exclude, which is how the original bug
+          # survived an earlier attempt to fix it.
+          #
+          # This drops the historical sharing with run-mem-${arch} jobs, which
+          # is fine -- run-mem-x86 builds with explicit -m flags tied to
+          # MAKE_ARCH, never -march=native, so it has no such hazard.
+          key: ccache-${{ runner.arch }}-${{ env.MAKE_ARCH }}-n${{ env.NATIVE_ISA }}-kswv-${{ github.sha }}
           restore-keys: |
-            ccache-${{ runner.arch }}-${{ env.MAKE_ARCH }}-
+            ccache-${{ runner.arch }}-${{ env.MAKE_ARCH }}-n${{ env.NATIVE_ISA }}-
 
       - name: Build + run kswv unit test
         # Builds the doctest-based test/bwa_mem3_tests_unit binary via the


### PR DESCRIPTION
The `kswv-x86` job intermittently dies with `Illegal instruction (core dumped)`, exit 132. It did so on #290 ([run 30180446768](https://github.com/fg-labs/bwa-mem3/actions/runs/30180446768)); a plain re-run went green. That signature — fails, re-run passes, nothing in the diff can explain it — is a cache serving the wrong object, not a flaky test.

## What's happening

Five targets in that job link objects compiled at `-march=native`: `src/kswv.native.o` and `src/bandedSWA.native.o`, behind `kswv_nrow_zero_test`, `kswv_freed_cell_test`, `bandedswa_padding_test`, `bandedswa_highzdrop_seed_test` and `bandedswa_high_h0_zdrop_test`.

ccache hashes the literal command line and the compiler binary. It never looks at the host CPU. So on two runners with the same gcc, `-march=native` hashes identically while the code it emits does not. Restore the previous run's ccache onto a different runner and you get back an object built for a CPU you aren't running on.

The key already tried to stop this, and its comment claims `MAKE_ARCH` makes the cache microarch-aware. It doesn't. `MAKE_ARCH` has three values — `avx2`, `avx512bw`, `arm64` — while `-march=native` encodes the *exact* microarch. Ice Lake, Sapphire Rapids and Granite Rapids all land in the `avx512bw` bucket and share one `ccache-X64-avx512bw-` prefix. That is exactly what happened on #290.

## The fix

Fingerprint what `-march=native` resolves to and put it in the key. `gcc -march=native -Q --help=target` prints the target options *as resolved*, so it answers the question ccache can't: what will this compiler emit on this host. It tracks the compiler version too.

Both `key` and `restore-keys` carry it. Leaving the prefix at `MAKE_ARCH` would re-admit the very match being excluded — that's how the previous attempt still let this through.

`CCACHE_EXTRAFILES` points at the same dump, so it also enters ccache's own hash. The key partitioning already prevents two microarchs sharing an entry; this makes a false hit impossible even if a future job forgets the key component.

There's a fallback if `-Q --help=target` is ever unavailable (compiler version + cpuinfo). It's coarser but still varies by host — the one thing it must never do is collapse to a constant, which would silently re-merge every microarch, so an empty fingerprint fails the step loudly.

## Verification

Two runners differing only in CPU, both gcc 11.5.0:

| Instance | CPU | `-march=` resolves to | Fingerprint |
|---|---|---|---|
| `c6a.large` | AMD EPYC 7R13 | `znver3` | `d28541a460f17afe` |
| `c7i.large` | Xeon Platinum 8488C | `sapphirerapids` | `a53e5d4f76f28be5` |

Same compiler, different fingerprints — so the caches no longer collide.

And the hazard reproduced end to end, with an `__AVX512F__`-guarded probe:

```
built on 8488C            2 zmm instructions    probe=1016
built on 7R13             0 zmm instructions    probe=16
8488C binary run on 7R13  Illegal instruction (core dumped), exit 132
```

Exit 132, same as CI. Distinct fingerprints put those two builds in separate cache entries, so that transplant can't happen.

## Scope

Confined to this workflow — it's the only one that builds a `.native.o` target. The `run-mem` jobs compile with explicit `-m` flags tied to `MAKE_ARCH`, never `-march=native`, so their coarser key carries no such hazard and is left alone.

## Note on what this does not fix

The first cache run after merge is a cold miss per microarch, which is the intended cost. Separately, the same job picks its tier with `grep -q avx512bw /proc/cpuinfo` and silently falls back to avx2, so AVX-512BW coverage is luck rather than guarantee — unrelated to this bug and handled separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build cache reliability by separating cached compiler results according to each runner’s detected CPU instruction set.
  * Prevented incompatible cache entries from being reused across different processor architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->