### PR TITLE
ci(kswv): sweep every host-reachable SIMD tier instead of just one

### DIFF
--- a/.github/scripts/kswv-tier-sweep.sh
+++ b/.github/scripts/kswv-tier-sweep.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# .github/scripts/kswv-tier-sweep.sh
+#
+# Run the unit/kswv doctest suite once per SIMD tier this host can actually
+# host, and record which tiers were exercised.
+#
+# Why this exists
+# ---------------
+# The kswv job used to run the suite exactly once, at whatever tier the runner
+# happened to expose: `grep -q avx512bw /proc/cpuinfo` picked MAKE_ARCH and
+# silently fell back to avx2. AVX-512BW is one of the two tiers that carried
+# the PR #290 query-padding bug, so a runner-fleet refresh could drop precisely
+# the coverage that matters most, and no artifact would say so. Worse, a single
+# run only ever exercises ONE tier, while the kernels differ per tier by
+# construction.
+#
+# How tier selection works
+# ------------------------
+# BWAMEM3_FORCE_TIER can only downgrade. An up-tier (or cross-family, or
+# unknown) request is ignored with a warning and leaves the tier unchanged --
+# see the runtime-line logic in src/simd_dispatch.cpp. Forcing blindly would
+# therefore run the host tier N times and cheerfully report N tiers.
+#
+# So the gate is bwa-mem3's own banner: it annotates an ignored request as
+# ", ignored" on the `SIMD runtime:` line. That makes the dispatcher the single
+# authority on which tier a run actually used -- no second copy of the CPU
+# detection logic to drift out of lockstep with it. (Same idiom as
+# test/regression/all_tiers_parity.sh, which sweeps tiers for SAM parity.)
+#
+# Inputs (environment):
+#   BWA_MEM3      path to the built bwa-mem3 binary, used as the tier oracle
+#   TEST_BIN      path to bwa_mem3_tests_unit
+#   OUT_DIR       directory to write per-tier JUnit XML into
+#   ARCH_LABEL    "x86" | "arm" -- selects the candidate tier list, names files
+# Optional:
+#   REQUIRE_TIERS space-separated tiers that MUST have run; exit 1 otherwise.
+#                 Unset by default: a runner without AVX-512 cannot be blamed
+#                 for lacking it, and failing every such run would train people
+#                 to ignore this job. Set it on a runner class you control to
+#                 turn "we lost the avx512bw leg" into a hard error.
+#   SUMMARY_FILE  file to append a markdown summary to (default $GITHUB_STEP_SUMMARY)
+
+set -uo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+: "${TEST_BIN:?TEST_BIN must be set}"
+: "${OUT_DIR:?OUT_DIR must be set}"
+: "${ARCH_LABEL:?ARCH_LABEL must be set}"
+
+SUMMARY_FILE="${SUMMARY_FILE:-${GITHUB_STEP_SUMMARY:-/dev/null}}"
+REQUIRE_TIERS="${REQUIRE_TIERS:-}"
+
+mkdir -p "$OUT_DIR"
+
+# Candidates, highest first so the most capable (and most bug-prone) kernel is
+# reported at the top of the summary. arm64 has exactly one tier; the x86 list
+# covers the three that have distinct kswv kernels plus sse41, whose kernels
+# are exit() stubs and which therefore checks the skip path rather than the
+# kernels (the unit tests gate on bwamem3_simd_tier() and skip cleanly there).
+case "$ARCH_LABEL" in
+    arm) CANDIDATES="neon" ;;
+    x86) CANDIDATES="avx512bw avx2 sse41" ;;
+    *)   echo "::error::unknown ARCH_LABEL '$ARCH_LABEL' (expected x86 or arm)"; exit 1 ;;
+esac
+
+# Ask the dispatcher what a given force actually selects. Prints the effective
+# tier name and returns 0; prints nothing and returns 0 when the request was
+# refused (host cannot reach that tier); returns 2 when the oracle itself is
+# unusable.
+#
+# The 2 matters. This runs inside a command substitution, i.e. a subshell, so
+# an `exit` here would only leave the subshell and the loop would carry on --
+# reporting every tier as "not available" and finishing with "no SIMD tier
+# could be exercised", which reads as "old runner" and buries the real fault.
+# Returning a distinct status lets the caller tell "can't" from "broken".
+effective_tier() {
+    local want="$1" line
+    line="$(BWAMEM3_FORCE_TIER="$want" "$BWA_MEM3" version 2>/dev/null \
+            | grep '^SIMD runtime:' || true)"
+    [ -n "$line" ] || return 2
+    case "$line" in
+        *", ignored"*) return 0 ;;   # refused: host cannot reach this tier
+    esac
+    printf '%s\n' "$line" | sed -n 's/^SIMD runtime: \([a-z0-9]*\).*/\1/p'
+}
+
+# doctest with --reporters=junit --out=FILE writes the report to FILE and
+# prints nothing to stdout, so the run itself leaves no readable trace in the
+# CI log. Recover the counts from the report so both the log and the summary
+# say what actually happened per tier.
+counts_from_junit() {
+    local f="$1" line
+    if [ ! -s "$f" ]; then
+        echo "? ? ?"
+        return
+    fi
+    line="$(grep -m1 -oE '<testsuite [^>]*' "$f")"
+    printf '%s %s %s\n' \
+        "$(printf '%s' "$line" | sed -n 's/.*tests="\([0-9]*\)".*/\1/p')" \
+        "$(printf '%s' "$line" | sed -n 's/.*failures="\([0-9]*\)".*/\1/p')" \
+        "$(printf '%s' "$line" | sed -n 's/.*errors="\([0-9]*\)".*/\1/p')"
+}
+
+ran=""
+skipped=""
+rows=""
+overall=0
+
+for tier in $CANDIDATES; do
+    got="$(effective_tier "$tier")"
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+        echo "::error::no 'SIMD runtime:' banner from $BWA_MEM3 -- tier oracle is broken, not a low-tier runner"
+        exit 1
+    fi
+    if [ -z "$got" ]; then
+        skipped="$skipped $tier"
+        echo "--- tier $tier: not available on this host, skipping"
+        continue
+    fi
+    if [ "$got" != "$tier" ]; then
+        # Banner accepted the request but reported a different tier. Never
+        # expected; bail rather than attribute one tier's results to another.
+        echo "::error::asked for tier '$tier' but dispatcher reports '$got'"
+        exit 1
+    fi
+
+    echo "--- tier $tier: running unit/kswv"
+    report="$OUT_DIR/kswv-unit-${ARCH_LABEL}-${tier}.xml"
+    BWAMEM3_FORCE_TIER="$tier" "$TEST_BIN" --test-suite="unit/kswv" \
+        --reporters=junit --out="$report"
+    status=$?
+    read -r n_tests n_fail n_err <<EOF
+$(counts_from_junit "$report")
+EOF
+    if [ "$status" -ne 0 ]; then
+        overall=$status
+        echo "::error::unit/kswv failed at tier $tier (exit $status, ${n_fail} failures, ${n_err} errors)"
+        rows="$rows| \`$tier\` | $n_tests | $n_fail | $n_err | **FAILED** |"$'\n'
+    else
+        echo "    tier $tier: $n_tests tests, $n_fail failures, $n_err errors -- pass"
+        rows="$rows| \`$tier\` | $n_tests | $n_fail | $n_err | pass |"$'\n'
+    fi
+    ran="$ran $tier"
+done
+
+# The point of the whole exercise: make the tier set a visible, durable fact
+# rather than something you have to reconstruct from a ccache key.
+{
+    echo "### kswv unit suite — SIMD tier sweep (${ARCH_LABEL})"
+    echo
+    echo "| tier | tests | failures | errors | status |"
+    echo "|---|---|---|---|---|"
+    printf '%s' "$rows"
+    for t in $skipped; do echo "| \`$t\` | — | — | — | not available on this runner |"; done
+    echo
+} >> "$SUMMARY_FILE"
+
+if [ -z "$ran" ]; then
+    echo "::error::no SIMD tier could be exercised on this runner"
+    exit 1
+fi
+
+case " $ran " in
+    *" avx512bw "*) ;;
+    *)
+        if [ "$ARCH_LABEL" = "x86" ]; then
+            echo "::warning::AVX-512BW was NOT exercised on this runner; the avx512bw kswv kernel is untested by this run"
+            echo "> :warning: \`avx512bw\` not exercised — that kernel is untested by this run." >> "$SUMMARY_FILE"
+        fi
+        ;;
+esac
+
+for req in $REQUIRE_TIERS; do
+    case " $ran " in
+        *" $req "*) ;;
+        *) echo "::error::required tier '$req' was not exercised"; overall=1 ;;
+    esac
+done
+
+echo "tiers exercised:${ran:- none}"
+echo "tiers skipped:${skipped:- none}"
+exit "$overall"

--- a/.github/workflows/proto-neon-kswv.yml
+++ b/.github/workflows/proto-neon-kswv.yml
@@ -524,29 +524,41 @@ jobs:
           restore-keys: |
             ccache-${{ runner.arch }}-${{ env.MAKE_ARCH }}-n${{ env.NATIVE_ISA }}-
 
-      - name: Build + run kswv unit test
+      - name: Build + run kswv unit test (all host-reachable SIMD tiers)
         # Builds the doctest-based test/bwa_mem3_tests_unit binary via the
         # parent `test-binaries` target so ARCH_FLAGS_FROM_PARENT plumbing
         # propagates and the test TU sees the same __AVX2__ / __AVX512BW__
         # / NEON surface libbwa was built with.
+        #
+        # bwa-mem3 itself is built too, purely as the tier oracle: its version
+        # banner is the only thing that reliably reports which tier a given
+        # BWAMEM3_FORCE_TIER actually selected (an unreachable request is
+        # ignored, not refused). Incremental on top of libbwa.a -- one compile
+        # and a link. See .github/scripts/kswv-tier-sweep.sh for the rest.
+        #
+        # Sweeping matters because a single run only ever exercises ONE tier,
+        # and which one was decided by whichever runner we landed on. The
+        # kernels differ per tier by construction, and avx512bw is one of the
+        # two that carried the #290 padding bug.
         run: |
           mkdir -p /tmp/ci-out
           ccache --zero-stats >/dev/null
           make arch="$MAKE_ARCH" CXX="ccache g++" CC="ccache gcc" test-binaries
-          ./test/bwa_mem3_tests_unit --test-suite="unit/kswv" \
-            --reporters=junit \
-            --out=/tmp/ci-out/kswv-unit-${{ matrix.arch }}.xml \
-            2>&1 | tee /tmp/selftest.log
-          status=${PIPESTATUS[0]}
-          tail -25 /tmp/selftest.log >> "$GITHUB_STEP_SUMMARY"
-          exit $status
+          make arch="$MAKE_ARCH" CXX="ccache g++" CC="ccache gcc" bwa-mem3
+          BWA_MEM3=./bwa-mem3 \
+          TEST_BIN=./test/bwa_mem3_tests_unit \
+          OUT_DIR=/tmp/ci-out \
+          ARCH_LABEL=${{ matrix.arch }} \
+            bash .github/scripts/kswv-tier-sweep.sh
 
-      - name: Upload kswv unit test JUnit report
+      - name: Upload kswv unit test JUnit reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: kswv-unit-${{ matrix.arch }}
-          path: /tmp/ci-out/kswv-unit-${{ matrix.arch }}.xml
+          # One XML per tier that ran (kswv-unit-<arch>-<tier>.xml), so the
+          # artifact set itself records which tiers were covered.
+          path: /tmp/ci-out/kswv-unit-${{ matrix.arch }}-*.xml
           if-no-files-found: warn
           retention-days: 1
 


### PR DESCRIPTION
> Was stacked on #301; #301 is now squash-merged and this has been rebased onto `main`, so it stands alone.

The `kswv` job ran the `unit/kswv` suite exactly once, at whatever tier the runner happened to expose — `grep -q avx512bw /proc/cpuinfo`, silent fall back to avx2.

Two problems. A single run exercises **one** tier, while the kswv kernels are separate bodies of code per tier. And which tier gets tested is decided by the scheduler, leaving no durable record.

Not hypothetical: AVX-512BW is one of the two tiers that carried the #290 padding bug, and the fleet is visibly heterogeneous. Two runs of this job earlier today landed on `avx512bw` hosts; the next landed on an **AMD EPYC 9V74 reporting only avx2**. Under the old step that run silently tested one fewer kernel and said nothing about it.

## What changes

Sweep every tier the host can actually reach, one JUnit report each. An AVX-512 runner now covers `avx512bw` + `avx2` + `sse41` instead of `avx512bw` alone.

Reachability is decided by **bwa-mem3's own banner**, not a second copy of the CPU detection. `BWAMEM3_FORCE_TIER` only downgrades — an up-tier, cross-family or unknown request is *ignored with a warning and leaves the tier unchanged* (`src/simd_dispatch.cpp`). Forcing blindly would run the host tier N times and cheerfully report N tiers. The banner marks an ignored request `", ignored"` on its `SIMD runtime:` line, which makes the dispatcher the single authority. Same idiom as `test/regression/all_tiers_parity.sh` — which, incidentally, already sweeps tiers for SAM parity and is wired into nothing.

Logic lives in `.github/scripts/kswv-tier-sweep.sh` rather than inline YAML so it's runnable and testable outside CI.

## Absence is now loud

A summary table per run:

| tier | tests | failures | errors | status |
|---|---|---|---|---|
| `avx512bw` | 31 | 0 | 0 | pass |
| `avx2` | 31 | 0 | 0 | pass |
| `sse41` | — | — | — | not available on this runner |

Missing `avx512bw` on x86 also raises a `::warning::` and a summary note.

**It does not hard-fail.** A runner without AVX-512 can't be blamed for lacking it, and failing every such run trains people to ignore the job. `REQUIRE_TIERS` is there to make it an error on a runner class you control — that's the knob to reach for if you'd rather this be enforced.

Counts come from the JUnit report because doctest with `--reporters=junit --out=FILE` prints nothing to stdout — the step this replaces `tail`'d a log that was empty for that reason.

`sse41` is swept too. Its kswv kernels are `exit()` stubs, so that leg tests the skip path, not the kernels. It only became safe to run once #290 gated the mixed-length tests on `bwamem3_simd_tier()`; before that, forcing sse41 hit the stub and killed the test binary mid-suite.

## Verification

End-to-end on arm64 against real binaries (`neon`: 31 tests, 0 failures), and against mocks for the paths one host can't reach:

- AVX-512 host → sweeps 3 tiers, exit 0
- avx2-only host → skips `avx512bw`, warns, exit 0
- failure at one tier → exit 1, later tiers still run, row marked **FAILED**
- `REQUIRE_TIERS=avx512bw` unmet → exit 1
- broken oracle → **one** error saying the oracle is broken, not "no tier available"

That last case was a real bug the mocks caught: `effective_tier` runs in a command substitution, so its `exit` only left the subshell — the loop carried on, printed the error three times, and finished with "no SIMD tier could be exercised", which reads as *old runner* rather than *broken build*. It now returns a distinct status so the caller can tell "can't" from "broken".

## Cost

Roughly 3× the unit-suite runtime on x86 (the suite is seconds; the build dominates and is unchanged), plus one extra link for the `bwa-mem3` tier oracle, incremental on top of `libbwa.a`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated KSWV testing across all SIMD tiers supported by the host.
  * Added per-tier JUnit reports and an aggregated Markdown test summary.
  * CI now uploads test results for every exercised SIMD tier.
  * Added checks for unavailable, failed, or required SIMD tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->