### PR TITLE
fix(index): raise the int32 per-base memory estimate from 6 to 8 bytes

### DIFF
--- a/docs/src/cli/index-cmd.md
+++ b/docs/src/cli/index-cmd.md
@@ -68,7 +68,8 @@ precondition that is checked before the build starts, not a target the builder
 spills to meet. A reference whose estimated requirement exceeds the budget is
 rejected with exit code 3 and a message naming both the `--max-memory` value
 that would clear it and the host RAM that would clear it automatically. Human
-genomes need roughly 12 bytes per base of doubled text — about 72 GB for hg38 —
+genomes need roughly 12 bytes per base of doubled text (8 below ~1.07 Gbp, where
+the suffix array still fits 32-bit entries) — about 72 GB for hg38 —
 so plan on a host with ~76 GB of RAM or more.
 
 ### `--tmp-dir PATH` — scratch directory

--- a/docs/src/user-guide/indexing.md
+++ b/docs/src/user-guide/indexing.md
@@ -121,11 +121,18 @@ typical multi-core host, indexing hg38 takes a few minutes (longer if pinned to 
 single core).
 
 Peak memory is roughly **12 bytes per base of doubled text**, i.e. ~72 GB for
-hg38. `--max-memory` is a precondition checked before the build starts, not a
-spill target: a reference that does not fit the budget is rejected up front
-(exit code 3) rather than built more slowly. Budget hg38 on a host with ~76 GB
-of RAM or more; the rejection message names both the `--max-memory` override
-and the host size that would work without one.
+hg38. Below ~1.07 Gbp the suffix array still fits 32-bit entries and the cost
+drops to ~8 bytes per base. `--max-memory` is a precondition checked before the
+build starts, not a spill target: a reference that does not fit the budget is
+rejected up front (exit code 3) rather than built more slowly. Budget hg38 on a
+host with ~76 GB of RAM or more; the rejection message names both the
+`--max-memory` override and the host size that would work without one.
+
+`--meth` needs about **twice** that, because it builds a second index over a
+per-strand-converted reference whose text is twice as long: ~144 GB estimated for
+hg38, so budget a host with ~152 GB of RAM or more. Both builds run in one
+process and the first does not fully release its memory before the second starts,
+so the per-base figures above already account for that overlap.
 
 bwa-mem3 builds the suffix array with
 [libsais](https://github.com/IlyaGrebnov/libsais), whose OpenMP-parallel

--- a/src/libsais_build.cpp
+++ b/src/libsais_build.cpp
@@ -134,10 +134,31 @@ bool libsais_sa_is_64bit(int64_t N) {
 }
 
 int64_t libsais_estimate_peak_bytes(int64_t N) {
-    // Per-base preflight headroom: 6 B/base (int32) / 12 B/base (int64) covers
-    // measured peaks on chr22 and chr1-6 with margin for libsais aux arrays and
-    // OMP/mimalloc overhead on small inputs.
-    return (N + 1) * (libsais_sa_is_64bit(N) ? 12 : 6);
+    // Per-base cost, calibrated against measured peak RSS rather than derived
+    // from the buffer arithmetic alone (buf is 1 B/base, the SA 4 or 8, and
+    // libsais's aux arrays plus the OMP/allocator arenas add the rest).
+    //
+    // Two properties have to hold, and the second is the binding one because
+    // `index --meth` runs two builds in one process -- the original over
+    // N = 2*l_pac, then a seed over 4*l_pac -- and does not return the first
+    // build's memory before the second starts. So the estimate for a build must
+    // also cover a --meth invocation whose *dominant* build is that size.
+    //
+    // Worst measured cost per base of N, over a size ladder from chr17 (0.08
+    // Gbp) to chr1-9 (1.67 Gbp) on a 64 GiB 12-core host:
+    //
+    //             single build   --meth process   estimate   margins
+    //   int32 SA      5.90 B         7.07 B          8         1.36 / 1.13
+    //   int64 SA      9.84 B        10.04 B         12         1.22 / 1.20
+    //
+    // The int32 constant was 6, i.e. only 1.02x over a single build's own peak
+    // and *below* the --meth process peak -- so a small-reference `--meth` build
+    // could exceed its budget by ~17% while every individual estimate cleared
+    // it. int64's 1.22x margin already absorbed the same carry-over, which is
+    // why the defect was confined to the int32 path. 8 restores a comparable
+    // margin; no --meth-specific term is needed, and none is wanted, since the
+    // carry-over measures as bounded rather than proportional.
+    return (N + 1) * (libsais_sa_is_64bit(N) ? 12 : 8);
 }
 
 void libsais_report_budget_shortfall(const char* what, int64_t need_bytes,

--- a/test/unit/test_index_memory_estimate.cpp
+++ b/test/unit/test_index_memory_estimate.cpp
@@ -12,7 +12,8 @@
 // estimate (12 B/base over a doubled 6.43 Gbase text = 71.9 GiB) lost to a
 // 32 GiB budget on every host, including a 256 GiB server. The thresholds below
 // are derived from the constants themselves — INT32_MAX - 10000 for the SA-width
-// switch, 6/12 B/base for the cost — not recorded from a run.
+// switch, 8/12 B/base for the cost — plus, in the last two cases, peak-RSS
+// figures recorded from real builds.
 //
 // `N` throughout is the DOUBLED text length (2 * l_pac), which is what libsais
 // is handed; a `--meth` seed index doubles it again (4 * l_pac).
@@ -41,14 +42,15 @@ TEST_CASE("libsais_sa_is_64bit: switches exactly at INT32_MAX - 10000") {
     CHECK(libsais_sa_is_64bit(0) == false);
 }
 
-TEST_CASE("libsais_estimate_peak_bytes: 6 B/base int32, 12 B/base int64") {
-    CHECK(libsais_estimate_peak_bytes(1000) == 1001 * 6);
+TEST_CASE("libsais_estimate_peak_bytes: 8 B/base int32, 12 B/base int64") {
+    CHECK(libsais_estimate_peak_bytes(1000) == 1001 * 8);
     CHECK(libsais_estimate_peak_bytes(kSwitchPoint) == (kSwitchPoint + 1) * 12);
-    // Crossing the width switch makes the estimate jump, not grow smoothly.
+    // Crossing the width switch makes the estimate jump, not grow smoothly:
+    // 8 -> 12 B/base, so a one-base increase costs 1.5x.
     const int64_t below = libsais_estimate_peak_bytes(kSwitchPoint - 2);
     const int64_t above = libsais_estimate_peak_bytes(kSwitchPoint - 1);
     CHECK(above > below);
-    CHECK(above >= below * 2);
+    CHECK(above == doctest::Approx((double)below * 1.5).epsilon(0.001));
 }
 
 TEST_CASE("libsais_estimate_peak_bytes: hg38 needs ~72 GiB, well past the old 32 GiB cap") {
@@ -87,4 +89,71 @@ TEST_CASE("libsais_estimate_peak_bytes: a --meth seed costs ~2x its original") {
     const int64_t budget = (c_orig + c_seed) / 2;
     CHECK(c_orig <= budget);
     CHECK(c_seed > budget);
+}
+
+// The estimate is a promise: the build it gates must not exceed it. These are
+// peak-RSS figures MEASURED with /usr/bin/time -l and RSS sampling on one
+// 64 GiB 12-core arm64 host, so they are a floor on the required margin rather
+// than a universal bound -- another host's allocator or thread count can peak
+// higher. They exist to stop the per-base constants being lowered back to a
+// value that real builds overrun, which is exactly what the int32 constant did
+// at 6 B/base.
+namespace {
+
+struct MeasuredPeak {
+    const char* label;
+    int64_t     N;            // doubled text length handed to libsais
+    int64_t     peak_bytes;   // observed peak RSS
+};
+
+// Single builds: `index` on cumulative hg38 slices (and each --meth run's
+// first build, which is an ordinary build of the original reference).
+const MeasuredPeak kSingleBuildPeaks[] = {
+    {"chr17       (int32)",   166514882,   902348800LL},
+    {"chr17 seed  (int32)",   333029764,  1776664576LL},
+    {"chr1        (int32)",   497912844,  2812051456LL},
+    {"chr1-2      (int32)",   982299902,  5185159168LL},
+    {"chr1-3      (int32)",  1378891020,  8129052672LL},
+    {"chr1-4      (int32)",  1759320130, 10151133184LL},
+    {"chr1-5      (int32)",  2122396648, 12057460736LL},
+    {"chr1-6      (int64)",  2464008606, 24248434688LL},
+    {"chr1-7      (int64)",  2782700552, 27249328128LL},
+    {"chr1-8      (int64)",  3072977824, 29934387200LL},
+    {"chr1-9      (int64)",  3349767258, 30999101440LL},
+};
+
+// `index --meth` whole-process peaks, keyed by the SEED build's N (= 4*l_pac),
+// which is the dominant build and therefore what the preflight checks.
+const MeasuredPeak kMethProcessPeaks[] = {
+    {"chr17 --meth  (int32)",  333029764,  2311536640LL},
+    {"chr1 --meth   (int32)",  995825688,  7044399104LL},
+    {"chr1-2 --meth (int32)", 1964599804, 11325145088LL},
+    {"chr1-3 --meth (int64)", 2757782040, 26843906048LL},
+    {"chr1-4 --meth (int64)", 3518640260, 35315105792LL},
+    {"chr1-5 --meth (int64)", 4244793296, 38338084864LL},
+};
+
+} // namespace
+
+TEST_CASE("libsais_estimate_peak_bytes: covers every measured single-build peak") {
+    for (const MeasuredPeak& m : kSingleBuildPeaks) {
+        const int64_t est = libsais_estimate_peak_bytes(m.N);
+        CAPTURE(m.label);
+        CAPTURE(est);
+        CAPTURE(m.peak_bytes);
+        CHECK(est > m.peak_bytes);
+    }
+}
+
+TEST_CASE("libsais_estimate_peak_bytes: covers every measured --meth process peak") {
+    // This is the property the old int32 constant broke: the seed build's
+    // estimate has to cover the whole invocation, because the original build's
+    // memory is still resident when the seed build runs.
+    for (const MeasuredPeak& m : kMethProcessPeaks) {
+        const int64_t est = libsais_estimate_peak_bytes(m.N);
+        CAPTURE(m.label);
+        CAPTURE(est);
+        CAPTURE(m.peak_bytes);
+        CHECK(est > m.peak_bytes);
+    }
 }


### PR DESCRIPTION
> **Stacked on #300** — base is `fix/index-auto-memory-budget`, which introduced `libsais_estimate_peak_bytes()`. Review/merge #300 first.

## Problem

The preflight estimate is a promise: the build it gates must not exceed it. Measured against real peak RSS, the int32 constant broke that promise.

`index --meth` runs **two** builds in one process — the original over `N = 2·l_pac`, then a seed over a per-strand-converted text twice as long again (`4·l_pac`) — and it does **not** release the first build's memory before the second starts. So a build's estimate has to cover a `--meth` invocation whose *dominant* build is that size.

Worst measured cost per base of text, over a size ladder from chr17 (0.08 Gbp) to chr1-9 (1.67 Gbp), on one 64 GiB 12-core host:

| SA width | single build | `--meth` process | estimate | margins |
|---|---|---|---|---|
| int32 | 5.90 B | **7.07 B** | 6 | 1.02x / **0.85x** |
| int64 | 9.84 B | 10.04 B | 12 | 1.22x / 1.20x |

At 6 B/base the int32 estimate sat **below** the `--meth` process peak, so a small-reference `--meth` build cleared every individual check and still overran its budget by ~17%:

| | estimate | actual process peak |
|---|---|---|
| chr17 `--meth` | 1.86 GiB | **2.15 GiB** |
| chr1 `--meth` | 5.60 GiB | **6.56 GiB** |

int64's larger margin already absorbed the same overlap — which is exactly why the defect was invisible: it is confined to references under ~537 Mbp, where the seed's `4·l_pac` text still fits 32-bit suffix-array entries. Every mammalian genome takes the int64 path.

## Change

**int32: 6 → 8 B/base.** Restores a margin comparable to int64's — 1.36x over a single build, 1.13x over the `--meth` process peak.

**int64: unchanged at 12.** It is already correct, and shaving it would not achieve anything: 11 B/base would put hg38 `--meth` at a 132 GiB estimate against a 128 GiB host's 121.6 GiB budget — still refused — while thinning the margin on an hour-long build that OOMs if the estimate is wrong.

**No `--meth`-specific carry-over term.** The overlap measures as *bounded* (0.1–3.4 GiB across an 8x size range, no trend) rather than proportional, because the second build largely reuses the first's retained pages. A proportional allowance would inflate hg38's requirement by tens of GiB to cover a few, re-creating the over-conservative-refusal problem #300 exists to fix.

## Evidence

Two ladders, all local, no cloud spend. Cumulative hg38 slices, `index` and `index --meth`, peak RSS via `/usr/bin/time -l` plus 0.25 s RSS sampling with phases attributed from the build log.

**Single builds** — `est/peak` must exceed 1.0:

| rung | `N` | peak | B/base | est/peak (before → after) |
|---|---|---|---|---|
| chr17 | 166,514,882 | 0.84 G | 5.42 | 1.11 → 1.48 |
| chr1 | 497,912,844 | 2.62 G | 5.65 | 1.06 → 1.42 |
| chr1-2 | 982,299,902 | 4.83 G | 5.28 | 1.14 → 1.51 |
| chr1-3 | 1,378,891,020 | 7.57 G | 5.90 | **1.02** → 1.36 |
| chr1-4 | 1,759,320,130 | 9.45 G | 5.77 | 1.04 → 1.39 |
| chr1-5 | 2,122,396,648 | 11.23 G | 5.68 | 1.06 → 1.41 |
| chr1-6 | 2,464,008,606 | 22.58 G | 9.84 | 1.22 (int64, unchanged) |
| chr1-7 | 2,782,700,552 | 25.38 G | 9.79 | 1.23 |
| chr1-8 | 3,072,977,824 | 27.88 G | 9.74 | 1.23 |
| chr1-9 | 3,349,767,258 | 28.87 G | 9.25 | 1.30 |

**`--meth` whole-process peaks** — keyed by the seed build's `N`, which is what the preflight checks:

| rung | `N_seed` | est_seed | process peak | est/peak (before → after) |
|---|---|---|---|---|
| chr17 | 333,029,764 | 1.86 → 2.48 G | 2.15 G | **0.87** → 1.15 |
| chr1 | 995,825,688 | 5.60 → 7.42 G | 6.56 G | **0.85** → 1.13 |
| chr1-2 | 1,964,599,804 | 11.00 → 14.63 G | 10.55 G | 1.04 → 1.39 |
| chr1-3 | 2,757,782,040 | 30.80 G | 25.00 G | 1.23 (int64) |
| chr1-4 | 3,518,640,260 | 39.30 G | 32.89 G | 1.20 |
| chr1-5 | 4,244,793,296 | 47.40 G | 35.71 G | 1.33 |

Live confirmation of the fixed case, chr1 `--meth` on the new binary: estimate **7.4 GiB**, measured peak **6.56 GiB** — estimate now above requirement.

**On the overlap itself:** 19–29% of the first build's peak is still resident when the second starts, but the second build *reuses* those pages rather than stacking on them, so the excess over a bare seed-alone build stays absolutely bounded and shrinks in relative terms as references grow (at chr1-5 it vanished entirely — peak landed within 0.4% of the bare model). It is not mimalloc purge delay: `MIMALLOC_PURGE_DELAY=0` leaves the peak unchanged to the megabyte.

## Tests

- **New regression table** in `test/unit/test_index_memory_estimate.cpp`: all 17 measured peaks above, asserted `est > peak`. These are one host's figures, so they are a floor on the required margin, not a universal bound — documented as such in the test. Their job is to stop the constants being lowered back to a value real builds overrun.
- Updated the constant-dependent assertions (`1001 * 6` → `1001 * 8`; the int32→int64 estimate jump is now 1.5x rather than 2x).
- `system_test`, full unit suite (2,962,394 assertions), and `libsais_memory_budget_test.sh` including its `--meth` case all pass.
- `mdbook build` exits 0; `make docs-cli` produces no diff (the help text carries no per-base figure).

## Output impact

**None.** Only the value compared against the budget changed. Verified byte-identical `--meth` output — all 9 files, original + seed — against the pre-#300 binary `0.7.0-e722ed0`.

## Docs

Both pages quoted "12 bytes per base" unconditionally; they now note the 8 B/base int32 regime and, in the user guide, that `--meth` needs roughly twice the memory (~144 GB estimated for hg38, so a ~152 GB host) with the reason why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory estimation for genome indexing, especially for 32-bit suffix-array builds.
  - Added more accurate safeguards based on measured peak memory usage.
  - Improved memory preflight handling for methylation-aware indexing.

- **Documentation**
  - Clarified memory requirements for large genomes and `--meth` indexing.
  - Documented early rejection when the configured memory limit is insufficient.
  - Added guidance for the 32-bit suffix-array size threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->