### PR TITLE
fix(meth): emit MQ:i and HN:i from the --meth BAM writer

### DIFF
--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -525,6 +525,14 @@ int meth_mem_aln_to_bam(bam1_t *b,
             bam_aux_append(b, "MC", 'Z', (int)mc.l + 1, (const uint8_t *)mc.s);
         free(mc.s);
     }
+    /* MQ:i — guarded on `mp` alone, not on the MC block's `mp->n_cigar > 0`, so
+     * a mate with no CIGAR still gets its MAPQ. The compat gate is always open
+     * under --meth (fastmap.cpp refuses --compat with --meth) but is read here
+     * anyway so this stays a copy of bam_writer.cpp rather than a divergence. */
+    if (mp && opt->compat->emit_mq) {
+        int32_t mq = (int32_t)mp->mapq;
+        bam_aux_append(b, "MQ", 'i', sizeof(mq), (const uint8_t *)&mq);
+    }
     if (p.score >= 0) {
         int32_t as = (int32_t)p.score;
         bam_aux_append(b, "AS", 'i', sizeof(as), (const uint8_t *)&as);
@@ -577,6 +585,14 @@ int meth_mem_aln_to_bam(bam1_t *b,
      * names. No f/r prefix stripping or chrom rewrite is needed; emit verbatim. */
     if (p.XA != NULL) {
         bam_aux_append(b, "XA", 'Z', (int)strlen(p.XA) + 1, (const uint8_t *)p.XA);
+    }
+    /* HN:i — the same mem_gen_alt call that fills p.XA fills p.HN, so this
+     * counts the hits XA enumerates. Like XA above it is already stated against
+     * the ORIGINAL bns, so the doubled C->T/G->A reference does not double-count
+     * it. See the MQ:i note above re: the compat gate. */
+    if (p.HN >= 0 && opt->compat->emit_hn) {
+        int32_t hn = (int32_t)p.HN;
+        bam_aux_append(b, "HN", 'i', sizeof(hn), (const uint8_t *)&hn);
     }
     /* Bismark-compatible XR:Z (read conversion) emitted on every record;
      * XG:Z (genome strand) and XM:Z (methylation call string) only on

--- a/test/regression/meth_output_integrity.sh
+++ b/test/regression/meth_output_integrity.sh
@@ -21,6 +21,13 @@
 #     complement of the input read with a consistent CIGAR length (no S1
 #     inconsistent-BAM); samtools quickcheck passes.
 #
+#  4. MQ:i / HN:i tag-set parity with the non-meth writer. src/meth_bam.cpp is a
+#     second BAM emitter alongside src/bam_writer.cpp, and a --meth BAM must not
+#     be a subset of a non-meth one: a record whose mate is mapped carries MQ:i
+#     equal to that mate's MAPQ, and a mapped record carries HN:i equal to its
+#     XA hit count. Checked on a pair with asymmetric MAPQ and asymmetric hit
+#     counts, so both tags are pinned to a value and not merely to presence.
+#
 # Inputs:
 #   BWA_MEM3 — path to the bwa-mem3 binary under test
 set -euo pipefail
@@ -98,4 +105,50 @@ read -r rev seq cig < <(samtools view seq.bam | mawk '(int($2/128)%2)==1{print (
 [ "${#seq}" = "60" ]       || fail "SEQ orient: SEQ length ${#seq}, want 60 (CIGAR consistency)"
 [ "$seq" = "$SEQ_R2_RC" ]  || fail "SEQ orient: reverse-mate SEQ is not revcomp(input read)"
 
-echo "PASS: meth_output_integrity (real-SNP vs conversion in AS/NM/MD; Bismark four-strand XR/XG; reverse SEQ orientation)"
+# --- 4. MQ:i / HN:i parity with the non-meth writer ------------------------
+# The fixture is deliberately ASYMMETRIC on both tags: chrB repeats chrA:241-420,
+# which contains R2's locus, so R2 has two equally good hits (MAPQ 0, one XA hit)
+# while R1 stays unique (MAPQ 60, no XA hits). That pins both tags to a VALUE
+# rather than to presence — a writer emitting the record's own MAPQ as MQ:i would
+# survive a symmetric MAPQ-60 pair, and an HN:i wired to a constant 0 would
+# survive a fixture with no repeats. Neither survives this one.
+#
+# The MAPQ preconditions are asserted first so that a future scoring change which
+# flattens the asymmetry is reported as a stale fixture rather than passing
+# vacuously.
+printf '>chrA\n%s\n>chrB\n%s\n' "$REF" "${REF:240:180}" > dup.fa
+"$BWA_MEM3" index --meth dup.fa >/dev/null 2>&1 || fail "dup index --meth nonzero exit"
+"$BWA_MEM3" mem --meth --meth-scoring genomic -t 1 dup.fa f1.fq f2.fq > dup.bam 2>/dev/null \
+    || fail "dup mem --meth nonzero exit"
+samtools quickcheck dup.bam || fail "dup invalid BAM"
+
+mq_hn() { # $1 bam  $2 mate flag bit -> "MAPQ MQ HN"
+    samtools view "$1" | mawk -v bit="$2" '
+        (int($2/bit)%2)==1 {
+            mq = ""; hn = ""
+            for (i = 12; i <= NF; i++) {
+                if ($i ~ /^MQ:i:/) mq = substr($i, 6)
+                if ($i ~ /^HN:i:/) hn = substr($i, 6)
+            }
+            print $5, mq, hn
+            exit
+        }'
+}
+read -r mapq1 mq1 hn1 < <(mq_hn dup.bam 64)
+read -r mapq2 mq2 hn2 < <(mq_hn dup.bam 128)
+[ "$mapq1" = "60" ] || fail "MQ/HN: stale fixture — R1 MAPQ $mapq1, want 60 (unique locus)"
+[ "$mapq2" = "0" ]  || fail "MQ/HN: stale fixture — R2 MAPQ $mapq2, want 0 (locus duplicated on chrB)"
+# Non-empty first, so an absent tag is reported as absent rather than as a value
+# mismatch against the empty string.
+[ -n "$mq1" ] || fail "MQ/HN: R1 has no MQ:i (the non-meth BAM writer emits it)"
+[ -n "$mq2" ] || fail "MQ/HN: R2 has no MQ:i (the non-meth BAM writer emits it)"
+[ "$mq1" = "$mapq2" ] || fail "MQ/HN: R1 MQ:i $mq1, want R2's MAPQ $mapq2 (not R1's own $mapq1)"
+[ "$mq2" = "$mapq1" ] || fail "MQ/HN: R2 MQ:i $mq2, want R1's MAPQ $mapq1 (not R2's own $mapq2)"
+# HN counts the hits XA enumerates: 0 for the unique mate, 1 for the mate whose
+# locus is duplicated on chrB.
+[ -n "$hn1" ] || fail "MQ/HN: R1 has no HN:i (the non-meth BAM writer emits it)"
+[ -n "$hn2" ] || fail "MQ/HN: R2 has no HN:i (the non-meth BAM writer emits it)"
+[ "$hn1" = "0" ] || fail "MQ/HN: R1 HN:i $hn1, want 0 (unique mapper, no XA hits)"
+[ "$hn2" = "1" ] || fail "MQ/HN: R2 HN:i $hn2, want 1 (the chrA copy of the duplicated locus)"
+
+echo "PASS: meth_output_integrity (real-SNP vs conversion in AS/NM/MD; Bismark four-strand XR/XG; reverse SEQ orientation; MQ:i/HN:i tag parity)"


### PR DESCRIPTION
Closes #296.

`src/meth_bam.cpp` is a second BAM emitter alongside `src/bam_writer.cpp`, and it was missing exactly two of its sibling's aux tags: `MQ:i` (mate MAPQ) and `HN:i` (hit count). A `--meth` BAM was therefore a strict subset of a non-meth one by those two tags.

## Evidence

From the bwa-mem3-bench aux-tag census (hg38, m7i):

| cell | primaries | `MQ` | `HN` | `MC` | `XA` |
|---|---|---|---|---|---|
| `meth-twist-emseq-5M` | 10,369,692 | 0 | 0 | 10,341,704 | 732,273 |
| `smoke-meth` | 20,740 | 0 | 0 | 20,678 | 1,432 |

A non-meth `wgs-5M` run over the same reference emits `MQ:i` on all 9,980,872 primaries and `HN:i` on every mapped record.

## Why this was an omission, not a design choice

Both blocks sit immediately after one the meth writer already has — `MQ` after `MC`, `HN` after `XA` — and both values are already in scope at that point: `mp->mapq` is the same `mem_aln_t` the `MC` block reads, and `p.HN` is filled by the same `mem_gen_alt` call that fills `p.XA`. The file annotates its deliberate meth divergences inline (the `XR:Z` suppression, the `SA` mirror note) and carries no such note for these two. The a priori objection to `HN` on a doubled reference — that it would double-count the C→T and G→A strands — does not apply, for the same reason already recorded above the `XA` block: `mem_gen_alt` runs against the original `bns`.

## Compat gate

Both appends read their `opt->compat->emit_mq` / `emit_hn` gate, as the non-meth writer does. `--compat` is refused under `--meth` today (`fastmap.cpp`), so the gates are always open there; reading them anyway keeps this a copy of `bam_writer.cpp` rather than a divergence that would go stale if a meth-capable target were ever added.

## Test

`test/regression/meth_output_integrity.sh` gains a fourth section asserting tag-set parity on the proper pair it already aligns: each mate carries `MQ:i` equal to the other mate's MAPQ, and each carries `HN:i` (`0` here — a unique mapper has no XA hits, and the tag must still be present). The script is already in the CI `--meth whole-aligner regressions (D3)` matrix row, so no workflow change is needed.

Verified test-first: the new section fails on `main` (`R1 has no MQ:i`), and the `HN` assertion was separately confirmed to fail with only the `HN` block removed. The full self-contained `--meth` regression set plus `test/run_unit_tests.sh` pass with the fix.

## Impact

No placement, score, flag, or methylation call changes — output-only, two added tags. `meth_rescue_batched_identical.sh` (byte-identical BAM comparison between two `--meth` runs) still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In meth-mode BAM output, optional mate tags for compatibility settings are now emitted correctly, preserving `MQ` (mate mapping quality) and `HN` (hit count) on paired records.
  * Improves parity between meth-mode BAM output and the standard BAM writer for mate alignments.

* **Tests**
  * Added regression coverage to validate `MQ`/`HN` presence and value parity between meth-mode and standard BAM outputs for mate records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->