### PR TITLE
perf(mem): read a pestat cohort in slices so compute starts sooner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,14 @@ jobs:
           CHR22_FA=/tmp/chr22/chr22.fa \
           bash test/regression/chain_scratch_per_thread.sh
 
+      - name: Cohort slicing does not change output
+        if: matrix.canonical == true
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          CHR22_FA=/tmp/chr22/chr22.fa \
+          CHR22_SIM_DIR=/tmp/chr22-sim \
+          bash test/regression/cohort_slice_identity.sh
+
       - name: Chunk cap stays opt-in (batching matches bwa-mem2 at every -t)
         if: matrix.canonical == true
         # bwa and bwa-mem2 both use an uncapped `chunk_size * n_threads` batch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,3 +644,14 @@ jobs:
 
       - name: stage_prof unit test
         run: make stage_prof_test && ./stage_prof_test
+
+      - name: Partial cohort slices report their compute CPU
+        # Only a STAGE_PROF build can run this, which is why it lives here and
+        # not in the matrix rows above. Cohort slicing gives step 1 an early
+        # exit; if that exit forgets to harvest g_ktfor, the slice's compute CPU
+        # is destroyed rather than merely unreported, and --profile under-counts
+        # in proportion to how much slicing is happening.
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          FIXTURES="$GITHUB_WORKSPACE/test/fixtures" \
+          bash test/regression/profile_slice_cpu.sh

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -63,6 +63,14 @@ Input/output options:
                  at any -t. Capping re-partitions the input and is NOT
                  byte-identical. Prefer -K if you want a fixed batch size AND
                  reproducibility [0]
+   --cohort-slices INT
+                 read the FIRST batch in INT slices as a geometric ramp ending at
+                 half the batch (INT=6 => batch/64, batch/32, ... batch/2), so
+                 alignment starts before the whole batch has been read. 0 = off
+                 (single read). Later batches are always read whole, since their
+                 read already overlaps the previous batch's compute. Does NOT move
+                 the batch boundary, so output is unchanged. Max 20. Overridden by
+                 BWA_MEM3_COHORT_SLICES [6]
    -v INT        verbose level: 1=error, 2=warning, 3=message, 4+=debugging [3]
    -T INT        minimum score to output [30]
    -h INT[,INT]  if there are <INT hits with score >80.00% of the max score, output all in XA [5,200]

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -191,9 +191,16 @@ By default, bwa-mem3 may downgrade the MAPQ of supplementary alignments.
 
 #### `-K INT` — fixed batch size
 
-Forces each batch to process exactly `INT` input bases regardless of the number
-of threads. **Recommended whenever reproducibility or bwa/bwa-mem2 comparison
+Sets the per-batch **target** to `INT` input bases regardless of the number of
+threads. **Recommended whenever reproducibility or bwa/bwa-mem2 comparison
 matters.**
+
+`INT` is a target rather than a hard delivered-base limit: the reader stops at
+the first whole record on or past `INT`, so a batch delivers slightly more than
+`INT` bases (never a partial record, and never a split read pair). This is the
+same behaviour as `bwa` and `bwa-mem2`, and it is what makes the batch boundary
+reproducible — for a given input and `INT`, the boundary always falls on the same
+record.
 
 Without `-K` the batch size is `chunk_size × -t` (10,000,000 × `-t` by default),
 so it moves with the thread count. That is not merely a scheduling detail:
@@ -208,15 +215,20 @@ Fix `-K` to the same value on both sides and the output becomes independent of
 
 #### `--chunk-cap INT` — upper bound on the auto-scaled batch size
 
-Caps the default `chunk_size × -t` batch at `INT` bases. `0` (the default)
-disables it, so out of the box bwa-mem3 batches **exactly** like `bwa` and
-`bwa-mem2` at any `-t`.
+Caps the default `chunk_size × -t` batch **target** at `INT` bases. As with `-K`,
+`INT` bounds the target the reader aims for, not the bases it delivers — the
+final record is always read whole. `0` (the default) disables the cap, so out of
+the box bwa-mem3 batches **exactly** like `bwa` and `bwa-mem2` at any `-t`.
 
 Capping keeps the read/compute/write pipeline overlapped at very high `-t`,
 where a single batch would otherwise be enormous (10M × 192 ≈ 1.9 Gbase) and the
 input would be only three or four batches — the first batch's read and the last
-batch's write then overlap nothing. On a 64-core host that fill/drain costs
-roughly 1.6 s of a 26 s alignment.
+batch's write then overlap nothing. On a 64-core host that fill/drain cost was
+measured at roughly 1.6 s of a 26 s alignment.
+
+> **Note:** that 1.6 s / 26 s figure predates the read-arena lifetime rework and
+> has not been re-measured against the current implementation. Treat it as an
+> indication of the effect's scale, not as a current number.
 
 It is **opt-in because it re-partitions the input**, and by the `mem_pestat`
 mechanism described under `-K` that changes output. A capped run is not
@@ -239,7 +251,7 @@ Precedence, highest first:
 
 | Setting | Effect |
 |---|---|
-| `-K INT` | pins the batch size exactly; never capped |
+| `-K INT` | pins the batch target; never capped |
 | `BWA_MEM3_CHUNK_CAP` | overrides the cap from either source below (`0` = off) |
 | `--chunk-cap INT` | caps the auto-scaled batch (`0` = off) |
 | `--fast` | implies `--chunk-cap 256000000` |

--- a/docs/src/user-guide/aligning.md
+++ b/docs/src/user-guide/aligning.md
@@ -65,8 +65,12 @@ string is embedded as an `RG:Z:` tag on every output record.
 ### Chunk size: `-K`
 
 ```text
--K INT   process INT input bases in each batch, regardless of -t []
+-K INT   per-batch target of INT input bases, regardless of -t []
 ```
+
+`INT` is a target, not a hard delivered-base limit: the reader finishes the
+record it is on, so a batch delivers a little more than `INT` bases and never a
+partial record or a split pair. `bwa` and `bwa-mem2` behave the same way.
 
 Larger `-K` values increase memory use but can improve throughput on very deep
 or very wide batches.

--- a/docs/src/whats-different/equivalence.md
+++ b/docs/src/whats-different/equivalence.md
@@ -280,7 +280,7 @@ Any equivalence claim on this page is implicitly a claim **at a fixed batch size
 Two consequences:
 
 - **`bwa-mem3 -t N` must be compared against `bwa-mem2 -t N`**, not against `bwa-mem2 -t M`. Comparing across thread counts measures the batching, not the aligner.
-- **Pass `-K` to both sides** if you want the comparison to be independent of `-t` altogether. `-K` pins the batch size exactly, is never capped, and is the reason it exists in all three tools.
+- **Pass `-K` to both sides** if you want the comparison to be independent of `-t` altogether. `-K` pins the batch target for reproducible partitioning, is never capped, and is the reason it exists in all three tools. (It is a target, not a hard delivered-base limit — the reader finishes the record it is on — but all three tools round it the same way, so the partition matches.)
 
 `--chunk-cap` (off by default) bounds the auto-scaled batch and therefore re-partitions the input; it is opt-in for exactly this reason, warns on stderr when it engages, and is implied by `--fast`. A run with `--chunk-cap` in effect is **not** byte-identical to `bwa`/`bwa-mem2` at the same `-t`. See [`mem` → `--chunk-cap`](../cli/mem.md) and [Aligning → `-K`](../user-guide/aligning.md).
 

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -91,7 +91,11 @@ bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_, void *ks2_,
     int64_t size = 0, m, n, size2 = 0;
     bseq1_t *seqs;
     m = n = 0; seqs = 0;
-    read_arena_t *arena = read_arena_create();
+    /* In/out: see bseq_read_fast. NULL in = fresh arena; non-NULL = keep carving
+     * from the caller's, so one cohort read in several slices ends up with one
+     * arena whose lifetime spans them all. */
+    const int arena_created_here = (*arena_out == NULL);
+    read_arena_t *arena = arena_created_here ? read_arena_create() : *arena_out;
     char buf[len];
     
     while (kseq_read(ks) >= 0)
@@ -172,10 +176,11 @@ bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_, void *ks2_,
         if (ks2 && kseq_read(ks2) >= 0)
             fprintf(stderr, "[W::%s] the 1st file has fewer sequences.\n", __func__);
     }
-    /* PIPE-F6: hand the arena to the caller, or destroy it if this batch
-     * carved nothing (n == 0 → seqs stays NULL and the pipeline treats it as
-     * clean EOF, freeing nothing). */
-    if (n == 0) { read_arena_destroy(arena); arena = NULL; }
+    /* PIPE-F6: hand the arena to the caller, or destroy it if this batch carved
+     * nothing (n == 0 → seqs stays NULL and the pipeline treats it as clean EOF,
+     * freeing nothing). Only an arena created here may be destroyed here; a
+     * carried one still backs earlier slices of an in-flight cohort. */
+    if (n == 0 && arena_created_here) { read_arena_destroy(arena); arena = NULL; }
     *arena_out = arena;
     *n_ = n;
     *s = size;
@@ -189,7 +194,11 @@ bseq1_t *bseq_read_orig(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
     int64_t size = 0, m, n;
     bseq1_t *seqs;
     m = n = 0; seqs = 0;
-    read_arena_t *arena = read_arena_create();
+    /* In/out: see bseq_read_fast. NULL in = fresh arena; non-NULL = keep carving
+     * from the caller's, so one cohort read in several slices ends up with one
+     * arena whose lifetime spans them all. */
+    const int arena_created_here = (*arena_out == NULL);
+    read_arena_t *arena = arena_created_here ? read_arena_create() : *arena_out;
     while (kseq_read(ks) >= 0)
     {
         if (ks2 && kseq_read(ks2) < 0) { // the 2nd file has fewer reads
@@ -227,8 +236,9 @@ bseq1_t *bseq_read_orig(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
         if (ks2 && kseq_read(ks2) >= 0)
             fprintf(stderr, "[W::%s] the 1st file has fewer sequences.\n", __func__);
     }
-    /* PIPE-F6: see bseq_read above — hand off, or free the empty arena at EOF. */
-    if (n == 0) { read_arena_destroy(arena); arena = NULL; }
+    /* PIPE-F6: see bseq_read above — hand off, or free the empty arena at EOF,
+     * but only when this call created it. */
+    if (n == 0 && arena_created_here) { read_arena_destroy(arena); arena = NULL; }
     *arena_out = arena;
     *n_ = n;
     *s = size;

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -2596,6 +2596,93 @@ static void worker_sam(void *data, int seqid, int batch_size, int tid)
     }
 }
 
+/* Align phase for one slice of a pestat cohort: seeding + BSW only.
+ *
+ * Split out of mem_process_seqs so the pipeline can align a cohort in several
+ * smaller physical reads while mem_pestat still sees the whole cohort. Nothing
+ * here depends on how the cohort is partitioned: seeding and BSW are per-read
+ * independent, and the read ids that feed the tie-break hashes come from the
+ * global n_processed counter, so a read gets the same id under any slicing.
+ *
+ * `seqs` and `regs` point at THIS slice (i.e. cohort base + offset), and
+ * `n_processed` is the global id of the slice's first read. The caller's
+ * w.seqs / w.regs / w.n_processed are saved and restored, so a slice can never
+ * leave w.regs pointing into the middle of the allocation -- worker_free()
+ * frees that pointer. */
+void mem_align_cohort_slice(mem_opt_t *opt,
+                            int64_t n_processed,
+                            int n,
+                            bseq1_t *seqs,
+                            mem_alnreg_v *regs,
+                            worker_t &w)
+{
+    bseq1_t      *saved_seqs = w.seqs;
+    mem_alnreg_v *saved_regs = w.regs;
+    int64_t       saved_np   = w.n_processed;
+
+    w.opt = opt;
+    w.seqs = seqs;
+    w.regs = regs;
+    w.n_processed = n_processed;
+
+    uint64_t tim = __rdtsc();
+    kt_for(worker_bwt_aln, &w, n);
+    tprof[WORKER10][0] += __rdtsc() - tim;
+
+    w.seqs = saved_seqs;
+    w.regs = saved_regs;
+    w.n_processed = saved_np;
+}
+
+/* Pair + emit phase for a complete pestat cohort.
+ *
+ * mem_pestat runs here, over the cohort's contiguous regs -- exactly the read
+ * set bwa-mem2 would have handed it for the same batch -- so the inferred
+ * insert-size distribution, and therefore pairing, mate rescue and MAPQ, are
+ * unchanged by however many slices the align phase used. */
+void mem_pair_and_emit_cohort(mem_opt_t *opt,
+                              int64_t n_processed,
+                              int n,
+                              bseq1_t *seqs,
+                              const mem_pestat_t *pes0,
+                              worker_t &w)
+{
+    mem_pestat_t pes[4];
+    double ctime = cputime(), rtime = realtime();
+
+    w.opt = opt;
+    w.seqs = seqs;
+    w.n_processed = n_processed;
+    w.pes = &pes[0];
+
+    if (opt->flag & MEM_F_PE) {
+        if (pes0)
+            memcpy(pes, pes0, 4 * sizeof(mem_pestat_t));
+        else {
+            /* D3 (--meth): insert-size inference operates on alnreg.rb which are
+             * in ORIGINAL doubled-pac space, so use the ORIGINAL l_pac. */
+            const bntseq_t *pestat_bns = mem_aln_bns(&w);
+            fprintf(stderr, "[0000] Inferring insert size distribution of PE reads from data, "
+                    "l_pac: %lld, n: %d\n", (long long)pestat_bns->l_pac, n);
+            mem_pestat(opt, pestat_bns->l_pac, n, w.regs, pes);
+        }
+        /* Publish the FR proper-pair insert high bound onto opt so the NEXT
+         * cohort's mate-concordant chain cap (which runs before pairing) can use
+         * it as its window (--extend-mate-concordant auto). pes index 1 = FR. */
+        if (!pes[1].failed && pes[1].high > 0)
+            opt->est_insert_high = pes[1].high;
+    }
+
+    uint64_t tim = __rdtsc();
+    fprintf(stderr, "[0000] 3. Calling kt_for - worker_sam\n");
+    kt_for(worker_sam, &w, n);
+    tprof[WORKER20][0] += __rdtsc() - tim;
+
+    fprintf(stderr, "\t[0000][ M::%s] Processed %d reads in %.3f "
+            "CPU sec, %.3f real sec\n",
+            __func__, n, cputime() - ctime, realtime() - rtime);
+}
+
 void mem_process_seqs(mem_opt_t *opt,
                       int64_t n_processed,
                       int n,

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -4380,7 +4380,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     sp.regid = av->n - 1;
 
                     if (numPairsLeft >= *wsize_pair) {
-                        fprintf(stderr, "[0000][%0.4d] Re-allocating seqPairArrays, in Left\n", tid);
+                        if (bwa_verbose >= 4) fprintf(stderr, "[0000][%0.4d] Re-allocating seqPairArrays, in Left\n", tid);
                         *wsize_pair +=  1024;
                         // assert(*wsize_pair > numPairsLeft);
                         *wsize_pair += numPairsLeft + 1024;
@@ -4405,7 +4405,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     leftQerOffset += s->qbeg;
                     if (leftQerOffset >= *wsize_buf_qer)
                     {
-                        fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufQers in %s (left)\n",
+                        if (bwa_verbose >= 4) fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufQers in %s (left)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_qer;
                         *wsize_buf_qer = seqbuf_grow_capacity(tmp);
@@ -4429,7 +4429,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     leftRefOffset += tmp;
                     if (leftRefOffset >= *wsize_buf_ref)
                     {
-                        fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufRefs in %s (left)\n",
+                        if (bwa_verbose >= 4) fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufRefs in %s (left)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_ref;
                         *wsize_buf_ref = seqbuf_grow_capacity(tmp);
@@ -4615,7 +4615,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
                     if (numPairsRight >= *wsize_pair)
                     {
-                        fprintf(stderr, "[0000] [%0.4d] Re-allocating seqPairArrays Right\n", tid);
+                        if (bwa_verbose >= 4) fprintf(stderr, "[0000] [%0.4d] Re-allocating seqPairArrays Right\n", tid);
                         *wsize_pair += 1024;
                         // assert(*wsize_pair > numPairsRight);
                         *wsize_pair += numPairsLeft + 1024;
@@ -4642,7 +4642,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     rightQerOffset += sp.len2;
                     if (rightQerOffset >= *wsize_buf_qer)
                     {
-                        fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufQers in %s (right)\n",
+                        if (bwa_verbose >= 4) fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufQers in %s (right)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_qer;
                         *wsize_buf_qer = seqbuf_grow_capacity(tmp);
@@ -4662,7 +4662,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     rightRefOffset += sp.len1;
                     if (rightRefOffset >= *wsize_buf_ref)
                     {
-                        fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufRefs in %s (right)\n",
+                        if (bwa_verbose >= 4) fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufRefs in %s (right)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_ref;
                         *wsize_buf_ref = seqbuf_grow_capacity(tmp);

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -646,6 +646,47 @@ void mem_process_seqs(mem_opt_t *opt, int64_t n_processed,
                       int n, bseq1_t *seqs, const mem_pestat_t *pes0,
                       worker_t &w);
 
+/**
+ * Align one slice of a pestat cohort: seeding + banded SW only, no pairing.
+ *
+ * mem_process_seqs() is the single-slice special case of
+ * mem_align_cohort_slice() + mem_pair_and_emit_cohort(). Splitting them lets the
+ * pipeline read and align a cohort in several smaller pieces -- so the first
+ * read of a run does not stall the whole compute pipeline -- while mem_pestat
+ * still sees exactly the read set it would have seen for the un-sliced batch.
+ * That is what keeps the output byte-identical: seeding and BSW are per-read
+ * independent, and read ids come from the global n_processed counter rather
+ * than from a position within the batch.
+ *
+ * @param n_processed global id of this slice's FIRST read (cohort base + offset)
+ * @param n           reads in this slice; must be even for paired input so a
+ *                    slice boundary never splits a pair
+ * @param seqs        this slice's reads (cohort array + offset)
+ * @param regs        this slice's alnreg output (cohort regs + the same offset);
+ *                    must remain live until mem_pair_and_emit_cohort() runs
+ *
+ * w.seqs / w.regs / w.n_processed are saved and restored around the call.
+ */
+void mem_align_cohort_slice(mem_opt_t *opt, int64_t n_processed,
+                            int n, bseq1_t *seqs, mem_alnreg_v *regs,
+                            worker_t &w);
+
+/**
+ * Infer the insert size over a complete cohort, then pair and emit it.
+ *
+ * Must be called with `w.regs` still pointing at the cohort's base and with
+ * every slice's alnregs intact: mem_pestat() reads regs[0..n) to build the
+ * insert-size distribution, and worker_sam then consumes and frees them.
+ *
+ * @param n_processed global id of the cohort's first read
+ * @param n           reads in the whole cohort
+ * @param seqs        the cohort's contiguous reads
+ * @param pes0        insert-size info from -I, or NULL to infer from data
+ */
+void mem_pair_and_emit_cohort(mem_opt_t *opt, int64_t n_processed,
+                              int n, bseq1_t *seqs, const mem_pestat_t *pes0,
+                              worker_t &w);
+
 
 /**
  * Generate CIGAR and forward-strand position from alignment region

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -1489,7 +1489,7 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
                 assert(sp.len1 >= 0 && sp.len2 >= 0);
                 if (refOffset + sp.len1 >= *wsize_buf_ref)
                 {
-                    fprintf(stderr, "[0000][%0.4d] Re-allocating (doubling) seqBufRefs in %s\n",
+                    if (bwa_verbose >= 4) fprintf(stderr, "[0000][%0.4d] Re-allocating (doubling) seqBufRefs in %s\n",
                             tid, __func__);
                     int64_t tmp = *wsize_buf_ref;
                     *wsize_buf_ref = seqbuf_grow_capacity(tmp);
@@ -1509,7 +1509,7 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
             
                 if (qerOffset + sp.len2 >= *wsize_buf_qer)
                 {
-                    fprintf(stderr, "[0000][%0.4d] Re-allocating (doubling) seqBufQers in %s\n",
+                    if (bwa_verbose >= 4) fprintf(stderr, "[0000][%0.4d] Re-allocating (doubling) seqBufQers in %s\n",
                             tid, __func__);
                     int64_t tmp = *wsize_buf_qer;
                     *wsize_buf_qer = seqbuf_grow_capacity(tmp);
@@ -1529,7 +1529,7 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
             
                 if (pcnt >= *wsize_pair)
                 {
-                    fprintf(stderr, "[0000][%0.4d] Re-allocating seqPairs in %s\n", tid, __func__);
+                    if (bwa_verbose >= 4) fprintf(stderr, "[0000][%0.4d] Re-allocating seqPairs in %s\n", tid, __func__);
                     *wsize_pair += 1024;
                     mmc->seqPairArrayAux[tid] = (SeqPair *) realloc(mmc->seqPairArrayAux[tid],
                                                         (*wsize_pair + MAX_LINE_LEN)

--- a/src/fast_reader_bseq.c
+++ b/src/fast_reader_bseq.c
@@ -83,7 +83,13 @@ bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
     int64_t size = 0, m, n;
     bseq1_t *seqs;
     m = n = 0; seqs = 0;
-    read_arena_t *arena = read_arena_create();
+    /* `arena_out` is in/out: NULL in means "create a fresh arena", non-NULL means
+     * "keep carving from this one". Cohort slicing reads one batch in several
+     * calls but consumes all of its fields together at output, so the arena's
+     * lifetime is the COHORT, not the individual read -- carrying it across
+     * slices is what keeps that one arena, destroyed once, correct. */
+    const int arena_created_here = (*arena_out == NULL);
+    read_arena_t *arena = arena_created_here ? read_arena_create() : *arena_out;
     for (;;) {
         /* Tokenize the next record(s). fr_fastq_next scans record boundaries and
          * pulls bytes through the codec layer, which charges its read()/inflate
@@ -135,11 +141,13 @@ bseq1_t *bseq_read_fast(int64_t chunk_size, int *n_, void *ks1_, void *ks2_, int
         if (p2 && fr_fastq_next(p2, &rr) == 1)
             fprintf(stderr, "[W::%s] the 1st file has fewer sequences.\n", __func__);
     }
-    /* PIPE-F6: hand the per-chunk arena (backing every read's name/seq/qual) to
-     * the caller, which destroys it in the write stage once the chunk is fully
-     * consumed. An empty batch (n == 0 → seqs == NULL, read as clean EOF by the
-     * pipeline) carved nothing, so free the arena here and report none. */
-    if (n == 0) { read_arena_destroy(arena); arena = NULL; }
+    /* PIPE-F6: hand the arena (backing every read's name/seq/qual) to the caller,
+     * which destroys it in the write stage once everything it backs is consumed.
+     * An empty batch (n == 0 → seqs == NULL, read as clean EOF by the pipeline)
+     * carved nothing, so an arena created HERE is freed here and reported as
+     * none. A CARRIED arena is never destroyed on this path: it still backs the
+     * earlier slices of an in-flight cohort, and it is not ours to free. */
+    if (n == 0 && arena_created_here) { read_arena_destroy(arena); arena = NULL; }
     *arena_out = arena;
     *n_ = n;
     *s = size;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -296,8 +296,25 @@ void worker_alloc(const mem_opt_t *opt, worker_t &w, int32_t nreads, int32_t nth
             scratchMem/1e6, nthreads);
 
 
-    /* SWA mem allocation */
-    int64_t wsize = BATCH_SIZE * SEEDS_PER_READ;
+    /* SWA mem allocation.
+     *
+     * These are a STARTING size, not a bound: seqBufRef/Qer double via
+     * seqbuf_grow_capacity() and the seqPairArrays realloc on demand, both in
+     * mem_chain2aln_across_reads_V2 and the batched mate-rescue path. So the
+     * only thing the initial value buys is avoiding a few early reallocs.
+     *
+     * It used to start at BATCH_SIZE * SEEDS_PER_READ. SEEDS_PER_READ is 500 --
+     * a worst-case seeds-per-read bound -- but these arrays hold extension
+     * PAIRS, roughly a couple per chain, not one per seed. The result was
+     * ~504 MB per thread reserved up front and, being per-thread, growth linear
+     * in -t: 32.2 GB at -t 64 and ~97 GB at -t 192, dwarfing even the index.
+     *
+     * Start from AVG_SEEDS_PER_READ instead -- the same per-read seed estimate
+     * the chaining scratch is sized with -- for an 8x smaller reservation, and
+     * let the existing growth paths cover anything heavier. Byte-identical:
+     * capacity affects only where the extension data lives, never its
+     * contents. */
+    int64_t wsize = BATCH_SIZE * AVG_SEEDS_PER_READ;
     for(int l=0; l<nthreads; l++)
     {
         w.mmc.seqBufLeftRef[l*CACHE_LINE]  = (uint8_t *)
@@ -419,6 +436,33 @@ void worker_free(worker_t &w, int32_t nthreads)
 void memoryAlloc(ktp_aux_t *aux, worker_t &w, int32_t nreads, int32_t nthreads)
 {
     worker_alloc(aux->opt, w, nreads, nthreads);
+}
+
+/* Copy the compute step's --profile counters out of the per-thread kt_for
+ * accumulator and into this chunk's profile row (see stage_prof.h).
+ *
+ * Step 1 has two exits -- a whole cohort, and a partial cohort that is still
+ * accumulating slices -- and g_ktfor is reset at every step-1 entry, so a path
+ * that forgets to harvest does not merely lose detail: that slice's compute CPU
+ * is gone. Both exits call this, so adding a third cannot silently drop it.
+ *
+ * `sp_p0` is the sp_wall() reading taken at step-1 entry.
+ */
+static void sp_harvest_proc(prof_chunk_t *p, double sp_p0)
+{
+    p->proc_wall      = sp_wall() - sp_p0;
+    p->proc_cpu       = g_ktfor.proc_cpu;
+    p->thr_busy_min   = g_ktfor.thr_busy_min;
+    p->thr_busy_max   = g_ktfor.thr_busy_max;
+    p->thr_busy_mean  = g_ktfor.thr_busy_mean;
+    p->thr_busy_stdev = g_ktfor.thr_busy_stdev;
+    /* encode = SAM/BAM-build CPU (accurate, summed over compute threads);
+     * compute = the rest of the alignment CPU. Same clock, so subtractable.
+     * A slice that only seeds and extends never enters mem_aln2sam, so its
+     * encode is legitimately 0 and compute is the whole of proc_cpu. */
+    p->encode  = g_ktfor.encode;
+    p->compute = (g_ktfor.proc_cpu > g_ktfor.encode)
+                 ? g_ktfor.proc_cpu - g_ktfor.encode : NAN;
 }
 
 ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, worker_t &w)
@@ -865,7 +909,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                 /* Partial cohort: hand the pipeline a non-NULL empty item. NULL
                  * would retire this worker (see ktp_worker's step advance). */
                 tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
-                if (sp_enabled()) ret->prof.proc_wall = sp_wall() - sp_p0;
+                if (sp_enabled()) sp_harvest_proc(&ret->prof, sp_p0);
                 return ret;
             }
 
@@ -883,19 +927,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         }
         tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
 
-        if (sp_enabled()) {
-            ret->prof.proc_wall      = sp_wall() - sp_p0;
-            ret->prof.proc_cpu       = g_ktfor.proc_cpu;
-            ret->prof.thr_busy_min   = g_ktfor.thr_busy_min;
-            ret->prof.thr_busy_max   = g_ktfor.thr_busy_max;
-            ret->prof.thr_busy_mean  = g_ktfor.thr_busy_mean;
-            ret->prof.thr_busy_stdev = g_ktfor.thr_busy_stdev;
-            /* encode = SAM/BAM-build CPU (accurate, summed over compute threads);
-             * compute = the rest of the alignment CPU. Same clock, so subtractable. */
-            ret->prof.encode  = g_ktfor.encode;
-            ret->prof.compute = (g_ktfor.proc_cpu > g_ktfor.encode)
-                                ? g_ktfor.proc_cpu - g_ktfor.encode : NAN;
-        }
+        if (sp_enabled()) sp_harvest_proc(&ret->prof, sp_p0);
 
         aux->n_processed += ret->n_seqs;
         return ret;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -61,6 +61,19 @@ int affy[256];
 extern uint64_t tprof[LIM_R][LIM_C];
 // ---------------
 
+/* --cohort-slices / BWA_MEM3_COHORT_SLICES. Named here rather than repeated at
+ * each site because the value is needed in four places -- the ramp's shift
+ * clamp, the flag's range check, that check's error message, and the `mem
+ * --help` default -- and a help text or a validator that disagrees with the
+ * ramp is exactly the drift this consolidates away.
+ *
+ * MAX is 20 because the ramp shift saturates there (task_size >> 20): a larger
+ * value is indistinguishable from 20, so asking for one is a mistake worth
+ * naming rather than silently accepting. See the ramp in the read step for how
+ * the default is derived. */
+#define COHORT_SLICES_DEFAULT 6
+#define COHORT_SLICES_MAX     20
+
 #if defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)
 /* ARM/Apple Silicon - no CPUID instruction, use system calls */
 
@@ -425,11 +438,96 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
             sp_r0 = sp_wall();
         }
 
-        /* Read "reads" from input file (fread) */
+        /* Read "reads" from input file (fread).
+         *
+         * A cohort is one task_size batch. Normally it is read in a single call
+         * and this is exactly the old code path. When slicing is enabled the
+         * FIRST cohort is read in a geometric ramp that doubles each slice and
+         * ends at task/2: with the default cohort_slices = 6 that is task/64,
+         * task/32, ... task/2. Compute therefore starts working while the rest
+         * is still being read -- only the first read of a run overlaps nothing,
+         * and it is the largest single unhidden cost in the pipeline.
+         *
+         * The target for every slice is clamped to the bases the cohort still
+         * needs. That clamp is load-bearing, not defensive: both readers stop at
+         * the first whole-record, even-n boundary at or PAST the requested size,
+         * so each slice overshoots independently. Reading T/8 + T/4 + T/2 + T/8
+         * without the clamp lands at T + e1+e2+e3+e4, whereas one read of T lands
+         * at T + e -- a different last record, hence a different cohort, hence a
+         * different mem_pestat. With the clamp, the first even-n boundary at or
+         * past (cohort_bases + slice_target) is provably the same record as the
+         * first at or past T whenever the slice crosses T, because every earlier
+         * boundary sits strictly below it. */
+        int64_t slice_target = aux->task_size - aux->cohort_bases;
+        if (slice_target <= 0) slice_target = aux->task_size;   /* new cohort */
+        /* Normally only the first cohort ramps -- later ones are already
+         * overlapped by the pipeline. slice_all is a STRESS knob for the
+         * identity test: it slices EVERY cohort and drops the efficiency floor,
+         * so a short run exercises the accumulator, the cohort-id advance and
+         * the boundary clamp at dozens of boundaries instead of one. It is not
+         * a performance mode -- tiny slices cost more in kt_for passes and lost
+         * SIMD batching than they can ever recover in overlap. */
+        if (aux->cohort_slices > 0 &&
+            (aux->cohort_slice_all || aux->cohort_index == 0) &&
+            aux->cohort_slice < aux->cohort_slices) {
+            int shift = (int)(aux->cohort_slices - aux->cohort_slice);
+            if (shift > COHORT_SLICES_MAX) shift = COHORT_SLICES_MAX;
+            int64_t ramped = aux->task_size >> shift;
+            /* A slice must stay large enough for its own SMEM/BSW batching to be
+             * efficient; below this the extra kt_for passes cost more than the
+             * overlap they buy. The stress knob deliberately bypasses this. */
+            int64_t floor_bases = aux->cohort_slice_all ? 1 : 1000000;
+            if (ramped < floor_bases) ramped = floor_bases;
+            if (ramped < slice_target) slice_target = ramped;
+        }
+
         int64_t sz = 0;
+        /* ONE arena per cohort, not per read call. The accumulator below copies
+         * only the bseq1_t structs into aux->cohort_seqs and shares name/seq/qual
+         * BY POINTER -- so those bytes must outlive the slice that carved them and
+         * stay alive until the whole cohort has been paired and written. Carrying
+         * the cohort's arena into each slice's read gives exactly that: the reader
+         * appends to it (see read_arena.h -- blocks are chained and never moved,
+         * so earlier pointers stay valid), and the completing slice hands the
+         * single arena to the write stage, which destroys it once.
+         *
+         * Scoping the arena per read call instead is a use-after-free: the write
+         * stage destroys every item's arena unconditionally, including the empty
+         * items partial slices return, freeing the strings the cohort still
+         * references. */
+        ret->read_arena = aux->cohort_arena;
         ret->seqs = aux->legacy_reader
-            ? bseq_read_orig(aux->task_size, &ret->n_seqs, aux->ks, aux->ks2, &sz, &ret->read_arena)
-            : bseq_read_fast(aux->task_size, &ret->n_seqs, aux->frks, aux->frks2, &sz, &ret->read_arena);
+            ? bseq_read_orig(slice_target, &ret->n_seqs, aux->ks, aux->ks2, &sz, &ret->read_arena)
+            : bseq_read_fast(slice_target, &ret->n_seqs, aux->frks, aux->frks2, &sz, &ret->read_arena);
+        aux->cohort_arena = ret->read_arena;
+
+        /* A short read means the input ran out, which ends the cohort early. */
+        aux->cohort_bases += sz;
+        /* Is a cohort mid-accumulation? cohort_slice counts the partial slices of
+         * the current cohort and is reset the moment one completes, so a non-zero
+         * value means step 1 is holding earlier slices that still have to be
+         * paired and emitted. Read from cohort_slice rather than cohort_n because
+         * only step 0 touches it: step 0 and step 1 run concurrently on different
+         * items, and cohort_n belongs to step 1. Captured before the bookkeeping
+         * below resets it. */
+        const int mid_cohort = (aux->cohort_slice > 0);
+        ret->cohort_complete = (sz < slice_target) ||
+                               (aux->cohort_bases >= aux->task_size) ||
+                               (ret->seqs == NULL) || (ret->n_seqs == 0);
+        if (ret->cohort_complete) {
+            aux->cohort_bases = 0;
+            aux->cohort_slice = 0;
+            aux->cohort_index++;
+            /* This item carries the cohort's arena to the write stage, which
+             * destroys it. Drop our reference so the NEXT cohort starts fresh. */
+            aux->cohort_arena = NULL;
+        } else {
+            aux->cohort_slice++;
+            /* Partial slice: the arena stays with the cohort, not this item. The
+             * write stage destroys ret->read_arena unconditionally, so it must
+             * not see it here -- the strings are still live. */
+            ret->read_arena = NULL;
+        }
 
         tprof[READ_IO][0] += __rdtsc() - tim;
 
@@ -445,10 +543,37 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
             ret->prof.n_bp = sz;
         }
 
-        fprintf(stderr, "[0000] read_chunk: %lld, work_chunk_size: %lld, nseq: %d\n",
-                (long long)aux->task_size, (long long)sz, ret->n_seqs);
+        /* `read_chunk` keeps meaning the COHORT (batch) target, as it did before
+         * slicing existed. Reporting slice_target here instead would repurpose an
+         * existing field rather than add one: the batch size is the thing this
+         * change is careful NOT to move -- byte-identity depends on it -- so it is
+         * exactly what a reader of this line wants, and
+         * test/regression/chunk_cap_optin.sh asserts on it. The slice request is
+         * reported as its own field, and only when the cohort is actually being
+         * sliced, so the common single-slice line stays character-for-character
+         * what it was. `work_chunk_size` is unchanged: bases actually delivered by
+         * this read, which for a slice is that slice's real size (the readers stop
+         * at the first whole-record boundary at or past the request, so delivered
+         * and requested differ). */
+        if (slice_target != aux->task_size)
+            fprintf(stderr, "[0000] read_chunk: %lld, slice: %lld, work_chunk_size: %lld, nseq: %d%s\n",
+                    (long long)aux->task_size, (long long)slice_target,
+                    (long long)sz, ret->n_seqs,
+                    ret->cohort_complete ? "" : " (cohort slice)");
+        else
+            fprintf(stderr, "[0000] read_chunk: %lld, work_chunk_size: %lld, nseq: %d%s\n",
+                    (long long)aux->task_size, (long long)sz, ret->n_seqs,
+                    ret->cohort_complete ? "" : " (cohort slice)");
 
-        if (ret->seqs == 0) {
+        /* No reads. Normally that is clean EOF: returning 0 retires this worker.
+         * But if a cohort is still accumulating, the input ended exactly ON a
+         * slice boundary (the previous slice delivered at least its target, so it
+         * did not end the cohort, and there is nothing left to read). Its earlier
+         * slices are already aligned and still have to be paired, emitted, and
+         * have their arena destroyed. Retiring here dropped them silently --
+         * short output, exit status 0. Hand step 1 an empty item instead: the
+         * accumulator appends nothing, aligns nothing, and flushes the cohort. */
+        if (ret->seqs == 0 && !mid_cohort) {
             free(ret);
             return 0;
         }
@@ -547,16 +672,39 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
     else if (step == 1)  /* Step 2: Main processing-engine */
     {
         static int task = 0;
-        if (w.nreads < ret->n_seqs)
+        /* regs must hold the whole COHORT, not just the reads this item carries.
+         * A sliced cohort aligns each slice as it arrives and keeps the results
+         * until mem_pair_and_emit_cohort consumes them, so growing this array
+         * must PRESERVE what the earlier slices already wrote -- hence realloc,
+         * not free() + calloc(). The old free()+calloc() sized from this slice's
+         * ret->n_seqs alone and discarded every earlier slice of the cohort,
+         * which emitted the cohort's leading reads as unmapped.
+         *
+         * Not zeroed: mem_kernel2_core kv_init()s every entry of the range it is
+         * given before writing it (src/bwamem.cpp), so no reader ever observes
+         * an entry the align phase has not initialized. That is also why the
+         * pre-existing `w.nreads >= n_seqs` case has always been safe without
+         * zeroing, and why dropping the whole-array calloc is output-neutral.
+         *
+         * Only regs is sized by the read count. chain_scratch/seed_scratch are
+         * per-thread windows sized by nthreads * BATCH_SIZE and are unaffected
+         * by how many reads a chunk turns out to hold. */
+        int32_t regs_want = aux->cohort_n + ret->n_seqs;
+        if (w.nreads < regs_want)
         {
             fprintf(stderr, "[0000] Reallocating initial memory allocations!!\n");
-            /* Only regs is sized by the read count. chain_scratch/seed_scratch
-             * are per-thread windows sized by nthreads * BATCH_SIZE and are
-             * unaffected by how many reads a chunk turns out to hold. */
-            free(w.regs);
-            w.nreads = ret->n_seqs;
-            w.regs = (mem_alnreg_v *) calloc(w.nreads, sizeof(mem_alnreg_v));
-            assert(w.regs != NULL);
+            /* Into a temporary, and err_fatal rather than assert, for the same
+             * reason as the seed-scratch check below: assert compiles out under
+             * NDEBUG, so in a release build a failed realloc would null the live
+             * pointer, drop the previous allocation, and let the align phase
+             * dereference NULL a few lines later. */
+            mem_alnreg_v *regs_tmp = (mem_alnreg_v *) realloc(w.regs,
+                                              (size_t) regs_want * sizeof(mem_alnreg_v));
+            if (regs_tmp == NULL)
+                err_fatal(__func__, "failed to grow the cohort's regs array to %d reads",
+                          regs_want);
+            w.regs = regs_tmp;
+            w.nreads = regs_want;
         }
 
         /* The per-thread chaining scratch must never be resized per chunk: it is
@@ -642,14 +790,96 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
             }
             free(sep[0]); free(sep[1]);
         }
-        else {
-            /* pure (single/paired-end), reads processing */
+        else if (ret->cohort_complete && aux->cohort_n == 0) {
+            /* The common case: this slice IS the whole cohort. Byte-for-byte the
+             * pre-slicing code path -- no accumulation, no copy. */
             mem_process_seqs(opt,
                              aux->n_processed,
                              ret->n_seqs,
                              ret->seqs,
                              aux->pes0,
                              w);
+        }
+        else {
+            /* Multi-slice cohort. Append this slice to the cohort array, align
+             * just this slice, and only pair + emit once the cohort is whole.
+             *
+             * Only the bseq1_t structs are copied; the per-read name/seq/qual
+             * allocations are shared by pointer and the slice's own array is
+             * freed. The pipeline is one-item-in / one-item-out, so the cohort
+             * must be handed to the write step as a single contiguous array. */
+            if (aux->cohort_n == 0) aux->cohort_first_id = aux->n_processed;
+
+            if (aux->cohort_n + ret->n_seqs > aux->cohort_cap) {
+                int want = aux->cohort_n + ret->n_seqs;
+                int cap  = aux->cohort_cap ? aux->cohort_cap : 1024;
+                while (cap < want) cap <<= 1;
+                /* Temporary + err_fatal, not assert -- see the regs growth in
+                 * step 1. A release-build realloc failure here would null the
+                 * accumulated cohort, leak every slice already copied into it,
+                 * and be dereferenced by the memcpy immediately below. */
+                bseq1_t *cohort_tmp = (bseq1_t *) realloc(aux->cohort_seqs,
+                                                       (size_t) cap * sizeof(bseq1_t));
+                if (cohort_tmp == NULL)
+                    err_fatal(__func__, "failed to grow the cohort buffer to %d reads", cap);
+                aux->cohort_seqs = cohort_tmp;
+                aux->cohort_cap = cap;
+            }
+            /* Guarded because the EOF-on-slice-boundary item reaches here with
+             * seqs == NULL and n_seqs == 0 -- it exists only to flush the cohort
+             * (see step 0). memcpy(dst, NULL, 0) is UB in C/C++ even at zero
+             * length, and UBSan's nonnull-attribute check reports it. */
+            if (ret->n_seqs > 0)
+                memcpy(aux->cohort_seqs + aux->cohort_n, ret->seqs,
+                       (size_t) ret->n_seqs * sizeof(bseq1_t));
+            int slice_off = aux->cohort_n;
+            aux->cohort_n += ret->n_seqs;
+            free(ret->seqs);            /* structs copied out; strings still owned */
+            ret->seqs = NULL; ret->n_seqs = 0;
+
+            /* Re-base ids to the cohort. Only bseq_classify reads .id, and that
+             * path is excluded from slicing, but a stale per-slice id would be a
+             * trap for the next reader. */
+            for (int i = 0; i < aux->cohort_n - slice_off; ++i)
+                aux->cohort_seqs[slice_off + i].id = slice_off + i;
+
+            /* regs is sized once per item, at the top of this step, to the whole
+             * cohort (cohort_n + this slice's reads) and grown with realloc so
+             * the earlier slices' alignments survive -- they are computed as each
+             * slice arrives but consumed only by mem_pair_and_emit_cohort once
+             * the cohort is whole. Nothing to do here but rely on that.
+             *
+             * Sizing there rather than here is what makes the invariant hold for
+             * BOTH paths: the single-slice fast path above needs the same array
+             * and never reaches this branch. */
+            assert(w.nreads >= aux->cohort_n);
+
+            mem_align_cohort_slice(opt,
+                                   aux->cohort_first_id + slice_off,
+                                   aux->cohort_n - slice_off,
+                                   aux->cohort_seqs + slice_off,
+                                   w.regs + slice_off,
+                                   w);
+
+            if (!ret->cohort_complete) {
+                /* Partial cohort: hand the pipeline a non-NULL empty item. NULL
+                 * would retire this worker (see ktp_worker's step advance). */
+                tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
+                if (sp_enabled()) ret->prof.proc_wall = sp_wall() - sp_p0;
+                return ret;
+            }
+
+            mem_pair_and_emit_cohort(opt,
+                                     aux->cohort_first_id,
+                                     aux->cohort_n,
+                                     aux->cohort_seqs,
+                                     aux->pes0,
+                                     w);
+
+            /* Hand the cohort to the write step, which frees the array. */
+            ret->seqs   = aux->cohort_seqs;
+            ret->n_seqs = aux->cohort_n;
+            aux->cohort_seqs = NULL; aux->cohort_n = 0; aux->cohort_cap = 0;
         }
         tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
 
@@ -1105,6 +1335,14 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                 at any -t. Capping re-partitions the input and is NOT\n");
     fprintf(stderr, "                 byte-identical. Prefer -K if you want a fixed batch size AND\n");
     fprintf(stderr, "                 reproducibility [0]\n");
+    fprintf(stderr, "   --cohort-slices INT\n");
+    fprintf(stderr, "                 read the FIRST batch in INT slices as a geometric ramp ending at\n");
+    fprintf(stderr, "                 half the batch (INT=6 => batch/64, batch/32, ... batch/2), so\n");
+    fprintf(stderr, "                 alignment starts before the whole batch has been read. 0 = off\n");
+    fprintf(stderr, "                 (single read). Later batches are always read whole, since their\n");
+    fprintf(stderr, "                 read already overlaps the previous batch's compute. Does NOT move\n");
+    fprintf(stderr, "                 the batch boundary, so output is unchanged. Max 20. Overridden by\n");
+    fprintf(stderr, "                 BWA_MEM3_COHORT_SLICES [%d]\n", (int)COHORT_SLICES_DEFAULT);
     fprintf(stderr, "   -v INT        verbose level: 1=error, 2=warning, 3=message, 4+=debugging [%d]\n", bwa_verbose);
     fprintf(stderr, "   -T INT        minimum score to output [%d]\n", opt->T);
     fprintf(stderr, "   -h INT[,INT]  if there are <INT hits with score >%.2f%% of the max score, output all in XA [%d,%d]\n",
@@ -1242,6 +1480,21 @@ int main_mem(int argc, char *argv[])
      * task_size block below. */
     int64_t      chunk_cap                 = 0;
     int          chunk_cap_set             = 0;
+    /* --cohort-slices: how many geometric slices to read the FIRST batch in, so
+     * compute can start before the whole batch has been read. Byte-identical --
+     * the batch (pestat cohort) boundary is unchanged, only the physical read
+     * granularity inside it. 0 = one slice, i.e. the pre-slicing behaviour.
+     *
+     * The default was swept, not guessed. Wall time improves monotonically with
+     * depth because each extra slice halves the still-unoverlapped head again,
+     * and 6 takes the first slice to task/64 -- small next to the compute it
+     * unblocks, and about where the 1 Mbase slice floor starts truncating the
+     * ramp on ordinary inputs anyway. The measured sweep is in the PR that
+     * introduced this option rather than here: it is a wall-clock result for one
+     * host, thread count and input, so it dates in a way the shape of the curve
+     * does not, and it would read as live justification long after it stopped
+     * being one. */
+    int64_t      cohort_slices             = COHORT_SLICES_DEFAULT;
 
     mem_opt_t    *opt, opt0;
     gzFile        fp = 0, fp2 = 0;
@@ -1290,6 +1543,7 @@ int main_mem(int argc, char *argv[])
         OPT_EXTEND_MATE_CONCORDANT,
         OPT_COMPAT,
         OPT_CHUNK_CAP,
+        OPT_COHORT_SLICES,
 #ifdef STAGE_PROF
         OPT_PROFILE,
 #endif
@@ -1305,6 +1559,7 @@ int main_mem(int argc, char *argv[])
         {"adaptive-band",            no_argument,       0, OPT_ADAPTIVE_BAND},
         {"extend-mate-concordant",   optional_argument, 0, OPT_EXTEND_MATE_CONCORDANT},
         {"chunk-cap",                required_argument, 0, OPT_CHUNK_CAP},
+        {"cohort-slices",            required_argument, 0, OPT_COHORT_SLICES},
         {"meth",                     optional_argument, 0, OPT_METH},
         {"meth-scoring",             required_argument, 0, OPT_METH_SCORING},
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
@@ -1584,6 +1839,28 @@ int main_mem(int argc, char *argv[])
             }
             chunk_cap = (int64_t)v;
             chunk_cap_set = 1;
+        }
+        else if (c == OPT_COHORT_SLICES) {
+            /* Same validation as --chunk-cap above, for the same reason: a bare
+             * atoll maps every unparseable value to 0, and 0 here means "no
+             * slicing". `--cohort-slices 3x` would silently disable the feature
+             * it was meant to configure. Capped at COHORT_SLICES_MAX because the
+             * ramp shift is clamped there anyway, so a larger value is
+             * indistinguishable from it and asking for it is a mistake worth
+             * naming. */
+            char *end = NULL;
+            errno = 0;
+            long long v = strtoll(optarg, &end, 10);
+            if (end == optarg || end == NULL || *end != '\0' ||
+                errno == ERANGE || v < 0 || v > COHORT_SLICES_MAX) {
+                fprintf(stderr, "ERROR: --cohort-slices requires an integer in "
+                                "0..%d (0 = off), got '%s'\n",
+                        (int)COHORT_SLICES_MAX, optarg);
+                free(opt);
+                if (out_opened) fclose(aux.fp);
+                return 1;
+            }
+            cohort_slices = (int64_t)v;
         }
         else if (c == OPT_SKIP_CONTAINED_EXT) opt->skip_contained_ext = 1;
         else if (c == OPT_ADAPTIVE_BAND) opt->band_start = ADAPTIVE_BAND_START;
@@ -2379,6 +2656,65 @@ int main_mem(int argc, char *argv[])
                     __func__, (long long)scaled, (long long)cap);
     }
     tprof[MISC][1] = opt->chunk_size = aux.actual_chunk_size = aux.task_size;
+
+    /* Cohort slicing. The first batch's read overlaps nothing -- the compute
+     * pipeline has nothing to chew on until it lands -- and with the cap now
+     * opt-in that first read is `chunk_size * n_threads` bases, the largest
+     * single unhidden cost in the run. Reading the FIRST cohort as a geometric
+     * ramp lets compute start on the first slice -- task/64 at the default
+     * cohort_slices = 6 -- while the rest is still arriving.
+     *
+     * This does not move the cohort boundary, so mem_pestat sees exactly the
+     * read set it would have seen otherwise and the output is unchanged. See
+     * the slice-target clamp in the read step for why the boundary is preserved
+     * even though each read overshoots its request.
+     *
+     * Steady-state cohorts stay single-slice: once the pipeline is full,
+     * read(N+1) already overlaps compute(N), so slicing them would only add
+     * kt_for passes and shrink the SIMD batches for no overlap gain. */
+    {
+        int64_t slices = cohort_slices;
+        /* Validated like BWA_MEM3_CHUNK_CAP, and non-fatal for the same reason
+         * (the index is already loaded here): a bare atoll turns a typo into 0,
+         * which means "no slicing" -- silently disabling the thing the variable
+         * was set to configure. An empty value leaves the CLI/default alone. */
+        const char *cs_env = getenv("BWA_MEM3_COHORT_SLICES");
+        if (cs_env && *cs_env) {
+            char *cs_end = NULL;
+            errno = 0;
+            long long cs_v = strtoll(cs_env, &cs_end, 10);
+            if (cs_end == cs_env || cs_end == NULL || *cs_end != '\0' ||
+                errno == ERANGE || cs_v < 0 || cs_v > 20) {
+                fprintf(stderr, "WARNING: BWA_MEM3_COHORT_SLICES='%s' is not an "
+                                "integer in 0..20; ignoring it and using %lld\n",
+                        cs_env, (long long)slices);
+            } else {
+                slices = (int64_t)cs_v;
+            }
+        }
+        /* -p re-derives pairing from adjacency across the WHOLE array
+         * (bseq_classify carries has_last state), so a slice boundary between
+         * two mates would classify them as two SEs, change n_sep[], and shift
+         * the read-id base handed to the second mem_process_seqs. Classification
+         * must therefore precede alignment, which is incompatible with aligning
+         * slices early. Fall back to un-sliced cohorts. */
+        if (opt->flag & MEM_F_SMARTPE) {
+            if (slices > 0)
+                fprintf(stderr, "[M::%s] -p (smart pairing) is incompatible with "
+                        "cohort slicing; reading each batch in one slice\n", __func__);
+            slices = 0;
+        }
+        aux.cohort_slices = slices > 0 ? slices : 0;
+        /* Stress knob for test/regression/cohort_slice_identity.sh: slice every
+         * cohort, not just the first, so a small input exercises the accumulator
+         * and the boundary clamp many times over. Deliberately env-only -- it
+         * trades throughput for coverage and is not a mode users should pick. */
+        const char *sa_env = getenv("BWA_MEM3_COHORT_SLICE_ALL");
+        aux.cohort_slice_all = (sa_env && *sa_env && strcmp(sa_env, "0") != 0) ? 1 : 0;
+        if (aux.cohort_slice_all && aux.cohort_slices > 0)
+            fprintf(stderr, "[M::%s] BWA_MEM3_COHORT_SLICE_ALL set: slicing every "
+                    "cohort (stress mode; slower)\n", __func__);
+    }
 
     /* Pipeline depth. The 3-step pipeline (read / process / write) is gated by
      * how many of those steps can run at once. With 2 workers only 2 of the 3

--- a/src/fastmap.h
+++ b/src/fastmap.h
@@ -73,6 +73,31 @@ typedef struct {
 	int64_t ntasks;
 	int64_t task_size;
 	int64_t actual_chunk_size;
+	/* --- pestat cohort slicing -------------------------------------------
+	 * A "cohort" is one task_size batch: exactly the read set bwa-mem2 would
+	 * hand mem_pestat. It may be read as several smaller slices so that the
+	 * first read of a run does not stall the compute pipeline, but the cohort
+	 * boundary itself is never moved -- that is what keeps output identical.
+	 *
+	 * Owned by the read step (step 0) and the process step (step 1), both of
+	 * which kt_pipeline serialises, so none of this needs a lock. */
+	int64_t cohort_slices;      /* slices for the FIRST cohort; 0 = off (one slice) */
+	int     cohort_slice_all;   /* stress knob: slice EVERY cohort (identity testing) */
+	int64_t cohort_bases;       /* bases of the current cohort read so far */
+	int64_t cohort_index;       /* how many cohorts have been started */
+	int     cohort_slice;       /* slice number within the current cohort */
+	/* The in-flight cohort's string arena, carried across its slices. Every slice
+	 * carves name/seq/qual from this one arena; the accumulator shares those
+	 * bytes by pointer, so they must live until the whole cohort is written. The
+	 * completing slice hands it to the write stage (which destroys it) and this
+	 * goes back to NULL so the next cohort creates a fresh one. See read_arena.h
+	 * for why the cohort, not the read call, is the arena's unit. */
+	read_arena_t *cohort_arena;
+	/* Accumulator for a multi-slice cohort, owned by step 1. */
+	bseq1_t *cohort_seqs;       /* contiguous reads for the cohort being built */
+	int      cohort_n;          /* reads accumulated so far */
+	int      cohort_cap;        /* capacity of cohort_seqs, in reads */
+	int64_t  cohort_first_id;   /* global id of the cohort's first read */
 	FILE *fp;
 	uint8_t *ref_string;
 	int      ref_string_is_shm;   /* 1 if ref_string aliases shm pages; do not _mm_free. */
@@ -106,6 +131,11 @@ typedef struct {
 	 * output is written. NULL when the chunk carried no reads (clean EOF). */
 	read_arena_t *read_arena;
 	prof_chunk_t prof;   /* stage_prof: per-chunk read/process/write timing (--profile) */
+	/* Set by the read step when this slice completes a pestat cohort (either it
+	 * reached task_size or the input ran out). Until then the process step
+	 * aligns the slice and returns an empty item, which the pipeline passes
+	 * through harmlessly -- returning NULL would retire the worker. */
+	int cohort_complete;
 } ktp_data_t;
 
     

--- a/src/read_arena.h
+++ b/src/read_arena.h
@@ -15,12 +15,20 @@
  * are byte-identical to the former per-field malloc/strdup path.
  *
  * Ownership / lifetime contract:
- *   - Exactly one arena is created per read-chunk, by the reader, and returned
- *     to the pipeline alongside the bseq1_t array. It is stored on the chunk
- *     (ktp_data_t.read_arena) and destroyed exactly once, in the write stage,
- *     after every field it backs has been consumed.
- *   - The arena is owned by a single chunk and never shared mutably between the
- *     threads processing different chunks (each chunk carries its own).
+ *   - Exactly one arena per COHORT -- the set of reads whose fields are consumed
+ *     together, which is one mem_pestat batch. It is created by the reader on the
+ *     first read of the cohort, returned to the pipeline alongside the bseq1_t
+ *     array, stored on the chunk (ktp_data_t.read_arena), and destroyed exactly
+ *     once, in the write stage, after every field it backs has been consumed.
+ *   - A cohort may be READ in several calls (cohort slicing exists so compute can
+ *     start before the whole batch has arrived). The `read_arena_t **arena_out`
+ *     parameter is therefore in/out: NULL in means "create a fresh arena",
+ *     non-NULL means "keep carving from this one". Only the call that CREATED an
+ *     arena may destroy it on the empty-batch path; a carried arena still backs
+ *     the earlier slices. This is why the unit is the cohort and not the read
+ *     call -- the fields outlive the call that carved them.
+ *   - The arena is owned by a single cohort and never shared mutably between the
+ *     threads processing different cohorts (each carries its own).
  *   - Only allocation grows the arena, and that happens solely on the read
  *     thread during ingest; the process/write stages only READ the fields (the
  *     in-place 2-bit sequence encoding and --meth C->T/G->A projection mutate

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -1,7 +1,9 @@
 # Regression scripts
 
 End-to-end parity and invariant checks. `chr22_parity.sh` runs on every
-matrix row; the rest run on the canonical AVX2 row only. Each script:
+matrix row; the rest run on the canonical AVX2 row only, except
+`profile_slice_cpu.sh`, which runs from the `profiling-build` job (see below).
+Each script:
 
 - is self-contained (set -euo pipefail; explicit env-var contract)
 - emits `PASS:` on success and `FAIL:` on failure
@@ -18,7 +20,16 @@ matrix row; the rest run on the canonical AVX2 row only. Each script:
 | `header_parity.sh`           | `AH:*` on generated @SQ (#281); `--compat` skips the .hdr/.dict sidecar | "header parity regression (AH:*, --compat @HD/@SQ)" |
 | `default_hd_parity.sh`       | default `@HD` byte-identical across SAM/`--bam`/`--meth` (#288)        | "default @HD parity across output paths"            |
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
+| `profile_slice_cpu.sh`       | `--profile` accounts for a partial cohort slice's compute CPU (needs `STAGE_PROF=1`) | "Partial cohort slices report their compute CPU"    |
+
+The table is a reading guide, not an inventory — `ls test/regression/*.sh` is
+the authoritative list, and `ci.yml` is where each one is actually wired up.
 
 Each script reads its inputs from environment variables — see the comment
 block at the top of each file. `.github/workflows/ci.yml` sets those vars
 and invokes the scripts.
+
+One exception to "any binary will do": `profile_slice_cpu.sh` asserts on
+`--profile` output, which a default build compiles out entirely, so it needs a
+binary from `make STAGE_PROF=1`. It fails loudly rather than skipping if handed
+one without `--profile`, and CI runs it from the `profiling-build` job.

--- a/test/regression/chunk_cap_optin.sh
+++ b/test/regression/chunk_cap_optin.sh
@@ -98,8 +98,16 @@ expect 160000000 -t 16 --chunk-cap 256000000   # below the cap: untouched
 expect 320000000 -t 32 --chunk-cap 0           # 0 disables
 
 # --- --fast implies the cap; explicit flags still win -----------------------
+# Both argument orders, and both a non-zero cap and an explicit 0. --fast's cap is
+# applied after the option loop and only when --chunk-cap was absent
+# (`if (!chunk_cap_set)`), so precedence is order-independent by construction --
+# these cases pin that, so a parser change that started consuming --fast after the
+# flag (and clobbering it) cannot silently re-enable the implied cap.
 expect 256000000 -t 32 --fast
 expect  64000000 -t 32 --fast --chunk-cap 64000000
+expect  64000000 -t 32 --chunk-cap 64000000 --fast
+expect 320000000 -t 32 --fast --chunk-cap 0     # explicit 0 beats --fast's cap
+expect 320000000 -t 32 --chunk-cap 0 --fast
 
 # --- BWA_MEM3_CHUNK_CAP wins over everything except -K ----------------------
 # The env override exists for cap sweeps, so it has to beat both the CLI flag and

--- a/test/regression/cohort_slice_identity.sh
+++ b/test/regression/cohort_slice_identity.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# test/regression/cohort_slice_identity.sh
+#
+# Regression: reading a batch in several slices must not change the output.
+#
+# A batch is also the mem_pestat cohort -- the read set the insert-size
+# distribution is inferred from -- and those percentile bounds feed pairing,
+# mate rescue and MAPQ. Slicing exists purely so compute can start before the
+# whole first batch has been read; it must never move the batch BOUNDARY.
+#
+# The subtle failure this guards against: both readers stop at the first
+# whole-record, even-n boundary at or PAST the requested size, so slices
+# overshoot independently. Without clamping each slice's target to the bases the
+# cohort still needs, T/8 + T/4 + T/2 + T/8 lands on a different final record
+# than a single read of T -- a different cohort, a different mem_pestat, and
+# quietly different alignments. The drift is a record or two per slice, so it
+# shows up as neither a crash nor a record-count change; only a byte comparison
+# catches it.
+#
+# Two things make this test actually powerful rather than merely present:
+#
+#   1. BWA_MEM3_COHORT_SLICE_ALL slices EVERY cohort, not just the first (which
+#      is all production does). Measured against a build with the clamp removed:
+#      slicing only the first cohort differs by 4 lines, slicing every cohort
+#      differs by 24912. The same bug, ~6000x the signal.
+#
+#   2. The input must have a genuinely variable insert size. With a constant
+#      insert, mem_pestat returns the same bounds for every possible subset of
+#      reads, so cohort composition cannot affect output and the comparison is
+#      vacuous no matter what the code does. The test asserts non-vacuity below
+#      by requiring the inferred percentiles to differ between cohorts.
+#
+# Inputs (env vars):
+#   BWA_MEM3       -- path to the bwa-mem3 binary under test
+#   CHR22_FA       -- path to chr22.fa, pre-indexed with bwa-mem3 by the caller
+#   CHR22_SIM_DIR  -- directory with reads.r1.fastq.gz / reads.r2.fastq.gz
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+: "${CHR22_FA:?CHR22_FA must be set}"
+: "${CHR22_SIM_DIR:?CHR22_SIM_DIR must be set}"
+
+R1="$CHR22_SIM_DIR/reads.r1.fastq.gz"
+R2="$CHR22_SIM_DIR/reads.r2.fastq.gz"
+[ -f "$R1" ] && [ -f "$R2" ] || { echo "FAIL: missing $R1 / $R2" >&2; exit 1; }
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/cohort_slice.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+# -K is deliberately small so the input spans MANY cohorts: that exercises the
+# accumulator, the cohort-id advance, the realloc growth path and the boundary
+# clamp repeatedly rather than once.
+K=2000000
+
+# Partial slices are the reads that did NOT end their cohort; step 0 marks
+# exactly those lines with a trailing " (cohort slice)".
+slice_count() {   # $1 = a run's stderr log
+    grep -c '(cohort slice)$' "$1" || true
+}
+
+align() {   # $1 = tag, $2 = --cohort-slices value, $3 = slice-every-cohort (0/1)
+    local tag="$1" slices="$2" all="$3"
+    BWA_MEM3_COHORT_SLICE_ALL="$all" \
+        "$BWA_MEM3" mem -t 4 -K "$K" --cohort-slices "$slices" \
+        "$CHR22_FA" "$R1" "$R2" 2> "$WORK/$tag.err" \
+        | grep -v '^@' > "$WORK/$tag.sam"
+    local n; n=$(wc -l < "$WORK/$tag.sam")
+    [ "$n" -gt 0 ] || { echo "FAIL: $tag produced no records" >&2
+                        tail -15 "$WORK/$tag.err" >&2; exit 1; }
+    echo "  $tag: $n records, $(grep -c 'Inferring insert size' "$WORK/$tag.err" || true) cohorts, $(slice_count "$WORK/$tag.err") partial slice(s)"
+}
+
+align unsliced 0 0
+align first3   3 0
+align all3     3 1
+align all8     8 1
+
+# The all-cohort runs have to actually slice more than the first cohort, or the
+# comparisons below prove nothing about the path they exist to cover. If
+# BWA_MEM3_COHORT_SLICE_ALL were ignored -- misspelled, dropped from the option
+# block, or parsed as off -- all3/all8 would degenerate into first3/first8:
+# still slicing cohort 0, still byte-identical, still passing every cmp.
+unsliced_slices=$(slice_count "$WORK/unsliced.err")
+first3_slices=$(slice_count "$WORK/first3.err")
+all3_slices=$(slice_count "$WORK/all3.err")
+all8_slices=$(slice_count "$WORK/all8.err")
+if [ "$unsliced_slices" -ne 0 ]; then
+    echo "FAIL: --cohort-slices 0 produced $unsliced_slices partial slice(s); it must produce none." >&2
+    exit 1
+fi
+if [ "$first3_slices" -le 0 ]; then
+    echo "FAIL: --cohort-slices 3 produced no partial slices, so nothing below is" >&2
+    echo "      exercising the accumulator at all." >&2
+    exit 1
+fi
+if [ "$all3_slices" -le "$first3_slices" ] || [ "$all8_slices" -le "$first3_slices" ]; then
+    echo "FAIL: all-cohort slicing did not produce slices beyond the first cohort" >&2
+    echo "      (first3=$first3_slices all3=$all3_slices all8=$all8_slices)." >&2
+    echo "      BWA_MEM3_COHORT_SLICE_ALL is not taking effect, so the every-cohort" >&2
+    echo "      path is untested. See the slice_all gate in kt_pipeline step 0." >&2
+    exit 1
+fi
+echo "  slice-all effective: first3=$first3_slices all3=$all3_slices all8=$all8_slices partial slice(s)"
+
+# Non-vacuity. If every cohort infers the same insert-size bounds then cohort
+# composition cannot influence the output and an IDENTICAL result below would
+# prove nothing about the clamp.
+distinct=$(grep -h "percentile" "$WORK/unsliced.err" | sort -u | wc -l | tr -d ' ')
+total=$(grep -hc "percentile" "$WORK/unsliced.err" | tr -d ' ')
+echo "  non-vacuity: $distinct distinct percentile tuples across $total cohorts"
+if [ "${distinct:-0}" -lt 2 ]; then
+    echo "FAIL: mem_pestat inferred identical bounds for every cohort, so this" >&2
+    echo "      fixture cannot detect cohort divergence. Use reads with a" >&2
+    echo "      variable insert size." >&2
+    exit 1
+fi
+
+fail=0
+for t in first3 all3 all8; do
+    if cmp -s "$WORK/unsliced.sam" "$WORK/$t.sam"; then
+        echo "  unsliced vs $t: IDENTICAL"
+    else
+        echo "  unsliced vs $t: DIFFERS" >&2
+        diff "$WORK/unsliced.sam" "$WORK/$t.sam" > "$WORK/$t.diff" 2>&1 || true
+        echo "    differing lines: $(grep -c '^[<>]' "$WORK/$t.diff" || true)" >&2
+        head -4 "$WORK/$t.diff" >&2
+        fail=1
+    fi
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo "FAIL: cohort slicing changed the output; the batch boundary moved." >&2
+    echo "      See the slice-target clamp in kt_pipeline step 0 (src/fastmap.cpp)." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# EOF landing exactly ON a slice boundary.
+#
+# A partial slice does not end its cohort, so when the input runs out right after
+# one, step 0 is asked for the next slice and gets zero reads while a cohort is
+# still accumulating. Retiring the pipeline at that point discards every read
+# already accumulated AND leaks the cohort's string arena -- silently, with exit
+# status 0, so only a record count catches it.
+#
+# The full-length runs above cannot detect this: whichever slice consumes the
+# last record is short, which ends its cohort normally. The input has to stop
+# exactly where a slice stopped.
+#
+# The truncation point is taken from the binary's own slice log rather than
+# computed, so it stays correct regardless of read length, -K or the ramp shape.
+# ---------------------------------------------------------------------------
+first_slice_reads=$(awk '/\(cohort slice\)$/ { sub(/.*nseq: /, ""); sub(/ .*/, ""); print; exit }' \
+                    "$WORK/all3.err")
+if [ -z "${first_slice_reads:-}" ] || [ "$first_slice_reads" -lt 2 ]; then
+    echo "FAIL: could not read the first partial slice's record count from the" >&2
+    echo "      all3 log, so the EOF-on-a-slice-boundary case cannot be built." >&2
+    exit 1
+fi
+
+pairs=$(( first_slice_reads / 2 ))
+expected=$(( pairs * 2 ))
+# gzip exits non-zero when head closes the pipe early; that is expected here.
+set +o pipefail
+gzip -cd "$R1" | head -n $(( pairs * 4 )) | gzip > "$WORK/eof.r1.fastq.gz"
+gzip -cd "$R2" | head -n $(( pairs * 4 )) | gzip > "$WORK/eof.r2.fastq.gz"
+set -o pipefail
+
+echo "  EOF-on-boundary: truncating to $pairs pairs ($expected records), the first"
+echo "                   partial slice's exact size"
+
+align_eof() {   # $1 = tag, $2 = --cohort-slices value, $3 = slice-every-cohort (0/1)
+    local tag="$1" slices="$2" all="$3" n rc
+    set +e
+    BWA_MEM3_COHORT_SLICE_ALL="$all" \
+        "$BWA_MEM3" mem -t 4 -K "$K" --cohort-slices "$slices" \
+        "$CHR22_FA" "$WORK/eof.r1.fastq.gz" "$WORK/eof.r2.fastq.gz" \
+        > "$WORK/$tag.full.sam" 2> "$WORK/$tag.err"
+    rc=$?
+    set -e
+    [ "$rc" -eq 0 ] || { echo "FAIL: $tag exited $rc" >&2
+                         tail -15 "$WORK/$tag.err" >&2; exit 1; }
+    grep -v '^@' "$WORK/$tag.full.sam" > "$WORK/$tag.sam" || true
+    n=$(wc -l < "$WORK/$tag.sam" | tr -d ' ')
+    if [ "$n" -ne "$expected" ]; then
+        echo "FAIL: $tag emitted $n records, expected $expected." >&2
+        echo "      Reads accumulated in an in-flight cohort were dropped when the" >&2
+        echo "      input ended on a slice boundary. See the zero-read/EOF early" >&2
+        echo "      return in kt_pipeline step 0 (src/fastmap.cpp): it must still" >&2
+        echo "      flush a cohort that step 1 is holding." >&2
+        exit 1
+    fi
+    echo "  $tag: $n records"
+}
+
+align_eof eof_unsliced 0 0
+align_eof eof_first3   3 0
+align_eof eof_all3     3 1
+align_eof eof_all8     8 1
+
+for t in eof_first3 eof_all3 eof_all8; do
+    if cmp -s "$WORK/eof_unsliced.sam" "$WORK/$t.sam"; then
+        echo "  eof_unsliced vs $t: IDENTICAL"
+    else
+        echo "  eof_unsliced vs $t: DIFFERS" >&2
+        diff "$WORK/eof_unsliced.sam" "$WORK/$t.sam" > "$WORK/$t.diff" 2>&1 || true
+        echo "    differing lines: $(grep -c '^[<>]' "$WORK/$t.diff" || true)" >&2
+        head -4 "$WORK/$t.diff" >&2
+        fail=1
+    fi
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo "FAIL: cohort slicing changed the output when the input ended exactly on" >&2
+    echo "      a slice boundary." >&2
+    exit 1
+fi
+
+echo "PASS: output is identical with and without cohort slicing, including with"
+echo "      every cohort sliced 8 ways, and when the input ends exactly on a"
+echo "      slice boundary."

--- a/test/regression/profile_slice_cpu.sh
+++ b/test/regression/profile_slice_cpu.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# test/regression/profile_slice_cpu.sh
+#
+# Regression: --profile must account for the compute CPU of a PARTIAL cohort.
+#
+# Cohort slicing gave step 1 a second exit. A cohort that is still accumulating
+# slices returns early -- it has seeded and extended its slice, but pairing and
+# SAM must wait for the whole cohort -- and that path originally saved only
+# proc_wall. Because g_ktfor is reset at every step-1 entry, the slice's
+# proc_cpu / compute / encode / thr_busy_* were not merely omitted from the row,
+# they were destroyed: nothing else ever reads them.
+#
+# The consequence is a profiler that quietly lies in proportion to how much
+# slicing is happening. At -t 64 the ramp covers ~40% of the run's bases, so
+# ~40% of the compute CPU vanished from the report -- and since the aggregate
+# row derives from the per-chunk rows, the in-PROCESS() budget could not be made
+# to balance. Nothing crashes and no alignment changes, so only an explicit
+# check on the profile output catches it.
+#
+# What makes this test sharp rather than merely present:
+#
+#   1. BWA_MEM3_COHORT_SLICE_ALL=1 slices EVERY cohort rather than only the
+#      first (which is all production does), so a short run produces dozens of
+#      partial slices instead of a handful.
+#
+#   2. The assertion is a boolean, not a threshold: every chunk that read bases
+#      must report proc_cpu > 0. A slice that ran kt_for cannot legitimately
+#      have consumed zero CPU, so there is nothing to tune and nothing to flake.
+#      Before the fix every ramp slice reports exactly 0.0000.
+#
+# Inputs (env vars):
+#   BWA_MEM3 -- path to a bwa-mem3 binary built with STAGE_PROF=1 (so --profile
+#               exists). A default build compiles profiling out entirely.
+#   FIXTURES -- directory containing synthetic_1mb.fa (default: test/fixtures)
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+FIXTURES="${FIXTURES:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)}"
+
+[[ -x "$BWA_MEM3" ]] || { echo "FAIL: binary not executable: $BWA_MEM3" >&2; exit 1; }
+
+src_ref="$FIXTURES/synthetic_1mb.fa"
+[[ -s "$src_ref" ]] || { echo "FAIL: synthetic_1mb.fa missing: $src_ref" >&2; exit 1; }
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/profile_slice_cpu.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+# --profile only exists in a STAGE_PROF=1 build; without it there is nothing to
+# assert on, and silently passing would make this test worthless in CI.
+# `mem` with no arguments prints usage and exits nonzero, so the output has to be
+# captured before grepping -- piping it straight into grep trips pipefail.
+"$BWA_MEM3" mem > "$WORK/usage.txt" 2>&1 || true
+if ! grep -q -- '--profile' "$WORK/usage.txt"; then
+    echo "FAIL: this binary has no --profile; build with STAGE_PROF=1" >&2
+    exit 1
+fi
+
+ref="$WORK/ref.fa"
+cp "$src_ref" "$ref"
+"$BWA_MEM3" index "$ref" > "$WORK/index.log" 2>&1 \
+    || { echo "FAIL: could not index the reference" >&2; tail -20 "$WORK/index.log" >&2; exit 1; }
+
+# Reads are generated here rather than committed. They must come FROM the
+# reference so they align and the aligner does real per-slice work -- a slice
+# whose reads all fail to seed would report near-zero CPU for honest reasons.
+READS="$WORK/reads.fa"
+READ_LEN=100
+N_READS=20000
+awk -v len="$READ_LEN" -v n="$N_READS" '
+    /^>/  { next }
+          { seq = seq $0 }
+    END {
+        if (length(seq) < len * 2) { print "reference too short" > "/dev/stderr"; exit 1 }
+        # Walk the reference with a stride, wrapping around, so the reads are
+        # spread over the whole sequence instead of piling onto one locus.
+        span   = length(seq) - len
+        stride = 7
+        pos    = 1
+        for (i = 0; i < n; i++) {
+            printf(">r%d\n%s\n", i, substr(seq, pos, len))
+            pos += stride
+            if (pos > span) pos = (pos % span) + 1
+        }
+    }
+' "$ref" > "$READS"
+[[ -s "$READS" ]] || { echo "FAIL: read generation produced nothing" >&2; exit 1; }
+
+# -K is deliberately small so the input spans many cohorts, each of which
+# SLICE_ALL then splits -- exercising the partial-cohort exit repeatedly.
+K=200000
+
+align() {   # $1 = tag, $2 = --cohort-slices, $3 = slice-every-cohort (0/1)
+    local tag="$1" slices="$2" all="$3"
+    BWA_MEM3_COHORT_SLICE_ALL="$all" \
+        "$BWA_MEM3" mem -t 4 -K "$K" --cohort-slices "$slices" \
+        --profile "$WORK/$tag.tsv" "$ref" "$READS" \
+        > "$WORK/$tag.sam" 2> "$WORK/$tag.err" \
+        || { echo "FAIL: $tag exited nonzero" >&2; tail -20 "$WORK/$tag.err" >&2; exit 1; }
+    [[ -s "$WORK/$tag.tsv" ]] || { echo "FAIL: $tag wrote no profile TSV" >&2; exit 1; }
+}
+
+align unsliced 0 0
+align sliced   4 1
+
+# Resolve columns by header name: the TSV schema is append-friendly and a
+# hard-coded index would rot the next time a field is added.
+#
+# A missing header is fatal rather than an empty index, because an empty index
+# does NOT reliably fail: awk reads `$""` as `$0`, so `$bp+0 > 0` silently
+# degrades into "the whole line coerced to a number", and every assertion below
+# would pass on a broken build. It is also implementation-dependent -- mawk and
+# gawk (what CI runs) take the `$0` reading, while the BWK awk on macOS errors
+# out -- so checking here is what makes the behaviour the same everywhere.
+col() {   # $1 = tsv, $2 = header name -> 1-based column index; fails if absent
+    local idx
+    idx=$(awk -F'\t' -v want="$2" 'NR==1 { for (i=1;i<=NF;i++) if ($i==want) { print i; exit } }' "$1")
+    if [[ -z "$idx" ]]; then
+        echo "FAIL: $1 has no '$2' column; header is: $(head -1 "$1")" >&2
+        return 1
+    fi
+    printf '%s\n' "$idx"
+}
+
+# Rows that read bases (n_bp > 0), excluding the ALL aggregate.
+data_rows() {   # $1 = tsv
+    local f="$1" c_chunk c_bp
+    c_chunk=$(col "$f" chunk) || return 1
+    c_bp=$(col "$f" n_bp)     || return 1
+    awk -F'\t' -v ch="$c_chunk" -v bp="$c_bp" \
+        'NR>1 && $ch!="ALL" && $bp+0 > 0' "$f"
+}
+
+n_unsliced=$(data_rows "$WORK/unsliced.tsv" | wc -l | tr -d ' ')
+n_sliced=$(data_rows "$WORK/sliced.tsv" | wc -l | tr -d ' ')
+partials=$(grep -c 'cohort slice' "$WORK/sliced.err" || true)
+
+echo "  unsliced: $n_unsliced chunk rows"
+echo "  sliced:   $n_sliced chunk rows, $partials partial slice(s) reported by the reader"
+
+# Non-vacuity. If slicing did not actually split any cohort then every row takes
+# the cohort-complete exit, the partial-cohort path is never entered, and the
+# assertion below would pass on a broken build.
+if [ "$n_sliced" -le "$n_unsliced" ] || [ "${partials:-0}" -lt 3 ]; then
+    echo "FAIL: slicing did not produce partial cohorts, so this run cannot" >&2
+    echo "      detect the bug. Expected more rows than the $n_unsliced" >&2
+    echo "      unsliced rows and at least 3 partial slices, got $n_sliced" >&2
+    echo "      rows and ${partials:-0} partial slices." >&2
+    exit 1
+fi
+
+# The assertion: a chunk that read bases ran kt_for, so it cannot have used
+# zero compute CPU. `compute` is derived from proc_cpu, so it must be populated
+# too (an empty cell is NaN -- see sp_chunk_init).
+check() {   # $1 = tsv, $2 = tag
+    local f="$1" tag="$2" c_chunk c_bp c_cpu c_comp
+    c_chunk=$(col "$f" chunk)    || return 1
+    c_bp=$(col "$f" n_bp)        || return 1
+    c_cpu=$(col "$f" proc_cpu)   || return 1
+    c_comp=$(col "$f" compute)   || return 1
+    awk -F'\t' -v ch="$c_chunk" -v bp="$c_bp" -v cpu="$c_cpu" -v comp="$c_comp" -v tag="$tag" '
+        NR>1 && $ch!="ALL" && $bp+0 > 0 {
+            rows++
+            if ($cpu+0 <= 0) { printf("  %s chunk %s: %s bases but proc_cpu=%s\n", tag, $ch, $bp, $cpu); bad++ }
+            else if ($comp == "")   { printf("  %s chunk %s: proc_cpu=%s but compute is empty\n", tag, $ch, $cpu); bad++ }
+            else total += $cpu
+        }
+        END {
+            printf("  %s: %d/%d rows report compute CPU, %.4f CPU sec total\n", tag, rows-bad, rows, total)
+            exit (bad > 0)
+        }
+    ' "$f"
+}
+
+fail=0
+check "$WORK/unsliced.tsv" unsliced || fail=1
+check "$WORK/sliced.tsv"   sliced   || fail=1
+
+if [ "$fail" -ne 0 ]; then
+    # Two causes reach here, and the diagnostics above say which: an unresolved
+    # TSV column (a schema change -- col() names the missing header), or the
+    # regression itself. Don't attribute the former to the latter.
+    echo "FAIL: --profile did not account for every chunk that read bases." >&2
+    echo "      If a column could not be resolved, the TSV schema changed and" >&2
+    echo "      this script needs updating. Otherwise a partial cohort failed to" >&2
+    echo "      harvest g_ktfor before returning; see sp_harvest_proc() and" >&2
+    echo "      step 1 of kt_pipeline (src/fastmap.cpp)." >&2
+    exit 1
+fi
+
+echo "PASS: every chunk that read bases reports its compute CPU, including the"
+echo "      partial cohort slices that return before pairing and SAM."


### PR DESCRIPTION
> **Stacked on #298, which is stacked on #297.** This PR's diff is against #298. The stack order is deliberate: #297 makes uncapping affordable on memory, #298 uncaps (restoring byte-identity with bwa/bwa-mem2 at `-t >= 26`) at a cost of +4.1% wall, and this PR gives that wall cost back.

The first batch's read overlaps nothing — the compute pipeline has nothing to work on until it lands. Now that the chunk cap is opt-in (#298), that first read is a full `chunk_size * n_threads` bases, which makes it the largest single unhidden cost in a run.

This reads the **first** batch as a geometric ramp (task/8, task/4, task/2, …) so seeding and BSW start on a small slice while the rest is still arriving. Steady-state batches stay single-slice: once the pipeline is full, `read(N+1)` already overlaps `compute(N)`, so slicing them further would only add `kt_for` passes and shrink the SIMD batches for no overlap gain.

## Measured

c8g.16xlarge, wgs-5M, 3 reps, interleaved, warm page cache, default (uncapped) batching:

| `-t` | slices=0 | slices=6 | delta | peak RSS |
|---:|---:|---:|---:|---|
| 16 | 86.63 s | 86.16 s | **−0.55%** | 14.50 → 14.46 GB |
| 64 | 26.08 s | **23.94 s** | **−8.2%** | 24.80 → 24.30 GB |

Rep-to-rep CV 0.02–0.05%. The win scales with the batch, so it is small at `-t 16` (a 160 Mbase first read) and large at `-t 64` (640 Mbase). Peak RSS is unchanged or slightly lower, so the cohort accumulator costs nothing.

**Ramp depth was swept rather than guessed** (`-t 64`, `main_mem` seconds):

| `--cohort-slices` | 0 | 2 | 3 | 4 | **6** |
|---|---:|---:|---:|---:|---:|
| | 26.08 | 24.36 | 24.27 | 24.09 | **23.94** |

Monotonically better with depth — each extra slice halves the still-unoverlapped head again — so the default is **6**, not the 3 an earlier prototype used. Below `-t 26` the 1 Mbase floor makes deeper settings a no-op on most inputs.

**Slicing every cohort was also measured, and rejected.** Steady-state cohorts stay single-slice on the theory that once the pipeline is full there is no head left to hide. Forcing all cohorts to slice costs **+3.8% wall** (SIMD batches shrink and `kt_for` passes multiply) while saving 1.04 GB RSS — a real speed-for-memory trade, but the wrong default. The knob (`BWA_MEM3_COHORT_SLICE_ALL`) exists for the identity test.

For context, a non-byte-identical taper prototype measured −7.7% on this workload. This beats it while keeping the output identical.

## Why it is byte-identical

`mem_pestat` is the only thing in the default path whose result depends on how reads are partitioned into batches. Read ids come from the global `n_processed` counter, so seeding, BSW, the `hash_64` tie-breaks and SAM encoding are all partition-invariant. Slicing changes only the *physical read granularity* inside a batch, never the batch boundary, so `mem_pestat` sees exactly the read set it saw before.

That the work-item partition *within* a batch is also output-neutral was verified separately, by building at three different `BATCH_SIZE` values and diffing 10M records on **NEON, AVX2 and AVX-512BW** — relevant because fg-labs/bwa-mem3#290 showed this bug class splitting AVX2-vs-everything-else rather than x86-vs-ARM.

`mem_process_seqs` is split into `mem_align_cohort_slice` (seeding + BSW over one slice) and `mem_pair_and_emit_cohort` (`mem_pestat` + pairing + SAM over the whole cohort). The old entry point remains as the single-slice case and is still exactly what runs for every unsliced batch.

## Two details that are load-bearing, not defensive

**Each slice's read target is clamped to the bases the cohort still needs.** Both readers stop at the first whole-record, even-`n` boundary at or *past* the request, so slices overshoot independently: `T/8 + T/4 + T/2 + T/8` lands at `T + e1+e2+e3+e4` where a single read of `T` lands at `T + e` — a different last record, so a different cohort, so a different `mem_pestat`. With the clamp, the boundary is provably the record the unsliced read would have stopped at.

**`-p` (`MEM_F_SMARTPE`) falls back to unsliced batches.** `bseq_classify` pairs adjacent records and carries state across the whole array, so a slice boundary between two mates would classify them as two single-end reads, change `n_sep[]`, and shift the read-id base handed to the second `mem_process_seqs`.

## Test

`test/regression/cohort_slice_identity.sh`, wired into CI. Two things make it powerful rather than merely present.

**It slices every cohort, not just the first.** Production only ramps the first batch, so a test mirroring production exercises the accumulator exactly once per run. `BWA_MEM3_COHORT_SLICE_ALL=1` slices all of them, turning a ~30-cohort run into 240 sliced boundaries. Against a build with the clamp deliberately removed:

| slicing | differing lines |
|---|---:|
| first cohort only | 4 |
| **every cohort** | **24,912** |

Same bug, ~6000× the signal. The broken build also collapses to **16 cohorts instead of 30** — direct evidence the boundary moved, since overshooting slices produce larger cohorts.

**It asserts its own non-vacuity.** With a constant insert size `mem_pestat` returns identical bounds for every possible subset of reads, so cohort composition cannot affect output and an IDENTICAL result would prove nothing. The test requires the inferred percentiles to actually differ between cohorts, and fails loudly if they don't. On the local e_coli fixture: 26 distinct `(25,50,75)` tuples across 30 cohorts.

The failure mode when the clamp is removed is exactly the predicted one — a pair flipping from proper to distant because shifted insert-size bounds changed mate rescue:

```
< ...  83  chrUn_KN707896v1_decoy  5372  ...  =  4727   -795   MC:Z:13S136M1S
> ...  81  chrUn_KN707896v1_decoy  5372  ...  =  26083  20563  MC:Z:18S132M
```

Note this is a bug class that a record-count check or a crash test would sail past: the record count is unchanged and the output stays well-formed.

## Byte-identity verification

On c8g at the default batch, each matching both the unsliced build and a repeat-run determinism control:

- `-t 16` md5 `5774c6ef428a3bb3a9eef35d454826a2`
- `-t 64` md5 `b9c1e797e46738021424bc577f7487f7`

## Interface

`--cohort-slices INT` (default 6, 0 = off), with a `BWA_MEM3_COHORT_SLICES` env override for sweeps.

## Cross-architecture stack measurement

All three PRs in the stack were re-measured together on **two 64-vCPU hosts**, wgs-5M, 3 reps, interleaved, warm page cache, so each commit's contribution is separable and the whole is checked against `main`:

| `-t 64` | c8g.16xlarge (NEON) | c6a.16xlarge (AVX2) |
|---|---:|---:|
| `main` (8dbf218) | 24.81 s | 30.58 s |
| `+A` (#297) | 24.77 s (−0.15%) | 30.47 s (−0.35%) |
| `+uncap` (#298) | 26.10 s (+5.23%) | 32.02 s (+4.72%) |
| `+B` (#305) | **24.15 s (−2.63%)** | **30.27 s (−1.01%)** |

Rep-to-rep CV 0.02–0.7%. Peak RSS at `-t 64`: `main` 21.92 / 22.05 GB, `+A` 18.73 / 18.77, full stack 24.62 / 24.50.

**Net: the stack is faster than `main` at `-t 64` on both architectures while restoring byte-identity with bwa/bwa-mem2, which `main` does not have at `-t >= 26`.** It costs ~2.8 GB of peak RSS at `-t 64` (uncapping adds ~6.1 GB, #297 gives back ~3.2); at `-t 16` and `-t 32` the stack is a net memory win of ~2 GB.

Output digests were identical on both hosts at every thread count:

```
-t 16  main=5774c6ef  A=5774c6ef  uncap=5774c6ef  B_off=5774c6ef  B_on=5774c6ef
-t 32  main=08096206  A=08096206  uncap=9465e564  B_off=9465e564  B_on=9465e564
-t 64  main=08096206  A=08096206  uncap=b9c1e797  B_off=b9c1e797  B_on=b9c1e797
```

Four things follow. #297 is byte-neutral (`main == A` everywhere). #305 is byte-neutral (`uncap == B_off == B_on` everywhere). The cap is the *only* thing that changes output, and only at `-t >= 26`. And `main` produces the same digest at `-t 32` and `-t 64` because the cap pins both batches to 256 Mbase — a direct demonstration of the mechanism #298 fixes. The digests also match between NEON and AVX2, so cross-architecture byte-identity holds through the whole stack.

## Interaction with #293 — needs deciding before both land

#293 (`perf(io): pool per-read string fields in a per-chunk arena`) states its contract as *"one arena per chunk, created by the reader, destroyed once in the write stage after every field it backs is consumed."*

That invariant does not survive this PR. Here the read step emits **slices** and the write step receives **cohorts**, so #293 would build one arena per *slice* — but a partial-cohort slice returns an empty item that reaches step 2 **immediately**, destroying that slice's arena while the cohort accumulator still holds `bseq1_t` structs pointing into it. Use-after-free on `name`/`seq`/`qual`, and it would fire on the first cohort of every run.

The two PRs merge cleanly and then corrupt reads, so this needs a deliberate fix rather than a merge resolution. Either the cohort accumulator takes ownership of slice arenas and frees them at cohort write, or #293's arena becomes per-cohort. Whichever lands second should adapt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional cohort slicing for `bwa-mem3 mem` via `--cohort-slices`, with runtime controls and enhanced profiling for partial slices.
* **Bug Fixes**
  * Fixed read-arena lifetime/ownership across multi-slice processing, including correct handling for empty batches and EOF at slice boundaries.
* **Refactor**
  * Split cohort processing into separate slice-alignment and cohort-wide pairing/emission stages.
* **Documentation**
  * Clarified `-K` target vs hard limits, `--chunk-cap` semantics, and precedence.
* **Tests**
  * Added/expanded regression coverage for cohort-slice output identity, EOF-on-boundary behavior, profiling CPU reporting, and cap precedence/overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->