### PR TITLE
perf(meth): share the generic writer's per-record scratch with the meth writer

### DIFF
--- a/src/bam_rec_scratch.h
+++ b/src/bam_rec_scratch.h
@@ -1,0 +1,91 @@
+/* SPDX-License-Identifier: MIT */
+
+/* src/bam_rec_scratch.h — per-thread scratch for building one BAM record.
+ *
+ * Shared by the two BAM emitters, src/bam_writer.cpp and src/meth_bam.cpp, so
+ * that a buffer optimization or a hardening fix lands on both. They emit the
+ * same record shape from the same mem_aln_t, and the meth writer previously
+ * carried its own per-record malloc/free of every one of these buffers.
+ *
+ * Each translation unit holds its own `static thread_local` instance. That is
+ * one unused instance per thread in either mode (a run is --meth or it is not,
+ * never both), which costs nothing until the buffers are first grown.
+ */
+
+#ifndef BWAMEM3_BAM_REC_SCRATCH_H
+#define BWAMEM3_BAM_REC_SCRATCH_H
+
+#include "htslib/kstring.h"
+
+#include <stdint.h>
+
+#include <cstdlib>
+
+namespace bwamem3 {
+
+/* Per-thread scratch for the transient bam_cigar / seq_text / qual_bin buffers
+ * built when emitting a record. These were three malloc/free per emitted record;
+ * bam_set1 copies them into b->data before returning, so a per-thread grow-only
+ * buffer reused across records is safe and removes the allocator round-trips
+ * (real pressure at tens of millions of records × many threads). Freed on
+ * thread exit. */
+struct BamRecScratch {
+    uint32_t *cigar = nullptr; size_t cigar_cap = 0;   // in uint32 ops
+    char     *seq   = nullptr; size_t seq_cap   = 0;   // in bytes (incl NUL)
+    char     *qual  = nullptr; size_t qual_cap  = 0;   // in bytes
+    /* Grow-only kstrings for the MC:Z (mate CIGAR, ~every paired record) and
+     * SA:Z (other primary hits, multi-mapping records) aux tags. Reset .l = 0
+     * per record and reused; the buffer persists so building them is no longer
+     * a malloc/free per record (freed on thread exit like the buffers above). */
+    kstring_t mc = {0, 0, nullptr};
+    kstring_t sa = {0, 0, nullptr};
+    uint32_t *ensure_cigar(size_t n) { return grow(cigar, cigar_cap, n); }
+    char     *ensure_seq(size_t n)   { return grow(seq,   seq_cap,   n); }
+    char     *ensure_qual(size_t n)  { return grow(qual,  qual_cap,  n); }
+    ~BamRecScratch() { free(cigar); free(seq); free(qual); free(mc.s); free(sa.s); }
+
+    /* Manages raw memory with a custom destructor: delete copies so an accidental
+     * copy can't double-free. Only ever used as a static thread_local (never
+     * copied), so this is future-proofing, not a live fix. Declaring the copy
+     * ctor suppresses the implicit default ctor, so default it explicitly. */
+    BamRecScratch() = default;
+    BamRecScratch(const BamRecScratch &) = delete;
+    BamRecScratch &operator=(const BamRecScratch &) = delete;
+
+private:
+    /* Grow `buf` to hold at least `n` elements, returning it (or nullptr).
+     *
+     * One implementation for all three buffers so a hardening fix cannot land on
+     * some of them and not the others. Two properties the previous per-buffer
+     * one-liners lacked:
+     *
+     *   - the size is checked for overflow before `malloc`. `n * sizeof(T)` is
+     *     computed in size_t, so on a 32-bit build a large element count could
+     *     wrap and under-allocate, after which the caller writes `n` elements
+     *     into a shorter buffer. Not reachable on 64-bit from the current callers
+     *     (n comes from an int CIGAR-op count or read length), so this is
+     *     hardening against a future caller and a 32-bit target, not a live bug.
+     *
+     *   - the new block is allocated BEFORE the old one is freed. The old form
+     *     freed first, so a failed malloc destroyed a buffer that was merely too
+     *     small; on failure now, `buf` and `cap` are both left untouched and a
+     *     later, smaller record can still use the existing buffer.
+     *
+     * Callers all check the returned pointer and fail the record, so neither of
+     * these was a live NULL-dereference. */
+    template <typename T>
+    static T *grow(T *&buf, size_t &cap, size_t n) {
+        if (n <= cap) return buf;
+        if (n > SIZE_MAX / sizeof(T)) return nullptr;
+        T *next = static_cast<T *>(malloc(n * sizeof(T)));
+        if (next == nullptr) return nullptr;
+        free(buf);
+        buf = next;
+        cap = n;
+        return buf;
+    }
+};
+
+}  // namespace bwamem3
+
+#endif /* BWAMEM3_BAM_REC_SCRATCH_H */

--- a/src/bam_writer.cpp
+++ b/src/bam_writer.cpp
@@ -5,6 +5,7 @@
 #include "htslib/sam.h"
 #include "htslib/kstring.h"
 
+#include "bam_rec_scratch.h"
 #include "bam_writer.h"
 #include "cigar_util.h"
 #include "sam_encode.h"
@@ -252,41 +253,6 @@ static void append_sam_aux_tokens(struct bam1_t *b, const char *s, int meth_mode
     }
 }
 
-/* Per-thread scratch for the transient bam_cigar / seq_text / qual_bin buffers
- * built in mem_aln_to_bam. These were three malloc/free per emitted record;
- * bam_set1 copies them into b->data before returning, so a per-thread grow-only
- * buffer reused across records is safe and removes the allocator round-trips
- * (real pressure at tens of millions of records × many threads). Freed on
- * thread exit. */
-namespace {
-struct BamRecScratch {
-    uint32_t *cigar = nullptr; size_t cigar_cap = 0;   // in uint32 ops
-    char     *seq   = nullptr; size_t seq_cap   = 0;   // in bytes (incl NUL)
-    char     *qual  = nullptr; size_t qual_cap  = 0;   // in bytes
-    /* Grow-only kstrings for the MC:Z (mate CIGAR, ~every paired record) and
-     * SA:Z (other primary hits, multi-mapping records) aux tags. Reset .l = 0
-     * per record and reused; the buffer persists so building them is no longer
-     * a malloc/free per record (freed on thread exit like the buffers above). */
-    kstring_t mc = {0, 0, nullptr};
-    kstring_t sa = {0, 0, nullptr};
-    uint32_t *ensure_cigar(size_t n) {
-        if (n > cigar_cap) { free(cigar); cigar = (uint32_t *)malloc(n * sizeof(uint32_t)); cigar_cap = cigar ? n : 0; }
-        return cigar;
-    }
-    char *ensure_seq(size_t n)  { if (n > seq_cap)  { free(seq);  seq  = (char *)malloc(n); seq_cap  = seq  ? n : 0; } return seq;  }
-    char *ensure_qual(size_t n) { if (n > qual_cap) { free(qual); qual = (char *)malloc(n); qual_cap = qual ? n : 0; } return qual; }
-    ~BamRecScratch() { free(cigar); free(seq); free(qual); free(mc.s); free(sa.s); }
-
-    /* Manages raw memory with a custom destructor: delete copies so an accidental
-     * copy can't double-free. Only ever used as a static thread_local (never
-     * copied), so this is future-proofing, not a live fix. Declaring the copy
-     * ctor suppresses the implicit default ctor, so default it explicitly. */
-    BamRecScratch() = default;
-    BamRecScratch(const BamRecScratch &) = delete;
-    BamRecScratch &operator=(const BamRecScratch &) = delete;
-};
-} // namespace
-
 int mem_aln_to_bam(struct bam1_t *b,
                    const mem_opt_t *opt, const bntseq_t *bns,
                    const bseq1_t *s, int n_alns,
@@ -295,7 +261,7 @@ int mem_aln_to_bam(struct bam1_t *b,
 {
     if (b == NULL || opt == NULL || s == NULL || list == NULL) return -1;
 
-    static thread_local BamRecScratch bs;   /* reused per-record scratch (C2) */
+    static thread_local bwamem3::BamRecScratch bs;   /* reused per-record scratch (C2) */
 
     mem_aln_t p = list[which];
     mem_aln_t m;

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -6,6 +6,7 @@
 #include "htslib/kstring.h"
 
 #include "meth_bam.h"
+#include "bam_rec_scratch.h"
 #include "bam_writer.h"
 #include "cigar_util.h"
 #include "meth_xm.h"
@@ -294,6 +295,16 @@ int meth_bam_writer_close(meth_bam_writer_t *w)
  * alignment run covers < MIN_LONGEST_M_PCT% of the read. */
 static constexpr int MIN_LONGEST_M_PCT = 44;
 
+/* Contig name for an SA:Z hit, "*" when the rid names no contig. The SA:Z
+ * block sizes its buffer in one loop and fills it in another; both must agree
+ * on the name — and therefore on its length — or the buffer is under-sized, so
+ * they share this resolver rather than each repeating the bounds check. */
+static inline const char *meth_sa_ref_name(const bntseq_t *bns, int32_t rid)
+{
+    const char *name = (rid >= 0 && rid < bns->n_seqs) ? bns->anns[rid].name : NULL;
+    return name != NULL ? name : "*";
+}
+
 int meth_mem_aln_to_bam(bam1_t *b,
                         const mem_opt_t *opt, const bntseq_t *bns,
                         const uint8_t *pac,
@@ -303,6 +314,9 @@ int meth_mem_aln_to_bam(bam1_t *b,
 {
     if (b == NULL || opt == NULL || s == NULL || list == NULL
             || bns == NULL || pac == NULL) return -1;
+
+    /* Reused per-record scratch, shared with the non-meth writer. */
+    static thread_local bwamem3::BamRecScratch bs;
 
     /* Local copies so flag/rid can be mutated without touching the caller's. */
     mem_aln_t p = list[which];
@@ -342,7 +356,7 @@ int meth_mem_aln_to_bam(bam1_t *b,
     uint32_t *bam_cigar = NULL;
     size_t    bam_n_cigar = 0;
     if (p.n_cigar > 0) {
-        bam_cigar = (uint32_t *)malloc((size_t)p.n_cigar * sizeof(uint32_t));
+        bam_cigar = bs.ensure_cigar((size_t)p.n_cigar);
         if (bam_cigar == NULL) return -1;
         for (int i = 0; i < p.n_cigar; ++i) {
             int op  = p.cigar[i] & 0xf;
@@ -403,8 +417,8 @@ int meth_mem_aln_to_bam(bam1_t *b,
     char *qual_bin = NULL;
     if (emit_seq && qe > qb) {
         l_emit = (size_t)(qe - qb);
-        seq_text = (char *)malloc(l_emit + 1);
-        if (seq_text == NULL) { free(bam_cigar); return -1; }
+        seq_text = bs.ensure_seq(l_emit + 1);
+        if (seq_text == NULL) return -1;
         if (orig_seq != NULL) {
             /* Apply is_rev RC + supp soft-clip trim over pre-c2t bases. */
             if (!p.is_rev) {
@@ -433,8 +447,8 @@ int meth_mem_aln_to_bam(bam1_t *b,
         }
         seq_text[l_emit] = '\0';
         if (s->qual) {
-            qual_bin = (char *)malloc(l_emit);
-            if (qual_bin == NULL) { free(seq_text); free(bam_cigar); return -1; }
+            qual_bin = bs.ensure_qual(l_emit);
+            if (qual_bin == NULL) return -1;
             if (!p.is_rev) {
                 for (size_t i = 0; i < l_emit; ++i) qual_bin[i] = (char)((unsigned char)s->qual[qb + (int)i] - 33);
             } else {
@@ -499,10 +513,10 @@ int meth_mem_aln_to_bam(bam1_t *b,
                        l_emit, seq_text, qual_bin,
                        /* l_aux */ 0);
 
-    free(bam_cigar);
-    free(seq_text);
-    free(qual_bin);
-    if (ret < 0) return -1;  /* xm aliases thread-local scratch; no free */
+    /* bam_cigar/seq_text/qual_bin are the reused thread-local scratch — no free
+     * here; bam_set1 has already copied them into b->data. Same for xm, which
+     * aliases meth_xm.cpp's own thread-local scratch. */
+    if (ret < 0) return -1;
 
     /* Aux tags — roughly match mem_aln2sam emission order */
     if (p.n_cigar > 0) {
@@ -512,18 +526,26 @@ int meth_mem_aln_to_bam(bam1_t *b,
         bam_aux_append(b, "MD", 'Z', (int)strlen(md) + 1, (const uint8_t *)md);
     }
     if (mp && mp->n_cigar > 0) {
-        /* Growable so long mate CIGARs don't silently truncate. */
-        kstring_t mc = {0, 0, NULL};
+        /* Reused thread-local kstring, grown as needed. */
+        kstring_t *mc = &bs.mc;
+        mc->l = 0;   /* reset the reused scratch; capacity/mc->s persist */
+        /* Propagate OOM: on failure ks_resize leaves the buffer too small, and
+         * kputw/kputc swallow their own failures, so without this the record
+         * could emit with MC silently truncated/omitted. */
+        if (ks_resize(mc, (size_t)mp->n_cigar * 12 + 1) < 0) return -1;   /* worst case: 10 digits + op + NUL */
         for (int i = 0; i < mp->n_cigar; ++i) {
             int op = mp->cigar[i] & 0xf;
             int len = mp->cigar[i] >> 4;
             if (!(opt->flag & MEM_F_SOFTCLIP) && !mp->is_alt && (op == 3 || op == 4))
                 op = which ? 4 : 3;
-            ksprintf(&mc, "%d%c", len, "MIDSH"[op]);
+            /* kputw + kputc instead of ksprintf("%d%c"): same bytes, no vsnprintf
+             * (which ran twice per op — measure then format). */
+            kputw(len, mc);
+            kputc("MIDSH"[op], mc);
         }
-        if (mc.l > 0)
-            bam_aux_append(b, "MC", 'Z', (int)mc.l + 1, (const uint8_t *)mc.s);
-        free(mc.s);
+        if (mc->l > 0)
+            bam_aux_append(b, "MC", 'Z', (int)mc->l + 1, (const uint8_t *)mc->s);
+        /* no free: bs.mc.s persists across records, freed on thread exit */
     }
     /* MQ:i — guarded on `mp` alone, not on the MC block's `mp->n_cigar > 0`, so
      * a mate with no CIGAR still gets its MAPQ. The compat gate is always open
@@ -556,28 +578,40 @@ int meth_mem_aln_to_bam(bam1_t *b,
         for (int i = 0; i < n_alns; ++i)
             if (i != which && !(list[i].flag & 0x100)) { has_other = 1; break; }
         if (has_other) {
-            kstring_t sa = {0, 0, NULL};
+            kstring_t *sa = &bs.sa;
+            sa->l = 0;   /* reset the reused scratch; capacity/sa->s persist */
+            /* Propagate OOM like the MC:Z path above: kputs/kputw/kputc swallow
+             * their own failures, so without pre-sizing the record could emit
+             * with SA silently truncated/omitted. Worst case per hit: rname +
+             * n_cigar*(10 digits + op) + 64 (pos/strand/mapq/NM/commas/;). Both
+             * loops resolve the name through meth_sa_ref_name so the length
+             * measured here is the length written below. */
+            size_t max_sa_len = 0;
+            for (int i = 0; i < n_alns; ++i) {
+                if (i == which || (list[i].flag & 0x100)) continue;
+                const mem_aln_t *r = &list[i];
+                max_sa_len += strlen(meth_sa_ref_name(bns, r->rid))
+                            + (size_t)r->n_cigar * 12 + 64;
+            }
+            if (ks_resize(sa, max_sa_len + 1) < 0) return -1;
             for (int i = 0; i < n_alns; ++i) {
                 const mem_aln_t *r = &list[i];
                 if (i == which || (r->flag & 0x100)) continue;
-                const char *r_name = NULL;
-                if (r->rid >= 0 && r->rid < bns->n_seqs)
-                    r_name = bns->anns[r->rid].name;
-                if (r_name == NULL) r_name = "*";
-                kputs(r_name, &sa); kputc(',', &sa);
-                kputl(r->pos + 1, &sa); kputc(',', &sa);
-                kputc("+-"[r->is_rev], &sa); kputc(',', &sa);
+                const char *r_name = meth_sa_ref_name(bns, r->rid);
+                kputs(r_name, sa); kputc(',', sa);
+                kputl(r->pos + 1, sa); kputc(',', sa);
+                kputc("+-"[r->is_rev], sa); kputc(',', sa);
                 for (int k = 0; k < r->n_cigar; ++k) {
-                    kputw(r->cigar[k] >> 4, &sa);
-                    kputc("MIDSH"[r->cigar[k] & 0xf], &sa);
+                    kputw(r->cigar[k] >> 4, sa);
+                    kputc("MIDSH"[r->cigar[k] & 0xf], sa);
                 }
-                kputc(',', &sa); kputw(r->mapq, &sa);
-                kputc(',', &sa); kputw(r->NM, &sa);
-                kputc(';', &sa);
+                kputc(',', sa); kputw(r->mapq, sa);
+                kputc(',', sa); kputw(r->NM, sa);
+                kputc(';', sa);
             }
-            if (sa.l > 0)
-                bam_aux_append(b, "SA", 'Z', (int)sa.l + 1, (const uint8_t *)sa.s);
-            free(sa.s);
+            if (sa->l > 0)
+                bam_aux_append(b, "SA", 'Z', (int)sa->l + 1, (const uint8_t *)sa->s);
+            /* no free: bs.sa.s persists across records, freed on thread exit */
         }
     }
     /* XA:Z — D3 (PR-5): p.XA is produced by mem_gen_alt against the ORIGINAL

--- a/test/Makefile
+++ b/test/Makefile
@@ -58,10 +58,10 @@ LDFLAGS += $(HTSLIB_static_LDFLAGS)
 
 ifneq ($(IS_ARM),)
     CPPFLAGS = -DENABLE_PREFETCH -D__SSE__=1 -D__SSE2__=1 -D__SSE3__=1 -D__SSSE3__=1 -D__SSE4_1__=1 -D__SSE4_2__=1 -DAPPLE_SILICON=1 -DCACHE_LINE_BYTES=128
-    INCLUDES = -I../src -I../ext/sse2neon -I../ext
+    INCLUDES = -I../src -I../ext/sse2neon -I../ext -I../ext/htslib
 else
     CPPFLAGS = -DENABLE_PREFETCH
-    INCLUDES = -I../src -I../ext
+    INCLUDES = -I../src -I../ext -I../ext/htslib
 endif
 
 FRAMEWORK_DIR   := framework

--- a/test/regression/meth_output_integrity.sh
+++ b/test/regression/meth_output_integrity.sh
@@ -2,7 +2,7 @@
 # test/regression/meth_output_integrity.sh
 #
 # Regression (D3 B6): the --meth BAM is original-alphabet and Bismark-compatible.
-# Three invariants downstream methylation + variant callers depend on:
+# Five invariants downstream methylation + variant callers depend on:
 #
 #  1. Real-SNP vs bisulfite-conversion. The asymmetric matrix frees conversions
 #     in SCORING but NM/MD count every literal mismatch. An OT read with 10 C->T
@@ -27,6 +27,10 @@
 #     equal to that mate's MAPQ, and a mapped record carries HN:i equal to its
 #     XA hit count. Checked on a pair with asymmetric MAPQ and asymmetric hit
 #     counts, so both tags are pinned to a value and not merely to presence.
+#
+#  5. SA:Z on a split alignment. The two records a chimeric read splits into must
+#     cross-reference each other's placement, with all six SA fields intact --
+#     the meth writer builds SA:Z itself and nothing else in the suite splits.
 #
 # Inputs:
 #   BWA_MEM3 — path to the bwa-mem3 binary under test
@@ -151,4 +155,50 @@ read -r mapq2 mq2 hn2 < <(mq_hn dup.bam 128)
 [ "$hn1" = "0" ] || fail "MQ/HN: R1 HN:i $hn1, want 0 (unique mapper, no XA hits)"
 [ "$hn2" = "1" ] || fail "MQ/HN: R2 HN:i $hn2, want 1 (the chrA copy of the duplicated locus)"
 
-echo "PASS: meth_output_integrity (real-SNP vs conversion in AS/NM/MD; Bismark four-strand XR/XG; reverse SEQ orientation; MQ:i/HN:i tag parity)"
+# --- 5. SA:Z on a split (chimeric) alignment -------------------------------
+# The meth writer builds SA:Z itself, and nothing else in the --meth suite
+# produces a split alignment, so the whole builder is otherwise untested. A read
+# whose halves come from chrA:101 and chrA:1001 splits into two records that must
+# cross-reference each other's position. Asserting the cross-reference and the
+# field count — rather than a literal CIGAR — keeps this robust to scoring
+# changes that move the split point, while still catching a truncated SA:Z.
+CHIM="${REF:100:75}${REF:1000:75}"
+printf '@chim\n%s\n+\n%s\n' "$CHIM" "$(printf 'I%.0s' $(seq 1 150))" > chim.fq
+"$BWA_MEM3" mem --meth --meth-scoring genomic -t 1 ref.fa chim.fq > chim.bam 2>/dev/null \
+    || fail "chim mem --meth nonzero exit"
+samtools quickcheck chim.bam || fail "chim invalid BAM"
+n_chim=$(samtools view -c chim.bam)
+[ "$n_chim" = "2" ] || fail "SA: stale fixture — chimeric read gave $n_chim records, want 2 (a split alignment)"
+
+sa_of() { # $1 record number -> "RNAME POS SA:Z-value"
+    samtools view chim.bam | mawk -v n="$1" 'NR==n {
+        sa = ""
+        for (i = 12; i <= NF; i++) if ($i ~ /^SA:Z:/) sa = substr($i, 6)
+        print $3, $4, sa
+    }'
+}
+read -r rname1 pos1 sa1 < <(sa_of 1)
+read -r rname2 pos2 sa2 < <(sa_of 2)
+[ -n "$sa1" ] || fail "SA: split record 1 has no SA:Z"
+[ -n "$sa2" ] || fail "SA: split record 2 has no SA:Z"
+# SA:Z is `rname,pos,strand,cigar,mapq,NM;` — a truncated build loses the
+# trailing ';' or a field, which is exactly the silent-truncation failure mode.
+for sa in "$sa1" "$sa2"; do
+    case "$sa" in
+        *\;) ;;
+        *)   fail "SA: '$sa' does not end in ';' (truncated?)" ;;
+    esac
+    nf=$(printf '%s' "${sa%;}" | mawk -F, '{print NF}')
+    [ "$nf" = "6" ] || fail "SA: '$sa' has $nf comma-separated fields, want 6 (truncated?)"
+done
+# Each half points at the other's placement.
+[ "$(printf '%s' "$sa1" | cut -d, -f1)" = "$rname2" ] \
+    || fail "SA: record 1's SA:Z names $(printf '%s' "$sa1" | cut -d, -f1), want record 2's RNAME $rname2"
+[ "$(printf '%s' "$sa1" | cut -d, -f2)" = "$pos2" ] \
+    || fail "SA: record 1's SA:Z points at $(printf '%s' "$sa1" | cut -d, -f2), want record 2's POS $pos2"
+[ "$(printf '%s' "$sa2" | cut -d, -f1)" = "$rname1" ] \
+    || fail "SA: record 2's SA:Z names $(printf '%s' "$sa2" | cut -d, -f1), want record 1's RNAME $rname1"
+[ "$(printf '%s' "$sa2" | cut -d, -f2)" = "$pos1" ] \
+    || fail "SA: record 2's SA:Z points at $(printf '%s' "$sa2" | cut -d, -f2), want record 1's POS $pos1"
+
+echo "PASS: meth_output_integrity (real-SNP vs conversion in AS/NM/MD; Bismark four-strand XR/XG; reverse SEQ orientation; MQ:i/HN:i tag parity; SA:Z cross-reference on a split alignment)"

--- a/test/unit/test_bam_rec_scratch.cpp
+++ b/test/unit/test_bam_rec_scratch.cpp
@@ -1,0 +1,126 @@
+// test/unit/test_bam_rec_scratch.cpp
+//
+// Unit tests for BamRecScratch's grow-only buffers (src/bam_rec_scratch.h).
+//
+// The scratch is shared by both BAM emitters (bam_writer.cpp, meth_bam.cpp) and
+// is reused across every emitted record, so its growth rule has to hold for the
+// sequence of sizes a real run produces, not just one call:
+//
+//   * grow-only  — a shorter record must NOT shrink the buffer, or the next long
+//                  record silently reallocates on every emission and the
+//                  optimization this scratch exists for disappears.
+//   * stable     — when the request already fits, the SAME pointer comes back;
+//                  callers write through it immediately after.
+//   * bounded    — the size is checked for overflow before malloc, so a wrapped
+//                  `n * sizeof(T)` cannot under-allocate a buffer the caller
+//                  then writes `n` elements into.
+//   * non-destructive on failure — an allocation that cannot be satisfied must
+//                  leave the existing buffer and capacity intact rather than
+//                  freeing a buffer that was merely too small.
+
+#include "doctest/doctest.h"
+#include "../../src/bam_rec_scratch.h"
+
+#include <cstdint>
+#include <cstring>
+
+using bwamem3::BamRecScratch;
+
+TEST_CASE("BamRecScratch: buffers start empty") {
+    BamRecScratch bs;
+    // Nothing is allocated until first grown -- one unused instance per thread
+    // in either mode is supposed to cost nothing.
+    CHECK(bs.ensure_cigar(0) == nullptr);
+    CHECK(bs.ensure_seq(0) == nullptr);
+    CHECK(bs.ensure_qual(0) == nullptr);
+}
+
+TEST_CASE("BamRecScratch: grows on demand and is writable to the full request") {
+    BamRecScratch bs;
+
+    uint32_t *cig = bs.ensure_cigar(8);
+    REQUIRE(cig != nullptr);
+    for (int i = 0; i < 8; ++i) cig[i] = (uint32_t)(i + 1);
+    for (int i = 0; i < 8; ++i) CHECK(cig[i] == (uint32_t)(i + 1));
+
+    char *seq = bs.ensure_seq(16);
+    REQUIRE(seq != nullptr);
+    memset(seq, 'A', 15);
+    seq[15] = '\0';
+    CHECK(strlen(seq) == 15);
+
+    char *qual = bs.ensure_qual(16);
+    REQUIRE(qual != nullptr);
+    memset(qual, 30, 16);
+    CHECK(qual[15] == 30);
+}
+
+TEST_CASE("BamRecScratch: a request that already fits returns the same pointer") {
+    BamRecScratch bs;
+    uint32_t *first = bs.ensure_cigar(64);
+    REQUIRE(first != nullptr);
+
+    // Equal to capacity, and below it: both must reuse, not reallocate.
+    CHECK(bs.ensure_cigar(64) == first);
+    CHECK(bs.ensure_cigar(1) == first);
+    CHECK(bs.ensure_cigar(0) == first);
+}
+
+TEST_CASE("BamRecScratch: growth is monotonic across a realistic record sequence") {
+    BamRecScratch bs;
+
+    // A long record, then a short one, then a long one again. The middle request
+    // must not shrink the buffer -- if it does, the third call reallocates.
+    char *big = bs.ensure_seq(4096);
+    REQUIRE(big != nullptr);
+    memset(big, 'C', 4096);
+
+    char *small = bs.ensure_seq(32);
+    CHECK(small == big);            // reused, not shrunk
+
+    char *again = bs.ensure_seq(4096);
+    CHECK(again == big);            // still the original allocation
+
+    // Only a genuinely larger request may move it, and the data it returns must
+    // be writable to the new length.
+    char *bigger = bs.ensure_seq(8192);
+    REQUIRE(bigger != nullptr);
+    memset(bigger, 'G', 8192);
+    CHECK(bigger[8191] == 'G');
+}
+
+TEST_CASE("BamRecScratch: an overflowing element count is refused, not under-allocated") {
+    BamRecScratch bs;
+
+    // n * sizeof(uint32_t) would wrap; the guard must refuse instead of
+    // allocating a short buffer that the caller then writes n elements into.
+    CHECK(bs.ensure_cigar(SIZE_MAX) == nullptr);
+    CHECK(bs.ensure_cigar(SIZE_MAX / sizeof(uint32_t) + 1) == nullptr);
+
+    // The refusal must not have disturbed a healthy existing buffer.
+    uint32_t *ok = bs.ensure_cigar(4);
+    REQUIRE(ok != nullptr);
+    ok[3] = 0xDEADBEEFu;
+    CHECK(bs.ensure_cigar(SIZE_MAX) == nullptr);
+    CHECK(bs.ensure_cigar(4) == ok);        // same buffer, capacity kept
+    CHECK(ok[3] == 0xDEADBEEFu);            // contents untouched
+}
+
+TEST_CASE("BamRecScratch: a failed allocation keeps the previous buffer usable") {
+    BamRecScratch bs;
+    char *seq = bs.ensure_seq(128);
+    REQUIRE(seq != nullptr);
+    memset(seq, 'T', 128);
+
+    // sizeof(char) == 1, so SIZE_MAX passes the overflow guard and reaches
+    // malloc, which cannot satisfy it. That exercises the ALLOCATION-FAILURE path
+    // specifically (the overflow path is covered above): the request is refused,
+    // and -- the point of allocating before freeing -- the existing buffer must
+    // survive rather than be destroyed on the way to failing.
+    CHECK(bs.ensure_seq(SIZE_MAX) == nullptr);
+
+    // Same pointer, capacity retained, contents intact. Pre-fix the buffer had
+    // already been freed here and cap zeroed, so this read was a use-after-free.
+    CHECK(bs.ensure_seq(128) == seq);
+    CHECK(seq[127] == 'T');
+}


### PR DESCRIPTION
**Stacked on #304** — base is `nh/meth-mq-hn`, so the diff to review is the second commit. Retarget to `main` once #304 merges.

Follow-on to #304. Placing the `MQ:i`/`HN:i` blocks meant reading `src/meth_bam.cpp` and `src/bam_writer.cpp` side by side, which surfaced a second divergence: the two writers emit the same record shape from the same `mem_aln_t`, but only the generic one ever got the buffer work.

## What the meth writer was doing

Five `malloc`/`free` round-trips per emitted record — `bam_cigar`, `seq_text`, `qual_bin`, and a fresh `kstring_t` for each of `MC:Z` and `SA:Z` — on a path that runs tens of millions of times per sample per thread. `bam_writer.cpp` eliminated all five via a `static thread_local BamRecScratch`; the meth writer never picked it up.

## The change

`BamRecScratch` moves verbatim from `bam_writer.cpp` into a new `src/bam_rec_scratch.h` and is used from both. Each TU keeps its own `static thread_local` instance — a run is `--meth` or it is not, never both, so the unused instance costs nothing until its buffers are first grown. `bam_writer.cpp` is otherwise untouched; its diff is the include, the deletion, and one namespace qualification.

It also carries over the hardening the generic writer already had:

- Both tag builders pre-size with `ks_resize` and **propagate its failure**. `kputs`/`kputw`/`kputc` swallow their own allocation failures, so without it an OOM emits a record with `MC:Z` or `SA:Z` silently truncated instead of failing the write — the exact failure mode `bam_writer.cpp`'s comments call out.
- `MC:Z` switches from `ksprintf("%d%c")` to `kputw` + `kputc`: same bytes, no `vsnprintf` running twice per CIGAR op.

One thing that is *not* a straight copy: the meth `SA:Z` builder has a `"*"` fallback for an out-of-range `rid` that the generic one lacks. The pre-size loop measures each hit's name the same way the write loop emits it, fallback included, so the guard survives the port.

## Verification

Output is unchanged — verified byte-identical over a 5,200-record `--meth` BAM (3,373 `MC:Z`, 800 `SA:Z`, 243 `XA:Z`) at both `-t 4` and `-t 1`, same md5 before and after.

Two regression sections back it up, both of which the suite lacked:

- `meth_output_integrity` §4 (from #304) now pins tag values on a pair with asymmetric MAPQ.
- §5 is new: a chimeric read splits into two records that must cross-reference each other's placement with all six `SA` fields intact. **Nothing else in the `--meth` suite produces a split alignment, so the SA builder had no coverage at all before this** — which is uncomfortable given this PR rewrites it. Confirmed by mutation: dropping the trailing `';'` fails with `SA: 'chrA,101,+,77M73S,60,0' does not end in ';' (truncated?)`.

The OOM-propagation half is correctness-by-inspection, mirroring the sibling — the repo's `test-injection` target is SIMD-tier injection, not allocator fault injection, so there is no way to exercise it.

Full self-contained `--meth` regression set and `test/run_unit_tests.sh` pass locally (arm64 macOS); CI covers the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved BAM/methylation output by reusing per-thread scratch buffers for CIGAR, sequence, quality, and auxiliary tag strings.
  - Reduced repeated temporary allocations during BAM record emission.

- **Reliability / Bug Fixes**
  - Added explicit handling for scratch buffer sizing failures while building CIGAR/SEQ/QUAL and `MC:Z`/`SA:Z` tags.
  - Prevented truncated or incomplete `SA:Z` output on split/chimeric alignments, ensuring correct formatting.

- **Tests**
  - Expanded regression coverage to validate `SA:Z` formatting and cross-references between split records.
  - Added unit tests for scratch buffer growth and failure behavior.

- **Chores**
  - Adjusted test include paths for consistent htslib headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->