### PR TITLE
perf(mem): start the BSW scratch from a realistic size and let it grow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,3 +644,14 @@ jobs:
 
       - name: stage_prof unit test
         run: make stage_prof_test && ./stage_prof_test
+
+      - name: Partial cohort slices report their compute CPU
+        # Only a STAGE_PROF build can run this, which is why it lives here and
+        # not in the matrix rows above. Cohort slicing gives step 1 an early
+        # exit; if that exit forgets to harvest g_ktfor, the slice's compute CPU
+        # is destroyed rather than merely unreported, and --profile under-counts
+        # in proportion to how much slicing is happening.
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          FIXTURES="$GITHUB_WORKSPACE/test/fixtures" \
+          bash test/regression/profile_slice_cpu.sh

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -4380,7 +4380,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     sp.regid = av->n - 1;
 
                     if (numPairsLeft >= *wsize_pair) {
-                        fprintf(stderr, "[0000][%0.4d] Re-allocating seqPairArrays, in Left\n", tid);
+                        if (bwa_verbose >= 4) fprintf(stderr, "[0000][%0.4d] Re-allocating seqPairArrays, in Left\n", tid);
                         *wsize_pair +=  1024;
                         // assert(*wsize_pair > numPairsLeft);
                         *wsize_pair += numPairsLeft + 1024;
@@ -4405,7 +4405,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     leftQerOffset += s->qbeg;
                     if (leftQerOffset >= *wsize_buf_qer)
                     {
-                        fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufQers in %s (left)\n",
+                        if (bwa_verbose >= 4) fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufQers in %s (left)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_qer;
                         *wsize_buf_qer = seqbuf_grow_capacity(tmp);
@@ -4429,7 +4429,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     leftRefOffset += tmp;
                     if (leftRefOffset >= *wsize_buf_ref)
                     {
-                        fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufRefs in %s (left)\n",
+                        if (bwa_verbose >= 4) fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufRefs in %s (left)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_ref;
                         *wsize_buf_ref = seqbuf_grow_capacity(tmp);
@@ -4615,7 +4615,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
 
                     if (numPairsRight >= *wsize_pair)
                     {
-                        fprintf(stderr, "[0000] [%0.4d] Re-allocating seqPairArrays Right\n", tid);
+                        if (bwa_verbose >= 4) fprintf(stderr, "[0000] [%0.4d] Re-allocating seqPairArrays Right\n", tid);
                         *wsize_pair += 1024;
                         // assert(*wsize_pair > numPairsRight);
                         *wsize_pair += numPairsLeft + 1024;
@@ -4642,7 +4642,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     rightQerOffset += sp.len2;
                     if (rightQerOffset >= *wsize_buf_qer)
                     {
-                        fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufQers in %s (right)\n",
+                        if (bwa_verbose >= 4) fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufQers in %s (right)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_qer;
                         *wsize_buf_qer = seqbuf_grow_capacity(tmp);
@@ -4662,7 +4662,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                     rightRefOffset += sp.len1;
                     if (rightRefOffset >= *wsize_buf_ref)
                     {
-                        fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufRefs in %s (right)\n",
+                        if (bwa_verbose >= 4) fprintf(stderr, "[%0.4d] Re-allocating (doubling) seqBufRefs in %s (right)\n",
                                 tid, __func__);
                         int64_t tmp = *wsize_buf_ref;
                         *wsize_buf_ref = seqbuf_grow_capacity(tmp);

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -1489,7 +1489,7 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
                 assert(sp.len1 >= 0 && sp.len2 >= 0);
                 if (refOffset + sp.len1 >= *wsize_buf_ref)
                 {
-                    fprintf(stderr, "[0000][%0.4d] Re-allocating (doubling) seqBufRefs in %s\n",
+                    if (bwa_verbose >= 4) fprintf(stderr, "[0000][%0.4d] Re-allocating (doubling) seqBufRefs in %s\n",
                             tid, __func__);
                     int64_t tmp = *wsize_buf_ref;
                     *wsize_buf_ref = seqbuf_grow_capacity(tmp);
@@ -1509,7 +1509,7 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
             
                 if (qerOffset + sp.len2 >= *wsize_buf_qer)
                 {
-                    fprintf(stderr, "[0000][%0.4d] Re-allocating (doubling) seqBufQers in %s\n",
+                    if (bwa_verbose >= 4) fprintf(stderr, "[0000][%0.4d] Re-allocating (doubling) seqBufQers in %s\n",
                             tid, __func__);
                     int64_t tmp = *wsize_buf_qer;
                     *wsize_buf_qer = seqbuf_grow_capacity(tmp);
@@ -1529,7 +1529,7 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
             
                 if (pcnt >= *wsize_pair)
                 {
-                    fprintf(stderr, "[0000][%0.4d] Re-allocating seqPairs in %s\n", tid, __func__);
+                    if (bwa_verbose >= 4) fprintf(stderr, "[0000][%0.4d] Re-allocating seqPairs in %s\n", tid, __func__);
                     *wsize_pair += 1024;
                     mmc->seqPairArrayAux[tid] = (SeqPair *) realloc(mmc->seqPairArrayAux[tid],
                                                         (*wsize_pair + MAX_LINE_LEN)

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -438,6 +438,33 @@ void memoryAlloc(ktp_aux_t *aux, worker_t &w, int32_t nreads, int32_t nthreads)
     worker_alloc(aux->opt, w, nreads, nthreads);
 }
 
+/* Copy the compute step's --profile counters out of the per-thread kt_for
+ * accumulator and into this chunk's profile row (see stage_prof.h).
+ *
+ * Step 1 has two exits -- a whole cohort, and a partial cohort that is still
+ * accumulating slices -- and g_ktfor is reset at every step-1 entry, so a path
+ * that forgets to harvest does not merely lose detail: that slice's compute CPU
+ * is gone. Both exits call this, so adding a third cannot silently drop it.
+ *
+ * `sp_p0` is the sp_wall() reading taken at step-1 entry.
+ */
+static void sp_harvest_proc(prof_chunk_t *p, double sp_p0)
+{
+    p->proc_wall      = sp_wall() - sp_p0;
+    p->proc_cpu       = g_ktfor.proc_cpu;
+    p->thr_busy_min   = g_ktfor.thr_busy_min;
+    p->thr_busy_max   = g_ktfor.thr_busy_max;
+    p->thr_busy_mean  = g_ktfor.thr_busy_mean;
+    p->thr_busy_stdev = g_ktfor.thr_busy_stdev;
+    /* encode = SAM/BAM-build CPU (accurate, summed over compute threads);
+     * compute = the rest of the alignment CPU. Same clock, so subtractable.
+     * A slice that only seeds and extends never enters mem_aln2sam, so its
+     * encode is legitimately 0 and compute is the whole of proc_cpu. */
+    p->encode  = g_ktfor.encode;
+    p->compute = (g_ktfor.proc_cpu > g_ktfor.encode)
+                 ? g_ktfor.proc_cpu - g_ktfor.encode : NAN;
+}
+
 ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, worker_t &w)
 {
     ktp_aux_t *aux = (ktp_aux_t*) shared;
@@ -882,7 +909,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                 /* Partial cohort: hand the pipeline a non-NULL empty item. NULL
                  * would retire this worker (see ktp_worker's step advance). */
                 tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
-                if (sp_enabled()) ret->prof.proc_wall = sp_wall() - sp_p0;
+                if (sp_enabled()) sp_harvest_proc(&ret->prof, sp_p0);
                 return ret;
             }
 
@@ -900,19 +927,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         }
         tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
 
-        if (sp_enabled()) {
-            ret->prof.proc_wall      = sp_wall() - sp_p0;
-            ret->prof.proc_cpu       = g_ktfor.proc_cpu;
-            ret->prof.thr_busy_min   = g_ktfor.thr_busy_min;
-            ret->prof.thr_busy_max   = g_ktfor.thr_busy_max;
-            ret->prof.thr_busy_mean  = g_ktfor.thr_busy_mean;
-            ret->prof.thr_busy_stdev = g_ktfor.thr_busy_stdev;
-            /* encode = SAM/BAM-build CPU (accurate, summed over compute threads);
-             * compute = the rest of the alignment CPU. Same clock, so subtractable. */
-            ret->prof.encode  = g_ktfor.encode;
-            ret->prof.compute = (g_ktfor.proc_cpu > g_ktfor.encode)
-                                ? g_ktfor.proc_cpu - g_ktfor.encode : NAN;
-        }
+        if (sp_enabled()) sp_harvest_proc(&ret->prof, sp_p0);
 
         aux->n_processed += ret->n_seqs;
         return ret;

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -296,8 +296,25 @@ void worker_alloc(const mem_opt_t *opt, worker_t &w, int32_t nreads, int32_t nth
             scratchMem/1e6, nthreads);
 
 
-    /* SWA mem allocation */
-    int64_t wsize = BATCH_SIZE * SEEDS_PER_READ;
+    /* SWA mem allocation.
+     *
+     * These are a STARTING size, not a bound: seqBufRef/Qer double via
+     * seqbuf_grow_capacity() and the seqPairArrays realloc on demand, both in
+     * mem_chain2aln_across_reads_V2 and the batched mate-rescue path. So the
+     * only thing the initial value buys is avoiding a few early reallocs.
+     *
+     * It used to start at BATCH_SIZE * SEEDS_PER_READ. SEEDS_PER_READ is 500 --
+     * a worst-case seeds-per-read bound -- but these arrays hold extension
+     * PAIRS, roughly a couple per chain, not one per seed. The result was
+     * ~504 MB per thread reserved up front and, being per-thread, growth linear
+     * in -t: 32.2 GB at -t 64 and ~97 GB at -t 192, dwarfing even the index.
+     *
+     * Start from AVG_SEEDS_PER_READ instead -- the same per-read seed estimate
+     * the chaining scratch is sized with -- for an 8x smaller reservation, and
+     * let the existing growth paths cover anything heavier. Byte-identical:
+     * capacity affects only where the extension data lives, never its
+     * contents. */
+    int64_t wsize = BATCH_SIZE * AVG_SEEDS_PER_READ;
     for(int l=0; l<nthreads; l++)
     {
         w.mmc.seqBufLeftRef[l*CACHE_LINE]  = (uint8_t *)

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -22,3 +22,8 @@ matrix row; the rest run on the canonical AVX2 row only. Each script:
 Each script reads its inputs from environment variables — see the comment
 block at the top of each file. `.github/workflows/ci.yml` sets those vars
 and invokes the scripts.
+
+One exception to "any binary will do": `profile_slice_cpu.sh` asserts on
+`--profile` output, which a default build compiles out entirely, so it needs a
+binary from `make STAGE_PROF=1`. It fails loudly rather than skipping if handed
+one without `--profile`, and CI runs it from the `profiling-build` job.

--- a/test/regression/profile_slice_cpu.sh
+++ b/test/regression/profile_slice_cpu.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# test/regression/profile_slice_cpu.sh
+#
+# Regression: --profile must account for the compute CPU of a PARTIAL cohort.
+#
+# Cohort slicing gave step 1 a second exit. A cohort that is still accumulating
+# slices returns early -- it has seeded and extended its slice, but pairing and
+# SAM must wait for the whole cohort -- and that path originally saved only
+# proc_wall. Because g_ktfor is reset at every step-1 entry, the slice's
+# proc_cpu / compute / encode / thr_busy_* were not merely omitted from the row,
+# they were destroyed: nothing else ever reads them.
+#
+# The consequence is a profiler that quietly lies in proportion to how much
+# slicing is happening. At -t 64 the ramp covers ~40% of the run's bases, so
+# ~40% of the compute CPU vanished from the report -- and since the aggregate
+# row derives from the per-chunk rows, the in-PROCESS() budget could not be made
+# to balance. Nothing crashes and no alignment changes, so only an explicit
+# check on the profile output catches it.
+#
+# What makes this test sharp rather than merely present:
+#
+#   1. BWA_MEM3_COHORT_SLICE_ALL=1 slices EVERY cohort rather than only the
+#      first (which is all production does), so a short run produces dozens of
+#      partial slices instead of a handful.
+#
+#   2. The assertion is a boolean, not a threshold: every chunk that read bases
+#      must report proc_cpu > 0. A slice that ran kt_for cannot legitimately
+#      have consumed zero CPU, so there is nothing to tune and nothing to flake.
+#      Before the fix every ramp slice reports exactly 0.0000.
+#
+# Inputs (env vars):
+#   BWA_MEM3 -- path to a bwa-mem3 binary built with STAGE_PROF=1 (so --profile
+#               exists). A default build compiles profiling out entirely.
+#   FIXTURES -- directory containing synthetic_1mb.fa (default: test/fixtures)
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+FIXTURES="${FIXTURES:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)}"
+
+[[ -x "$BWA_MEM3" ]] || { echo "FAIL: binary not executable: $BWA_MEM3" >&2; exit 1; }
+
+src_ref="$FIXTURES/synthetic_1mb.fa"
+[[ -s "$src_ref" ]] || { echo "FAIL: synthetic_1mb.fa missing: $src_ref" >&2; exit 1; }
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/profile_slice_cpu.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+# --profile only exists in a STAGE_PROF=1 build; without it there is nothing to
+# assert on, and silently passing would make this test worthless in CI.
+# `mem` with no arguments prints usage and exits nonzero, so the output has to be
+# captured before grepping -- piping it straight into grep trips pipefail.
+"$BWA_MEM3" mem > "$WORK/usage.txt" 2>&1 || true
+if ! grep -q -- '--profile' "$WORK/usage.txt"; then
+    echo "FAIL: this binary has no --profile; build with STAGE_PROF=1" >&2
+    exit 1
+fi
+
+ref="$WORK/ref.fa"
+cp "$src_ref" "$ref"
+"$BWA_MEM3" index "$ref" > "$WORK/index.log" 2>&1 \
+    || { echo "FAIL: could not index the reference" >&2; tail -20 "$WORK/index.log" >&2; exit 1; }
+
+# Reads are generated here rather than committed. They must come FROM the
+# reference so they align and the aligner does real per-slice work -- a slice
+# whose reads all fail to seed would report near-zero CPU for honest reasons.
+READS="$WORK/reads.fa"
+READ_LEN=100
+N_READS=20000
+awk -v len="$READ_LEN" -v n="$N_READS" '
+    /^>/  { next }
+          { seq = seq $0 }
+    END {
+        if (length(seq) < len * 2) { print "reference too short" > "/dev/stderr"; exit 1 }
+        # Walk the reference with a stride, wrapping around, so the reads are
+        # spread over the whole sequence instead of piling onto one locus.
+        span   = length(seq) - len
+        stride = 7
+        pos    = 1
+        for (i = 0; i < n; i++) {
+            printf(">r%d\n%s\n", i, substr(seq, pos, len))
+            pos += stride
+            if (pos > span) pos = (pos % span) + 1
+        }
+    }
+' "$ref" > "$READS"
+[[ -s "$READS" ]] || { echo "FAIL: read generation produced nothing" >&2; exit 1; }
+
+# -K is deliberately small so the input spans many cohorts, each of which
+# SLICE_ALL then splits -- exercising the partial-cohort exit repeatedly.
+K=200000
+
+align() {   # $1 = tag, $2 = --cohort-slices, $3 = slice-every-cohort (0/1)
+    local tag="$1" slices="$2" all="$3"
+    BWA_MEM3_COHORT_SLICE_ALL="$all" \
+        "$BWA_MEM3" mem -t 4 -K "$K" --cohort-slices "$slices" \
+        --profile "$WORK/$tag.tsv" "$ref" "$READS" \
+        > "$WORK/$tag.sam" 2> "$WORK/$tag.err" \
+        || { echo "FAIL: $tag exited nonzero" >&2; tail -20 "$WORK/$tag.err" >&2; exit 1; }
+    [[ -s "$WORK/$tag.tsv" ]] || { echo "FAIL: $tag wrote no profile TSV" >&2; exit 1; }
+}
+
+align unsliced 0 0
+align sliced   4 1
+
+# Resolve columns by header name: the TSV schema is append-friendly and a
+# hard-coded index would rot the next time a field is added.
+#
+# A missing header is fatal rather than an empty index, because an empty index
+# does NOT reliably fail: awk reads `$""` as `$0`, so `$bp+0 > 0` silently
+# degrades into "the whole line coerced to a number", and every assertion below
+# would pass on a broken build. It is also implementation-dependent -- mawk and
+# gawk (what CI runs) take the `$0` reading, while the BWK awk on macOS errors
+# out -- so checking here is what makes the behaviour the same everywhere.
+col() {   # $1 = tsv, $2 = header name -> 1-based column index; fails if absent
+    local idx
+    idx=$(awk -F'\t' -v want="$2" 'NR==1 { for (i=1;i<=NF;i++) if ($i==want) { print i; exit } }' "$1")
+    if [[ -z "$idx" ]]; then
+        echo "FAIL: $1 has no '$2' column; header is: $(head -1 "$1")" >&2
+        return 1
+    fi
+    printf '%s\n' "$idx"
+}
+
+# Rows that read bases (n_bp > 0), excluding the ALL aggregate.
+data_rows() {   # $1 = tsv
+    local f="$1" c_chunk c_bp
+    c_chunk=$(col "$f" chunk) || return 1
+    c_bp=$(col "$f" n_bp)     || return 1
+    awk -F'\t' -v ch="$c_chunk" -v bp="$c_bp" \
+        'NR>1 && $ch!="ALL" && $bp+0 > 0' "$f"
+}
+
+n_unsliced=$(data_rows "$WORK/unsliced.tsv" | wc -l | tr -d ' ')
+n_sliced=$(data_rows "$WORK/sliced.tsv" | wc -l | tr -d ' ')
+partials=$(grep -c 'cohort slice' "$WORK/sliced.err" || true)
+
+echo "  unsliced: $n_unsliced chunk rows"
+echo "  sliced:   $n_sliced chunk rows, $partials partial slice(s) reported by the reader"
+
+# Non-vacuity. If slicing did not actually split any cohort then every row takes
+# the cohort-complete exit, the partial-cohort path is never entered, and the
+# assertion below would pass on a broken build.
+if [ "$n_sliced" -le "$n_unsliced" ] || [ "${partials:-0}" -lt 3 ]; then
+    echo "FAIL: slicing did not produce partial cohorts, so this run cannot" >&2
+    echo "      detect the bug. Expected more rows than the $n_unsliced" >&2
+    echo "      unsliced rows and at least 3 partial slices, got $n_sliced" >&2
+    echo "      rows and ${partials:-0} partial slices." >&2
+    exit 1
+fi
+
+# The assertion: a chunk that read bases ran kt_for, so it cannot have used
+# zero compute CPU. `compute` is derived from proc_cpu, so it must be populated
+# too (an empty cell is NaN -- see sp_chunk_init).
+check() {   # $1 = tsv, $2 = tag
+    local f="$1" tag="$2" c_chunk c_bp c_cpu c_comp
+    c_chunk=$(col "$f" chunk)    || return 1
+    c_bp=$(col "$f" n_bp)        || return 1
+    c_cpu=$(col "$f" proc_cpu)   || return 1
+    c_comp=$(col "$f" compute)   || return 1
+    awk -F'\t' -v ch="$c_chunk" -v bp="$c_bp" -v cpu="$c_cpu" -v comp="$c_comp" -v tag="$tag" '
+        NR>1 && $ch!="ALL" && $bp+0 > 0 {
+            rows++
+            if ($cpu+0 <= 0) { printf("  %s chunk %s: %s bases but proc_cpu=%s\n", tag, $ch, $bp, $cpu); bad++ }
+            else if ($comp == "")   { printf("  %s chunk %s: proc_cpu=%s but compute is empty\n", tag, $ch, $cpu); bad++ }
+            else total += $cpu
+        }
+        END {
+            printf("  %s: %d/%d rows report compute CPU, %.4f CPU sec total\n", tag, rows-bad, rows, total)
+            exit (bad > 0)
+        }
+    ' "$f"
+}
+
+fail=0
+check "$WORK/unsliced.tsv" unsliced || fail=1
+check "$WORK/sliced.tsv"   sliced   || fail=1
+
+if [ "$fail" -ne 0 ]; then
+    # Two causes reach here, and the diagnostics above say which: an unresolved
+    # TSV column (a schema change -- col() names the missing header), or the
+    # regression itself. Don't attribute the former to the latter.
+    echo "FAIL: --profile did not account for every chunk that read bases." >&2
+    echo "      If a column could not be resolved, the TSV schema changed and" >&2
+    echo "      this script needs updating. Otherwise a partial cohort failed to" >&2
+    echo "      harvest g_ktfor before returning; see sp_harvest_proc() and" >&2
+    echo "      step 1 of kt_pipeline (src/fastmap.cpp)." >&2
+    exit 1
+fi
+
+echo "PASS: every chunk that read bases reports its compute CPU, including the"
+echo "      partial cohort slices that return before pairing and SAM."


### PR DESCRIPTION
> **Stacked on #305 → #298 → #297.** This PR's diff is against #305. It is independent of the cohort work and could be rebased onto `main` if the stack lands out of order.

The banded-SW scratch — `seqBufLeftRef`/`RightRef`, `seqBufLeftQer`/`RightQer` and the three `seqPairArray`s — started at `BATCH_SIZE * SEEDS_PER_READ` entries **per thread**.

`SEEDS_PER_READ` is 500, a worst-case seeds-per-read bound. But these arrays hold extension **pairs**, roughly a couple per chain rather than one per seed. So the reservation was ~504 MB per thread before a single read was aligned, and being per-thread it grew linearly in `-t`:

| `-t` | BSW reservation |
|---:|---:|
| 4 | 2.0 GB |
| 64 | **32.2 GB** |
| 192 | ~97 GB |

At `-t 64` that is larger than the FM-index.

## Why shrinking it is safe

Nothing depended on that size being a bound. Both buffer families already grow on demand:

- `seqBufRef`/`Qer` double via `seqbuf_grow_capacity()` (`bwamem_pair.cpp:1490-1526`, `bwamem.cpp:4300-4324`)
- the `seqPairArray`s `realloc` when `numPairs >= *wsize_pair` (`bwamem.cpp:4274`, `4508`)

in both `mem_chain2aln_across_reads_V2` and the batched mate-rescue path. The initial value only ever avoided a few early reallocs.

This starts from `AVG_SEEDS_PER_READ` instead — the same per-read seed estimate the chaining scratch is sized with — for an 8× smaller reservation:

```
-t 4  (e_coli)   BSW pre-allocation   2015.24 ->  257.95 MB
-t 64 (wgs-5M)   BSW pre-allocation  32243.78 -> 4127.26 MB
```

## What this does *not* buy — read before approving

Measured on c8g.16xlarge, wgs-5M, `-t 64`, 2 reps: **peak RSS moves only 24.64 → 24.51 GB**, and wall is unchanged within noise.

Almost none of those 28 GB were ever touched — they were `_mm_malloc`'d pages the kernel never backed. So this is a **reservation** fix, not a resident-memory one, and it should not be sold as an RSS win. I initially described it as one; the measurement says otherwise.

Its actual value:

- not failing on hosts with `vm.overcommit_memory=2` or a virtual-size `rlimit`, where a 32–97 GB reservation can be refused outright
- not misreporting the tool's needs to a scheduler that sizes from VSZ rather than RSS
- removing a term that grows linearly in `-t`, which is the same reason #297 was worth doing

If the project would rather not carry the change for a benefit that is invisible in RSS, that is a reasonable call — the reason to take it is high-`-t` robustness, not throughput.

## Byte-identity

Capacity determines where extension data lives, never its contents. Verified against the pre-change build:

- e_coli, 400k simulated pairs with a **variable insert size** (a constant insert would make `mem_pestat` batch-invariant and the comparison vacuous), including with every cohort sliced 5 ways — identical
- wgs-5M at `-t 64` — md5 `b9c1e797e4673802`, matching every other configuration in the headroom sweep

## One behavioural note

The six growth-path log lines are gated behind `-v 4`. They were effectively dead when the reservation was 8× oversized; with a right-sized start they fire on the first batches of *every* thread, which at `-t 64` is a great deal of stderr for an event that is now routine and expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced upfront reservation sizes during fast mapping initialization to improve memory efficiency.
  * Limited verbose reallocation/debug output to high-verbosity runs to reduce noisy stderr logging.

* **Tests / CI**
  * Added a regression test to verify `--profile` compute CPU harvesting with `--cohort-slices`, including partial cohort slice exits.
  * Extended CI to run the new profiling regression step for profiling-enabled builds.
  * Updated regression test documentation with the profiling-enabled execution requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->