### PR TITLE
docs(kswv): the phase-1 boundary-mask cost is measured now, not unmeasurable

### DIFF
--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -638,8 +638,31 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
      * len2 = qe + 1 per pair (bwamem_pair.cpp:875): those groups are ragged
      * whatever the input lengths were, so jsplit < ncol and the per-cell range
      * covers most of the row. The measured phase-0 parity therefore does not
-     * carry over to phase 1, and bwa-bsw-bench cannot see it -- that harness
-     * only ever calls getScores* with phase 0.
+     * carry over to phase 1.
+     *
+     * That cost is now MEASURED, not just predicted: bwa-bsw-bench drives phase 1
+     * and times it separately (its rescue mode prints a phase-1 table alongside
+     * phase 0), and on quiet cloud hosts the per-cell range costs phase-1 8-bit
+     * throughput -7.2% at qlen 100 and -4.3% at qlen 150 on avx512bw, and
+     * -2.1% / -1.4% on Graviton4 NEON. Phase 0 is at parity on every tier, as
+     * this fast path intends.
+     *
+     * Two cross-checks fall out of that, and both hold, which is what makes the
+     * attribution to THIS range rather than something ambient:
+     *   - avx2 measures ~0 (-0.8% / +0.5%, i.e. noise). It must: avx2 never had
+     *     the hoist to restore, so the fix did not change its code at all (see
+     *     the register-pressure note in the avx2 kernel below).
+     *   - the cost vanishes at qlen 250 (+0.5% avx512bw, -0.0% NEON), where the
+     *     router picks the 16-bit kernel, which this hoist does not touch.
+     *
+     * The lever, if that ever matters: sort a phase-1 batch by len2 so each lane
+     * group's quanta agree and jsplit returns to ncol. bwamem.cpp:3462 already
+     * does precisely this for the extend path (sortPairsLen with key_by_max,
+     * "so ncol/minq are tight"), and it is byte-identical there because results
+     * scatter back by regid. Not done here because the end-to-end payoff is
+     * projected below the +/-0.5% noise floor: kswv is ~31% of mem CPU and phase 1
+     * is a fraction of that, and EXT-13 -- the same technique -- was predicted at
+     * 1-3% and measured -0.19%.
      * Dummy tail lanes carry len1 == len2 == 0, pinning both to 0 for
      * a partial final group: no fast path, still correct. */
     int minLen1 = p[0].len1, jsplit = ncol;


### PR DESCRIPTION
Comment-only follow-up to #290. No non-comment line changes; `kswv.cpp` still compiles.

## What was stale

The boundary-mask comment above `jsplit` correctly predicted that the phase-0 parity would not carry over to phase 1, then said:

> The measured phase-0 parity therefore does not carry over to phase 1, and bwa-bsw-bench cannot see it — that harness only ever calls `getScores*` with phase 0.

That stopped being true. bwa-bsw-bench now drives phase 1 and times it as its own table, so the predicted cost has been measured on quiet cloud hosts (c7i.4xlarge, c8g.4xlarge, `--n 20000 --reps 7`, two passes agreeing within 1.4%):

| tier | qlen 100 | qlen 150 | qlen 250 |
|---|---:|---:|---:|
| avx512bw | **−7.2%** | **−4.3%** | +0.5% |
| NEON | −2.1% | −1.4% | −0.0% |
| avx2 | −0.8% | +0.5% | −0.3% |

Phase 0 is at parity on every tier, which is what the split is for.

## The two cross-checks are the useful part

Either number alone would just be a measurement. Together they attribute the cost to *this column range* and nothing ambient:

- **avx2 measures noise, and must** — avx2 never had the hoist to restore (its 16-register file spills once the mask is loop-invariant, per the note in that kernel), so #290 did not change its code path at all. A nonzero avx2 delta would have meant the measurement was picking up something else.
- **The cost vanishes at qlen 250**, where the router picks the 16-bit kernel this hoist does not touch.

## Also recorded: the lever, and why it wasn't pulled

Sorting a phase-1 batch by `len2` returns `jsplit` to `ncol` and the per-cell range disappears. `bwamem.cpp:3462` already does exactly this for the extend path (`sortPairsLen` with `key_by_max`, "so `ncol`/`minq` are tight"), and it is byte-identical there because results scatter back by `regid`.

Not done, and the comment now says why: `kswv` is ~31% of `mem` CPU and phase 1 is a fraction of that, so the projected end-to-end effect is below the ±0.5% noise floor — and EXT-13, the same technique, was predicted at 1–3% and measured **−0.19%**. Writing the reason down is the point; otherwise the next person re-derives the idea and re-learns the disappointment.

## One clarification for the record

I had initially read the cloud gate result — pre-fix passes the rescue padding gate at all three x86 tiers, fails only on NEON — as narrowing #290 to "NEON-specific". That is not right, and #290's commit message is accurate as written. The two reconcile: AVX-512BW gated its hoist on `HasFreed`, so it stayed correct under `--meth`, which is what the padding gate exercises; its defect is confined to the non-meth symmetric path where the symptom is a wrong `XS`/`csub`. NEON applied the hoisted mask to both instantiations, so only NEON breaks in a way that gate can see. Worth knowing that the padding gate does **not** cover the AVX-512BW symptom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated performance-related comments for the NEON boundary-mask computation.
  * Documented observed behavior across processing phases, hardware paths, and larger query lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->