### PR TITLE
chore: gitignore the build artifacts the fork rename left uncovered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.a
+*.d
 *.dSYM
 .*.swp
 a.out
@@ -7,6 +8,23 @@ bwa-mem2
 bwa-mem2.*
 !docs/src/related-projects/bwa-mem2.md
 src/version.h
+
+# Build outputs, all produced at the repo root. Anchored with a leading slash so
+# they cannot shadow same-named docs pages the way bwa-mem2.* would without the
+# negation above.
+/bwa-mem3
+/bwa-mem3.arm64
+
+# Standalone test and benchmark binaries (see the `clean` targets in Makefile
+# and test/Makefile). /*_test covers the doctest and regression binaries; the
+# rest do not fit that suffix.
+/*_test
+/fast_reader_selftest
+/fr_fastq_bench
+
+# doctest suites built by test/Makefile
+/test/bwa_mem3_tests_unit
+/test/bwa_mem3_tests_integration
 *.gcno
 *.gcda
 coverage.info


### PR DESCRIPTION
`.gitignore` still ignores `bwa-mem2` and `bwa-mem2.*` from before the fork was renamed, so **none of the binaries this build actually produces are covered**. A working worktree accumulates 47 untracked files that `git status` offers up every time — the two `bwa-mem3` binaries, the root standalone test and benchmark binaries, the two doctest suites under `test/`, and every `test/**/*.d` depfile.

That is a footgun rather than cosmetic noise: staging anything in such a tree means enumerating paths by hand to avoid committing binaries.

## What's here

Patterns are taken from the `clean` targets in `Makefile` and `test/Makefile`, so they track what the build actually emits rather than what happened to be lying around.

The root binaries are anchored with a leading slash (`/bwa-mem3`, not `bwa-mem3`). An unanchored pattern matches at any depth, which is precisely why `bwa-mem2.*` needs its `!docs/src/related-projects/bwa-mem2.md` negation to avoid swallowing a docs page. Anchoring sidesteps that class of problem instead of adding another negation.

## Verification

- All **47** untracked artifacts in a built worktree are matched.
- `git ls-files | git check-ignore --stdin` is **empty** — no tracked path becomes ignored.

The only tracked path that came close to a naive pattern was `test/fast_reader_selftest.c`, which is a `.c` source and is unaffected (`/*_test` requires the `_test` suffix; `selftest` has no underscore before `test`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore rules to exclude additional build outputs, binaries, test executables, benchmarks, and generated dependency files.
  * Preserved required documentation and version files from being ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->