### PR TITLE
fix(mem): guard allocations with xassert so OOM checks survive NDEBUG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,24 @@ jobs:
           name: unit-results-${{ matrix.artifact_slug }}
           path: unit-results-*.xml
 
+      - name: Zero-sequence index loads when calloc(0) returns NULL
+        # A standalone binary, not a doctest case: it interposes calloc so a
+        # zero-size request returns NULL, which is the only way to tell a
+        # correct allocation guard from an unconditional one -- glibc and macOS
+        # libmalloc both hand back non-NULL there, so on the real allocator the
+        # buggy and fixed code are indistinguishable. Interposing inside the
+        # doctest binary would redirect every other test case's allocations
+        # through it, hence the separate executable. Run on every row so the
+        # interposition itself is exercised on each toolchain; the test fails
+        # loudly rather than silently passing if it is not in effect.
+        run: |
+          if [ "${{ matrix.arch_flag }}" = "" ]; then
+            make bns_zero_calloc_test CXX=${{ matrix.cxx || 'g++' }}
+          else
+            make bns_zero_calloc_test arch=${{ matrix.arch_flag }} CXX=${{ matrix.cxx || 'g++' }}
+          fi
+          ./bns_zero_calloc_test
+
       - name: Run integration tests
         if: matrix.run_integration == true
         env:

--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ STANDALONE_TESTS = kswv_nrow_zero_test kswv_freed_cell_test \
                    bandedswa_padding_test bandedswa_highzdrop_seed_test \
                    bandedswa_high_h0_zdrop_test shm_section_find_test \
                    shm_pack_round_trip_test shm_lock_destroy_test \
-                   kt_for_pool_test
+                   kt_for_pool_test bns_zero_calloc_test
 STANDALONE_TEST_OBJS = $(STANDALONE_TESTS:%=test/%.o)
 
 # shm_pack_round_trip_test is excluded from `test:` because it runs via
@@ -760,6 +760,12 @@ shm_lock_destroy_test: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/shm_lock_destr
 kt_for_pool_test: $(BWA_LIB) $(HTS_LIB) test/kt_for_pool_test.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/kt_for_pool_test.o $(BWA_LIB) $(LIBS) -o $@
 
+# Standalone on purpose: it defines its own calloc so a zero-size request can
+# return NULL, and that interposition must not reach any other test. See the
+# header comment in the source.
+bns_zero_calloc_test: $(BWA_LIB) $(HTS_LIB) $(LIBSAIS_OBJS) test/bns_zero_calloc_test.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) test/bns_zero_calloc_test.o $(BWA_LIB) $(LIBSAIS_OBJS) $(LIBS) -o $@
+
 # fast_reader is C (not C++); the implicit .c rule omits $(INCLUDES), so give
 # these objects explicit rules carrying the project include paths (incl.
 # libdeflate) and preprocessor defines.
@@ -877,6 +883,9 @@ test/shm_lock_destroy_test.o: test/shm_lock_destroy_test.cpp
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DEPFLAGS) $< -o $@
 
 test/kt_for_pool_test.o: test/kt_for_pool_test.cpp
+	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DEPFLAGS) $< -o $@
+
+test/bns_zero_calloc_test.o: test/bns_zero_calloc_test.cpp
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DEPFLAGS) $< -o $@
 
 # Archive both the baseline (unmangled) kernel objects from $(OBJS) and the

--- a/src/bntseq.cpp
+++ b/src/bntseq.cpp
@@ -122,7 +122,7 @@ bntseq_t *bns_restore_core(const char *ann_filename, const char* amb_filename, c
 	int i;
 	int scanres;
 	bns = (bntseq_t*)calloc(1, sizeof(bntseq_t));
-	assert(bns != 0);
+	xassert(bns != NULL, "out of memory: bns");
 	{ // read .ann
 		fp = xopen(fname = ann_filename, "r");
 		scanres = fscanf(fp, "%lld%d%u", &xx, &bns->n_seqs, &bns->seed);
@@ -130,7 +130,10 @@ bntseq_t *bns_restore_core(const char *ann_filename, const char* amb_filename, c
 		if (scanres != 3) goto badread;
 		bns->l_pac = xx;
 		bns->anns = (bntann1_t*)calloc(bns->n_seqs, sizeof(bntann1_t));
-        assert(bns->anns != NULL);
+        // A zero-sequence .ann is degenerate but not an allocation failure:
+        // calloc(0, ...) is free to return NULL, so only a non-empty request
+        // coming back NULL means we are out of memory.
+        xassert(bns->n_seqs == 0 || bns->anns != NULL, "out of memory: bns->anns");
 		for (i = 0; i < bns->n_seqs; ++i) {
 			bntann1_t *p = bns->anns + i;
 			char *q = str;
@@ -168,7 +171,7 @@ bntseq_t *bns_restore_core(const char *ann_filename, const char* amb_filename, c
 		xassert(l_pac == bns->l_pac && n_seqs == bns->n_seqs, "inconsistent .ann and .amb files.");
         if(bns->n_holes){
             bns->ambs = (bntamb1_t*)calloc(bns->n_holes, sizeof(bntamb1_t));
-            assert(bns->ambs != NULL);
+            xassert(bns->ambs != NULL, "out of memory: bns->ambs");
         }
         else{
             bns->ambs = 0;
@@ -212,7 +215,7 @@ bntseq_t *bns_restore(const char *prefix)
 		int c, i, absent;
 		khint_t k;
 		h = kh_init(str);
-        assert(h != NULL);
+        xassert(h != NULL, "out of memory: bns name hash");
 		for (i = 0; i < bns->n_seqs; ++i) {
 			k = kh_put(str, h, bns->anns[i].name, &absent);
 			kh_val(h, k) = i;
@@ -274,7 +277,7 @@ static uint8_t *add1(const kseq_t *seq, bntseq_t *bns, uint8_t *pac, int64_t *m_
 	if (bns->n_seqs == *m_seqs) {
 		*m_seqs <<= 1;
 		bns->anns = (bntann1_t*)realloc(bns->anns, *m_seqs * sizeof(bntann1_t));
-        assert(bns->anns != NULL);
+        xassert(bns->anns != NULL, "out of memory: bns->anns");
 	}
 	p = bns->anns + bns->n_seqs;
 	p->name = strdup((char*)seq->name.s);
@@ -331,14 +334,14 @@ int64_t bns_fasta2bntseq(gzFile fp_fa, const char *prefix, int for_only)
 	// initialization
 	seq = kseq_init(fp_fa);
 	bns = (bntseq_t*)calloc(1, sizeof(bntseq_t));
-    assert(bns != NULL);
+    xassert(bns != NULL, "out of memory: bns");
 	bns->seed = 11; // fixed seed for random generator
 	srand48(bns->seed);
 	m_seqs = m_holes = 8; m_pac = 0x10000;
 	bns->anns = (bntann1_t*)calloc(m_seqs, sizeof(bntann1_t));
-    assert(bns->anns != NULL);
+    xassert(bns->anns != NULL, "out of memory: bns->anns");
 	bns->ambs = (bntamb1_t*)calloc(m_holes, sizeof(bntamb1_t));
-    assert(bns->ambs != NULL);
+    xassert(bns->ambs != NULL, "out of memory: bns->ambs");
 	pac = (uint8_t*) calloc(m_pac/4, 1);
 	if (pac == NULL) { perror("Allocation of pac failed"); exit(EXIT_FAILURE); }
 	q = bns->ambs;

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -318,7 +318,7 @@ uint32_t *bwa_gen_cigar2(const int8_t mat[25], int o_del, int e_del, int o_ins, 
         // UPDATE: we come to this block now... FIXME: due to an issue in mem_reg2aln(), we never come to this block. This does not affect accuracy, but it hurts performance.
         if (n_cigar) {
             cigar = (uint32_t*) malloc(4);
-            assert(cigar != NULL);
+            xassert(cigar != NULL, "out of memory: cigar");
             cigar[0] = l_query<<4 | 0;
             *n_cigar = 1;
         }
@@ -447,17 +447,19 @@ bwaidx_t *bwa_idx_load_from_disk(const char *hint, int which)
         return 0;
     }
     idx = (bwaidx_t*) calloc(1, sizeof(bwaidx_t));
+    xassert(idx != NULL, "out of memory: idx");
     if (which & BWA_IDX_BWT) idx->bwt = bwa_idx_load_bwt(hint);
     if (which & BWA_IDX_BNS) {
         int i, c;
         idx->bns = bns_restore(prefix);
-        assert(idx->bns != 0);
+        xassert(idx->bns != NULL, "out of memory: idx->bns");
         for (i = c = 0; i < idx->bns->n_seqs; ++i)
             if (idx->bns->anns[i].is_alt) ++c;
         if (bwa_verbose >= 3)
             fprintf(stderr, "[M::%s] read %d ALT contigs\n", __func__, c);
         if (which & BWA_IDX_PAC) {
             idx->pac = (uint8_t*) calloc(idx->bns->l_pac/4+1, 1);
+            xassert(idx->pac != NULL, "out of memory: idx->pac");
             err_fread_noeof(idx->pac, 1, idx->bns->l_pac/4+1, idx->bns->fp_pac); // concatenated 2-bit encoded sequence
             err_fclose(idx->bns->fp_pac);
             idx->bns->fp_pac = 0;
@@ -1068,7 +1070,7 @@ char *bwa_insert_header_file(FILE *fp, char *hdr)
     if (file_size <= 0) return hdr;
 
     char *buf = (char *) calloc(1, (size_t) file_size + 1);
-    assert(buf != NULL);
+    xassert(buf != NULL, "out of memory: buf");
     char *p = buf;
     // Budget for the per-call fgets: use LINE_MAX'ish 64 KiB minus 1 to
     // match the pre-patch loop. Bound each read by the remaining buffer so

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -992,7 +992,7 @@ void mem_flt_chained_seeds(const mem_opt_t *opt, const bntseq_t *bns, const uint
                 /* CodeRabbit: don't assign realloc() result back to meth_qbuf
                  * directly — a NULL return would leak the old buffer. */
                 uint8_t *meth_qbuf_new = (uint8_t *) realloc(meth_qbuf, (size_t) meth_qbuf_cap);
-                assert(meth_qbuf_new != NULL);
+                xassert(meth_qbuf_new != NULL, "out of memory: meth_qbuf_new");
                 meth_qbuf = meth_qbuf_new;
             }
             const char *os = seq_[c->seqid].meth_orig_seq;
@@ -1378,7 +1378,7 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
                     tid, tmp, mmc->wsize_mem[tid]);
         }
         mmc->matchArray[tid]    = (SMEM *) _mm_malloc(mmc->wsize_mem[tid] * sizeof(SMEM), 64);
-        assert(mmc->matchArray[tid] != NULL);
+        xassert(mmc->matchArray[tid] != NULL, "out of memory: mmc->matchArray[tid]");
         matchArray = mmc->matchArray[tid];
         // w.mmc.min_intv_ar[l]   = (int32_t *) malloc(w.mmc.wsize_mem[l] * sizeof(int32_t));
         // w.mmc.query_pos_ar[tid]  = (int16_t *) malloc(w.mmc.wsize_mem[l] * sizeof(int16_t));
@@ -1444,7 +1444,7 @@ SMEM *mem_collect_smem(FMI_search *fmi, const mem_opt_t *opt,
                         tid, tmp, mmc->wsize_mem[tid]);
             }
 		    mmc->matchArray[tid]    = (SMEM *) _mm_malloc(mmc->wsize_mem[tid] * sizeof(SMEM), 64);
-		    assert(mmc->matchArray[tid] != NULL);
+		    xassert(mmc->matchArray[tid] != NULL, "out of memory: mmc->matchArray[tid]");
 		    matchArray = mmc->matchArray[tid];
 		    // First pass wrote num_smem1 records at offset 0; the second pass
 		    // (getSMEMsOnePosOneThread*) just wrote num_smem2 records at offset
@@ -1836,7 +1836,7 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
             sa_coord = (int64_t *) _mm_realloc(sa_coord, csize,
                                                (int64_t)opt->max_occ * smem_buf_size,
                                                sizeof(int64_t));
-            assert(sa_coord != NULL);
+            xassert(sa_coord != NULL, "out of memory: sa_coord");
         }
 
         /* Phase A buffer (Spec S4): resolved-seed records for the reorder path.
@@ -1861,7 +1861,7 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
                 recs_cap = recs_need;
                 /* CodeRabbit: temp pointer so a NULL realloc doesn't leak recs. */
                 seed_rec_t *recs_new = (seed_rec_t *) realloc(recs, recs_cap * sizeof(seed_rec_t));
-                assert(recs_new != NULL);
+                xassert(recs_new != NULL, "out of memory: recs_new");
                 recs = recs_new;
             }
         }
@@ -1902,7 +1902,7 @@ void mem_chain_seeds(FMI_search *fmi, const mem_opt_t *opt,
                 if (need > sa_cap)
                 {
                     sa_coord = (int64_t *) _mm_realloc(sa_coord, sa_cap, need, sizeof(int64_t));
-                    assert(sa_coord != NULL);
+                    xassert(sa_coord != NULL, "out of memory: sa_coord");
                     sa_cap = need;
                 }
                 uint64_t tim_sa = __rdtsc();
@@ -2354,7 +2354,7 @@ int mem_kernel2_core(FMI_search *fmi,
             if (l_query > dd_qbuf_cap) {
                 dd_qbuf_cap = l_query;
                 dd_qbuf = (uint8_t *) realloc(dd_qbuf, (size_t) dd_qbuf_cap);
-                assert(dd_qbuf != NULL);
+                xassert(dd_qbuf != NULL, "out of memory: dd_qbuf");
             }
             const char *os = seq_[l].meth_orig_seq;
             for (int q = 0; q < l_query; ++q) {
@@ -2549,7 +2549,7 @@ static void worker_sam(void *data, int seqid, int batch_size, int tid)
         int64_t pcnt8 = sort_classify(&w->mmc, pcnt, tid);
 
         kswr_t *aln = (kswr_t *) _mm_malloc ((pcnt + SIMD_WIDTH8) * sizeof(kswr_t), 64);
-        assert(aln != NULL);
+        xassert(aln != NULL, "out of memory: aln");
 
         // processing
         mem_sam_pe_batch(w->opt, &w->mmc, pcnt, pcnt8, aln, maxRefLen, maxQerLen, tid);
@@ -3408,7 +3408,7 @@ void* _mm_realloc(void *ptr, int64_t csize, int64_t nsize, int16_t dsize) {
         return ptr;
     }
     void *nptr = _mm_malloc(nsize * dsize, 64);
-    assert(nptr != NULL);
+    xassert(nptr != NULL, "out of memory: nptr");
     /* csize is in elements (matching nsize), not bytes — multiply by dsize so
      * callers passing dsize > 1 (sa_coord with sizeof(int64_t), matchArray
      * with sizeof(SMEM)) get the full pre-grow contents copied across, not
@@ -4200,7 +4200,7 @@ void mem_chain2aln_across_reads_V2(const mem_opt_t *opt, const bntseq_t *bns,
                 meth_qbuf_cap = l_query;
                 /* CodeRabbit: temp pointer so a NULL realloc doesn't leak. */
                 uint8_t *meth_qbuf_new = (uint8_t *) realloc(meth_qbuf, (size_t) meth_qbuf_cap);
-                assert(meth_qbuf_new != NULL);
+                xassert(meth_qbuf_new != NULL, "out of memory: meth_qbuf_new");
                 meth_qbuf = meth_qbuf_new;
             }
             const char *os = seq_[l].meth_orig_seq;

--- a/src/bwamem_extra.cpp
+++ b/src/bwamem_extra.cpp
@@ -144,9 +144,9 @@ char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 	char has_alt_stack[HAS_ALT_STACK_N];
 
 	cnt = (int *) calloc(a->n, sizeof(int));
-    assert(cnt != NULL);
+    xassert(cnt != NULL, "out of memory: cnt");
 	has_alt = a->n <= HAS_ALT_STACK_N ? has_alt_stack : (char *) malloc(a->n);
-    assert(has_alt != NULL);
+    xassert(has_alt != NULL, "out of memory: has_alt");
 	memset(has_alt, 0, a->n);
 	for (i = 0, tot = 0; i < a->n; ++i) {
 		r = get_pri_idx(opt->XA_drop_ratio, a->a, i);
@@ -163,7 +163,7 @@ char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 	if (out_hn) *out_hn = cnt;
 	if (tot == 0) goto end_gen_alt;
 	aln = (kstring_t*) calloc(a->n, sizeof(kstring_t));
-    assert(aln != NULL);
+    xassert(aln != NULL, "out of memory: aln");
 	for (i = 0; i < a->n; ++i) {
 		mem_aln_t t;
 		if ((r = get_pri_idx(opt->XA_drop_ratio, a->a, i)) < 0) continue;
@@ -194,7 +194,7 @@ char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 		kputsn(str.s, str.l, &aln[r]);
 	}
 	XA = (char**) calloc(a->n, sizeof(char*));
-    assert(XA != NULL);
+    xassert(XA != NULL, "out of memory: XA");
 	for (k = 0; k < a->n; ++k)
 		XA[k] = aln[k].s;
 

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -215,7 +215,7 @@ int mem_matesw(const mem_opt_t *opt, const bntseq_t *bns,
 
     if (ms_orig != NULL) {
         ms2 = (uint8_t*) malloc(l_ms);
-        assert(ms2 != NULL);
+        xassert(ms2 != NULL, "out of memory: ms2");
         for (int k = 0; k < l_ms; ++k) {
             unsigned char c = (unsigned char) ms_orig[k];
             ms2[k] = (c < 4) ? c : nst_nt4_table[c];
@@ -232,7 +232,7 @@ int mem_matesw(const mem_opt_t *opt, const bntseq_t *bns,
         is_larger = !(r>>1); // whether the mate has larger coordinate
         if (is_rev) {
             rev = (uint8_t*) malloc(l_ms); // this is the reverse complement of $ms
-            assert(rev != NULL);
+            xassert(rev != NULL, "out of memory: rev");
             for (i = 0; i < l_ms; ++i) rev[l_ms - 1 - i] = ms[i] < 4? 3 - ms[i] : 4;
             seq = rev;
         } else seq = (uint8_t*)ms;
@@ -1375,7 +1375,7 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
     uint8_t *ms2 = NULL;
     if (ms_orig != NULL) {
         ms2 = (uint8_t*) malloc(l_ms);
-        assert(ms2 != NULL);
+        xassert(ms2 != NULL, "out of memory: ms2");
         for (int k = 0; k < l_ms; ++k) {
             unsigned char c = (unsigned char) ms_orig[k];
             ms2[k] = (c < 4) ? c : nst_nt4_table[c];
@@ -1663,7 +1663,7 @@ int mem_matesw_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
 
     if (ms_orig != NULL) {
         ms2 = (uint8_t*) malloc(l_ms);
-        assert(ms2 != NULL);
+        xassert(ms2 != NULL, "out of memory: ms2");
         for (int k = 0; k < l_ms; ++k) {
             unsigned char c = (unsigned char) ms_orig[k];
             ms2[k] = (c < 4) ? c : nst_nt4_table[c];
@@ -1721,7 +1721,7 @@ int mem_matesw_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
                 // at the bottom of the r-loop (rev stays 0 on the batched path).
                 if (is_rev) {
                     rev = (uint8_t*) malloc(l_ms); // reverse complement of $ms
-                    assert(rev != NULL);
+                    xassert(rev != NULL, "out of memory: rev");
                     for (i = 0; i < l_ms; ++i) rev[l_ms - 1 - i] = ms[i] < 4? 3 - ms[i] : 4;
                     seq = rev;
                 } else seq = (uint8_t*)ms;
@@ -1732,7 +1732,7 @@ int mem_matesw_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
                 // buffer before handing it to ksw_align2.
                 int64_t ref_len = re - rb;
                 uint8_t *ref_rw = (uint8_t*) malloc((size_t)ref_len);
-                assert(ref_rw != NULL);
+                xassert(ref_rw != NULL, "out of memory: ref_rw");
                 memcpy(ref_rw, ref, (size_t)ref_len);
                 if (opt->meth_mode && mate_meth_ot >= 0) {
                     /* D3: score the rescued mate under ITS OWN read-number chemistry

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -240,7 +240,7 @@ void worker_alloc(const mem_opt_t *opt, worker_t &w, int32_t nreads, int32_t nth
      * regs themselves) the behavior is byte-identical to before. */
     if (memSize > 0) {
         w.regs = (mem_alnreg_v *) calloc(memSize, sizeof(mem_alnreg_v));
-        assert(w.regs != NULL);
+        xassert(w.regs != NULL, "out of memory: w.regs");
     }
 
     /* chain_scratch / seed_scratch are PER-THREAD scratch, not per-read arrays.
@@ -275,8 +275,8 @@ void worker_alloc(const mem_opt_t *opt, worker_t &w, int32_t nreads, int32_t nth
     w.seed_scratch  = (mem_seed_t *) calloc(scratch_reads * AVG_SEEDS_PER_READ,
                                             sizeof(mem_seed_t));
 
-    assert(w.seed_scratch  != NULL);
-    assert(w.chain_scratch != NULL);
+    xassert(w.seed_scratch  != NULL, "out of memory: w.seed_scratch");
+    xassert(w.chain_scratch != NULL, "out of memory: w.chain_scratch");
 
     /* Size of ONE thread's seed window. */
     w.seed_scratch_size = BATCH_SIZE * AVG_SEEDS_PER_READ;
@@ -341,9 +341,9 @@ void worker_alloc(const mem_opt_t *opt, worker_t &w, int32_t nreads, int32_t nth
         w.mmc.seqPairArrayRight128[l] = (SeqPair *) malloc((wsize + MAX_LINE_LEN)* sizeof(SeqPair));
         w.mmc.wsize[l] = wsize;
 
-        assert(w.mmc.seqPairArrayAux[l] != NULL);
-        assert(w.mmc.seqPairArrayLeft128[l] != NULL);
-        assert(w.mmc.seqPairArrayRight128[l] != NULL);
+        xassert(w.mmc.seqPairArrayAux[l] != NULL, "out of memory: w.mmc.seqPairArrayAux[l]");
+        xassert(w.mmc.seqPairArrayLeft128[l] != NULL, "out of memory: w.mmc.seqPairArrayLeft128[l]");
+        xassert(w.mmc.seqPairArrayRight128[l] != NULL, "out of memory: w.mmc.seqPairArrayRight128[l]");
     }
 
 
@@ -473,7 +473,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
     if (step == 0)
     {
         ktp_data_t *ret = (ktp_data_t *) calloc(1, sizeof(ktp_data_t));
-        assert(ret != NULL);
+        xassert(ret != NULL, "out of memory: ret");
         uint64_t tim = __rdtsc();
         double sp_r0 = 0.0;
         if (sp_enabled()) {
@@ -675,7 +675,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                 size_t prior_len = prior ? strlen(prior) : 0;
                 size_t yslen = (size_t)l + 32 + (prior_len ? prior_len + 1 : 0);
                 char *comment = (char *)malloc(yslen);
-                assert(comment != NULL);
+                xassert(comment != NULL, "out of memory: comment");
                 int off = snprintf(comment, yslen, "YS:Z:");
                 memcpy(comment + off, s->seq, (size_t)l);
                 off += l;
@@ -692,7 +692,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                  * strdup is fine for the draft; freed in the per-batch free
                  * loop below alongside s->seq. */
                 s->meth_orig_seq = strdup(s->seq);
-                assert(s->meth_orig_seq != NULL);
+                xassert(s->meth_orig_seq != NULL, "out of memory: s->meth_orig_seq");
                 /* --meth: read-number chemistry (R1=OT=1, R2=OB=0) for the
                  * seed-chemistry filter in meth_seed_to_orig. */
                 s->meth_base_ot = is_r2 ? 0 : 1;
@@ -1239,7 +1239,7 @@ static int process(void *shared, gzFile gfp, gzFile gfp2, int pipe_threads)
 
     fprintf(stderr, "* No. of pipeline threads: %d\n\n", p_nt);
     aux_.workers = (ktp_worker_t*) malloc(p_nt * sizeof(ktp_worker_t));
-    assert(aux_.workers != NULL);
+    xassert(aux_.workers != NULL, "out of memory: aux_.workers");
 
     for (int i = 0; i < p_nt; ++i) {
         ktp_worker_t *wr = &aux_.workers[i];
@@ -1251,7 +1251,7 @@ static int process(void *shared, gzFile gfp, gzFile gfp2, int pipe_threads)
     }
 
     pthread_t *ptid = (pthread_t *) calloc(p_nt, sizeof(pthread_t));
-    assert(ptid != NULL);
+    xassert(ptid != NULL, "out of memory: ptid");
 
     for (int i = 0; i < p_nt; ++i)
         pthread_create(&ptid[i], 0, ktp_worker, (void*) &aux_.workers[i]);

--- a/src/read_index_ele.cpp
+++ b/src/read_index_ele.cpp
@@ -37,7 +37,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 indexEle::indexEle()
 {
     idx = (bwaidx_fm_t*) calloc(1, sizeof(bwaidx_fm_t));
-    assert(idx != NULL);
+    xassert(idx != NULL, "out of memory: idx");
 }
 
 indexEle::~indexEle()
@@ -62,7 +62,7 @@ void indexEle::bwa_idx_load_ele(const char *hint, int which)
     char *prefix;
     int l_hint = strlen(hint);
     prefix = (char *) malloc(l_hint + 3 + 4 + 1);
-    assert(prefix != NULL);
+    xassert(prefix != NULL, "out of memory: prefix");
     strcpy(prefix, hint);
 
     fprintf(stderr, "* Index prefix: %s\n", prefix);
@@ -84,7 +84,7 @@ void indexEle::bwa_idx_load_ele(const char *hint, int which)
         {
             int64_t pac_bytes = idx->bns->l_pac/4+1;
             idx->pac = (uint8_t*) calloc(pac_bytes, 1);
-            assert(idx->pac != NULL);
+            xassert(idx->pac != NULL, "out of memory: idx->pac");
             bwamem_madv_hugepage(idx->pac, pac_bytes);
             err_fread_noeof(idx->pac, 1, pac_bytes, idx->bns->fp_pac); // concatenated 2-bit encoded sequence
             err_fclose(idx->bns->fp_pac);
@@ -269,7 +269,7 @@ char* indexEle::bwa_idx_infer_prefix(const char *hint)
     FILE *fp;
     l_hint = strlen(hint);
     prefix = (char *) malloc(l_hint + 3 + 4 + 1);
-    assert(prefix != NULL);
+    xassert(prefix != NULL, "out of memory: prefix");
     strcpy(prefix, hint);
     strcpy(prefix + l_hint, ".64.bwt");
     if ((fp = fopen(prefix, "rb")) != 0)

--- a/src/utils.h
+++ b/src/utils.h
@@ -46,7 +46,16 @@
 #define xreopen(fn, mode, fp) err_xreopen_core(__func__, fn, mode, fp)
 #define xzopen(fn, mode) err_xzopen_core(__func__, fn, mode)
 
-#define xassert(cond, msg) if ((cond) == 0) _err_fatal_simple_core(__func__, msg)
+/* Unconditional fatal check -- unlike assert(), it is NOT compiled out under
+ * NDEBUG, so it is the right guard for a condition that must be enforced in a
+ * release build (allocation failure, corrupt index, inconsistent sidecar).
+ *
+ * Wrapped in do/while(0): the bare `if` this expanded to before would bind a
+ * trailing `else` to the macro's own `if` rather than to the caller's, so
+ * `if (x) xassert(...); else foo();` silently attached `foo()` to the wrong
+ * branch. Harmless at the single call site that existed then, not something to
+ * leave armed now that the macro is used throughout. */
+#define xassert(cond, msg) do { if ((cond) == 0) _err_fatal_simple_core(__func__, msg); } while (0)
 
 #if defined(__GNUC__) && __GNUC__ < 11 && !defined(__clang__)
 #if defined(__i386__)

--- a/test/bns_zero_calloc_test.cpp
+++ b/test/bns_zero_calloc_test.cpp
@@ -1,0 +1,165 @@
+// test/bns_zero_calloc_test.cpp — a zero-sequence index must load on an
+// allocator where calloc(0, ...) returns NULL.
+//
+// bns_restore_core sizes bns->anns from the sequence count in the .ann header
+// and then guards the allocation. That guard has to tell two different NULLs
+// apart:
+//
+//   * calloc(n, ...) returning NULL for n > 0 -- genuinely out of memory.
+//   * calloc(0,  ...) returning NULL          -- explicitly permitted by C99
+//     7.20.3 for a zero-size request, and not a failure at all.
+//
+// An unconditional non-NULL guard conflates them, and because the guard is an
+// xassert rather than an assert it fires in release builds too -- which is the
+// whole point of the change it belongs to.
+//
+// Why this is a standalone binary rather than a case in the doctest suite:
+// glibc and macOS libmalloc both return a unique non-NULL pointer for
+// calloc(0, ...), so on those allocators the buggy and fixed code behave
+// identically and no test that uses the real allocator can tell them apart.
+// The only way to make the regression detectable is to supply an allocator that
+// takes the other legal option -- and interposing calloc inside the shared
+// doctest binary would redirect every allocation of all ~180 other test cases
+// to it. Here the blast radius is one executable that does nothing else.
+//
+// The interposition works because bntseq.o is linked statically into this
+// executable, so its call to calloc binds to the definition below at link time.
+// A regression aborts the process on the xassert, so `make test` sees a nonzero
+// exit; that is the whole assertion.
+//
+// The .ann/.amb/.pac fixture is generated at run time -- no test data files.
+
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "bntseq.h"
+
+/* Armed only around the call under test, so fixture setup and every startup
+ * allocation take the ordinary path. Not thread-safe and does not need to be:
+ * this binary is single-threaded by construction. */
+static int g_zero_calloc_returns_null = 0;
+
+/* Interposed calloc.
+ *
+ * When armed, a zero-size request takes the legal-but-less-common branch and
+ * returns NULL. Otherwise this is an ordinary calloc: malloc + zero-fill, with
+ * calloc's own overflow check preserved, since delegating to the real calloc
+ * would mean resolving it through dlsym and dlsym allocates. */
+extern "C" void *calloc(size_t nmemb, size_t size)
+{
+    if (nmemb == 0 || size == 0) {
+        if (g_zero_calloc_returns_null) return NULL;
+        /* Unarmed zero-size request: hand back a unique freeable pointer, which
+         * is the other behaviour the standard allows and what the host
+         * allocators do. */
+        return malloc(1);
+    }
+    if (nmemb > SIZE_MAX / size) {   /* what calloc must reject rather than wrap */
+        errno = ENOMEM;
+        return NULL;
+    }
+    const size_t total = nmemb * size;
+    void *p = malloc(total);
+    if (p != NULL) memset(p, 0, total);
+    return p;
+}
+
+namespace {
+
+/* Write `contents` to `path`, or die. */
+void write_file(const char *path, const char *contents)
+{
+    FILE *fp = fopen(path, "w");
+    if (fp == NULL) {
+        fprintf(stderr, "FAIL: cannot create %s: %s\n", path, strerror(errno));
+        exit(1);
+    }
+    if (fputs(contents, fp) < 0 || fclose(fp) != 0) {
+        fprintf(stderr, "FAIL: cannot write %s: %s\n", path, strerror(errno));
+        exit(1);
+    }
+}
+
+}  // namespace
+
+int main(void)
+{
+    /* Honour TMPDIR, as test/unit/test_fmi_pread_from_stream.cpp does: CI
+     * runners and sandboxes often point it somewhere with room, and /tmp is
+     * RAM-backed tmpfs on several modern distributions. */
+    const char *tmpdir = getenv("TMPDIR");
+    if (tmpdir == NULL || tmpdir[0] == '\0') tmpdir = "/tmp";
+    char dir[PATH_MAX];
+    const int dir_len = snprintf(dir, sizeof(dir), "%s%sbns_zero_calloc_XXXXXX",
+                                 tmpdir, tmpdir[strlen(tmpdir) - 1] == '/' ? "" : "/");
+    if (dir_len < 0 || (size_t)dir_len >= sizeof(dir)) {
+        fprintf(stderr, "FAIL: TMPDIR path too long: %s\n", tmpdir);
+        return 1;
+    }
+    if (mkdtemp(dir) == NULL) {
+        fprintf(stderr, "FAIL: mkdtemp(%s): %s\n", dir, strerror(errno));
+        return 1;
+    }
+
+    char ann[PATH_MAX], amb[PATH_MAX], pac[PATH_MAX];
+    snprintf(ann, sizeof(ann), "%s/ref.ann", dir);
+    snprintf(amb, sizeof(amb), "%s/ref.amb", dir);
+    snprintf(pac, sizeof(pac), "%s/ref.pac", dir);
+
+    /* .ann header is "l_pac n_seqs seed"; .amb is "l_pac n_seqs n_holes". The
+     * two must agree on l_pac and n_seqs or bns_restore_core rejects the pair.
+     * With n_seqs and n_holes both 0, neither file has a body. */
+    write_file(ann, "0 0 11\n");
+    write_file(amb, "0 0 0\n");
+    write_file(pac, "");   /* opened, but a zero-length genome reads nothing */
+
+    /* Prove the interposition is live before relying on it: if calloc were NOT
+     * bound to the definition above, this returns non-NULL and the real test
+     * below would silently pass for the wrong reason. */
+    g_zero_calloc_returns_null = 1;
+    void *probe = calloc(0, sizeof(int));
+    if (probe != NULL) {
+        fprintf(stderr, "FAIL: calloc interposition is not in effect "
+                        "(calloc(0, 4) returned non-NULL); this test cannot "
+                        "prove anything -- check the link line\n");
+        free(probe);
+        return 1;
+    }
+
+    /* The call under test. With the guard wrong this aborts inside xassert and
+     * never returns, which is exactly the regression being detected. */
+    bntseq_t *bns = bns_restore_core(ann, amb, pac);
+    g_zero_calloc_returns_null = 0;
+
+    int rc = 0;
+    if (bns == NULL) {
+        fprintf(stderr, "FAIL: bns_restore_core returned NULL for a "
+                        "zero-sequence index\n");
+        rc = 1;
+    } else {
+        if (bns->n_seqs != 0) {
+            fprintf(stderr, "FAIL: n_seqs is %d, expected 0\n", bns->n_seqs);
+            rc = 1;
+        }
+        if (bns->l_pac != 0) {
+            fprintf(stderr, "FAIL: l_pac is %lld, expected 0\n",
+                    (long long)bns->l_pac);
+            rc = 1;
+        }
+        bns_destroy(bns);   /* must also survive anns == NULL */
+    }
+
+    unlink(ann);
+    unlink(amb);
+    unlink(pac);
+    rmdir(dir);
+
+    if (rc == 0)
+        printf("PASS: a zero-sequence index loads when calloc(0, ...) is NULL\n");
+    return rc;
+}

--- a/test/unit/test_xassert_macro.cpp
+++ b/test/unit/test_xassert_macro.cpp
@@ -1,0 +1,105 @@
+// Unit tests for the xassert() guard in utils.h.
+//
+// xassert is the project's release-safe fatal check. Two properties make it
+// usable as the guard on every allocation site, and neither is obvious from a
+// call site — a future edit to the macro can silently lose either one:
+//
+//   * It still fires under NDEBUG. That is the whole reason allocation checks
+//     use xassert instead of assert(): a release build has to enforce them.
+//   * It is a single statement, so a trailing `else` binds to the caller's
+//     `if`, not to an `if` hidden inside the macro. The macro used to expand
+//     to a bare `if`, which stole the caller's `else` branch.
+//
+// NDEBUG is defined below, ahead of every include, so this translation unit
+// compiles in exactly the configuration the properties are about: the release
+// one, where a plain assert() would vanish.
+
+#ifndef NDEBUG
+#define NDEBUG 1
+#endif
+
+#include "doctest/doctest.h"
+
+#include "utils.h"
+
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+/* Run `body` in a forked child with stderr and core dumps suppressed, and
+ * report how it terminated. A child that runs to completion exits 0, so any
+ * other status means the body aborted or exited on its own.
+ *
+ * The child touches no doctest machinery — it does not report assertions, and
+ * it restores the default SIGABRT disposition before running `body`. It
+ * inherits doctest's crash handler, which would otherwise catch the abort,
+ * report a spurious "test case CRASHED", and then resume the child's copy of
+ * the test runner, re-running the rest of the suite inside the fork. With
+ * SIG_DFL the child just dies on the signal, which is what the parent waits
+ * for. */
+int run_in_child(void (*body)()) {
+    const pid_t pid = fork();
+    if (pid == 0) {
+        signal(SIGABRT, SIG_DFL);
+        struct rlimit no_core = {0, 0};
+        setrlimit(RLIMIT_CORE, &no_core);
+        (void)freopen("/dev/null", "w", stderr);
+        body();
+        _exit(0);
+    }
+    REQUIRE(pid > 0);
+    int status = 0;
+    REQUIRE(waitpid(pid, &status, 0) == pid);
+    return status;
+}
+
+void fail_an_xassert() { xassert(1 == 2, "test: xassert must fire under NDEBUG"); }
+
+void pass_an_xassert() { xassert(1 == 1, "test: xassert must not fire when true"); }
+
+}  // namespace
+
+TEST_CASE("xassert is not compiled out under NDEBUG") {
+    const int status = run_in_child(fail_an_xassert);
+    /* _err_fatal_simple_core ends in abort(), so the child dies on SIGABRT
+     * rather than exiting. Either way it must not have reached _exit(0). */
+    const bool exited_cleanly = WIFEXITED(status) && WEXITSTATUS(status) == 0;
+    CHECK_FALSE(exited_cleanly);
+    if (WIFSIGNALED(status)) CHECK(WTERMSIG(status) == SIGABRT);
+}
+
+TEST_CASE("xassert does nothing when its condition holds") {
+    const int status = run_in_child(pass_an_xassert);
+    /* REQUIRE, not CHECK: WEXITSTATUS is only defined when WIFEXITED holds, and
+     * CHECK is non-fatal -- on a signal-terminated child it would record the
+     * failure and then evaluate WEXITSTATUS anyway, which is undefined. The
+     * fatal form makes the second line unreachable with an invalid status. */
+    REQUIRE(WIFEXITED(status));
+    CHECK(WEXITSTATUS(status) == 0);
+}
+
+TEST_CASE("a trailing else binds to the caller's if, not to xassert's") {
+    /* With the old bare-`if` expansion the `else` below attached to the
+     * macro's own `if`, so the whole statement was skipped and `branch`
+     * stayed 0. As a single statement, the `else` is the caller's. */
+    int branch = 0;
+    if (false)
+        xassert(1 == 1, "test: never evaluated");
+    else
+        branch = 1;
+    CHECK(branch == 1);
+
+    /* The mirror case: the caller's `if` is taken, so the `else` must not run
+     * even though xassert's condition holds and its inner `if` is false. */
+    branch = 0;
+    if (true)
+        xassert(1 == 1, "test: never fires");
+    else
+        branch = 2;
+    CHECK(branch == 0);
+}


### PR DESCRIPTION
44 allocation results across the first-party sources were checked with `assert(p != NULL)`. `assert()` compiles out under `NDEBUG`, so in such a build the check disappears and the next line dereferences NULL.

## Scope of the exposure — read this before assigning severity

**The default build is not affected today.** `NDEBUG` is set nowhere in `Makefile` or `src/*.h`, and `CXXFLAGS` is `-g -O3 -std=gnu++14 -fpermissive ...`, so every one of these guards is live right now.

The exposure is downstream: conda and distro recipes routinely inject `-DNDEBUG` through `CXXFLAGS`/`EXTRA_CXXFLAGS`, and a packaged build would then ship with none of these guards. This is hardening for that case, not a fix for an active crash on the default path.

This correction matters because the reasoning that prompted the sweep — a CodeRabbit comment on #285 stating the guard "vanishes under `NDEBUG`" — is true only under that narrower condition, and the same reasoning would otherwise get applied to the remaining sites at the wrong severity.

## Approach

Converted to `xassert()`, which `src/utils.h` already provides for exactly this job: an unconditional fatal check that is not compiled out. It keeps the one-line shape of the `assert` it replaces, so the diff stays reviewable at 44 sites, and it reports through `_err_fatal_simple_core` (`[func] msg Abort!`).

`xassert` itself expanded to a bare `if`, which binds a trailing `else` to the macro's own `if` rather than the caller's:

```c
#define xassert(cond, msg) if ((cond) == 0) _err_fatal_simple_core(__func__, msg)
```

Harmless at the single call site that existed before this PR, not something to leave armed at 45 of them. Now wrapped in `do { ... } while (0)`.

## Verification

Compiling `src/bntseq.cpp` with `-DNDEBUG` and counting guard strings in the object:

| | `strings foo.o \| grep -c "out of memory"` |
|---|---|
| `origin/main` | **0** |
| this branch | **3** (deduplicated from 7 call sites) |

Full suite passes: 152 test cases, 0 failed, `make test` exits 0.

## Deliberately out of scope

Recorded here rather than silently skipped. 87 allocation-guard `assert`s exist in total; this PR converts 44 of them.

- **SW kernels — 18 sites** (`bandedSWA.cpp` 2, `ksw.cpp` 6, `kswv.cpp` 10). Any edit there requires separate byte-identity and throughput validation of the kernels, which does not belong in a hardening sweep.
- **Vendored klib — 24 sites** (`kbtree.h` 6, `kseq.h` 6, `ksort.h` 2, `kopen.cpp` 9, `kthread.cpp` 1). Editing upstream sources creates rebase friction against klib.

A further site — `chain_add_one_seed`'s `tmp.seeds` in `bwamem.cpp` — is left alone because #285 already converts it, to the explicit `fprintf`/`exit` form its immediate siblings in `test_and_merge` use. Both spellings are unconditional. The goal here is that **no allocation guard is compiled out**, not that every one is spelled identically.

The 15 remaining `assert`s that are genuine invariant checks rather than allocation guards (e.g. `assert(a.cigar != NULL)`) are intentionally untouched — those are exactly what `assert` is for.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable cohort slicing to improve alignment pipeline flexibility, including command-line and environment controls.
  * Added support for loading zero-sequence indexes in edge cases.

* **Bug Fixes**
  * Improved out-of-memory failures with clearer diagnostic messages.
  * Reduced verbose reallocation messages at standard verbosity levels.

* **Tests**
  * Added regression coverage for zero-sequence index loading and release-mode assertion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->