### PR TITLE
fix(profile): record the compute CPU of a partial cohort slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,3 +624,14 @@ jobs:
 
       - name: stage_prof unit test
         run: make stage_prof_test && ./stage_prof_test
+
+      - name: Partial cohort slices report their compute CPU
+        # Only a STAGE_PROF build can run this, which is why it lives here and
+        # not in the matrix rows above. Cohort slicing gives step 1 an early
+        # exit; if that exit forgets to harvest g_ktfor, the slice's compute CPU
+        # is destroyed rather than merely unreported, and --profile under-counts
+        # in proportion to how much slicing is happening.
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          FIXTURES="$GITHUB_WORKSPACE/test/fixtures" \
+          bash test/regression/profile_slice_cpu.sh

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -425,6 +425,33 @@ void memoryAlloc(ktp_aux_t *aux, worker_t &w, int32_t nreads, int32_t nthreads)
     worker_alloc(aux->opt, w, nreads, nthreads);
 }
 
+/* Copy the compute step's --profile counters out of the per-thread kt_for
+ * accumulator and into this chunk's profile row (see stage_prof.h).
+ *
+ * Step 1 has two exits -- a whole cohort, and a partial cohort that is still
+ * accumulating slices -- and g_ktfor is reset at every step-1 entry, so a path
+ * that forgets to harvest does not merely lose detail: that slice's compute CPU
+ * is gone. Both exits call this, so adding a third cannot silently drop it.
+ *
+ * `sp_p0` is the sp_wall() reading taken at step-1 entry.
+ */
+static void sp_harvest_proc(prof_chunk_t *p, double sp_p0)
+{
+    p->proc_wall      = sp_wall() - sp_p0;
+    p->proc_cpu       = g_ktfor.proc_cpu;
+    p->thr_busy_min   = g_ktfor.thr_busy_min;
+    p->thr_busy_max   = g_ktfor.thr_busy_max;
+    p->thr_busy_mean  = g_ktfor.thr_busy_mean;
+    p->thr_busy_stdev = g_ktfor.thr_busy_stdev;
+    /* encode = SAM/BAM-build CPU (accurate, summed over compute threads);
+     * compute = the rest of the alignment CPU. Same clock, so subtractable.
+     * A slice that only seeds and extends never enters mem_aln2sam, so its
+     * encode is legitimately 0 and compute is the whole of proc_cpu. */
+    p->encode  = g_ktfor.encode;
+    p->compute = (g_ktfor.proc_cpu > g_ktfor.encode)
+                 ? g_ktfor.proc_cpu - g_ktfor.encode : NAN;
+}
+
 ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, worker_t &w)
 {
     ktp_aux_t *aux = (ktp_aux_t*) shared;
@@ -849,7 +876,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                 /* Partial cohort: hand the pipeline a non-NULL empty item. NULL
                  * would retire this worker (see ktp_worker's step advance). */
                 tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
-                if (sp_enabled()) ret->prof.proc_wall = sp_wall() - sp_p0;
+                if (sp_enabled()) sp_harvest_proc(&ret->prof, sp_p0);
                 return ret;
             }
 
@@ -867,19 +894,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         }
         tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
 
-        if (sp_enabled()) {
-            ret->prof.proc_wall      = sp_wall() - sp_p0;
-            ret->prof.proc_cpu       = g_ktfor.proc_cpu;
-            ret->prof.thr_busy_min   = g_ktfor.thr_busy_min;
-            ret->prof.thr_busy_max   = g_ktfor.thr_busy_max;
-            ret->prof.thr_busy_mean  = g_ktfor.thr_busy_mean;
-            ret->prof.thr_busy_stdev = g_ktfor.thr_busy_stdev;
-            /* encode = SAM/BAM-build CPU (accurate, summed over compute threads);
-             * compute = the rest of the alignment CPU. Same clock, so subtractable. */
-            ret->prof.encode  = g_ktfor.encode;
-            ret->prof.compute = (g_ktfor.proc_cpu > g_ktfor.encode)
-                                ? g_ktfor.proc_cpu - g_ktfor.encode : NAN;
-        }
+        if (sp_enabled()) sp_harvest_proc(&ret->prof, sp_p0);
 
         aux->n_processed += ret->n_seqs;
         return ret;

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -22,3 +22,8 @@ matrix row; the rest run on the canonical AVX2 row only. Each script:
 Each script reads its inputs from environment variables — see the comment
 block at the top of each file. `.github/workflows/ci.yml` sets those vars
 and invokes the scripts.
+
+One exception to "any binary will do": `profile_slice_cpu.sh` asserts on
+`--profile` output, which a default build compiles out entirely, so it needs a
+binary from `make STAGE_PROF=1`. It fails loudly rather than skipping if handed
+one without `--profile`, and CI runs it from the `profiling-build` job.

--- a/test/regression/profile_slice_cpu.sh
+++ b/test/regression/profile_slice_cpu.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# test/regression/profile_slice_cpu.sh
+#
+# Regression: --profile must account for the compute CPU of a PARTIAL cohort.
+#
+# Cohort slicing gave step 1 a second exit. A cohort that is still accumulating
+# slices returns early -- it has seeded and extended its slice, but pairing and
+# SAM must wait for the whole cohort -- and that path originally saved only
+# proc_wall. Because g_ktfor is reset at every step-1 entry, the slice's
+# proc_cpu / compute / encode / thr_busy_* were not merely omitted from the row,
+# they were destroyed: nothing else ever reads them.
+#
+# The consequence is a profiler that quietly lies in proportion to how much
+# slicing is happening. At -t 64 the ramp covers ~40% of the run's bases, so
+# ~40% of the compute CPU vanished from the report -- and since the aggregate
+# row derives from the per-chunk rows, the in-PROCESS() budget could not be made
+# to balance. Nothing crashes and no alignment changes, so only an explicit
+# check on the profile output catches it.
+#
+# What makes this test sharp rather than merely present:
+#
+#   1. BWA_MEM3_COHORT_SLICE_ALL=1 slices EVERY cohort rather than only the
+#      first (which is all production does), so a short run produces dozens of
+#      partial slices instead of a handful.
+#
+#   2. The assertion is a boolean, not a threshold: every chunk that read bases
+#      must report proc_cpu > 0. A slice that ran kt_for cannot legitimately
+#      have consumed zero CPU, so there is nothing to tune and nothing to flake.
+#      Before the fix every ramp slice reports exactly 0.0000.
+#
+# Inputs (env vars):
+#   BWA_MEM3 -- path to a bwa-mem3 binary built with STAGE_PROF=1 (so --profile
+#               exists). A default build compiles profiling out entirely.
+#   FIXTURES -- directory containing synthetic_1mb.fa (default: test/fixtures)
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+FIXTURES="${FIXTURES:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)}"
+
+[[ -x "$BWA_MEM3" ]] || { echo "FAIL: binary not executable: $BWA_MEM3" >&2; exit 1; }
+
+src_ref="$FIXTURES/synthetic_1mb.fa"
+[[ -s "$src_ref" ]] || { echo "FAIL: synthetic_1mb.fa missing: $src_ref" >&2; exit 1; }
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/profile_slice_cpu.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT
+
+# --profile only exists in a STAGE_PROF=1 build; without it there is nothing to
+# assert on, and silently passing would make this test worthless in CI.
+# `mem` with no arguments prints usage and exits nonzero, so the output has to be
+# captured before grepping -- piping it straight into grep trips pipefail.
+"$BWA_MEM3" mem > "$WORK/usage.txt" 2>&1 || true
+if ! grep -q -- '--profile' "$WORK/usage.txt"; then
+    echo "FAIL: this binary has no --profile; build with STAGE_PROF=1" >&2
+    exit 1
+fi
+
+ref="$WORK/ref.fa"
+cp "$src_ref" "$ref"
+"$BWA_MEM3" index "$ref" > "$WORK/index.log" 2>&1 \
+    || { echo "FAIL: could not index the reference" >&2; tail -20 "$WORK/index.log" >&2; exit 1; }
+
+# Reads are generated here rather than committed. They must come FROM the
+# reference so they align and the aligner does real per-slice work -- a slice
+# whose reads all fail to seed would report near-zero CPU for honest reasons.
+READS="$WORK/reads.fa"
+READ_LEN=100
+N_READS=20000
+awk -v len="$READ_LEN" -v n="$N_READS" '
+    /^>/  { next }
+          { seq = seq $0 }
+    END {
+        if (length(seq) < len * 2) { print "reference too short" > "/dev/stderr"; exit 1 }
+        # Walk the reference with a stride, wrapping around, so the reads are
+        # spread over the whole sequence instead of piling onto one locus.
+        span   = length(seq) - len
+        stride = 7
+        pos    = 1
+        for (i = 0; i < n; i++) {
+            printf(">r%d\n%s\n", i, substr(seq, pos, len))
+            pos += stride
+            if (pos > span) pos = (pos % span) + 1
+        }
+    }
+' "$ref" > "$READS"
+[[ -s "$READS" ]] || { echo "FAIL: read generation produced nothing" >&2; exit 1; }
+
+# -K is deliberately small so the input spans many cohorts, each of which
+# SLICE_ALL then splits -- exercising the partial-cohort exit repeatedly.
+K=200000
+
+align() {   # $1 = tag, $2 = --cohort-slices, $3 = slice-every-cohort (0/1)
+    local tag="$1" slices="$2" all="$3"
+    BWA_MEM3_COHORT_SLICE_ALL="$all" \
+        "$BWA_MEM3" mem -t 4 -K "$K" --cohort-slices "$slices" \
+        --profile "$WORK/$tag.tsv" "$ref" "$READS" \
+        > "$WORK/$tag.sam" 2> "$WORK/$tag.err" \
+        || { echo "FAIL: $tag exited nonzero" >&2; tail -20 "$WORK/$tag.err" >&2; exit 1; }
+    [[ -s "$WORK/$tag.tsv" ]] || { echo "FAIL: $tag wrote no profile TSV" >&2; exit 1; }
+}
+
+align unsliced 0 0
+align sliced   4 1
+
+# Resolve columns by header name: the TSV schema is append-friendly and a
+# hard-coded index would rot the next time a field is added.
+col() {   # $1 = tsv, $2 = header name -> 1-based column index
+    awk -F'\t' -v want="$2" 'NR==1 { for (i=1;i<=NF;i++) if ($i==want) { print i; exit } }' "$1"
+}
+
+# Rows that read bases (n_bp > 0), excluding the ALL aggregate.
+data_rows() {   # $1 = tsv
+    local f="$1" c_chunk c_bp
+    c_chunk=$(col "$f" chunk); c_bp=$(col "$f" n_bp)
+    awk -F'\t' -v ch="$c_chunk" -v bp="$c_bp" \
+        'NR>1 && $ch!="ALL" && $bp+0 > 0' "$f"
+}
+
+n_unsliced=$(data_rows "$WORK/unsliced.tsv" | wc -l | tr -d ' ')
+n_sliced=$(data_rows "$WORK/sliced.tsv" | wc -l | tr -d ' ')
+partials=$(grep -c 'cohort slice' "$WORK/sliced.err" || true)
+
+echo "  unsliced: $n_unsliced chunk rows"
+echo "  sliced:   $n_sliced chunk rows, $partials partial slice(s) reported by the reader"
+
+# Non-vacuity. If slicing did not actually split any cohort then every row takes
+# the cohort-complete exit, the partial-cohort path is never entered, and the
+# assertion below would pass on a broken build.
+if [ "$n_sliced" -le "$n_unsliced" ] || [ "${partials:-0}" -lt 3 ]; then
+    echo "FAIL: slicing did not produce partial cohorts, so this run cannot" >&2
+    echo "      detect the bug. Expected more rows than the $n_unsliced" >&2
+    echo "      unsliced rows and at least 3 partial slices, got $n_sliced" >&2
+    echo "      rows and ${partials:-0} partial slices." >&2
+    exit 1
+fi
+
+# The assertion: a chunk that read bases ran kt_for, so it cannot have used
+# zero compute CPU. `compute` is derived from proc_cpu, so it must be populated
+# too (an empty cell is NaN -- see sp_chunk_init).
+check() {   # $1 = tsv, $2 = tag
+    local f="$1" tag="$2" c_chunk c_bp c_cpu c_comp
+    c_chunk=$(col "$f" chunk); c_bp=$(col "$f" n_bp)
+    c_cpu=$(col "$f" proc_cpu); c_comp=$(col "$f" compute)
+    awk -F'\t' -v ch="$c_chunk" -v bp="$c_bp" -v cpu="$c_cpu" -v comp="$c_comp" -v tag="$tag" '
+        NR>1 && $ch!="ALL" && $bp+0 > 0 {
+            rows++
+            if ($cpu+0 <= 0) { printf("  %s chunk %s: %s bases but proc_cpu=%s\n", tag, $ch, $bp, $cpu); bad++ }
+            else if ($comp == "")   { printf("  %s chunk %s: proc_cpu=%s but compute is empty\n", tag, $ch, $cpu); bad++ }
+            else total += $cpu
+        }
+        END {
+            printf("  %s: %d/%d rows report compute CPU, %.4f CPU sec total\n", tag, rows-bad, rows, total)
+            exit (bad > 0)
+        }
+    ' "$f"
+}
+
+fail=0
+check "$WORK/unsliced.tsv" unsliced || fail=1
+check "$WORK/sliced.tsv"   sliced   || fail=1
+
+if [ "$fail" -ne 0 ]; then
+    echo "FAIL: --profile dropped the compute CPU of at least one chunk." >&2
+    echo "      A partial cohort must harvest g_ktfor before returning; see" >&2
+    echo "      sp_harvest_proc() and step 1 of kt_pipeline (src/fastmap.cpp)." >&2
+    exit 1
+fi
+
+echo "PASS: every chunk that read bases reports its compute CPU, including the"
+echo "      partial cohort slices that return before pairing and SAM."


### PR DESCRIPTION
Stacked on #307. Fixes a bug that #305 introduced in `--profile` accounting. No behavioural change and no cost in a normal build.

## The bug

Cohort slicing gave step 1 a second exit. A cohort that is still accumulating slices seeds and extends its slice, then returns early, because `mem_pestat` needs the whole cohort before pairing and SAM can run. That path saved only `proc_wall`:

```c
if (!ret->cohort_complete) {
    tprof[MEM_PROCESS2][0] += __rdtsc() - tim;
    if (sp_enabled()) ret->prof.proc_wall = sp_wall() - sp_p0;   /* <- and nothing else */
    return ret;
}
```

`g_ktfor` is reset at every step-1 entry, so the slice's `proc_cpu` / `compute` / `encode` / `thr_busy_*` were not merely omitted from that chunk's row — they were destroyed. Nothing else ever reads them.

The result is a profiler that under-reports compute CPU in proportion to how much slicing is happening, and since the aggregate row is derived from the per-chunk rows, the in-`PROCESS()` budget cannot be made to balance at all. This is how it surfaced: I was trying to decompose the 16→64 thread-scaling loss and the numbers would not add up.

At `-t 64` the ramp covers ~40 % of a run's bases, so ~40 % of the compute CPU was missing. Forcing every cohort to slice 4 ways makes it starker — **0.0190 of 0.0851 CPU sec recorded, 78 % discarded**:

```
sliced chunk 40: 12600 bases but proc_cpu=0.0000
sliced chunk 41: 25000 bases but proc_cpu=0.0000
sliced chunk 42: 50000 bases but proc_cpu=0.0000
...
sliced: 10/50 rows report compute CPU, 0.0190 CPU sec total
```

## The fix

Both exits now go through `sp_harvest_proc()`. That is the point of extracting it rather than copying six assignments: a third exit cannot silently drop the harvest, which is exactly how this happened — the whole-cohort path was already correct and the new path was written beside it.

Every call sits inside `if (sp_enabled())`, which is a compile-time `0` unless built with `STAGE_PROF=1`, so a default build is unaffected. Verified: the default build compiles with no `unused-function` warning and `--profile` remains absent from its usage.

## Test

`test/regression/profile_slice_cpu.sh` asserts that every chunk which read bases reports `proc_cpu > 0`. That is a boolean rather than a threshold — a chunk that ran `kt_for` cannot have consumed zero CPU — so there is nothing to tune and nothing to flake.

Two things make it sharp rather than merely present:

- `BWA_MEM3_COHORT_SLICE_ALL=1` slices every cohort instead of only the first, turning a handful of partial slices into 40.
- It refuses to pass vacuously: if slicing produced no partial cohorts, the partial-cohort exit was never entered and the test fails with that explanation instead of reporting a green pass.

Verified both directions on the same binary:

| | rows reporting compute CPU | recorded |
|---|---:|---:|
| unfixed | 10 / 50 | 0.0190 CPU sec |
| fixed | 50 / 50 | 0.0933 CPU sec |

Reads are generated from the committed reference inside the test, so no fixture is added.

It runs from the existing `profiling-build` CI job, since a default build has no `--profile` to assert on. `test/regression/README.md` notes that requirement, because running this script against a default build fails rather than skips.

## Review notes

- `sp_harvest_proc` is placed just above `kt_pipeline` and takes the `sp_wall()` reading from step-1 entry as an argument, so it stays a pure copy-out with no hidden state.
- A slice that only seeds and extends never enters `mem_aln2sam`, so its `encode` is legitimately `0` and `compute` is the whole of `proc_cpu`. The comment says so, because a reader comparing a slice row against a steady-state row will otherwise wonder why `encode` is empty on one and not the other.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profiling accuracy for partial cohort slices by ensuring processing and compute CPU metrics are fully reported, including early-exit cases.

* **Tests**
  * Added regression coverage for compute CPU accounting in sliced profiling runs.
  * Added validation that profiling output includes complete, non-empty processing metrics.

* **Documentation**
  * Documented the build requirements and CI coverage for the new profiling regression test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->