### PR TITLE
test(regression): scope tier parity to tiers that can run, and wire it into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,26 @@ jobs:
           PIXI_MANIFEST="$GITHUB_WORKSPACE/test/holodeck/pixi.toml" \
           bash test/regression/longread_pe_parity.sh
 
+      - name: SIMD tier parity (avx2 vs avx512bw, chr22)
+        if: matrix.canonical == true
+        # One binary must emit byte-identical SAM whichever usable kernel tier it
+        # dispatches. Scope is avx2/avx512bw: there is no batched kswv kernel
+        # below AVX2 and forcing those tiers aborts the aligner (see the script
+        # header). Cross-build parity is a different property, already covered by
+        # chr22_parity.sh running on the sse41, avx2 and arm64 build jobs.
+        #
+        # On a runner without AVX-512BW there is only one sweepable tier and the
+        # script reports SKIPPED, not PASS — so this step is a no-op there rather
+        # than a false green. It still earns its place: the script had rotted
+        # unrun to the point of aborting on its first tier, and this keeps that
+        # from recurring silently.
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          PARITY_FA=/tmp/chr22/chr22.fa \
+          PARITY_R1=/tmp/chr22-sim/reads.r1.fastq.gz \
+          PARITY_R2=/tmp/chr22-sim/reads.r2.fastq.gz \
+          bash test/regression/all_tiers_parity.sh
+
       - name: Run unit-test harness
         if: matrix.canonical == true || matrix.arch_flag == 'sse41'
         run: |

--- a/test/regression/all_tiers_parity.sh
+++ b/test/regression/all_tiers_parity.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env bash
 # test/regression/all_tiers_parity.sh
 #
-# Regression: validates that running bwa-mem3 with each value of
-# BWAMEM3_FORCE_TIER produces byte-identical SAM output.
+# Regression: validates that one binary, on one host, produces byte-identical
+# SAM whichever of its usable kernels BWAMEM3_FORCE_TIER selects.
 #
-# Must be run on a host that can host every tier — e.g. an AVX-512BW host,
-# which can downgrade to avx2/avx/sse42/sse41 via the env var. Lower-tier
-# hosts skip the tiers above their host floor (BWAMEM3_FORCE_TIER refuses
-# up-tier requests, so we'd just be retesting the host tier).
+# SCOPE: avx2 and avx512bw only (plus neon on arm64, where there is one tier).
+# sse41/sse42/avx are excluded because there is no batched kswv kernel below
+# AVX2 and forcing them kills the aligner — see the ALL_TIERS comment for the
+# full reasoning and the measurement behind it.
+#
+# This script is therefore NOT the cross-build parity check, and should not be
+# mistaken for one. "Does a low-baseline build agree with an avx2 build?" is
+# answered by CI building at sse41/avx2/arm64 baselines and running
+# chr22_parity.sh on each, which asserts byte-identity against bwa itself — a
+# stronger oracle than self-comparison, and transitive across the three builds.
+#
+# Real coverage needs an avx512bw host: on an avx2-only x86 runner, or on arm64,
+# there is exactly one sweepable tier and the script reports SKIPPED rather than
+# claiming a pass it did not earn.
 #
 # Inputs:
 #   BWA_MEM3       — path to the multi-tier bwa-mem3 binary
@@ -31,15 +41,46 @@ trap 'rm -rf "$OUT_DIR"' EXIT
 HOST_TIER_RAW="$(BWAMEM3_DEBUG_SIMD=1 "$BWA_MEM3" 2>&1 || true)"
 HOST_TIER="$(printf '%s\n' "$HOST_TIER_RAW" | sed -n 's/.*SIMD tier: \([a-z0-9]*\).*/\1/p' | head -1)"
 
-# x86 tiers in low-to-high order. Skip any tier above the host (BWAMEM3_FORCE_TIER
+# Tiers in low-to-high order. Skip any tier above the host (BWAMEM3_FORCE_TIER
 # would refuse the request anyway).
-ALL_TIERS=(sse41 sse42 avx avx2 avx512bw neon)
+#
+# sse41/sse42/avx are DELIBERATELY ABSENT. There is no batched kswv kernel below
+# AVX2: src/kswv.cpp's SSE-only getScores8/getScores16 are stubs that
+# exit(EXIT_FAILURE). On a multi-tier build the main TUs are compiled at
+# BASELINE_ARCH (avx2 by default), so BWAMEM_BATCHED_MATESW is 1 and
+# mem_sam_pe_batch_run calls those stubs the moment a pair needs mate rescue.
+# Forcing any of those three tiers on paired-end input therefore kills the
+# aligner: exit 1, one [E::getScores8] per thread, header-only SAM. Measured
+# 2026-07-26 on a c7i.4xlarge, all three tiers, hg38 + 32k pairs.
+#
+# This is not a user-facing gap. Those tiers are unreachable in production --
+# a default build refuses to start below its floor (the simd_dispatch.cpp host
+# precheck, covered by host_floor_enforce.sh), and a genuine pre-AVX2 user
+# builds BASELINE_ARCH=sse41, which compiles BWAMEM_BATCHED_MATESW to 0 and
+# takes the correct scalar mem_sam_pe path. That low-baseline build is covered:
+# CI builds it and runs chr22_parity.sh on it, asserting byte-identity against
+# bwa itself -- as it does for the avx2 and arm64 builds, so the three builds
+# agree with each other transitively. That is a stronger oracle than this
+# script's self-comparison, and it is where cross-build parity actually lives.
+#
+# What remains here is the reachable-tier question: one binary, on one host,
+# must produce the same SAM whichever of its usable kernels it dispatches.
+# Restore a tier below avx2 here only alongside a runtime scalar fallback for
+# tiers with no batched kernel.
+ALL_TIERS=(avx2 avx512bw neon)
+
+# Every tier name the dispatcher can report, batched or not. Kept separate from
+# ALL_TIERS so that narrowing the sweep does not turn a correctly-detected
+# low-tier host into a bogus "detection broke" failure: an sse41-baseline build
+# reports HOST_TIER=sse41, which is a perfectly good detection and simply has no
+# tiers to sweep.
+KNOWN_TIERS=(sse41 sse42 avx avx2 avx512bw neon)
 
 # Fail fast if HOST_TIER didn't parse, or names a tier we don't know about —
 # silent fallthrough below would then test every x86 tier on a non-AVX-512 host
 # and produce a confusing SIGILL rather than a clear "detection broke" message.
 detected_ok=0
-for t in "${ALL_TIERS[@]}"; do
+for t in "${KNOWN_TIERS[@]}"; do
     if [[ "$t" == "$HOST_TIER" ]]; then
         detected_ok=1
         break
@@ -47,25 +88,51 @@ for t in "${ALL_TIERS[@]}"; do
 done
 if [[ "$detected_ok" -ne 1 ]]; then
     echo "FAIL: could not detect host SIMD tier from BWAMEM3_DEBUG_SIMD output" >&2
-    echo "  parsed HOST_TIER='$HOST_TIER' (expected one of: ${ALL_TIERS[*]})" >&2
+    echo "  parsed HOST_TIER='$HOST_TIER' (expected one of: ${KNOWN_TIERS[*]})" >&2
     echo "  raw output was:" >&2
     printf '%s\n' "$HOST_TIER_RAW" >&2
     exit 2
 fi
 echo "Host tier: $HOST_TIER"
 
-# On arm64 there's only one tier; the dispatcher always picks NEON.
+# Select the sweepable tiers: those that both have a batched kswv kernel
+# (ALL_TIERS) and are at or below the host (BWAMEM3_FORCE_TIER is downgrade-only
+# and refuses up-tier requests).
+#
+# Rank against KNOWN_TIERS rather than walking ALL_TIERS until HOST_TIER matches.
+# The old walk relied on the host tier appearing in the list it was iterating;
+# once sub-AVX2 tiers were dropped from that list, an sse41 host would never
+# match, the loop would never break, and it would end up "testing" avx2 and
+# avx512bw -- tiers ABOVE the host, which the dispatcher refuses.
+host_rank=-1
+for i in "${!KNOWN_TIERS[@]}"; do
+    if [[ "${KNOWN_TIERS[$i]}" == "$HOST_TIER" ]]; then host_rank=$i; break; fi
+done
+
 if [[ "$HOST_TIER" == "neon" ]]; then
+    # arm64 has exactly one tier; the dispatcher always picks NEON.
     TIERS=("neon")
 else
     TIERS=()
     for t in "${ALL_TIERS[@]}"; do
         if [[ "$t" == "neon" ]]; then continue; fi
-        TIERS+=("$t")
-        if [[ "$t" == "$HOST_TIER" ]]; then
-            break
-        fi
+        for i in "${!KNOWN_TIERS[@]}"; do
+            if [[ "${KNOWN_TIERS[$i]}" == "$t" ]]; then
+                if [[ "$i" -le "$host_rank" ]]; then TIERS+=("$t"); fi
+                break
+            fi
+        done
     done
+fi
+
+# A host below the batched floor (an sse41/sse42/avx baseline build) has nothing
+# to sweep. Say so plainly instead of reporting an empty pass.
+if [[ "${#TIERS[@]}" -eq 0 ]]; then
+    echo "ALL TIERS PARITY: SKIPPED -- host tier '$HOST_TIER' is below the batched-kswv"
+    echo "  floor (avx2), so this build has no sweepable tiers. Its correctness is covered"
+    echo "  by chr22_parity.sh, which runs on this build in CI and asserts byte-identity"
+    echo "  against bwa. This is NOT a pass."
+    exit 0
 fi
 
 echo "Testing tiers: ${TIERS[*]}"
@@ -90,6 +157,7 @@ VARIANT_LABELS=(default match4)
 VARIANT_ARGS=("" "-A 4")
 
 EXIT=0
+COMPARISONS=0
 for vi in "${!VARIANT_LABELS[@]}"; do
     vlabel="${VARIANT_LABELS[$vi]}"
     # shellcheck disable=SC2206  # intentional word-splitting of the arg string
@@ -99,9 +167,21 @@ for vi in "${!VARIANT_LABELS[@]}"; do
 
     for t in "${TIERS[@]}"; do
         echo ">>> Generating SAM for tier=$t"
+        # Check the exit status explicitly. Relying on `set -e` here aborted the
+        # whole script with no message at all -- the aligner's stderr goes to a
+        # per-tier log, so the operator saw "Generating SAM for tier=X" and a
+        # bare exit code. Say what happened and show the log.
+        set +e
         BWAMEM3_FORCE_TIER="$t" "$BWA_MEM3" mem -t 1 ${vargs[@]+"${vargs[@]}"} \
             "$PARITY_FA" "$PARITY_R1" "$PARITY_R2" \
             > "$OUT_DIR/$vlabel.$t.sam" 2>"$OUT_DIR/$vlabel.$t.log"
+        rc=$?
+        set -e
+        if [[ $rc -ne 0 ]]; then
+            echo "FAIL: [$vlabel] bwa-mem3 exited $rc at tier=$t" >&2
+            sed 's/^/      /' "$OUT_DIR/$vlabel.$t.log" | tail -10 >&2
+            exit 1
+        fi
         echo "    Produced $(wc -c < "$OUT_DIR/$vlabel.$t.sam") bytes"
     done
 
@@ -115,11 +195,25 @@ for vi in "${!VARIANT_LABELS[@]}"; do
             EXIT=1
         else
             echo "OK: [$vlabel] tier $t matches $REF_TIER"
+            COMPARISONS=$((COMPARISONS+1))
         fi
     done
 done
 
-if [[ "$EXIT" -eq 0 ]]; then
-    echo "ALL TIERS PARITY: PASS"
+# NON-VACUITY. With a single testable tier the loop above `continue`s on the
+# reference tier and compares nothing -- and this script used to print
+# "ALL TIERS PARITY: PASS" on the back of zero comparisons. That is the normal
+# case on an avx2-only x86 runner and on every arm64 host (one NEON tier), so
+# the reassuring line would have been the usual outcome rather than the
+# exception. Report the count, and never say PASS for zero.
+if [[ "$EXIT" -ne 0 ]]; then
+    exit "$EXIT"
 fi
-exit "$EXIT"
+if [[ "$COMPARISONS" -eq 0 ]]; then
+    echo "ALL TIERS PARITY: SKIPPED -- only one testable tier on this host (${TIERS[*]}),"
+    echo "  so nothing was compared. This is expected on arm64 and on x86 hosts without"
+    echo "  AVX-512BW; it is NOT a pass. Run on an avx512bw host for real coverage."
+    exit 0
+fi
+echo "ALL TIERS PARITY: PASS ($COMPARISONS comparison(s) across ${#TIERS[@]} tiers: ${TIERS[*]})"
+exit 0


### PR DESCRIPTION
`test/regression/all_tiers_parity.sh` swept `BWAMEM3_FORCE_TIER` over `sse41 sse42 avx avx2 avx512bw`. The first three abort the aligner, so the script died on its first tier having compared nothing — and nothing ran it, so nobody noticed.

## Why those tiers abort

There is no batched kswv kernel below AVX2: `src/kswv.cpp`'s SSE-only `getScores8`/`getScores16` are `exit(EXIT_FAILURE)` stubs. Their comment says "the dispatcher never calls them" and treats the `exit()` as a guard against "a future change opening a runtime call site." That call site is already open — on a multi-tier build the main TUs compile at `BASELINE_ARCH` (avx2), so `BWAMEM_BATCHED_MATESW` is 1 and `mem_sam_pe_batch_run` calls the stubs as soon as a pair needs mate rescue.

Measured on a `c7i.4xlarge`, hg38 + 32k pairs:

| tier | exit | records | `E::getScores` |
|---|---:|---:|---:|
| `sse41` | 1 | 0 | 3 |
| `sse42` | 1 | 0 | 3 |
| `avx` | 1 | 0 | 3 |
| `avx2` | 0 | 64763 | 0 |
| `avx512bw` | 0 | 64763 | 0 |

## Why narrow the sweep instead of fixing the aligner

Because this is not user-facing. Those tiers are unreachable in production:

- A default build refuses to start below its floor (the `simd_dispatch.cpp` host precheck, covered by `host_floor_enforce.sh`).
- A genuine pre-AVX2 user builds `BASELINE_ARCH=sse41`, where the compile-time gate is 0 and mate rescue takes the legacy scalar `mem_sam_pe` path.

I verified that second case rather than assuming it — an `sse41`-baseline build produces alignment records byte-identical to the avx512bw build (`f71ab60d…`, as does a `DISABLE_BATCHED_MATESW=1` control). And the comparison isn't vacuous: the forced-`sse41` crash *proves* this input exercises batched mate rescue, since the stub is only reachable from `mem_sam_pe_batch_run`.

So the only cost of the missing tiers is testability, and the fix that would restore them — a runtime scalar fallback for tiers with no batched kernel — is real surgery in the mate-rescue path for no user-visible gain. Flagged in the `ALL_TIERS` comment as the prerequisite if anyone wants those tiers back.

## This is not the cross-build parity check

Easy to conflate, so the header now says so. "Does a low-baseline build agree with an avx2 build?" is already answered: CI builds at `sse41`, `avx2` and arm64 baselines and runs `chr22_parity.sh` on each, asserting byte-identity **against bwa itself** — a stronger oracle than this script's self-comparison, and transitive across the three builds. What remains here is the reachable-tier question: one binary, one host, same SAM whichever usable kernel it dispatches.

## Three defects fixed while scoping it

- **Vacuous pass.** With one testable tier the diff loop skipped the reference tier, compared nothing, and printed `ALL TIERS PARITY: PASS`. That is the normal case on an avx2-only runner and on *every* arm64 host — the reassuring line was the usual outcome, not the exception. Now counts comparisons and reports `SKIPPED` (never `PASS`) at zero.
- **Silent abort.** The `mem` invocation relied on `set -e`, so a failing tier killed the script with no message at all — stderr went to a per-tier log nobody printed. The operator saw `Generating SAM for tier=sse41` and a bare exit code. Now checks the status and shows the log.
- **Tier selection.** It walked the sweep list looking for the host tier, which breaks once that list no longer contains every tier: an `sse41` host would match nothing, never break, and "test" tiers *above* the host. Now ranks against a separate `KNOWN_TIERS`, and a host below the batched floor reports `SKIPPED` with the reason.

## Verification

Driven against a stub binary across every host tier and outcome:

```
sse41    -> SKIPPED (host below the batched-kswv floor)
avx2     -> Testing tiers: avx2            -> SKIPPED (nothing compared)
avx512bw -> Testing tiers: avx2 avx512bw   -> PASS (2 comparisons across 2 tiers)
neon     -> Testing tiers: neon            -> SKIPPED
bogus    -> FAIL: could not detect host SIMD tier
```

Red cases both fail loudly: tiers emitting different SAM → `FAIL: tier avx2 differs from avx512bw`; a tier exiting 1 → `FAIL: bwa-mem3 exited 1 at tier=avx2` with the log, where it previously died silently.

## CI

Wired into the canonical job, reusing the chr22 fixture already built there. On a runner without AVX-512BW it reports `SKIPPED` rather than a false green — a no-op, but it keeps the script from rotting unrun, which is how it reached the state above.

Full findings: `reports/2026-07-26-sse41-mate-rescue-tier-failure.md` (not in this repo).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SIMD tier parity checks across supported hardware configurations.
  * Regression checks now provide clearer results when comparisons cannot be performed, reporting “Skipped” instead of an incorrect pass.
  * Added more informative diagnostics when a tier-specific test fails.

* **Tests**
  * Added continuous integration coverage to verify identical alignment output across applicable SIMD tiers.
  * Refined tier selection and handling for systems without advanced SIMD support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->