### PR TITLE
perf(mem): size the cohort ramp so it cannot outrun the reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,17 @@ jobs:
           CHR22_SIM_DIR=/tmp/chr22-sim \
           bash test/regression/cohort_slice_identity.sh
 
+      - name: Cohort ramp values are validated (flag and environment alike)
+        if: matrix.canonical == true
+        # --cohort-ramp-first takes plain bases, and atoll("16M") is 16 -- a
+        # positive value, so an unvalidated parse configures a 16-BYTE first
+        # slice for a user who asked for 16 Mbases, silently. The flag must
+        # refuse it and the env spelling must report and ignore it.
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          FIXTURES="$GITHUB_WORKSPACE/test/fixtures" \
+          bash test/regression/cohort_ramp_validation.sh
+
       - name: Chunk cap stays opt-in (batching matches bwa-mem2 at every -t)
         if: matrix.canonical == true
         # bwa and bwa-mem2 both use an uncapped `chunk_size * n_threads` batch.

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -64,13 +64,26 @@ Input/output options:
                  byte-identical. Prefer -K if you want a fixed batch size AND
                  reproducibility [0]
    --cohort-slices INT
-                 read the FIRST batch in INT slices as a geometric ramp ending at
-                 half the batch (INT=6 => batch/64, batch/32, ... batch/2), so
+                 read the FIRST batch as a ramp of up to INT growing slices, so
                  alignment starts before the whole batch has been read. 0 = off
-                 (single read). Later batches are always read whole, since their
-                 read already overlaps the previous batch's compute. Does NOT move
-                 the batch boundary, so output is unchanged. Max 20. Overridden by
-                 BWA_MEM3_COHORT_SLICES [6]
+                 (single read). The slice SIZES come from --cohort-ramp-first and
+                 --cohort-ramp-ratio. Later batches are always read whole, since
+                 their read already overlaps the previous batch's compute. Does NOT
+                 move the batch boundary, so output is unchanged. Max 20. Overridden
+                 by BWA_MEM3_COHORT_SLICES [6]
+   --cohort-ramp-first INT
+                 bases in the FIRST ramp slice. An absolute size, not a fraction of
+                 the batch: this slice's read overlaps nothing and each extra slice
+                 costs one more pipeline pass, and neither cost scales with the
+                 batch. Capped at half the batch so a small batch still gets two
+                 slices. 0 selects the fractional shape (batch / ratio^slices).
+                 Output-neutral. Overridden by BWA_MEM3_COHORT_RAMP_FIRST [16000000]
+   --cohort-ramp-ratio FLOAT
+                 growth factor between consecutive ramp slices. Growing faster than
+                 the reader can deliver the next slice while the current one is
+                 being aligned stalls the pipeline, and that ceiling FALLS as -t
+                 rises because only compute scales with threads. Output-neutral.
+                 Overridden by BWA_MEM3_COHORT_RAMP_RATIO [1.6]
    -v INT        verbose level: 1=error, 2=warning, 3=message, 4+=debugging [3]
    -T INT        minimum score to output [30]
    -h INT[,INT]  if there are <INT hits with score >80.00% of the max score, output all in XA [5,200]

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -90,15 +90,77 @@ static int cal_sub(const mem_opt_t *opt, mem_alnreg_v *r)
     return j < r->n? r->a[j].score : opt->min_seed_len * opt->a;
 }
 
+/* Value at index `k` of the ascending order described by `cnt[0..max_ins]`.
+ *
+ * The counts are a permutation-free description of the sorted array: value v
+ * occupies the index range [cumulative(v-1), cumulative(v)). So the element the
+ * sorted array would hold at `k` is the first v whose cumulative count exceeds k.
+ * Callers only ever pass k < total, which the percentile expressions guarantee.
+ */
+static inline int isize_at_rank(const int64_t *cnt, int max_ins, int64_t k)
+{
+    int64_t seen = 0;
+    for (int v = 0; v <= max_ins; ++v) {
+        seen += cnt[v];
+        if (seen > k) return v;
+    }
+    return max_ins;   /* unreachable while k < total; keeps the return total */
+}
+
 void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n,
                 const mem_alnreg_v *regs, mem_pestat_t pes[4])
 {
-    int i, d, max;
-    uint64_v isize[4];
-    
+    int i, d;
+    int64_t max;
+    /* Insert-size distribution as counts rather than a collected-then-sorted
+     * array. The candidate loop below discards anything above max_ins, so
+     * the values are bounded and a direct-address count array is EXACT -- there
+     * is no bucketing here and nothing is approximated.
+     *
+     * Walking the counts in ascending order visits the same values, the same
+     * number of times, in the same order as walking the sorted array would, and
+     * that is what makes this bit-identical rather than merely equal to within
+     * rounding. In particular the mean and variance loops below add each value
+     * `count` times instead of multiplying by count: multiplying is algebraically
+     * the same and numerically different, because floating-point addition is not
+     * associative and the original summed the elements one at a time.
+     *
+     * This drops an O(m log m) sort and the kvec growth it fed on. mem_pestat is
+     * serial (it needs the whole cohort before pairing can start), so its cost is
+     * a fixed term that thread count cannot reduce -- measured at 30 ns/read,
+     * invariant in both -t and cohort size, i.e. ~0.30 s of every run's wall. */
+    /* Bounded before it sizes an allocation. The old code used max_ins purely as
+     * a filter on collected values, so any value at all was harmless; here it is
+     * a direct-address array bound, and 4*(max_ins+1)*8 bytes with an unbounded
+     * max_ins is a caller-controlled allocation. mem_opt_init() sets 10000 (320
+     * kB) and no CLI option changes it, but max_ins is read from the caller's
+     * mem_opt_t and this is a library entry point -- an INT_MAX field would ask
+     * for 64 GB and a negative one would convert to a huge size_t. Neither is a
+     * value any caller means, so clamp rather than trust:
+     *
+     *   < 0        -> 0. No insert size satisfies `is <= 0`, so every
+     *                 orientation ends up failed for want of pairs, which is
+     *                 the same outcome as a cohort with no usable pairs.
+     *   > the cap  -> the cap. 1 Mbase is orders of magnitude past any real
+     *                 paired-end library and still only 32 MB of counters.
+     *
+     * The candidate filter below uses this bounded value, not opt->max_ins:
+     * filtering on the unclamped field while indexing a clamped array is a
+     * heap overflow, not a fallback. */
+    const int kMaxInsCap = 1000000;
+    int max_ins = opt->max_ins;
+    if (max_ins < 0 || max_ins > kMaxInsCap) {
+        int clamped = max_ins < 0 ? 0 : kMaxInsCap;
+        fprintf(stderr, "[0000][PE] max_ins of %d is out of range; using %d\n",
+                max_ins, clamped);
+        max_ins = clamped;
+    }
+    int64_t *cnt_buf = (int64_t *) calloc((size_t)4 * ((size_t)max_ins + 1), sizeof(int64_t));
+    int64_t *cnt[4], total[4];
+    xassert(cnt_buf != NULL, "out of memory allocating insert-size histogram");
+    for (d = 0; d < 4; ++d) { cnt[d] = cnt_buf + (size_t)d * ((size_t)max_ins + 1); total[d] = 0; }
+
     memset(pes, 0, 4 * sizeof(mem_pestat_t));
-    // memset(isize, 0, sizeof(kvec_t(int)) * 4);
-    memset(isize, 0, sizeof(uint64_v) * 4);
     for (i = 0; i < n>>1; ++i) {
         int dir;
         int64_t is;
@@ -110,36 +172,42 @@ void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n,
         if (cal_sub(opt, r[1]) > MIN_RATIO * r[1]->a[0].score) continue;
         if (r[0]->a[0].rid != r[1]->a[0].rid) continue; // not on the same chr
         dir = mem_infer_dir(l_pac, r[0]->a[0].rb, r[1]->a[0].rb, &is);
-        if (is && is <= opt->max_ins) kv_push(uint64_t, isize[dir], is);
+        if (is && is <= max_ins) { ++cnt[dir][is]; ++total[dir]; }   /* bounded, not opt->max_ins */
     }
-    if (bwa_verbose >= 3) fprintf(stderr, "[0000][PE] # candidate unique pairs for (FF, FR, RF, RR): (%ld, %ld, %ld, %ld)\n", isize[0].n, isize[1].n, isize[2].n, isize[3].n);
+    if (bwa_verbose >= 3) fprintf(stderr, "[0000][PE] # candidate unique pairs for (FF, FR, RF, RR): (%lld, %lld, %lld, %lld)\n",
+                                  (long long)total[0], (long long)total[1], (long long)total[2], (long long)total[3]);
     for (d = 0; d < 4; ++d) { // TODO: this block is nearly identical to the one in bwtsw2_pair.c. It would be better to merge these two.
         mem_pestat_t *r = &pes[d];
-        uint64_v *q = &isize[d];
+        int64_t *q = cnt[d], nq = total[d];
         int p25, p50, p75, x;
-        if (q->n < MIN_DIR_CNT) {
+        if (nq < MIN_DIR_CNT) {
             fprintf(stderr, "[0000][PE] skip orientation %c%c as there are not enough pairs\n", "FR"[d>>1&1], "FR"[d&1]);
             r->failed = 1;
-            free(q->a);
             continue;
         } else fprintf(stderr, "[0000][PE] analyzing insert size distribution for orientation %c%c...\n", "FR"[d>>1&1], "FR"[d&1]);
-        ks_introsort_64(q->n, q->a);
-        p25 = q->a[(int)(.25 * q->n + .499)];
-        p50 = q->a[(int)(.50 * q->n + .499)];
-        p75 = q->a[(int)(.75 * q->n + .499)];
+        /* Same indices the sorted array was subscripted with, so the same values. */
+        p25 = isize_at_rank(q, max_ins, (int64_t)(.25 * nq + .499));
+        p50 = isize_at_rank(q, max_ins, (int64_t)(.50 * nq + .499));
+        p75 = isize_at_rank(q, max_ins, (int64_t)(.75 * nq + .499));
         r->low  = (int)(p25 - OUTLIER_BOUND * (p75 - p25) + .499);
         if (r->low < 1) r->low = 1;
         r->high = (int)(p75 + OUTLIER_BOUND * (p75 - p25) + .499);
         fprintf(stderr, "[0000][PE] (25, 50, 75) percentile: (%d, %d, %d)\n", p25, p50, p75);
         fprintf(stderr, "[0000][PE] low and high boundaries for computing mean and std.dev: (%d, %d)\n", r->low, r->high);
-        for (i = x = 0, r->avg = 0; i < q->n; ++i)
-            if (q->a[i] >= r->low && q->a[i] <= r->high)
-                r->avg += q->a[i], ++x;
+        /* The sorted array is ascending, so its [low, high] filter selects one
+         * contiguous run -- exactly this range of values, each repeated its own
+         * count of times. Hence the inner loops, and hence identical arithmetic. */
+        int lo = r->low  > 0       ? r->low  : 0;
+        int hi = r->high < max_ins ? r->high : max_ins;
+        for (x = 0, r->avg = 0; lo <= hi; ++lo)
+            for (int64_t k = 0; k < q[lo]; ++k)
+                r->avg += lo, ++x;
         assert(x != 0);
         r->avg /= x;
-        for (i = 0, r->std = 0; i < q->n; ++i)
-            if (q->a[i] >= r->low && q->a[i] <= r->high)
-                r->std += (q->a[i] - r->avg) * (q->a[i] - r->avg);
+        lo = r->low > 0 ? r->low : 0;
+        for (r->std = 0; lo <= hi; ++lo)
+            for (int64_t k = 0; k < q[lo]; ++k)
+                r->std += (lo - r->avg) * (lo - r->avg);
         r->std = sqrt(r->std / x);
         fprintf(stderr, "[0000][PE] mean and std.dev: (%.2f, %.2f)\n", r->avg, r->std);
         r->low  = (int)(p25 - MAPPING_BOUND * (p75 - p25) + .499);
@@ -148,12 +216,12 @@ void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n,
         if (r->high < r->avg + MAX_STDDEV * r->std) r->high = (int)(r->avg + MAX_STDDEV * r->std + .499);
         if (r->low < 1) r->low = 1;
         fprintf(stderr, "[0000][PE] low and high boundaries for proper pairs: (%d, %d)\n", r->low, r->high);
-        free(q->a);
     }
+    free(cnt_buf);
     for (d = 0, max = 0; d < 4; ++d)
-        max = max > isize[d].n? max : isize[d].n;
+        max = max > total[d]? max : total[d];
     for (d = 0; d < 4; ++d)
-        if (pes[d].failed == 0 && isize[d].n < max * MIN_DIR_RATIO) {
+        if (pes[d].failed == 0 && total[d] < max * MIN_DIR_RATIO) {
             pes[d].failed = 1;
             fprintf(stderr, "[0000][PE] skip orientation %c%c\n", "FR"[d>>1&1], "FR"[d&1]);
         }

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -74,6 +74,64 @@ extern uint64_t tprof[LIM_R][LIM_C];
 #define COHORT_SLICES_DEFAULT 6
 #define COHORT_SLICES_MAX     20
 
+/* Ramp SHAPE defaults (--cohort-ramp-first / --cohort-ramp-ratio). At file scope
+ * for the same reason as the constants above: usage() is defined before
+ * main_mem, so a function-local default cannot be printed in `mem --help` and
+ * would have to be duplicated as a literal there. See the derivation at the
+ * cohort_ramp_ratio declaration in main_mem.
+ *
+ * Kept ABOVE the architecture split below, like the constants above: these are
+ * read by kt_pipeline, usage() and main_mem on every architecture, so defining
+ * them inside the ARM branch would leave them undeclared on x86. */
+static const double  cohort_ramp_ratio_default = 1.6;
+static const int64_t cohort_ramp_first_default = 16000000;
+
+/* Strict parsers shared by the batch-shaping options (--chunk-cap,
+ * --cohort-slices, --cohort-ramp-ratio, --cohort-ramp-first) and by each one's
+ * BWA_MEM3_* env override.
+ *
+ * Every one of those options had to reject what atoll()/atof() silently accept:
+ * a typo parses as 0, and 0 means "off" or "use the default" for all of them,
+ * so an unvalidated parse quietly disables the very thing the option was set to
+ * configure -- and atoll("16M") is 16, a SIXTEEN-BYTE first slice rather than
+ * 16 Mbases. That made every site carry the same errno/end-pointer/range
+ * checks, which is how one site once shipped a bare atoll() while its siblings
+ * were already hardened, and how the env spelling of --cohort-slices came to
+ * hardcode its upper bound instead of naming COHORT_SLICES_MAX. One
+ * implementation each removes both failure modes.
+ *
+ * Both return 0 on success and -1 on rejection, leaving *out untouched, so the
+ * caller keeps its own choice of fatal (CLI, nothing loaded yet) versus warn
+ * and carry on (env, index already read). */
+
+/* Reject unless `s` is a complete decimal integer within [min, max]. */
+static int parse_bounded_i64(const char *s, int64_t min, int64_t max, int64_t *out)
+{
+    char *end = NULL;
+    errno = 0;
+    const long long v = strtoll(s, &end, 10);
+    if (end == s || end == NULL || *end != '\0' || errno == ERANGE ||
+        (int64_t)v < min || (int64_t)v > max)
+        return -1;
+    *out = (int64_t)v;
+    return 0;
+}
+
+/* Reject unless `s` is a complete floating-point number. Range is deliberately
+ * NOT checked: the ramp-ratio sites share a documented `<= 1` fallback that
+ * reports and substitutes the default rather than failing, so only parseability
+ * belongs here. */
+static int parse_full_double(const char *s, double *out)
+{
+    char *end = NULL;
+    errno = 0;
+    const double v = strtod(s, &end);
+    if (end == s || end == NULL || *end != '\0' || errno == ERANGE)
+        return -1;
+    *out = v;
+    return 0;
+}
+
 #if defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)
 /* ARM/Apple Silicon - no CPUID instruction, use system calls */
 
@@ -486,11 +544,13 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
          *
          * A cohort is one task_size batch. Normally it is read in a single call
          * and this is exactly the old code path. When slicing is enabled the
-         * FIRST cohort is read in a geometric ramp that doubles each slice and
-         * ends at task/2: with the default cohort_slices = 6 that is task/64,
-         * task/32, ... task/2. Compute therefore starts working while the rest
-         * is still being read -- only the first read of a run overlaps nothing,
-         * and it is the largest single unhidden cost in the pipeline.
+         * FIRST cohort is read as a ramp of growing slices: the first is an
+         * absolute cohort_ramp_first bases (16 Mbase by default, capped at
+         * task/2) and each next is cohort_ramp_ratio times the previous (1.6 by
+         * default), for at most cohort_slices slices. Compute therefore starts
+         * working while the rest is still being read -- only the first read of a
+         * run overlaps nothing, and it is the largest single unhidden cost in
+         * the pipeline.
          *
          * The target for every slice is clamped to the bases the cohort still
          * needs. That clamp is load-bearing, not defensive: both readers stop at
@@ -514,14 +574,70 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         if (aux->cohort_slices > 0 &&
             (aux->cohort_slice_all || aux->cohort_index == 0) &&
             aux->cohort_slice < aux->cohort_slices) {
-            int shift = (int)(aux->cohort_slices - aux->cohort_slice);
-            if (shift > COHORT_SLICES_MAX) shift = COHORT_SLICES_MAX;
-            int64_t ramped = aux->task_size >> shift;
+            /* How fast the ramp is allowed to grow. Doubling every slice is only
+             * free while the reader can deliver slice k+1 inside the time step 1
+             * spends on slice k; past that the ramp starves the very pipeline it
+             * exists to fill. See cohort_ramp_ratio in fastmap.h. */
+            double ratio = aux->cohort_ramp_ratio;
+            int64_t ramped;
+            if (aux->cohort_slice == 0 || aux->ramp_prev_target <= 0) {
+                /* The first slice is an ABSOLUTE size, not a fraction of the
+                 * cohort. Both costs it trades against are absolute -- its own
+                 * read overlaps nothing, and every extra slice costs one more
+                 * kt_for pass -- so nothing about the right answer scales with
+                 * task_size. Sizing it as task_size/ratio^depth made it grow with
+                 * -t, which is backwards: task_size is chunk_size * n_threads, so
+                 * at -t 128 a 1280 Mbase cohort would open with a 76 Mbase slice
+                 * and 0.37 s of pure unhidden fill, against 0.077 s for a fixed
+                 * 16 Mbase. The penalty grows linearly with thread count.
+                 *
+                 * Capped at half the cohort so a small task_size (a short test,
+                 * or an explicit -K) still gets at least two slices.
+                 *
+                 * The stress knob keeps the fractional shape on purpose: it
+                 * exists to make a short run cross as many cohort boundaries as
+                 * possible, and is explicitly not a performance mode. */
+                if (aux->cohort_ramp_first > 0 && !aux->cohort_slice_all) {
+                    ramped = aux->cohort_ramp_first;
+                    if (ramped > aux->task_size >> 1) ramped = aux->task_size >> 1;
+                } else if (ratio == 2.0) {
+                    /* Ratio 2 keeps the original integer shift, so pinning the
+                     * ratio to 2 with --cohort-ramp-first 0 reproduces the
+                     * pre-existing slice sizes exactly rather than approximately
+                     * via pow(). That exactness is what makes an A/B against the
+                     * old shape meaningful. */
+                    int shift = (int)(aux->cohort_slices - aux->cohort_slice);
+                    if (shift > COHORT_SLICES_MAX) shift = COHORT_SLICES_MAX;
+                    ramped = aux->task_size >> shift;
+                } else {
+                    double denom = pow(ratio, (double)aux->cohort_slices);
+                    ramped = (denom > 1.0)
+                             ? (int64_t)((double)aux->task_size / denom)
+                             : aux->task_size;
+                }
+            } else {
+                /* Saturate in double space, before the narrowing cast. The
+                 * ratio is only validated as > 1.0, so a sweep value like 30
+                 * or 100 compounds ramp_prev_target past INT64_MAX within a
+                 * handful of slices, and converting an out-of-range double to
+                 * int64_t is undefined behaviour. Saturating at task_size
+                 * costs nothing: slice_target is never above task_size, so a
+                 * ramp at or past it already means "the whole cohort", and it
+                 * keeps the stored ramp_prev_target from compounding away. */
+                const double grown = (double)aux->ramp_prev_target * ratio;
+                ramped = (grown >= (double)aux->task_size)
+                         ? aux->task_size
+                         : (int64_t)grown;
+            }
+
             /* A slice must stay large enough for its own SMEM/BSW batching to be
              * efficient; below this the extra kt_for passes cost more than the
              * overlap they buy. The stress knob deliberately bypasses this. */
             int64_t floor_bases = aux->cohort_slice_all ? 1 : 1000000;
             if (ramped < floor_bases) ramped = floor_bases;
+            /* Remember the REQUESTED size, not what the reader returns: the ramp
+             * shape must not drift with each slice's whole-record overshoot. */
+            aux->ramp_prev_target = ramped;
             if (ramped < slice_target) slice_target = ramped;
         }
 
@@ -561,6 +677,7 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         if (ret->cohort_complete) {
             aux->cohort_bases = 0;
             aux->cohort_slice = 0;
+            aux->ramp_prev_target = 0;
             aux->cohort_index++;
             /* This item carries the cohort's arena to the write stage, which
              * destroys it. Drop our reference so the NEXT cohort starts fresh. */
@@ -1368,13 +1485,29 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                 byte-identical. Prefer -K if you want a fixed batch size AND\n");
     fprintf(stderr, "                 reproducibility [0]\n");
     fprintf(stderr, "   --cohort-slices INT\n");
-    fprintf(stderr, "                 read the FIRST batch in INT slices as a geometric ramp ending at\n");
-    fprintf(stderr, "                 half the batch (INT=6 => batch/64, batch/32, ... batch/2), so\n");
+    fprintf(stderr, "                 read the FIRST batch as a ramp of up to INT growing slices, so\n");
     fprintf(stderr, "                 alignment starts before the whole batch has been read. 0 = off\n");
-    fprintf(stderr, "                 (single read). Later batches are always read whole, since their\n");
-    fprintf(stderr, "                 read already overlaps the previous batch's compute. Does NOT move\n");
-    fprintf(stderr, "                 the batch boundary, so output is unchanged. Max 20. Overridden by\n");
-    fprintf(stderr, "                 BWA_MEM3_COHORT_SLICES [%d]\n", (int)COHORT_SLICES_DEFAULT);
+    fprintf(stderr, "                 (single read). The slice SIZES come from --cohort-ramp-first and\n");
+    fprintf(stderr, "                 --cohort-ramp-ratio. Later batches are always read whole, since\n");
+    fprintf(stderr, "                 their read already overlaps the previous batch's compute. Does NOT\n");
+    fprintf(stderr, "                 move the batch boundary, so output is unchanged. Max %d. Overridden\n",
+            (int)COHORT_SLICES_MAX);
+    fprintf(stderr, "                 by BWA_MEM3_COHORT_SLICES [%d]\n", (int)COHORT_SLICES_DEFAULT);
+    fprintf(stderr, "   --cohort-ramp-first INT\n");
+    fprintf(stderr, "                 bases in the FIRST ramp slice. An absolute size, not a fraction of\n");
+    fprintf(stderr, "                 the batch: this slice's read overlaps nothing and each extra slice\n");
+    fprintf(stderr, "                 costs one more pipeline pass, and neither cost scales with the\n");
+    fprintf(stderr, "                 batch. Capped at half the batch so a small batch still gets two\n");
+    fprintf(stderr, "                 slices. 0 selects the fractional shape (batch / ratio^slices).\n");
+    fprintf(stderr, "                 Output-neutral. Overridden by BWA_MEM3_COHORT_RAMP_FIRST [%lld]\n",
+            (long long)cohort_ramp_first_default);
+    fprintf(stderr, "   --cohort-ramp-ratio FLOAT\n");
+    fprintf(stderr, "                 growth factor between consecutive ramp slices. Growing faster than\n");
+    fprintf(stderr, "                 the reader can deliver the next slice while the current one is\n");
+    fprintf(stderr, "                 being aligned stalls the pipeline, and that ceiling FALLS as -t\n");
+    fprintf(stderr, "                 rises because only compute scales with threads. Output-neutral.\n");
+    fprintf(stderr, "                 Overridden by BWA_MEM3_COHORT_RAMP_RATIO [%.1f]\n",
+            cohort_ramp_ratio_default);
     fprintf(stderr, "   -v INT        verbose level: 1=error, 2=warning, 3=message, 4+=debugging [%d]\n", bwa_verbose);
     fprintf(stderr, "   -T INT        minimum score to output [%d]\n", opt->T);
     fprintf(stderr, "   -h INT[,INT]  if there are <INT hits with score >%.2f%% of the max score, output all in XA [%d,%d]\n",
@@ -1517,16 +1650,90 @@ int main_mem(int argc, char *argv[])
      * the batch (pestat cohort) boundary is unchanged, only the physical read
      * granularity inside it. 0 = one slice, i.e. the pre-slicing behaviour.
      *
-     * The default was swept, not guessed. Wall time improves monotonically with
-     * depth because each extra slice halves the still-unoverlapped head again,
-     * and 6 takes the first slice to task/64 -- small next to the compute it
-     * unblocks, and about where the 1 Mbase slice floor starts truncating the
-     * ramp on ordinary inputs anyway. The measured sweep is in the PR that
+     * The default was swept, not guessed. This is the ramp's DEPTH only -- an
+     * upper bound on how many slices the first cohort is carved into. Their sizes
+     * come from cohort_ramp_first and cohort_ramp_ratio below, so the depth binds
+     * only until the ramp reaches the cohort or the 1 Mbase slice floor, which is
+     * about where 6 lands on ordinary inputs. The measured sweep is in the PR that
      * introduced this option rather than here: it is a wall-clock result for one
      * host, thread count and input, so it dates in a way the shape of the curve
      * does not, and it would read as live justification long after it stopped
      * being one. */
     int64_t      cohort_slices             = COHORT_SLICES_DEFAULT;
+    /* --cohort-ramp-first / --cohort-ramp-ratio: the ramp's shape. Output-neutral
+     * at any setting -- these change slice SIZES, and the cohort boundary is
+     * pinned by the slice-target clamp, not by how the cohort is carved up.
+     *
+     * A ramp schedule pays exactly three costs, all measured on wgs-5M/hg38
+     * (c8g.16xlarge, warm cache, from --profile):
+     *
+     *   fill      the first slice's read, which by definition overlaps nothing.
+     *             Reading is single-threaded and flat at 4.83 ms/Mbase at every -t.
+     *   stalls    while step 1 computes slice k the reader must deliver slice k+1,
+     *             so growth of r stalls unless r <= (compute s/base)/(read s/base).
+     *             Compute is 31.5 / 15.4 / 7.87 ms/Mbase at -t 16 / 32 / 64, so
+     *             that ceiling is 6.5 / 3.2 / 1.63 -- it FALLS as threads are
+     *             added, because only compute scales.
+     *   overhead  every extra slice is one more kt_for pass over the pipeline:
+     *             0.0351 / 0.0498 / 0.0689 s per slice at -t 16 / 32 / 64,
+     *             measured from Sproc_wall against ramp slice count.
+     *
+     * Those pull in opposite directions and the third is easy to forget: at low
+     * -t stalls are impossible and overhead rules, so few large slices win; at
+     * high -t the stall ceiling binds and the ratio must stay under it.
+     *
+     * A cost model over those three terms suggested r=1.80, and measurement
+     * refused it: at -t 64 that is ABOVE the 1.63 ceiling, and the run sat right on
+     * the cliff -- mid-run stall 0.109 s on one rep and 0.614 s on the next, with a
+     * 0.54 s PROCESS spread. The model under-predicts stalls near the ceiling, so
+     * the ratio stays at 1.6, under it.
+     *
+     * Measured in one binary, three shapes selected by the env knobs, 3 reps
+     * interleaved, warm cache, warmup discarded, EVERY arm writing SAM to a real
+     * file (head / mid / overhead from --profile; ramp = slice count):
+     *
+     *    -t   shape                 ramp    head     mid    ovhd    PROCESS
+     *    16   fractional, r=2.0        7   0.018   0.000   0.211   86.44
+     *    16   fractional, r=1.6        6   0.051   0.000   0.175   86.51
+     *    16   absolute 16 Mb, r=1.6    5   0.081   0.000   0.140   86.50
+     *    32   fractional, r=2.0        7   0.034   0.000   0.299   44.45
+     *    32   fractional, r=1.6        6   0.099   0.000   0.249   44.47
+     *    32   absolute 16 Mb, r=1.6    6   0.087   0.000   0.249   44.49
+     *    64   fractional, r=2.0        7   0.066   0.416   0.413   23.99
+     *    64   fractional, r=1.6        6   0.199   0.000   0.345   23.62
+     *    64   absolute 16 Mb, r=1.6    7   0.095   0.018   0.413   23.61
+     *
+     * The ratio is what buys wall time: at -t 64 it takes the mid-run stall from
+     * 0.416 s to zero, -1.5% end to end. It costs 0.06-0.07 s (0.07%) at -t 16/32,
+     * where no stall was possible to begin with.
+     *
+     * The absolute first slice is a WASH on this input at every rung -- -0.005 /
+     * -0.012 / -0.017 s in the ramp terms, and inside the run-to-run spread end to
+     * end. It is here for what the table shows about how the fractional form
+     * SCALES, not for a speedup. Sizing the first slice as task_size/ratio^depth
+     * makes it grow with -t, because task_size is chunk_size * n_threads, and the
+     * measured head fill tracks that exactly: 0.051 -> 0.099 -> 0.199 s across
+     * -t 16 -> 32 -> 64, doubling with every rung. The absolute form is flat at
+     * 0.081 -> 0.087 -> 0.095 s. Extending the same arithmetic, -t 128 would open
+     * a 1280 Mbase cohort with a 76 Mbase slice and ~0.37 s of wholly unhidden
+     * fill. Fill and overhead are both absolute costs, so nothing about the right
+     * first slice scales with the cohort; the fractional form only looked free
+     * because it was never measured above -t 64.
+     *
+     * The honest cost of pinning it: at -t 64 the absolute slice needs one extra
+     * ramp slice (7 vs 6), and that +0.068 s of kt_for overhead eats most of the
+     * 0.104 s of head fill it saves. That trade gets better with -t, since fill
+     * would keep doubling while the per-slice cost does not.
+     *
+     * Deriving the ratio at run time from the ramp's own slices was implemented
+     * and rejected. Beyond a sign error, it is not robust: the estimate must come
+     * from the small early slices, which under-report compute throughput because
+     * fixed kt_for costs dominate, and its outcome at -t 64 flips sign on whether
+     * step 1 is one or two slices behind step 0 -- a scheduling artifact, not
+     * something a policy can pin. A fixed pair is deterministic and measured
+     * better. */
+    double       cohort_ramp_ratio         = cohort_ramp_ratio_default;
+    int64_t      cohort_ramp_first         = cohort_ramp_first_default;
 
     mem_opt_t    *opt, opt0;
     gzFile        fp = 0, fp2 = 0;
@@ -1576,6 +1783,8 @@ int main_mem(int argc, char *argv[])
         OPT_COMPAT,
         OPT_CHUNK_CAP,
         OPT_COHORT_SLICES,
+        OPT_COHORT_RAMP_RATIO,
+        OPT_COHORT_RAMP_FIRST,
 #ifdef STAGE_PROF
         OPT_PROFILE,
 #endif
@@ -1592,6 +1801,8 @@ int main_mem(int argc, char *argv[])
         {"extend-mate-concordant",   optional_argument, 0, OPT_EXTEND_MATE_CONCORDANT},
         {"chunk-cap",                required_argument, 0, OPT_CHUNK_CAP},
         {"cohort-slices",            required_argument, 0, OPT_COHORT_SLICES},
+        {"cohort-ramp-ratio",        required_argument, 0, OPT_COHORT_RAMP_RATIO},
+        {"cohort-ramp-first",        required_argument, 0, OPT_COHORT_RAMP_FIRST},
         {"meth",                     optional_argument, 0, OPT_METH},
         {"meth-scoring",             required_argument, 0, OPT_METH_SCORING},
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
@@ -1858,18 +2069,13 @@ int main_mem(int argc, char *argv[])
              * means "no cap". A typo would therefore silently change the batch
              * size, which is the exact class of invisible batching change this
              * option exists to make explicit. */
-            char *end = NULL;
-            errno = 0;
-            long long v = strtoll(optarg, &end, 10);
-            if (end == optarg || end == NULL || *end != '\0' ||
-                errno == ERANGE || v < 0) {
+            if (parse_bounded_i64(optarg, 0, INT64_MAX, &chunk_cap) != 0) {
                 fprintf(stderr, "ERROR: --chunk-cap requires a non-negative "
                                 "integer number of bases (0 = off), got '%s'\n", optarg);
                 free(opt);
                 if (out_opened) fclose(aux.fp);
                 return 1;
             }
-            chunk_cap = (int64_t)v;
             chunk_cap_set = 1;
         }
         else if (c == OPT_COHORT_SLICES) {
@@ -1880,11 +2086,7 @@ int main_mem(int argc, char *argv[])
              * ramp shift is clamped there anyway, so a larger value is
              * indistinguishable from it and asking for it is a mistake worth
              * naming. */
-            char *end = NULL;
-            errno = 0;
-            long long v = strtoll(optarg, &end, 10);
-            if (end == optarg || end == NULL || *end != '\0' ||
-                errno == ERANGE || v < 0 || v > COHORT_SLICES_MAX) {
+            if (parse_bounded_i64(optarg, 0, COHORT_SLICES_MAX, &cohort_slices) != 0) {
                 fprintf(stderr, "ERROR: --cohort-slices requires an integer in "
                                 "0..%d (0 = off), got '%s'\n",
                         (int)COHORT_SLICES_MAX, optarg);
@@ -1892,7 +2094,37 @@ int main_mem(int argc, char *argv[])
                 if (out_opened) fclose(aux.fp);
                 return 1;
             }
-            cohort_slices = (int64_t)v;
+        }
+        else if (c == OPT_COHORT_RAMP_RATIO) {
+            /* Validated like the two above. atof() maps anything unparseable to
+             * 0.0, which the `ratio <= 1` guard below then reports as a ratio the
+             * user never asked for and silently replaces with the default -- a
+             * confusing way to learn you made a typo. Only PARSEABILITY is
+             * enforced here; the `<= 1` range check stays where it is, because it
+             * is shared with the env override and is a documented fallback rather
+             * than an error. */
+            if (parse_full_double(optarg, &cohort_ramp_ratio) != 0) {
+                fprintf(stderr, "ERROR: --cohort-ramp-ratio requires a number, "
+                                "got '%s'\n", optarg);
+                free(opt);
+                if (out_opened) fclose(aux.fp);
+                return 1;
+            }
+        }
+        else if (c == OPT_COHORT_RAMP_FIRST) {
+            /* Validated for the same reason, and this one is the sharpest of the
+             * four: atoll("16M") is 16, which is > 0 and therefore accepted as a
+             * SIXTEEN-BYTE first slice rather than 16 Mbases. That is a silent
+             * ~million-fold error in the option this PR exists to introduce.
+             * --chunk-cap already rejects '100M' for exactly this reason. */
+            if (parse_bounded_i64(optarg, 0, INT64_MAX, &cohort_ramp_first) != 0) {
+                fprintf(stderr, "ERROR: --cohort-ramp-first requires a "
+                                "non-negative integer number of bases "
+                                "(0 = fraction of the batch), got '%s'\n", optarg);
+                free(opt);
+                if (out_opened) fclose(aux.fp);
+                return 1;
+            }
         }
         else if (c == OPT_SKIP_CONTAINED_EXT) opt->skip_contained_ext = 1;
         else if (c == OPT_ADAPTIVE_BAND) opt->band_start = ADAPTIVE_BAND_START;
@@ -2664,17 +2896,10 @@ int main_mem(int argc, char *argv[])
          * that work away when the documented default is still correct. */
         const char *cap_env = getenv("BWA_MEM3_CHUNK_CAP");
         if (cap_env && *cap_env) {
-            char *cap_end = NULL;
-            errno = 0;
-            long long env_v = strtoll(cap_env, &cap_end, 10);
-            if (cap_end == cap_env || cap_end == NULL || *cap_end != '\0' ||
-                errno == ERANGE || env_v < 0) {
+            if (parse_bounded_i64(cap_env, 0, INT64_MAX, &cap) != 0)
                 fprintf(stderr, "WARNING: BWA_MEM3_CHUNK_CAP='%s' is not a "
                                 "non-negative integer; ignoring it and using "
                                 "chunk cap %lld\n", cap_env, (long long)cap);
-            } else {
-                cap = (int64_t)env_v;
-            }
         }
         int64_t scaled = (int64_t)opt->chunk_size * (int64_t)opt->n_threads;
         aux.task_size = (cap > 0 && scaled > cap) ? cap : scaled;
@@ -2689,8 +2914,9 @@ int main_mem(int argc, char *argv[])
      * pipeline has nothing to chew on until it lands -- and with the cap now
      * opt-in that first read is `chunk_size * n_threads` bases, the largest
      * single unhidden cost in the run. Reading the FIRST cohort as a geometric
-     * ramp lets compute start on the first slice -- task/64 at the default
-     * cohort_slices = 6 -- while the rest is still arriving.
+     * ramp lets compute start on the first slice -- cohort_ramp_first bases,
+     * 16 Mbase by default, independent of -t -- while the rest is still
+     * arriving.
      *
      * This does not move the cohort boundary, so mem_pestat sees exactly the
      * read set it would have seen otherwise and the output is unchanged. See
@@ -2708,17 +2934,10 @@ int main_mem(int argc, char *argv[])
          * was set to configure. An empty value leaves the CLI/default alone. */
         const char *cs_env = getenv("BWA_MEM3_COHORT_SLICES");
         if (cs_env && *cs_env) {
-            char *cs_end = NULL;
-            errno = 0;
-            long long cs_v = strtoll(cs_env, &cs_end, 10);
-            if (cs_end == cs_env || cs_end == NULL || *cs_end != '\0' ||
-                errno == ERANGE || cs_v < 0 || cs_v > 20) {
+            if (parse_bounded_i64(cs_env, 0, COHORT_SLICES_MAX, &slices) != 0)
                 fprintf(stderr, "WARNING: BWA_MEM3_COHORT_SLICES='%s' is not an "
-                                "integer in 0..20; ignoring it and using %lld\n",
-                        cs_env, (long long)slices);
-            } else {
-                slices = (int64_t)cs_v;
-            }
+                                "integer in 0..%d; ignoring it and using %lld\n",
+                        cs_env, (int)COHORT_SLICES_MAX, (long long)slices);
         }
         /* -p re-derives pairing from adjacency across the WHOLE array
          * (bseq_classify carries has_last state), so a slice boundary between
@@ -2742,6 +2961,62 @@ int main_mem(int argc, char *argv[])
         if (aux.cohort_slice_all && aux.cohort_slices > 0)
             fprintf(stderr, "[M::%s] BWA_MEM3_COHORT_SLICE_ALL set: slicing every "
                     "cohort (stress mode; slower)\n", __func__);
+
+        /* Ramp growth ratio. Env override for sweeps, as with the slice count.
+         * A ratio at or below 1 would shrink the ramp rather than grow it, so it
+         * cannot reach the cohort at all; that is user error, not a mode, and the
+         * default is restored rather than reading the input in equal dribbles. */
+        double ramp_ratio = cohort_ramp_ratio;
+        const char *rr_env = getenv("BWA_MEM3_COHORT_RAMP_RATIO");
+        if (rr_env && *rr_env) {
+            /* Parsed exactly like --cohort-ramp-ratio, and for the same reason:
+             * atof() accepts a prefix, so '1.5x' silently becomes 1.5 and
+             * 'abc' becomes 0.0. The 0.0 case would at least surface via the
+             * `<= 1` guard below, but as a ratio the user never typed. Only
+             * PARSEABILITY is checked here -- the `<= 1` range check stays
+             * below, shared with the CLI value, because it is a documented
+             * fallback rather than an error. */
+            if (parse_full_double(rr_env, &ramp_ratio) != 0)
+                fprintf(stderr, "WARNING: BWA_MEM3_COHORT_RAMP_RATIO='%s' is not "
+                                "a number; ignoring it and using %.2f\n",
+                        rr_env, ramp_ratio);
+        }
+        /* Spelled as the negation of the ACCEPT condition, not `<= 1.0`, so NaN
+         * lands here too: strtod("nan") parses cleanly and every comparison
+         * against NaN is false, so `<= 1.0` would wave it through as a valid
+         * ratio. It would then poison the ramp -- prev * NaN is NaN, which is
+         * neither >= task_size nor convertible to int64_t, putting the ramp back
+         * on the undefined conversion the saturation in the read step exists to
+         * avoid. A ratio that cannot grow the ramp is user error either way. */
+        if (!(ramp_ratio > 1.0)) {
+            fprintf(stderr, "[M::%s] a cohort ramp ratio of %.3f would never grow "
+                    "the ramp to the cohort; using %.2f\n",
+                    __func__, ramp_ratio, cohort_ramp_ratio_default);
+            ramp_ratio = cohort_ramp_ratio_default;
+        }
+        aux.cohort_ramp_ratio = ramp_ratio;
+
+        /* First-slice size, also env-overridable for sweeps. 0 selects the old
+         * fractional shape (task_size / ratio^depth), which is what makes an
+         * exact A/B against the pre-absolute behaviour possible; negative is
+         * meaningless, so it is treated as 0 rather than silently clamped. */
+        int64_t ramp_first = cohort_ramp_first;
+        const char *rf_env = getenv("BWA_MEM3_COHORT_RAMP_FIRST");
+        if (rf_env && *rf_env) {
+            /* Validated exactly like --cohort-ramp-first. Without this, the env
+             * spelling reintroduces the bug the flag's validation exists to
+             * prevent: atoll("16M") is 16, a positive value, so
+             * BWA_MEM3_COHORT_RAMP_FIRST=16M would silently request a SIXTEEN
+             * BYTE first slice instead of 16 Mbases. Non-fatal here, unlike the
+             * flag, because the index is already loaded by this point -- same
+             * choice BWA_MEM3_CHUNK_CAP and BWA_MEM3_COHORT_SLICES make above. */
+            if (parse_bounded_i64(rf_env, 0, INT64_MAX, &ramp_first) != 0)
+                fprintf(stderr, "WARNING: BWA_MEM3_COHORT_RAMP_FIRST='%s' is not "
+                                "a non-negative integer number of bases; ignoring "
+                                "it and using %lld\n",
+                        rf_env, (long long)ramp_first);
+        }
+        aux.cohort_ramp_first = ramp_first > 0 ? ramp_first : 0;
     }
 
     /* Pipeline depth. The 3-step pipeline (read / process / write) is gated by

--- a/src/fastmap.h
+++ b/src/fastmap.h
@@ -93,6 +93,14 @@ typedef struct {
 	 * goes back to NULL so the next cohort creates a fresh one. See read_arena.h
 	 * for why the cohort, not the read call, is the arena's unit. */
 	read_arena_t *cohort_arena;
+	/* How fast the ramp grows per slice, and the previous slice's requested size
+	 * to grow from. The ratio is what decides whether step 1 ever waits: while
+	 * step 1 computes slice k the reader must deliver slice k+1, so the ramp is
+	 * only free while ratio <= (read seconds per base) / (compute seconds per
+	 * base). Both are step-0-only state, which kt_pipeline serialises. */
+	double  cohort_ramp_ratio;  /* growth per slice; see --cohort-ramp-ratio */
+	int64_t cohort_ramp_first;  /* first slice, in bases; 0 = fraction of task_size */
+	int64_t ramp_prev_target;   /* previous slice's REQUESTED size, in bases */
 	/* Accumulator for a multi-slice cohort, owned by step 1. */
 	bseq1_t *cohort_seqs;       /* contiguous reads for the cohort being built */
 	int      cohort_n;          /* reads accumulated so far */

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -20,6 +20,7 @@ Each script:
 | `header_parity.sh`           | `AH:*` on generated @SQ (#281); `--compat` skips the .hdr/.dict sidecar | "header parity regression (AH:*, --compat @HD/@SQ)" |
 | `default_hd_parity.sh`       | default `@HD` byte-identical across SAM/`--bam`/`--meth` (#288)        | "default @HD parity across output paths"            |
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
+| `cohort_ramp_validation.sh`  | `--cohort-ramp-first`/`-ratio` reject malformed values; env warns and falls back | "Cohort ramp values are validated (flag and environment alike)" |
 | `profile_slice_cpu.sh`       | `--profile` accounts for a partial cohort slice's compute CPU (needs `STAGE_PROF=1`) | "Partial cohort slices report their compute CPU"    |
 
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is

--- a/test/regression/cohort_ramp_validation.sh
+++ b/test/regression/cohort_ramp_validation.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# test/regression/cohort_ramp_validation.sh
+#
+# Regression: --cohort-ramp-first / --cohort-ramp-ratio and their environment
+# spellings must reject a malformed value instead of silently parsing a prefix.
+#
+# --cohort-ramp-first takes plain bases, and the C conversion the obvious
+# implementation reaches for accepts a prefix: atoll("16M") is 16. That is
+# positive, so it passes a `> 0` check and configures a SIXTEEN BYTE first
+# slice where the user asked for 16 Mbases -- a millionfold error that produces
+# no diagnostic and no crash, only a run that reads the input in dribbles. The
+# ratio has the same shape via atof(): "1.5x" becomes 1.5 and "abc" becomes 0.0.
+#
+# The two spellings are validated the same way but fail differently, on purpose:
+#
+#   flag  -> hard error, non-zero exit. Nothing is loaded yet, so refusing costs
+#            the user nothing and a typo in a script must not run for an hour.
+#   env   -> WARNING and fall back to the flag/default value. These are sweep
+#            knobs read after the index is loaded; aborting there would throw
+#            away minutes of work over a variable the run does not require.
+#            Same choice BWA_MEM3_CHUNK_CAP and BWA_MEM3_COHORT_SLICES make.
+#
+# A silent fallback is what this test rules out in the env case: without the
+# WARNING, `BWA_MEM3_COHORT_RAMP_FIRST=16M` and an unset variable are
+# indistinguishable from the outside.
+#
+# Inputs:
+#   BWA_MEM3 — path to bwa-mem3 binary
+#   FIXTURES — directory containing phix.fa and reads.fa (default: test/fixtures)
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+FIXTURES="${FIXTURES:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)}"
+
+src_ref="$FIXTURES/phix.fa"
+reads="$FIXTURES/reads.fa"
+[[ -x "$BWA_MEM3" ]] || { echo "FAIL: binary not executable: $BWA_MEM3" >&2; exit 1; }
+[[ -s "$src_ref" ]]  || { echo "FAIL: phix.fa missing: $src_ref" >&2; exit 1; }
+[[ -s "$reads" ]]    || { echo "FAIL: reads.fa missing: $reads" >&2; exit 1; }
+
+# Index a private copy so the test never writes into the fixtures tree.
+mdir="$(mktemp -d)"; err="$mdir/err.log"
+trap 'rm -rf "$mdir"' EXIT
+ref="$mdir/phix.fa"
+cp "$src_ref" "$ref"
+"$BWA_MEM3" index "$ref" >/dev/null 2>&1 || { echo "FAIL: index phix.fa" >&2; exit 1; }
+
+fails=0
+
+run_mem() {   # rest = mem args; env comes from the caller. Returns mem's exit code.
+    # `|| rc=$?` rather than toggling errexit, matching every other exit-code-
+    # capturing helper below. Disabling `set -e` around the call would also
+    # suppress failures from any command later added inside the window.
+    local rc=0
+    "$BWA_MEM3" mem "$@" "$ref" "$reads" >/dev/null 2>"$err" || rc=$?
+    return "$rc"
+}
+
+# --- the flags reject a malformed value outright ----------------------------
+# `=` form so a leading '-' is not taken for another option.
+reject_flag() {   # $1 = option name, $2 = value that must be refused
+    local opt="$1" val="$2" rc=0
+    run_mem "--$opt=$val" || rc=$?
+    if [[ "$rc" -eq 0 ]]; then
+        echo "FAIL: '--$opt=$val' was accepted; expected a non-zero exit"
+        fails=$((fails + 1))
+    elif ! grep -q "ERROR: --$opt requires" "$err"; then
+        echo "FAIL: '--$opt=$val' exited $rc but without the expected diagnostic"
+        fails=$((fails + 1))
+    else
+        echo "  ok: '--$opt=$val' rejected"
+    fi
+}
+
+reject_flag cohort-ramp-first 16M     # the millionfold case: bases take no suffix
+reject_flag cohort-ramp-first abc     # not a number at all
+reject_flag cohort-ramp-first -5      # negative
+reject_flag cohort-ramp-ratio 1.5x    # trailing junk after a valid prefix
+reject_flag cohort-ramp-ratio abc     # not a number at all
+
+# --- the flags accept a well-formed value -----------------------------------
+accept_flag() {   # $1 = option name, $2 = value that must be accepted
+    local opt="$1" val="$2" rc=0
+    run_mem "--$opt=$val" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        echo "FAIL: '--$opt=$val' exited $rc; expected success"
+        cat "$err" >&2
+        fails=$((fails + 1))
+    else
+        echo "  ok: '--$opt=$val' accepted"
+    fi
+}
+
+accept_flag cohort-ramp-first 4000000
+accept_flag cohort-ramp-first 0        # 0 selects the fractional ramp shape
+accept_flag cohort-ramp-ratio 2.5
+
+# --- the env spellings warn and fall back, rather than parsing a prefix -----
+env_warns() {   # $1 = variable, $2 = malformed value
+    local var="$1" val="$2" rc=0
+    env "$var=$val" bash -c '"$0" mem "$1" "$2" >/dev/null 2>"$3"' \
+        "$BWA_MEM3" "$ref" "$reads" "$err" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        echo "FAIL: '$var=$val' exited $rc; a bad sweep variable must not abort the run"
+        fails=$((fails + 1))
+    elif ! grep -q "WARNING: $var='$val'" "$err"; then
+        echo "FAIL: '$var=$val' was accepted silently; a prefix-parsed sweep"
+        echo "      variable is indistinguishable from an unset one"
+        fails=$((fails + 1))
+    else
+        echo "  ok: '$var=$val' reported and ignored"
+    fi
+}
+
+env_quiet() {   # $1 = variable, $2 = well-formed value
+    local var="$1" val="$2" rc=0
+    env "$var=$val" bash -c '"$0" mem "$1" "$2" >/dev/null 2>"$3"' \
+        "$BWA_MEM3" "$ref" "$reads" "$err" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        echo "FAIL: '$var=$val' exited $rc; expected success"
+        cat "$err" >&2
+        fails=$((fails + 1))
+    elif grep -q "WARNING: $var=" "$err"; then
+        echo "FAIL: '$var=$val' is well-formed but was reported as malformed"
+        fails=$((fails + 1))
+    else
+        echo "  ok: '$var=$val' accepted"
+    fi
+}
+
+env_warns BWA_MEM3_COHORT_RAMP_FIRST 16M
+env_warns BWA_MEM3_COHORT_RAMP_FIRST abc
+env_warns BWA_MEM3_COHORT_RAMP_FIRST -5
+env_warns BWA_MEM3_COHORT_RAMP_RATIO 1.5x
+env_warns BWA_MEM3_COHORT_RAMP_RATIO abc
+env_quiet BWA_MEM3_COHORT_RAMP_FIRST 4000000
+env_quiet BWA_MEM3_COHORT_RAMP_FIRST 0
+env_quiet BWA_MEM3_COHORT_RAMP_RATIO 2.5
+# An EMPTY value leaves the flag/default alone rather than parsing as 0/0.0.
+env_quiet BWA_MEM3_COHORT_RAMP_FIRST ""
+env_quiet BWA_MEM3_COHORT_RAMP_RATIO ""
+
+# --- an extreme ratio must not run the ramp off the end of int64_t ----------
+# Only `> 1.0` bounds the ratio, so a sweep can ask for one that compounds the
+# ramp past INT64_MAX. The product is computed in double and then narrowed, and
+# narrowing an out-of-range double to int64_t is undefined behaviour -- the ramp
+# is supposed to saturate at the cohort size before the cast rather than wrap to
+# whatever the target architecture happens to produce.
+#
+# The ramp only schedules reads; the slice-target clamp keeps the cohort
+# boundary where an unsliced run would put it. So the contract to assert is that
+# an absurd ratio changes nothing observable: same exit status, and the same SAM
+# once @PG is dropped -- its CL: field records the differing command line, which
+# is the one legitimate difference between the two runs. (The undefined
+# conversion itself is only directly observable under a sanitizer; this pins the
+# behaviour that a wrapped ramp would break.)
+#
+# BWA_MEM3_COHORT_SLICE_ALL=1 is load-bearing here, not incidental. Without it
+# this check is VACUOUS: the ramp multiplication only runs on the SECOND and
+# later slices of a cohort, and the first slice is floored at 1 Mbase, so any
+# fixture smaller than that is consumed whole by slice 0 and the multiply is
+# never reached. The phiX fixture is 500 bases. Raising --cohort-slices or
+# lowering --cohort-ramp-first does NOT help -- the 1 Mbase floor applies to both
+# -- but the stress knob drops that floor to 1 base, which is exactly what makes
+# a tiny input produce a second slice.
+#
+# Because that is easy to lose again, each extreme ratio ASSERTS it actually
+# sliced by requiring a partial-slice line in the log. A future change that stops
+# the ramp from slicing turns this into a failure rather than a silent pass.
+strip_pg() { grep -v '^@PG' "$1"; }
+
+baseline="$mdir/baseline.sam"
+extreme="$mdir/extreme.sam"
+rc=0
+"$BWA_MEM3" mem --cohort-slices=0 "$ref" "$reads" >"$baseline" 2>"$err" || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+    echo "FAIL: unsliced baseline run exited $rc"
+    cat "$err" >&2
+    fails=$((fails + 1))
+else
+    # These two compound the ramp past INT64_MAX on the very first multiply, so
+    # they are the ones that reach the saturation.
+    for ratio in 1e18 1e300; do
+        rc=0
+        env BWA_MEM3_COHORT_SLICE_ALL=1 \
+            "$BWA_MEM3" mem --cohort-ramp-ratio="$ratio" "$ref" "$reads" \
+            >"$extreme" 2>"$err" || rc=$?
+        if [[ "$rc" -ne 0 ]]; then
+            echo "FAIL: '--cohort-ramp-ratio=$ratio' exited $rc; an extreme ratio"
+            echo "      must saturate the ramp, not abort the run"
+            cat "$err" >&2
+            fails=$((fails + 1))
+        elif ! grep -q '(cohort slice)' "$err"; then
+            echo "FAIL: '--cohort-ramp-ratio=$ratio' produced no partial slice, so the"
+            echo "      ramp multiplication never ran and this case proved nothing."
+            echo "      See the BWA_MEM3_COHORT_SLICE_ALL note above."
+            fails=$((fails + 1))
+        elif ! diff -q <(strip_pg "$baseline") <(strip_pg "$extreme") >/dev/null; then
+            echo "FAIL: '--cohort-ramp-ratio=$ratio' changed the output; the ramp"
+            echo "      schedules reads and must not move the cohort boundary"
+            fails=$((fails + 1))
+        else
+            echo "  ok: '--cohort-ramp-ratio=$ratio' saturated on a real second slice;"
+            echo "      output unchanged"
+        fi
+    done
+
+    # 'nan' is a GUARD case, not a saturation case: strtod parses it and every
+    # comparison against NaN is false, so a `<= 1` reject test would let it
+    # through as a valid ratio -- after which prev * NaN is NaN, which neither
+    # saturates nor converts. The accept test is spelled `!(ratio > 1.0)` so NaN
+    # takes the documented fallback instead, which means it never becomes the
+    # ratio and so never reaches the multiply. Assert the fallback fired; a
+    # partial-slice assertion would be wrong here for that reason.
+    rc=0
+    env BWA_MEM3_COHORT_SLICE_ALL=1 \
+        "$BWA_MEM3" mem --cohort-ramp-ratio=nan "$ref" "$reads" \
+        >"$extreme" 2>"$err" || rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        echo "FAIL: '--cohort-ramp-ratio=nan' exited $rc; it must fall back, not abort"
+        cat "$err" >&2
+        fails=$((fails + 1))
+    elif ! grep -q 'would never grow the ramp to the cohort' "$err"; then
+        echo "FAIL: '--cohort-ramp-ratio=nan' was accepted as a ratio; NaN must take"
+        echo "      the same documented fallback as a ratio at or below 1"
+        fails=$((fails + 1))
+    elif ! diff -q <(strip_pg "$baseline") <(strip_pg "$extreme") >/dev/null; then
+        echo "FAIL: '--cohort-ramp-ratio=nan' changed the output"
+        fails=$((fails + 1))
+    else
+        echo "  ok: '--cohort-ramp-ratio=nan' fell back to the default; output unchanged"
+    fi
+fi
+
+if [[ "$fails" -ne 0 ]]; then
+    echo "FAIL: cohort ramp validation ($fails failure(s))"
+    exit 1
+fi
+echo "PASS: cohort ramp values are validated identically by flag and environment"

--- a/test/unit/test_mem_pestat_max_ins.cpp
+++ b/test/unit/test_mem_pestat_max_ins.cpp
@@ -1,0 +1,160 @@
+// test/unit/test_mem_pestat_max_ins.cpp — mem_pestat bounds opt->max_ins before
+// it sizes the insert-size histogram.
+//
+// mem_pestat now counts insert sizes into a direct-address array rather than
+// collecting and sorting them, so opt->max_ins went from being a pure FILTER on
+// observed values -- where any value was harmless -- to being an ARRAY BOUND:
+// the function allocates 4 * (max_ins + 1) * sizeof(int64_t) up front.
+//
+// mem_opt_init() sets max_ins to 10000 (320 kB) and no CLI option changes it,
+// but mem_pestat reads the field from the caller's mem_opt_t and is a library
+// entry point, so the value is not the aligner's to guarantee. Unbounded:
+//
+//   INT_MAX  -- `(size_t)4 * (max_ins + 1)` overflows int before the conversion
+//               (undefined behaviour), and any surviving value asks for tens of
+//               GB of zeroed counters.
+//   negative -- `max_ins + 1` converts to an enormous size_t.
+//
+// Both are clamped instead: a negative value to 0, and anything past the cap to
+// the cap. n == 0 here, so the candidate loop never runs and `regs` is never
+// dereferenced -- the allocation is the whole point of the call, and the
+// assertions below only need mem_pestat to return normally with every
+// orientation marked failed for want of pairs.
+//
+// Without the clamp this test does not merely fail an assertion; it aborts on
+// the xassert for a failed calloc, or takes the process down with it.
+//
+// Fixtures are built in-memory; no test data files are read.
+
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <unistd.h>
+
+#include "doctest/doctest.h"
+#include "bwamem.h"
+
+namespace {
+
+/* The cap mem_pestat clamps to, mirrored from bwamem_pair.cpp. Duplicated on
+ * purpose: the boundary test below is only meaningful if it names the value
+ * independently of the code under test. */
+const int kMaxInsCap = 1000000;
+
+// Every orientation must report `failed` after a call with no pairs, whatever
+// max_ins was: total[d] is 0, which is below MIN_DIR_CNT.
+void expect_all_orientations_failed(const mem_pestat_t pes[4])
+{
+    for (int d = 0; d < 4; ++d) CHECK(pes[d].failed == 1);
+}
+
+// Run mem_pestat over an empty cohort with a given max_ins. Returns via `pes`.
+void pestat_with_max_ins(int max_ins, mem_pestat_t pes[4])
+{
+    mem_opt_t *opt = mem_opt_init();
+    REQUIRE(opt != NULL);
+    opt->max_ins = max_ins;
+    // l_pac is only read by mem_infer_dir inside the candidate loop, which n == 0
+    // skips entirely; any value does.
+    mem_pestat(opt, /*l_pac=*/1000000, /*n=*/0, /*regs=*/NULL, pes);
+    free(opt);
+}
+
+/* As above, but returns whatever mem_pestat wrote to stderr.
+ *
+ * Needed for the boundary case: with n == 0 every orientation ends up failed
+ * whether or not the clamp fired, so the return value cannot distinguish "at the
+ * cap, passed through" from "past the cap, clamped". The clamp's diagnostic is
+ * the only externally visible difference, which makes it the thing to assert on. */
+std::string pestat_stderr_with_max_ins(int max_ins, mem_pestat_t pes[4])
+{
+    fflush(stderr);
+    const int saved_stderr = dup(fileno(stderr));
+    REQUIRE(saved_stderr >= 0);
+
+    /* Honour TMPDIR, as test/unit/test_fmi_pread_from_stream.cpp does: CI
+     * runners point it at a writable scratch area, and /tmp is RAM-backed
+     * tmpfs on several modern distributions. */
+    const char *tmpdir = getenv("TMPDIR");
+    if (tmpdir == NULL || tmpdir[0] == '\0') tmpdir = "/tmp";
+    std::string tmpl_s = tmpdir;
+    if (tmpl_s[tmpl_s.size() - 1] != '/') tmpl_s += '/';
+    tmpl_s += "pestat_stderr_XXXXXX";
+    std::vector<char> tmpl(tmpl_s.begin(), tmpl_s.end());
+    tmpl.push_back('\0');
+    const int fd = mkstemp(tmpl.data());
+    REQUIRE(fd >= 0);
+    REQUIRE(dup2(fd, fileno(stderr)) >= 0);
+
+    pestat_with_max_ins(max_ins, pes);
+
+    fflush(stderr);
+    REQUIRE(dup2(saved_stderr, fileno(stderr)) >= 0);
+    close(saved_stderr);
+
+    std::string captured;
+    REQUIRE(lseek(fd, 0, SEEK_SET) == 0);
+    char buf[4096];
+    ssize_t got;
+    while ((got = read(fd, buf, sizeof(buf))) > 0) captured.append(buf, (size_t)got);
+    close(fd);
+    unlink(tmpl.data());
+    return captured;
+}
+
+} // namespace
+
+TEST_CASE("mem_pestat: the default max_ins is accepted unchanged")
+{
+    mem_opt_t *opt = mem_opt_init();
+    REQUIRE(opt != NULL);
+    // Pins the premise the clamp is built around: the aligner's own value is
+    // well inside the cap, so no production run takes the clamped path and this
+    // guard cannot perturb output.
+    CHECK(opt->max_ins == 10000);
+    free(opt);
+
+    mem_pestat_t pes[4];
+    pestat_with_max_ins(10000, pes);
+    expect_all_orientations_failed(pes);
+}
+
+TEST_CASE("mem_pestat: an oversized max_ins does not size the histogram")
+{
+    mem_pestat_t pes[4];
+    pestat_with_max_ins(INT_MAX, pes);
+    expect_all_orientations_failed(pes);
+}
+
+TEST_CASE("mem_pestat: max_ins at the cap passes through, one past it is clamped")
+{
+    // The clamp is `max_ins < 0 || max_ins > kMaxInsCap`, so the cap itself is
+    // ACCEPTED and cap+1 is the first clamped value. An off-by-one either way --
+    // `>=` here, or a cap of 999999 -- moves that edge, and only these two inputs
+    // sit close enough to notice.
+    mem_pestat_t pes[4];
+
+    const std::string at_cap = pestat_stderr_with_max_ins(kMaxInsCap, pes);
+    expect_all_orientations_failed(pes);
+    CHECK(at_cap.find("out of range") == std::string::npos);
+
+    const std::string past_cap = pestat_stderr_with_max_ins(kMaxInsCap + 1, pes);
+    expect_all_orientations_failed(pes);
+    CHECK(past_cap.find("out of range") != std::string::npos);
+    // Names the value it fell back to, not just that it complained.
+    CHECK(past_cap.find("using 1000000") != std::string::npos);
+}
+
+TEST_CASE("mem_pestat: a negative max_ins does not wrap to a huge allocation")
+{
+    mem_pestat_t pes[4];
+    pestat_with_max_ins(-1, pes);
+    expect_all_orientations_failed(pes);
+
+    // -INT_MAX rather than INT_MIN: negating INT_MIN is itself UB, and the point
+    // here is a large-magnitude negative, not that exact bit pattern.
+    pestat_with_max_ins(-INT_MAX, pes);
+    expect_all_orientations_failed(pes);
+}


### PR DESCRIPTION
Stacked on #313. Two changes to the ramp's shape: a ratio that stays under the reader's ceiling (a ~1.5 % win at `-t 64`) and a first slice that no longer grows with `-t` (a wash today, a fix for the thread ladder). Byte-identical; two defaults plus knobs.

> **Numbers restated.** The `-t 64` figures in the first version of this PR came from a sweep in which one arm wrote SAM to `/dev/null` while the others wrote to a file. That halved its `Σwrite` (1.63 s vs 3.18 s) and inflated the apparent gain by ~0.23 s. Everything below is a clean re-measure in which **every arm writes to a real file**, 3 reps, interleaved, warmup discarded. The correction removes the end-to-end claim for the absolute first slice entirely — see [What each half buys](#what-each-half-buys).

## The problem

The ramp (#305) reads the first cohort as a geometric series so compute starts before the whole batch lands. Two things about that series were wrong.

**It grew by doubling, and doubling is not free.** While step 1 computes slice *k* the reader must deliver slice *k+1*, so a ramp of ratio `r` only stays hidden while

```
r  <=  (compute seconds per base) / (read seconds per base)
```

That ceiling **falls as threads are added**, because reading is single-threaded and flat in `-t` while compute scales. Measured on wgs-5M/hg38 (c8g.16xlarge, warm page cache, via `--profile`):

| | read ms/Mbase | compute ms/Mbase | ceiling on `r` | `r=2` |
|---|---:|---:|---:|---|
| `-t 16` | 4.83 | 31.50 | 6.52 | fine |
| `-t 32` | 4.83 | 15.40 | 3.19 | fine |
| `-t 64` | 4.83 | 7.87 | **1.63** | **violated** |

So doubling is free up to roughly `-t 40` and starves step 1 above it — and the starvation lands on the *largest* ramp slices, where it is most expensive. Replaying the step-1 timeline from the per-chunk profile shows exactly that: at `-t 64` the reader falls behind on the 160 Mbase and 320 Mbase slices and step 1 idles **0.103 + 0.292 s** mid-run, while at `-t 16` and `-t 32` mid-run idle is **0.000 s**, as the ceiling predicts.

**The first slice was a fraction of the batch, so it grew with `-t`.** `task_size` is `chunk_size * n_threads`, so `task_size / ratio^depth` doubles every time the thread count does — and the first slice's read is by definition the one piece of I/O that overlaps nothing. The measured head fill tracks that exactly:

| first slice | `-t 16` | `-t 32` | `-t 64` |
|---|---:|---:|---:|
| fractional, `r=1.6` | 0.051 s | 0.099 s | 0.199 s |
| absolute 16 Mbase | 0.081 s | 0.087 s | 0.095 s |

Fill and per-slice overhead are both *absolute* costs, so nothing about the right first slice scales with the cohort. The fractional form only looked free because it was never measured above `-t 64`.

## The change

Default the ratio to **1.6**, just under the `-t 64` ceiling, and the first slice to an absolute **16 Mbase**, capped at half the batch so a small `-K` still slices at least twice. Both are exposed as `--cohort-ramp-ratio` / `--cohort-ramp-first`, with `BWA_MEM3_COHORT_RAMP_{RATIO,FIRST}` for sweeps.

Measured **in one binary** with the shape selected by those env knobs (a same-artifact A/B, not a cross-build comparison), 3 reps interleaved, warm cache, warmup discarded, every arm writing SAM to a real file. `head` / `mid` / `ovhd` from `--profile`; `ramp` is the slice count; `ovhd` is `(ramp-1) ×` the measured per-slice `kt_for` cost (0.0351 / 0.0498 / 0.0689 s at `-t 16/32/64`):

| `-t` | shape | ramp | head | mid | ovhd | **PROCESS** | CV |
|---:|---|---:|---:|---:|---:|---:|---:|
| 16 | fractional, `r=2.0` | 7 | 0.018 | 0.000 | 0.211 | 86.44 | 0.02 % |
| 16 | fractional, `r=1.6` | 6 | 0.051 | 0.000 | 0.175 | 86.51 | 0.02 % |
| 16 | **absolute 16 Mb, `r=1.6`** | 5 | 0.081 | 0.000 | 0.140 | 86.50 | 0.01 % |
| 32 | fractional, `r=2.0` | 7 | 0.034 | 0.000 | 0.299 | 44.45 | 0.02 % |
| 32 | fractional, `r=1.6` | 6 | 0.099 | 0.000 | 0.249 | 44.47 | 0.01 % |
| 32 | **absolute 16 Mb, `r=1.6`** | 6 | 0.087 | 0.000 | 0.249 | 44.49 | 0.04 % |
| 64 | fractional, `r=2.0` | 7 | 0.066 | **0.416** | 0.413 | 23.99 | 0.02 % |
| 64 | fractional, `r=1.6` | 6 | 0.199 | 0.000 | 0.345 | 23.62 | 0.03 % |
| 64 | **absolute 16 Mb, `r=1.6`** | 7 | 0.095 | 0.018 | 0.413 | **23.61** | 0.15 % |

The `dflt` arm was run with the knobs **unset**, so the table measures the compiled-in defaults a user actually gets.

### What each half buys

They are not the same claim, so they are stated separately.

**The ratio is the wall-time change.** At `-t 64` it takes mid-run starvation from 0.416 s to zero and `PROCESS()` from 23.99 to 23.62 — **−1.5 %**. It costs 0.07 s at `-t 16` and 0.02 s at `-t 32`, where the ceiling is 6.5 / 3.2 and no stall was possible to begin with.

**The absolute first slice is a wash on this input** — −0.005 / −0.012 / −0.017 s in the ramp terms at `-t 16/32/64`, and inside the run-to-run spread end to end (23.62 → 23.61 at `-t 64`). It is in this PR for how the alternative *scales*, not for a speedup. Extending the arithmetic in the table above, `-t 128` opens a 1280 Mbase cohort with a **76 Mbase** first slice and **~0.37 s** of wholly unhidden fill, against 0.077 s for a fixed 16 Mbase. That matters directly for the thread-ladder work.

Its honest cost: at `-t 64` the absolute slice needs one more ramp slice (7 vs 6), and that +0.068 s of `kt_for` overhead eats most of the 0.104 s of head fill it saves. The trade improves with `-t`, because fill keeps doubling while the per-slice cost does not.

## Byte-identity

Slice sizes are output-neutral by construction — the cohort boundary is pinned by the slice-target clamp, not by how the cohort is carved up — and that is verified rather than asserted:

- **All 27 runs of the sweep above** produce one digest per rung: `5774c6ef` / `9465e564` / `b9c1e797` at `-t 16/32/64`, **unchanged from the fixed-doubling shape**.
- `cohort_slice_identity.sh` passes across first-cohort-only, every-cohort-3-way and every-cohort-8-way slicing, on a bimodal-insert fixture that infers **13 distinct `mem_pestat` percentile tuples across 23 cohorts** — so the comparison is not vacuous.
- Passing `--cohort-ramp-first 0 --cohort-ramp-ratio 2` takes the original integer-shift path and reproduces the previous slice sizes **exactly**, rather than approximately via `pow()`. That is what makes the `old` arm above a true A/B.

## Why constants, and not derived at run time

The ceiling is a property of the workload and host, not only of `-t`, so a derived ratio is the obvious idea. I implemented it and **measured it worse: +3.8 % at `-t 64`**. It is not in this PR, for three reasons:

1. The constraint is `r <= read_bps / align_bps`, and I coded it inverted.
2. **Even corrected it is biased.** The estimate necessarily comes from the *early, small* slices, and small slices under-report compute throughput because fixed `kt_for` costs dominate — 10 Mbase at `-t 64` runs at 78 Mbase/s against 127 steady-state. Correcting the inversion alone just clamps to 2.0, i.e. a no-op.
3. **Modelling the corrected version against the measured per-slice data did not rescue it.** Its outcome at `-t 64` flips sign on whether step 1 is one or two slices behind step 0 when the next slice is sized (`lag1 h=0.9` → −0.056 s; `lag2 h=0.9` → **+0.050 s**). That is runtime scheduling, not something a policy can pin.

In the run as measured the ratio collapsed to its 1.1 floor and left a **424 Mbase unoverlapped remainder** — 1.36 s of mid-run idle, worse than the doubling it replaced. A fixed pair is deterministic and measured better; the reasoning is recorded in the `main_mem` comment so it does not have to be rediscovered.

## Review notes

- A grid search over the cost model recommended `first=16.3 Mb, r=1.80`. Measurement **refused** it: 1.80 is above the 1.63 ceiling at `-t 64` and the run sat on the cliff — mid-run stall 0.109 s on one rep and 0.614 s on the next, with a 0.54 s `PROCESS` spread. The model is accurate to 0.002 s at the low rungs and wrong by 0.28 s at the cliff. Hence 1.6, under the ceiling.
- `--cohort-ramp-ratio` / `--cohort-ramp-first` are undocumented in the usage text, matching their sibling `--cohort-slices`; all three are tuning knobs rather than user-facing options.
- A ratio at or below 1 cannot reach the cohort at all, so it is rejected with a message and the default restored, rather than silently reading the input in equal dribbles. A non-positive first slice selects the fractional path rather than being silently clamped.
- `BWA_MEM3_COHORT_SLICE_ALL` deliberately keeps the fractional shape: it exists to maximise cohort-boundary crossings for the identity test, and is explicitly not a performance mode.
- `ramp_prev_target` stores the **requested** slice size, not what the reader returns, so the ramp shape does not drift with each slice's whole-record overshoot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cohort ramp configuration via new command-line options and matching environment variables.
  * Enhanced partial cohort slice profiling to report compute CPU timing.

* **Bug Fixes**
  * Added strict validation for ramp settings (flags now fail; environment values warn and fall back).
  * Prevented excessive insert-size histogram allocation by bounding extreme max settings.

* **Chores**
  * Strengthened CI permissions and expanded regression coverage, including new cohort ramp validation and profiling checks.
  * Reduced allocation-message verbosity unless verbose logging is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->