### PR TITLE
perf(mem): count insert sizes instead of collecting and sorting them

### DIFF
--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -90,15 +90,77 @@ static int cal_sub(const mem_opt_t *opt, mem_alnreg_v *r)
     return j < r->n? r->a[j].score : opt->min_seed_len * opt->a;
 }
 
+/* Value at index `k` of the ascending order described by `cnt[0..max_ins]`.
+ *
+ * The counts are a permutation-free description of the sorted array: value v
+ * occupies the index range [cumulative(v-1), cumulative(v)). So the element the
+ * sorted array would hold at `k` is the first v whose cumulative count exceeds k.
+ * Callers only ever pass k < total, which the percentile expressions guarantee.
+ */
+static inline int isize_at_rank(const int64_t *cnt, int max_ins, int64_t k)
+{
+    int64_t seen = 0;
+    for (int v = 0; v <= max_ins; ++v) {
+        seen += cnt[v];
+        if (seen > k) return v;
+    }
+    return max_ins;   /* unreachable while k < total; keeps the return total */
+}
+
 void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n,
                 const mem_alnreg_v *regs, mem_pestat_t pes[4])
 {
-    int i, d, max;
-    uint64_v isize[4];
-    
+    int i, d;
+    int64_t max;
+    /* Insert-size distribution as counts rather than a collected-then-sorted
+     * array. The candidate loop below discards anything above max_ins, so
+     * the values are bounded and a direct-address count array is EXACT -- there
+     * is no bucketing here and nothing is approximated.
+     *
+     * Walking the counts in ascending order visits the same values, the same
+     * number of times, in the same order as walking the sorted array would, and
+     * that is what makes this bit-identical rather than merely equal to within
+     * rounding. In particular the mean and variance loops below add each value
+     * `count` times instead of multiplying by count: multiplying is algebraically
+     * the same and numerically different, because floating-point addition is not
+     * associative and the original summed the elements one at a time.
+     *
+     * This drops an O(m log m) sort and the kvec growth it fed on. mem_pestat is
+     * serial (it needs the whole cohort before pairing can start), so its cost is
+     * a fixed term that thread count cannot reduce -- measured at 30 ns/read,
+     * invariant in both -t and cohort size, i.e. ~0.30 s of every run's wall. */
+    /* Bounded before it sizes an allocation. The old code used max_ins purely as
+     * a filter on collected values, so any value at all was harmless; here it is
+     * a direct-address array bound, and 4*(max_ins+1)*8 bytes with an unbounded
+     * max_ins is a caller-controlled allocation. mem_opt_init() sets 10000 (320
+     * kB) and no CLI option changes it, but max_ins is read from the caller's
+     * mem_opt_t and this is a library entry point -- an INT_MAX field would ask
+     * for 64 GB and a negative one would convert to a huge size_t. Neither is a
+     * value any caller means, so clamp rather than trust:
+     *
+     *   < 0        -> 0. No insert size satisfies `is <= 0`, so every
+     *                 orientation ends up failed for want of pairs, which is
+     *                 the same outcome as a cohort with no usable pairs.
+     *   > the cap  -> the cap. 1 Mbase is orders of magnitude past any real
+     *                 paired-end library and still only 32 MB of counters.
+     *
+     * The candidate filter below uses this bounded value, not opt->max_ins:
+     * filtering on the unclamped field while indexing a clamped array is a
+     * heap overflow, not a fallback. */
+    const int kMaxInsCap = 1000000;
+    int max_ins = opt->max_ins;
+    if (max_ins < 0 || max_ins > kMaxInsCap) {
+        int clamped = max_ins < 0 ? 0 : kMaxInsCap;
+        fprintf(stderr, "[0000][PE] max_ins of %d is out of range; using %d\n",
+                max_ins, clamped);
+        max_ins = clamped;
+    }
+    int64_t *cnt_buf = (int64_t *) calloc((size_t)4 * ((size_t)max_ins + 1), sizeof(int64_t));
+    int64_t *cnt[4], total[4];
+    xassert(cnt_buf != NULL, "out of memory allocating insert-size histogram");
+    for (d = 0; d < 4; ++d) { cnt[d] = cnt_buf + (size_t)d * ((size_t)max_ins + 1); total[d] = 0; }
+
     memset(pes, 0, 4 * sizeof(mem_pestat_t));
-    // memset(isize, 0, sizeof(kvec_t(int)) * 4);
-    memset(isize, 0, sizeof(uint64_v) * 4);
     for (i = 0; i < n>>1; ++i) {
         int dir;
         int64_t is;
@@ -110,36 +172,42 @@ void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n,
         if (cal_sub(opt, r[1]) > MIN_RATIO * r[1]->a[0].score) continue;
         if (r[0]->a[0].rid != r[1]->a[0].rid) continue; // not on the same chr
         dir = mem_infer_dir(l_pac, r[0]->a[0].rb, r[1]->a[0].rb, &is);
-        if (is && is <= opt->max_ins) kv_push(uint64_t, isize[dir], is);
+        if (is && is <= max_ins) { ++cnt[dir][is]; ++total[dir]; }   /* bounded, not opt->max_ins */
     }
-    if (bwa_verbose >= 3) fprintf(stderr, "[0000][PE] # candidate unique pairs for (FF, FR, RF, RR): (%ld, %ld, %ld, %ld)\n", isize[0].n, isize[1].n, isize[2].n, isize[3].n);
+    if (bwa_verbose >= 3) fprintf(stderr, "[0000][PE] # candidate unique pairs for (FF, FR, RF, RR): (%lld, %lld, %lld, %lld)\n",
+                                  (long long)total[0], (long long)total[1], (long long)total[2], (long long)total[3]);
     for (d = 0; d < 4; ++d) { // TODO: this block is nearly identical to the one in bwtsw2_pair.c. It would be better to merge these two.
         mem_pestat_t *r = &pes[d];
-        uint64_v *q = &isize[d];
+        int64_t *q = cnt[d], nq = total[d];
         int p25, p50, p75, x;
-        if (q->n < MIN_DIR_CNT) {
+        if (nq < MIN_DIR_CNT) {
             fprintf(stderr, "[0000][PE] skip orientation %c%c as there are not enough pairs\n", "FR"[d>>1&1], "FR"[d&1]);
             r->failed = 1;
-            free(q->a);
             continue;
         } else fprintf(stderr, "[0000][PE] analyzing insert size distribution for orientation %c%c...\n", "FR"[d>>1&1], "FR"[d&1]);
-        ks_introsort_64(q->n, q->a);
-        p25 = q->a[(int)(.25 * q->n + .499)];
-        p50 = q->a[(int)(.50 * q->n + .499)];
-        p75 = q->a[(int)(.75 * q->n + .499)];
+        /* Same indices the sorted array was subscripted with, so the same values. */
+        p25 = isize_at_rank(q, max_ins, (int64_t)(.25 * nq + .499));
+        p50 = isize_at_rank(q, max_ins, (int64_t)(.50 * nq + .499));
+        p75 = isize_at_rank(q, max_ins, (int64_t)(.75 * nq + .499));
         r->low  = (int)(p25 - OUTLIER_BOUND * (p75 - p25) + .499);
         if (r->low < 1) r->low = 1;
         r->high = (int)(p75 + OUTLIER_BOUND * (p75 - p25) + .499);
         fprintf(stderr, "[0000][PE] (25, 50, 75) percentile: (%d, %d, %d)\n", p25, p50, p75);
         fprintf(stderr, "[0000][PE] low and high boundaries for computing mean and std.dev: (%d, %d)\n", r->low, r->high);
-        for (i = x = 0, r->avg = 0; i < q->n; ++i)
-            if (q->a[i] >= r->low && q->a[i] <= r->high)
-                r->avg += q->a[i], ++x;
+        /* The sorted array is ascending, so its [low, high] filter selects one
+         * contiguous run -- exactly this range of values, each repeated its own
+         * count of times. Hence the inner loops, and hence identical arithmetic. */
+        int lo = r->low  > 0       ? r->low  : 0;
+        int hi = r->high < max_ins ? r->high : max_ins;
+        for (x = 0, r->avg = 0; lo <= hi; ++lo)
+            for (int64_t k = 0; k < q[lo]; ++k)
+                r->avg += lo, ++x;
         assert(x != 0);
         r->avg /= x;
-        for (i = 0, r->std = 0; i < q->n; ++i)
-            if (q->a[i] >= r->low && q->a[i] <= r->high)
-                r->std += (q->a[i] - r->avg) * (q->a[i] - r->avg);
+        lo = r->low > 0 ? r->low : 0;
+        for (r->std = 0; lo <= hi; ++lo)
+            for (int64_t k = 0; k < q[lo]; ++k)
+                r->std += (lo - r->avg) * (lo - r->avg);
         r->std = sqrt(r->std / x);
         fprintf(stderr, "[0000][PE] mean and std.dev: (%.2f, %.2f)\n", r->avg, r->std);
         r->low  = (int)(p25 - MAPPING_BOUND * (p75 - p25) + .499);
@@ -148,12 +216,12 @@ void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n,
         if (r->high < r->avg + MAX_STDDEV * r->std) r->high = (int)(r->avg + MAX_STDDEV * r->std + .499);
         if (r->low < 1) r->low = 1;
         fprintf(stderr, "[0000][PE] low and high boundaries for proper pairs: (%d, %d)\n", r->low, r->high);
-        free(q->a);
     }
+    free(cnt_buf);
     for (d = 0, max = 0; d < 4; ++d)
-        max = max > isize[d].n? max : isize[d].n;
+        max = max > total[d]? max : total[d];
     for (d = 0; d < 4; ++d)
-        if (pes[d].failed == 0 && isize[d].n < max * MIN_DIR_RATIO) {
+        if (pes[d].failed == 0 && total[d] < max * MIN_DIR_RATIO) {
             pes[d].failed = 1;
             fprintf(stderr, "[0000][PE] skip orientation %c%c\n", "FR"[d>>1&1], "FR"[d&1]);
         }

--- a/test/unit/test_mem_pestat_max_ins.cpp
+++ b/test/unit/test_mem_pestat_max_ins.cpp
@@ -1,0 +1,90 @@
+// test/unit/test_mem_pestat_max_ins.cpp — mem_pestat bounds opt->max_ins before
+// it sizes the insert-size histogram.
+//
+// mem_pestat now counts insert sizes into a direct-address array rather than
+// collecting and sorting them, so opt->max_ins went from being a pure FILTER on
+// observed values -- where any value was harmless -- to being an ARRAY BOUND:
+// the function allocates 4 * (max_ins + 1) * sizeof(int64_t) up front.
+//
+// mem_opt_init() sets max_ins to 10000 (320 kB) and no CLI option changes it,
+// but mem_pestat reads the field from the caller's mem_opt_t and is a library
+// entry point, so the value is not the aligner's to guarantee. Unbounded:
+//
+//   INT_MAX  -- `(size_t)4 * (max_ins + 1)` overflows int before the conversion
+//               (undefined behaviour), and any surviving value asks for tens of
+//               GB of zeroed counters.
+//   negative -- `max_ins + 1` converts to an enormous size_t.
+//
+// Both are clamped instead: a negative value to 0, and anything past the cap to
+// the cap. n == 0 here, so the candidate loop never runs and `regs` is never
+// dereferenced -- the allocation is the whole point of the call, and the
+// assertions below only need mem_pestat to return normally with every
+// orientation marked failed for want of pairs.
+//
+// Without the clamp this test does not merely fail an assertion; it aborts on
+// the xassert for a failed calloc, or takes the process down with it.
+//
+// Fixtures are built in-memory; no test data files are read.
+
+#include <climits>
+#include <cstdlib>
+
+#include "doctest/doctest.h"
+#include "bwamem.h"
+
+namespace {
+
+// Every orientation must report `failed` after a call with no pairs, whatever
+// max_ins was: total[d] is 0, which is below MIN_DIR_CNT.
+void expect_all_orientations_failed(const mem_pestat_t pes[4])
+{
+    for (int d = 0; d < 4; ++d) CHECK(pes[d].failed == 1);
+}
+
+// Run mem_pestat over an empty cohort with a given max_ins. Returns via `pes`.
+void pestat_with_max_ins(int max_ins, mem_pestat_t pes[4])
+{
+    mem_opt_t *opt = mem_opt_init();
+    REQUIRE(opt != NULL);
+    opt->max_ins = max_ins;
+    // l_pac is only read by mem_infer_dir inside the candidate loop, which n == 0
+    // skips entirely; any value does.
+    mem_pestat(opt, /*l_pac=*/1000000, /*n=*/0, /*regs=*/NULL, pes);
+    free(opt);
+}
+
+} // namespace
+
+TEST_CASE("mem_pestat: the default max_ins is accepted unchanged")
+{
+    mem_opt_t *opt = mem_opt_init();
+    REQUIRE(opt != NULL);
+    // Pins the premise the clamp is built around: the aligner's own value is
+    // well inside the cap, so no production run takes the clamped path and this
+    // guard cannot perturb output.
+    CHECK(opt->max_ins == 10000);
+    free(opt);
+
+    mem_pestat_t pes[4];
+    pestat_with_max_ins(10000, pes);
+    expect_all_orientations_failed(pes);
+}
+
+TEST_CASE("mem_pestat: an oversized max_ins does not size the histogram")
+{
+    mem_pestat_t pes[4];
+    pestat_with_max_ins(INT_MAX, pes);
+    expect_all_orientations_failed(pes);
+}
+
+TEST_CASE("mem_pestat: a negative max_ins does not wrap to a huge allocation")
+{
+    mem_pestat_t pes[4];
+    pestat_with_max_ins(-1, pes);
+    expect_all_orientations_failed(pes);
+
+    // -INT_MAX rather than INT_MIN: negating INT_MIN is itself UB, and the point
+    // here is a large-magnitude negative, not that exact bit pattern.
+    pestat_with_max_ins(-INT_MAX, pes);
+    expect_all_orientations_failed(pes);
+}


### PR DESCRIPTION
Stacked on #315. Removes a sort from `mem_pestat`. Bit-identical, and the identity argument is structural rather than empirical.

> **Rebased** onto #315's re-measured tip (`dec5e2d`). Re-verified against that new parent, not assumed — see [Verification](#verification). `mem_pestat`'s cost is independent of the ramp shape #315 changed, so the timings below are unaffected.

## What it does

`mem_pestat` built a `uint64_v` of candidate insert sizes per orientation, sorted it with `ks_introsort_64`, then made three passes over the sorted array — percentiles, mean, variance. The sort is the expensive part and it is pure overhead: the array is only ever consulted through order statistics and a range-filtered sum.

Count them instead. The candidate loop already discards anything above `opt->max_ins` (10000, and there is no code path that raises it), so **a direct-address count array is exact — there is no bucketing here and nothing is approximated.** That drops an `O(m log m)` sort plus the kvec growth feeding it, and replaces four allocations with one 320 KB `calloc`.

## Why it is bit-identical

Not "equal to within rounding" — bit-identical, and the reason is iteration order. Walking the counts in ascending order visits the same values, the same number of times, in the same order as walking the sorted array. So:

- the percentiles subscript the same sorted positions, recovered as the first value whose cumulative count exceeds the index;
- the mean and variance loops add each value `count` times **rather than multiplying by count**.

That inner loop is load-bearing, not clumsy:

```c
for (x = 0, r->avg = 0; lo <= hi; ++lo)
    for (int64_t k = 0; k < q[lo]; ++k)
        r->avg += lo, ++x;
```

`r->avg += lo * q[lo]` would be algebraically identical and **numerically different** — floating-point addition is not associative, and the original summed the elements one at a time. Please don't let a future cleanup pass collapse it; the comment says so in the source.

The `[low, high]` filter also maps cleanly: the sorted array is ascending, so the filter selects one contiguous run — exactly this range of values, each repeated its own count.

## Verification

Against the parent binary, on PE reads with a **bimodal** insert size. That detail matters: with a constant insert, `mem_pestat` returns the same bounds for every subset of reads regardless of what the code does, so the comparison would be vacuous.

Re-run after the rebase, against the new parent `dec5e2d` (150k pairs, insert `N(300,25)` two-thirds of the time and `N(520,40)` otherwise, `-K 2000000` so the input spans 23 cohorts):

- Identical SAM at `-t 1` and `-t 4`, 300000 records each.
- Identical `(25, 50, 75) percentile`, `mean and std.dev`, and `boundaries for proper pairs` lines — **all 92 of them, across every cohort** — so the intermediate statistics match, not just the alignments they happened to produce.

From the pre-rebase round, against the original parent:

- Byte-identical end to end on wgs-5M at `-t 16` and `-t 64` (digests `5774c6ef`, `b9c1e797` — the same digests #315's 27-run sweep produces).

## Measurement

`mem_pestat` timed directly and summed over a run's cohorts, c8g.16xlarge / wgs-5M / warm cache:

| | parent | histogram | |
|---|---:|---:|---:|
| `-t 16` (10 cohorts) | 0.3259 s | **0.1846 s** | −43.4 % |
| `-t 64` (3 cohorts) | 0.3149 s | **0.1782 s** | −43.4 % |

The identical reduction at both rungs is the expected shape: `mem_pestat` is serial and its cost depends on cohort size only, so it is a fixed **~0.32 s of every run's wall that thread count cannot touch** — 30 ns/read before, 14 after.

End to end that is ~0.14 s at any `-t`, which at `-t 64` is ~0.6 % and **sits below this round's run-to-run spread** (PROCESS varied 23.63/23.74 parent, 23.45/23.82 histogram). So the direct timing is what I'm quoting; I am not claiming a resolvable wall win at 2 reps. #315's 3-rep sweep puts the parent's `-t 64` spread at 0.02–0.15 % CV, which still does not resolve 0.14 s reliably — the direct timer remains the right instrument for a term this size.

Why this term is worth attacking at all: it is one of the three components of the 16→64 scaling loss. `mem_pestat` being flat in `-t` while everything around it scales makes it a textbook Amdahl term — 30 ns/read invariant in both thread count *and* cohort size across five configurations.

## Not in this PR

The candidate loop is still serial and is now the larger half of what remains. Histogramming it per thread and reducing would be safe — merging counts is integer addition, hence order-independent, so byte-identity survives — but it needs its own `kt_for` and belongs in its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved paired-read insert-size statistics by switching to a direct-address histogram approach for percentile and boundary calculations.
  * Reduced sorting and allocation overhead during statistics processing.
* **Bug Fixes**
  * Fixed insert-size histogram sizing by clamping `max_ins` to safe limits and preventing invalid histogram allocations.
  * Updated orientation reporting logic to use cumulative counts for more consistent results.
* **Tests**
  * Added unit tests covering empty cohort handling and `max_ins` edge cases (default, extremely large, and negative values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->