### PR TITLE
docs(memory): measure the -t batch multiplier cost and correct the resident index figure

### DIFF
--- a/docs/src/best-practices/multi-sample.md
+++ b/docs/src/best-practices/multi-sample.md
@@ -7,9 +7,11 @@ sample after the first.
 
 ## The problem: repeated index loads
 
-The bwa-mem3 index for hg38 is roughly 11 GB on disk (~15 GB resident once
-loaded). Without shared memory, `bwa-mem3 mem` reads the entire index from disk
-on every invocation.
+The bwa-mem3 index for hg38 is roughly 11 GB on disk, and essentially the same
+once loaded (~10.5 GiB resident) — the loaded files *are* the required ones, so
+the two figures are the same bytes in different units, not a saving. Without
+shared memory, `bwa-mem3 mem` reads the entire index from disk on every
+invocation.
 On a fast NVMe drive this takes 30–60 seconds; on a network-attached or
 spinning-disk filesystem it can take several minutes. For a batch of 100
 samples, that adds hours of pure I/O overhead.
@@ -17,7 +19,7 @@ samples, that adds hours of pure I/O overhead.
 ## Staging the index once with `bwa-mem3 shm`
 
 ```bash
-# Stage the index into shared memory (one-time cost, ~15 GB for hg38).
+# Stage the index into shared memory (one-time cost, ~10.5 GiB for hg38).
 bwa-mem3 shm ref.fa
 
 # Align each sample. bwa-mem3 mem attaches automatically — no extra flag.

--- a/docs/src/getting-started/quick-shm.md
+++ b/docs/src/getting-started/quick-shm.md
@@ -1,6 +1,7 @@
 # Quick start: shared-memory index
 
-The bwa-mem3 hg38 index is roughly 11 GB on disk (~15 GB once loaded into RAM). By default, every
+The bwa-mem3 hg38 index is roughly 11 GB on disk and about the same once loaded into RAM
+(~10.5 GiB resident — the same bytes, stated in binary units). By default, every
 `bwa-mem3 mem` invocation reads the index from disk, which can take 30–60 seconds on a spinning
 disk and several seconds even on fast NVMe storage. For workloads that align many small samples
 in sequence on the same machine, this per-invocation overhead accumulates.
@@ -58,7 +59,7 @@ Shared-memory indexing is most beneficial when:
 - Aligning tens to hundreds of small samples (e.g. amplicon panels, targeted sequencing) where
   per-sample read time dominates the per-sample alignment time.
 - Running a batch pipeline on a single large machine where the index fits comfortably in RAM
-  (approximately 15 GB for hg38 with the standard index).
+  (approximately 10.5 GiB for hg38 with the standard index).
 - The same reference is used for all samples in the batch; a new `shm` invocation is required
   for each distinct reference.
 

--- a/docs/src/user-guide/memory-and-data-types.md
+++ b/docs/src/user-guide/memory-and-data-types.md
@@ -17,8 +17,21 @@ peak RSS  ≈  resident index  +  per-batch working set
 
 **Resident index.** The FM-index, packed reference (`.pac`), and related
 structures are loaded once and shared across all threads (there is no per-thread
-copy). For hg38 the resident index baseline is roughly **15 GB**. This is fixed
+copy). For hg38 the resident index baseline is roughly **10.5 GB**. This is fixed
 for a given reference and does not change with `-t` or `-K`.
+
+That figure is measured, not estimated: aligning 1,000 read pairs with `-K 1000000`
+(so the per-batch term is negligible) peaks at **10.57 GiB (11.4 GB)** at `-t 1`. It
+matches the files actually loaded — `.bwt.2bit.64` (9.73 GiB) plus `.pac`
+(0.74 GiB) — which is why it is what it is. The previous figure on this page, 15 GB,
+was `.bwt.2bit.64` **plus `.0123`** (15.73 GiB): the pre-pac-fetch load, superseded by
+the paragraph below.
+
+The *memory* figures on this page are binary (GiB) even where written "GB" — that is
+the convention the old 15 GB figure used, and the aligner's own profiler reports
+mebibytes. The `.0123` **file sizes** are the exception: those are decimal, so the
+~6.4 GB quoted below is the same 5.99 GiB file, stated the way the rest of the
+documentation states it.
 
 `mem` reconstructs the reference bases it needs for scoring and extension
 directly from the packed `.pac` on demand (*pac-fetch*), so the unpacked
@@ -41,7 +54,9 @@ larger.
 **original** reference's packed `.pac` for scoring/extension. The seed FM-index
 is roughly twice the size of a plain FM-index (its contigs are doubled), so the
 resident index for hg38 is on the order of **22 GB** (seed FM-index ~21 GB +
-original `.pac` ~1 GB), versus ~15 GB for a plain alignment.
+original `.pac` ~1 GB), versus ~10.5 GB for a plain alignment. (The `--meth`
+figure is an estimate from the index sizes; unlike the plain figure above it has
+not been re-measured.)
 
 As with plain alignment, the original reference's bases are pac-fetched from its
 `.pac` — the original unpacked `.0123` (~6.4 GB) is **neither built nor loaded**.
@@ -123,8 +138,11 @@ budget like this:
 per-batch budget  ≈  memory cap  −  resident index  −  headroom
 ```
 
-For hg38 under a 22 GB cap, that is roughly `22 − 15 − a couple GB ≈ a few GB`
-for the per-batch working set — not much. The levers, in order of preference:
+For hg38 under a 22 GB cap, that is roughly `22 − 10.5 − a couple GB ≈ 9 GB` for
+the per-batch working set. That is more headroom than this page used to claim,
+because the index baseline was overstated — but note from the grid above that the
+**default** batch at `-t 64` alone wants ~14 GB, so a 22 GB cap still needs `-K`.
+The levers, in order of preference:
 
 1. **Lower `-K`.** `-K 1000000` keeps the per-batch working set well under 1 GB
    for typical short reads and costs little throughput. This is the first thing
@@ -134,7 +152,7 @@ for the per-batch working set — not much. The levers, in order of preference:
    adjusting `-K` first so you keep your cores busy.
 3. **Use `bwa-mem3 shm`** if you run several samples on one host: the index is
    mapped from a shared segment and its pages are shared across processes, so the
-   ~15 GB index is paid once rather than per process. See
+   ~10.5 GB index is paid once rather than per process. See
    [Quick start: shared-memory index](../getting-started/quick-shm.md).
 
 > **Tip — a silent OOM looks like a truncated BAM**

--- a/docs/src/user-guide/memory-and-data-types.md
+++ b/docs/src/user-guide/memory-and-data-types.md
@@ -77,6 +77,43 @@ Two consequences worth remembering:
   [`-K` in the mem reference](../cli/mem.md)), which is why it is useful for
   reproducibility independent of memory.
 
+### What the multiplier costs, measured
+
+hg38, 5M read pairs, `c8g.16xlarge`, warm page cache, peak RSS from the aligner's
+own profiler. Batch size and thread count are varied independently, one run per
+cell:
+
+| effective batch | `-t 16` | `-t 64` |
+|---|---:|---:|
+| 160,000,000 bases | **14.45 GB** — default at `-t 16` | 16.94 GB — `-K 160000000` |
+| 640,000,000 bases | 22.29 GB — `-K 640000000` | **24.27 GB** — default at `-t 64` |
+
+Read it two ways:
+
+- **Down a column: the batch is what costs memory.** Quadrupling it adds 7.8 GB at
+  `-t 16` and 7.3 GB at `-t 64`.
+- **Across a row: threads cost little once the batch is pinned.** 48 extra threads
+  add 2.49 GB and 1.98 GB respectively — on the order of 40–50 MB per thread of
+  per-thread scratch.
+
+The bold cells are the defaults, and they sit on the diagonal. That is the whole
+point: with no `-K`, raising `-t` moves you down *and* across at the same time, so
+peak memory tracks the thread count even though only the batch term requires it.
+Along that diagonal peak RSS is **14.45 / 18.44 / 24.27 GB at `-t 16 / 32 / 64`**.
+Extrapolating the batch term (this part is arithmetic, not measurement) puts
+`-t 128` near 37 GB and `-t 192` near 50 GB — enough to decide a machine type.
+
+Pinning the batch is close to free: at `-t 64`, `-K 160000000` measured 23.88 s of
+in-process alignment time against the default's 23.98 s, so the ~30 % memory
+reduction cost no throughput. Those are single runs, so read the wall figures as
+"no measurable cost" rather than as a speedup.
+
+Two caveats before generalising. Every absolute value above includes the resident
+hg38 index, so it is the *differences* between cells that transfer to another
+reference, not the totals. And `-K` changes how reads are grouped into batches,
+which changes each batch's `mem_pestat` insert-size estimate — so a run with `-K`
+is not byte-identical to one without, even though it is stable across `-t`.
+
 ## Fitting a run inside a memory cap
 
 Under a hard cap (a `--memory` cgroup limit, a Slurm `--mem`, a container limit),

--- a/docs/src/user-guide/threading.md
+++ b/docs/src/user-guide/threading.md
@@ -25,7 +25,7 @@ Thread count and wall-clock alignment time scale well to approximately 16–32
 threads on a modern CPU. Beyond that, several effects conspire to flatten the
 curve:
 
-1. **FM-index bandwidth.** The resident index for hg38 is ~15 GB and does not fit
+1. **FM-index bandwidth.** The resident index for hg38 is ~10.57 GiB and does not fit
    in the L3 cache of any current server. At high thread counts, threads contend
    for memory bandwidth accessing the BWT.
 2. **IO contention.** On spinning disk or a shared network filesystem,
@@ -76,15 +76,15 @@ and [Best Practices: multi-sample workflows](../best-practices/multi-sample.md).
 > independent of `-t`; do this for regression tests, release gating, and any
 > comparison against `bwa`/`bwa-mem2`. See [Aligning → `-K`](aligning.md).
 
-Peak RAM is the resident index (~15 GB for hg38, ~22 GB under `--meth`) plus a
+Peak RAM is the resident index (~10.57 GiB for hg38, ~22 GiB under `--meth`) plus a
 per-batch working set that scales with the *effective* batch size. The index term
 is fixed with respect to `-t`; the per-batch term is **not**, because the default
 effective batch is `chunk_size × n_threads`. Raising `-t` therefore raises peak
 memory unless you pin the batch with `-K`.
 
-Measured on hg38 with 5M read pairs, peak RSS is **14.45 / 18.44 / 24.27 GB at
+Measured on hg38 with 5M read pairs, peak RSS is **14.45 / 18.44 / 24.27 GiB at
 `-t 16 / 32 / 64`**, and pinning `-K 160000000` at `-t 64` brings that back to
-16.94 GB — about 30 % less memory at no measurable throughput cost. So if you
+16.94 GiB — about 30 % less memory at no measurable throughput cost. So if you
 raise `-t` on a memory-constrained host, lower `-K` to compensate; and if you are
 sizing a machine for high thread counts, size it for the batch, not the index.
 

--- a/docs/src/user-guide/threading.md
+++ b/docs/src/user-guide/threading.md
@@ -77,11 +77,21 @@ and [Best Practices: multi-sample workflows](../best-practices/multi-sample.md).
 > comparison against `bwa`/`bwa-mem2`. See [Aligning → `-K`](aligning.md).
 
 Peak RAM is the resident index (~15 GB for hg38, ~22 GB under `--meth`) plus a
-per-batch working set that scales with the *effective* batch size
-(`chunk_size × n_threads`), and is fixed with respect to `-t`. The per-batch term
-is what tips memory-constrained or wide-window (e.g. Hi-C) runs into OOM, and
-`bwa-mem3 shm` lets concurrent processes share one physical copy of the index.
-For the full budgeting model and the `-K`/`-t` interaction, see
+per-batch working set that scales with the *effective* batch size. The index term
+is fixed with respect to `-t`; the per-batch term is **not**, because the default
+effective batch is `chunk_size × n_threads`. Raising `-t` therefore raises peak
+memory unless you pin the batch with `-K`.
+
+Measured on hg38 with 5M read pairs, peak RSS is **14.45 / 18.44 / 24.27 GB at
+`-t 16 / 32 / 64`**, and pinning `-K 160000000` at `-t 64` brings that back to
+16.94 GB — about 30 % less memory at no measurable throughput cost. So if you
+raise `-t` on a memory-constrained host, lower `-K` to compensate; and if you are
+sizing a machine for high thread counts, size it for the batch, not the index.
+
+The per-batch term is what tips memory-constrained or wide-window (e.g. Hi-C) runs
+into OOM, and `bwa-mem3 shm` lets concurrent processes share one physical copy of
+the index. For the full budgeting model, the measured `-K`/`-t` grid and the
+caveats on those numbers, see
 [Memory budgeting and data-type tuning](memory-and-data-types.md).
 
 ## IO recommendations


### PR DESCRIPTION
Docs only, off `main`, no dependency on the cohort/ramp stack.

The memory page already says the default effective batch is `chunk_size × n_threads` and that peak memory therefore grows with `-t`. It never said **by how much** — which is the number people actually need when picking an instance type or setting a cgroup limit.

## The measurement

Batch size and thread count varied independently, so the two terms can be separated. hg38, 5M read pairs, `c8g.16xlarge`, warm page cache, peak RSS from the aligner's own profiler, one run per cell:

| effective batch | `-t 16` | `-t 64` |
|---|---:|---:|
| 160,000,000 bases | **14.45 GB** — default at `-t 16` | 16.94 GB — `-K 160000000` |
| 640,000,000 bases | 22.29 GB — `-K 640000000` | **24.27 GB** — default at `-t 64` |

- **Down a column:** the batch dominates — quadrupling it costs 7.8 GB at `-t 16` and 7.3 GB at `-t 64`.
- **Across a row:** threads are cheap once the batch is pinned — 48 extra threads cost 2.49 GB and 1.98 GB, on the order of 40–50 MB per thread of scratch.

The defaults are the **diagonal**, which is the finding: with no `-K`, raising `-t` moves down *and* across at once, so memory tracks the thread count even though only the batch term requires it. Along the diagonal peak RSS is 14.45 / 18.44 / 24.27 GB at `-t 16 / 32 / 64`.

Pinning the batch is close to free: `-K 160000000` at `-t 64` measured 23.88 s of in-process time against the default's 23.98 s — about **30 % less memory at no throughput cost**.

## What I was careful about

- The `-t 128` ≈ 37 GB and `-t 192` ≈ 50 GB figures are **extrapolation of the batch term, not measurement**, and the page labels them that way.
- The wall-time comparison is single runs, so the text says "no measurable cost" rather than claiming a speedup.
- Absolute values include the resident index, so only the *differences* between cells transfer to another reference. Stated on the page.
- `-K` changes batch composition and hence each batch's `mem_pestat` estimate, so a `-K` run is not byte-identical to one without — stable across `-t`, but not the same output. Also stated, since the surrounding docs recommend `-K` for reproducibility and the distinction matters.

## Drive-by correction

`threading.md` described the per-batch working set as one that "scales with the *effective* batch size (`chunk_size × n_threads`), and is fixed with respect to `-t`." On the natural reading that is self-contradictory, and it inverts the guidance a reader tuning `-t` needs: the *index* term is fixed in `-t`; the per-batch term is exactly what is not.

## Second commit: the "~15 GB resident index" figure was wrong

Flagged in the first draft of this PR as "looks stale, needs its own measurement". I measured it, so it is fixed here too.

**It is exactly `.bwt.2bit.64 + .0123` = 9.73 + 5.99 = 15.73 GiB** — the pre-pac-fetch load. Today's pac-fetch path loads `.bwt.2bit.64 + .pac` = **10.48 GiB**, and aligning 1,000 read pairs with `-K 1000000` (negligible batch term) measures **10.57 GiB at `-t 1`**, 11.51 GiB at `-t 64`.

The page was already contradicting itself: two paragraphs below the 15 GB figure it says `.0123` is "neither loaded nor required on disk" and that pac-fetch cut peak RSS by ~6.2 GB.

Corrected in all eight places, plus the cap-budgeting arithmetic derived from it — under a 22 GB cap the per-batch budget is ~9 GB, not "a few GB". The text now also warns that the default `-t 64` batch alone wants ~14 GB, so more headroom does **not** mean the default fits.

Deliberately not changed:

- **`--meth` ~22 GB** — an estimate from index sizes, not re-measured. Now labelled as such.
- **"~11 GB on disk"** — correct as written, since pac-fetch also drops `.0123` from the on-disk requirement.
- **Unit convention.** This page mixes them: its 15 GB was binary (15.73 GiB) while its "`.0123` ~6.4 GB" is decimal for the same 5.99 GiB file. The measured line now states both explicitly; normalising the whole doc set is a separate job.

## Verification

`mdbook build` is clean and the new table renders; the six "potential incomplete link" warnings are identical on unmodified `main`, so nothing here introduced them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected hg38 shared-memory resident index estimates to ~10.5 GiB (replacing prior ~15 GB wording) across the memory, threading, multi-sample staging, and quick shared-memory guides.
  * Clarified that disk vs RAM sizing differences are primarily unit conversion (byte-for-byte equivalence), not real storage savings.
  * Expanded memory budgeting guidance with corrected baselines, refined peak RSS explanations, updated `--meth` and `-K` considerations, and added/adjusted measured RSS tables and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->