### PR TITLE
perf(bsw): admit high-h0 pairs to the 8-bit banded-SW tier

### DIFF
--- a/src/bandedSWA.cpp
+++ b/src/bandedSWA.cpp
@@ -972,18 +972,24 @@ void BandedPairWiseSW::smithWaterman256_8(uint8_t seq1SoA[],
     // with UNSIGNED order (== after _mm256_max_epu8), so the full [0,255] is usable.
     //
     // PRECONDITION (enforced by the caller): every pair reaching this kernel has
-    // passed bwamem.cpp's bsw8_envelope_ok(), which admits a pair only when
-    //   (a) its MAX ATTAINABLE score h0 + min(len1,len2)*maxStep stays below
-    //       255 - maxStep, so no row max can ever reach the byte ceiling, and
-    //   (b) h0 <= zdrop + 1.
+    // passed bwamem.cpp's bsw8_envelope_ok(), which admits a pair only when its
+    // MAX ATTAINABLE score h0 + min(len1,len2)*maxStep stays below 255 - maxStep,
+    // so no row max can ever reach the byte ceiling. That same bound caps the seed
+    // (h0 <= max attainable), so the seed byte fits a uint8 with no separate gate.
     // Under that gate the byte state is an exact absolute score for every cell:
     // it can neither overflow nor need rescaling, so this is a plain exact
     // unsigned [0,255] Smith-Waterman.
     //
+    // There is deliberately NO h0 <= zdrop + 1 precondition. That gate existed only
+    // to force the removed re-baseline floor B0 = max(0, h0 - (zdrop+1)) to zero;
+    // the separate concern it also covered — a high-h0 lane z-dropping before its
+    // row max builds up — is handled by the 8-bit z-drop/seed clamp fixed in #273.
+    // See EXT-4 in bsw8_envelope_ok().
+    //
     // This kernel previously carried a per-lane running score FLOOR B[l] (stored
     // byte = H_absolute - B[l]) plus a per-row probe that lowered B whenever a row
     // max climbed toward 255 — a "re-baseline" safety net for scores that overflow
-    // a byte. Condition (a) makes that net UNREACHABLE: it never fired on any
+    // a byte. The max-attainable bound makes that net UNREACHABLE: it never fired on any
     // in-envelope pair, so B was identically 0 and every stored byte already equalled
     // the absolute score. It has been removed, which deletes per row: a
     // _mm256_movemask_epi8 probe plus, per lane group, a B load and two int32 adds
@@ -2810,18 +2816,24 @@ void BandedPairWiseSW::smithWaterman512_8(uint8_t seq1SoA[],
     // with UNSIGNED order (_mm512_cmpgt_epu8_mask), so the full [0,255] is usable.
     //
     // PRECONDITION (enforced by the caller): every pair reaching this kernel has
-    // passed bwamem.cpp's bsw8_envelope_ok(), which admits a pair only when
-    //   (a) its MAX ATTAINABLE score h0 + min(len1,len2)*maxStep stays below
-    //       255 - maxStep, so no row max can ever reach the byte ceiling, and
-    //   (b) h0 <= zdrop + 1.
+    // passed bwamem.cpp's bsw8_envelope_ok(), which admits a pair only when its
+    // MAX ATTAINABLE score h0 + min(len1,len2)*maxStep stays below 255 - maxStep,
+    // so no row max can ever reach the byte ceiling. That same bound caps the seed
+    // (h0 <= max attainable), so the seed byte fits a uint8 with no separate gate.
     // Under that gate the byte state is an exact absolute score for every cell:
     // it can neither overflow nor need rescaling, so this is a plain exact
     // unsigned [0,255] Smith-Waterman.
     //
+    // There is deliberately NO h0 <= zdrop + 1 precondition. That gate existed only
+    // to force the removed re-baseline floor B0 = max(0, h0 - (zdrop+1)) to zero;
+    // the separate concern it also covered — a high-h0 lane z-dropping before its
+    // row max builds up — is handled by the 8-bit z-drop/seed clamp fixed in #273.
+    // See EXT-4 in bsw8_envelope_ok().
+    //
     // This kernel previously carried a per-lane running score FLOOR B[l] (stored
     // byte = H_absolute - B[l]) plus a per-row probe that lowered B whenever a row
     // max climbed toward 255 — a "re-baseline" safety net for scores that overflow
-    // a byte. Condition (a) makes that net UNREACHABLE: it never fired on any
+    // a byte. The max-attainable bound makes that net UNREACHABLE: it never fired on any
     // in-envelope pair, so B was identically 0 and every stored byte already equalled
     // the absolute score. It has been removed, which deletes per row: a
     // per-lane row-max probe plus, per lane group, a B load and two int32 adds in
@@ -5543,18 +5555,24 @@ void BandedPairWiseSW::smithWaterman128_8(uint8_t seq1SoA[],
     // with UNSIGNED order (== after _mm_max_epu8), so the full [0,255] is usable.
     //
     // PRECONDITION (enforced by the caller): every pair reaching this kernel has
-    // passed bwamem.cpp's bsw8_envelope_ok(), which admits a pair only when
-    //   (a) its MAX ATTAINABLE score h0 + min(len1,len2)*maxStep stays below
-    //       255 - maxStep, so no row max can ever reach the byte ceiling, and
-    //   (b) h0 <= zdrop + 1.
+    // passed bwamem.cpp's bsw8_envelope_ok(), which admits a pair only when its
+    // MAX ATTAINABLE score h0 + min(len1,len2)*maxStep stays below 255 - maxStep,
+    // so no row max can ever reach the byte ceiling. That same bound caps the seed
+    // (h0 <= max attainable), so the seed byte fits a uint8 with no separate gate.
     // Under that gate the byte state is an exact absolute score for every cell:
     // it can neither overflow nor need rescaling, so this is a plain exact
     // unsigned [0,255] Smith-Waterman.
     //
+    // There is deliberately NO h0 <= zdrop + 1 precondition. That gate existed only
+    // to force the removed re-baseline floor B0 = max(0, h0 - (zdrop+1)) to zero;
+    // the separate concern it also covered — a high-h0 lane z-dropping before its
+    // row max builds up — is handled by the 8-bit z-drop/seed clamp fixed in #273.
+    // See EXT-4 in bsw8_envelope_ok().
+    //
     // This kernel previously carried a per-lane running score FLOOR B[l] (stored
     // byte = H_absolute - B[l]) plus a per-row probe that lowered B whenever a row
     // max climbed toward 255 — a "re-baseline" safety net for scores that overflow
-    // a byte. Condition (a) makes that net UNREACHABLE: it never fired on any
+    // a byte. The max-attainable bound makes that net UNREACHABLE: it never fired on any
     // in-envelope pair, so B was identically 0 and every stored byte already equalled
     // the absolute score. It has been removed, which deletes per row: a
     // _mm_movemask_epi8 probe (a multi-instruction addv reduction on NEON) plus,

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -120,17 +120,20 @@ KSORT_INIT(mem_intv1, SMEM, intv_lt1)  // debug
  *     as a diagonal offset d = j - i in [-w, +w], which fits signed int8
  *     only for w <= 127. The default opt->w = 100 qualifies; wide-band
  *     retries (w doubling to 200/400/800) do NOT and fall back to 16-bit.
- *   - zdrop + maxStep <= 253      : keeps the re-baseline window non-empty,
- *     REBASE_HI = 255 - maxStep > REBASE_KEEP = zdrop + 1. The DP body AND the
- *     h0-prefix column/row seed (smithWaterman*_8 setup) are both unsigned-
- *     saturating [0,255], so the seeded byte h0' = min(h0, REBASE_KEEP) only
- *     needs to fit a uint8. maxStep is the largest per-step score increment,
+ *   - zdrop + maxStep <= 253      : zdrop is broadcast into the DP as a byte
+ *     (_mm256_set1_epi8), so it must fit one, and the maxStep headroom keeps the
+ *     z-drop comparison from wrapping at the top of the range. The DP body AND
+ *     the h0-prefix column/row seed (smithWaterman*_8 setup) are both unsigned-
+ *     saturating [0,255], and the seed is the raw h0 clamped to uint8 (the old
+ *     min(h0, zdrop+1) prefix clamp went away with the re-baseline floor).
+ *     maxStep is the largest per-step score increment,
  *     max(w_match, w_ambig, 1) = max(opt->a, 1).
- *   - h0 <= zdrop + 1             : keeps the initial floor B0 = max(0, h0 -
- *     REBASE_KEEP) == 0, so the seed score does not itself force a re-baseline.
  *   - h0 + min(len1,len2)*a < 255 - maxStep : the MAX ATTAINABLE score (seed
- *     plus an all-match diagonal over the shorter sequence) stays below REBASE_HI,
- *     so the running row max never reaches it and re-baseline never fires.
+ *     plus an all-match diagonal over the shorter sequence) stays below the byte
+ *     ceiling, so no row max can ever reach it. This is also what bounds h0
+ *     itself, which is why there is no separate h0 gate: the former
+ *     h0 <= zdrop + 1 condition existed to zero the removed re-baseline floor
+ *     and was dropped in EXT-4 (see bsw8_envelope_ok below).
  *
  * NOTE: minval (= h0 + min(len)*a) is still used by sortPairsLenExt as the
  * counting-sort bin index (hist[minval]) and must stay < MAX_SEQ_LEN8 there for
@@ -138,13 +141,17 @@ KSORT_INIT(mem_intv1, SMEM, intv_lt1)  // debug
  * decision. Pairs failing this envelope fall through to the existing 16-bit
  * (then scalar) buckets exactly as before. */
 #define BSW8_MAX_W 127                 /* max band: diagonal offset d=j-i must fit signed int8 */
-#define BSW8_MAX_ZDROP_STEP 253        /* keep the re-baseline window non-empty:
-                                          REBASE_HI=255-max_step > REBASE_KEEP=zdrop+1, i.e.
-                                          zdrop+max_step <= 253. The DP body AND the h0-prefix
-                                          column/row seed in the 8-bit wrappers are both
-                                          unsigned-saturating [0,255], so the seed byte
-                                          min(h0,REBASE_KEEP) just needs to fit a uint8.
-                                          See smithWaterman128_8 re-baseline + h0-prefix seed. */
+#define BSW8_MAX_ZDROP_STEP 253        /* zdrop is broadcast into the DP as a byte
+                                          (_mm256_set1_epi8), so it must fit one, and the
+                                          max_step headroom keeps the z-drop comparison from
+                                          wrapping: zdrop+max_step <= 253. The DP body AND the
+                                          h0-prefix column/row seed in the 8-bit wrappers are
+                                          both unsigned-saturating [0,255], and the seed is the
+                                          raw h0 clamped to uint8. NOTE: the 253 value dates from
+                                          the re-baseline era, where it also kept
+                                          255-max_step > zdrop+1; with re-baseline gone that
+                                          second role is moot, so this bound is now conservative
+                                          rather than tight. See smithWaterman128_8 h0-prefix seed. */
 
 static inline int bsw8_envelope_ok(int len1, int len2, int w,
                                    int score_a, int zdrop, int h0)
@@ -167,9 +174,10 @@ static inline int bsw8_envelope_ok(int len1, int len2, int w,
     int64_t max_step = score_a > 1 ? (int64_t)score_a : 1;   /* max(w_match, w_ambig, 1) */
     int64_t shorter  = len1 < len2 ? (int64_t)len1 : (int64_t)len2;
     /* Max attainable SW score: seed h0 plus an all-match diagonal over the
-     * shorter sequence. Must stay strictly below REBASE_HI = 255 - max_step so
-     * the running row max never triggers a (lossy) re-baseline; combined with
-     * h0 <= zdrop+1 (B0 == 0) the kernel runs as an exact unsigned [0,255] SW. */
+     * shorter sequence. Must stay strictly below the byte ceiling 255 - max_step
+     * so no row max can ever reach it; that alone makes the kernel an exact
+     * unsigned [0,255] SW, and since h0 <= max_score it also bounds the seed
+     * byte, so no separate h0 gate is needed. */
     int64_t max_score = (int64_t)h0 + shorter * (int64_t)score_a;
     return len1 < MAX_SEQ_LEN8 && len2 < MAX_SEQ_LEN8 &&
            /* target (rows, len1) >= query (cols, len2). The re-baseline 8-bit
@@ -185,7 +193,20 @@ static inline int bsw8_envelope_ok(int len1, int len2, int w,
            len1 >= len2 &&
            w <= BSW8_MAX_W &&
            zdrop + max_step <= BSW8_MAX_ZDROP_STEP &&
-           h0 <= zdrop + 1 &&
+           /* EXT-4: the former `h0 <= zdrop + 1` gate has been dropped. It was
+            * introduced to force the per-lane re-baseline floor B0 = max(0, h0 -
+            * (zdrop+1)) to zero; that re-baseline machinery was removed (the 8-bit
+            * DP is now a plain unsigned [0,255] SW), so h0's only remaining
+            * constraint is that the seed byte fit a uint8 — guaranteed by the
+            * max_score bound below (h0 <= max_score < 255 - max_step). A second,
+            * subtler role — bounding the seed against the z-drop horizon so a
+            * high-h0 lane does not z-drop before its row max builds up — was fixed
+            * in the kernel by #273 (correct 8-bit z-drop/seed clamp at high seed
+            * scores). getScores8 is now byte-identical to scalarBandedSWA across
+            * the newly-admitted h0 > zdrop+1 region for the default, moderate, and
+            * harsh scoring sweeps (see test/bandedswa_high_h0_zdrop_test.cpp).
+            * Admitting these pairs moves ~7.41% of Illumina extension pairs from
+            * the 8-lane 16-bit tier to the 16-lane 8-bit tier. */
            max_score < 255 - max_step;
 }
 

--- a/test/bandedswa_high_h0_zdrop_test.cpp
+++ b/test/bandedswa_high_h0_zdrop_test.cpp
@@ -160,6 +160,8 @@ int main() {
         {2, 8, 12, 2,  20, 100, "-A2 -B8 -O12 -E2 zdrop=20"},
         {3, 4,  6, 1,  20, 100, "-A3 zdrop=20"},
         {1, 4,  6, 1,  10,  20, "defaults zdrop=10 narrow band"},
+        {1, 9, 16, 3, 100, 100, "-B9 -O16 -E3 zdrop=100 (harsh probe)"},
+        {2, 20, 30, 5, 20, 100, "-A2 -B20 -O30 -E5 zdrop=20 (very harsh probe)"},
     };
     const long n = 20000;
 

--- a/test/bandedswa_highzdrop_seed_test.cpp
+++ b/test/bandedswa_highzdrop_seed_test.cpp
@@ -4,9 +4,13 @@
 // The 8-bit banded-SW DP body is unsigned [0,255]. The h0-prefix column/row
 // seed (smithWaterman*_8 wrapper setup) is now also unsigned-saturating
 // (subs_epu8); it previously used signed int8 ops, which required the seeded
-// byte min(h0, REBASE_KEEP) <= 127 and so capped zdrop at 126
-// (BSW8_MAX_ZDROP_STEP). With the unsigned seed the gate admits zdrop up to
-// ~252, and seed prefix bytes range over (127, 254].
+// byte -- then min(h0, zdrop + 1) -- to be <= 127, and so capped zdrop at 126
+// whenever h0 reached that clamp. With the unsigned seed the gate admits zdrop
+// up to 252 (zdrop + maxStep <= BSW8_MAX_ZDROP_STEP, which is 253), and seed
+// prefix bytes above 127: the `h0 <= zdrop + 1` clause this test retains permits
+// h0 up to 253, which the max-attainable-score bound
+// (h0 + shorter*a < 255 - maxStep) then narrows by the shorter sequence's
+// length -- to 233 for the len2 >= 20 this test draws. Never 254.
 //
 // This test exercises exactly that new regime: zdrop = 200 with h0 in
 // (127, 200], so every admitted pair seeds prefix bytes > 127 — the range the
@@ -31,6 +35,14 @@ struct Out { int score, tle, gtle, qle, gscore, max_off; };
 
 // Mirror of bwamem.cpp bsw8_envelope_ok for a = maxStep = 1 (this test's
 // scoring). Only admitted pairs are required to match scalar.
+//
+// Deliberately a SUBSET of the production gate: it retains the `h0 <= zdrop + 1`
+// condition that bsw8_envelope_ok dropped in EXT-4. This test is about the
+// unsigned h0-prefix seed above 127, not about the widened h0 envelope, so
+// holding its admitted set fixed keeps it a regression test for that one
+// property. Being stricter than production can only shrink the admitted set, so
+// it cannot produce a false failure. The newly admitted h0 > zdrop+1 region is
+// covered by test/bandedswa_high_h0_zdrop_test.cpp instead.
 bool envelope_ok(int len1, int len2, int w, int zdrop, int h0, int maxStep) {
     int shorter = len1 < len2 ? len1 : len2;
     return len1 < MAX_SEQ_LEN8 && len2 < MAX_SEQ_LEN8 && len1 >= len2 &&
@@ -120,7 +132,11 @@ int main() {
     for (long k = 0; k < admitted; ++k) {
         const SeqPair &q = apairs[k];
         long c = admittedIdx[k];
-        int h0p = q.h0 < zdrop + 1 ? q.h0 : zdrop + 1;   // seeded byte min(h0,REBASE_KEEP)
+        /* The kernel seeds the raw h0, clamped to uint8 only (the old
+         * min(h0, zdrop+1) prefix clamp went away with the re-baseline floor).
+         * Within this test's envelope h0 <= zdrop+1 <= 201, so the clamp is
+         * inert here; compute it the way the kernel does regardless. */
+        int h0p = q.h0 < 0 ? 0 : (q.h0 > 255 ? 255 : q.h0);   // seeded byte
         if (h0p > 127) seed_hi++;
         const Out &O = oracle[c];
         if (O.score != q.score || O.tle != q.tle || O.gtle != q.gtle ||


### PR DESCRIPTION
## What

Drops the `h0 <= zdrop + 1` condition from `bsw8_envelope_ok()`, the routing gate that decides whether an extension pair goes to the 8-bit (16/32/64-lane) banded-SW kernel or the 8-lane 16-bit tier.

That condition existed only to force the per-lane re-baseline floor `B0 = max(0, h0 - (zdrop+1))` to zero. The re-baseline machinery was removed earlier (the 8-bit DP is now a plain unsigned `[0,255]` Smith-Waterman), so the seed byte's only remaining constraint is that it fit a `uint8` — already guaranteed by the `max_score < 255 - max_step` bound. The subtler role of the condition (bounding the seed against the z-drop horizon, so a high-`h0` lane does not z-drop before its row max builds up) was corrected in the kernel by #273.

The other envelope conditions are unchanged: `len1 >= len2`, `w <= 127`, the byte-overflow bound, and the slab-size bounds all remain load-bearing and are kept.

## Effect

Routes ~7.4% of Illumina WGS extension pairs from the 16-bit tier to the 8-bit tier, effectively retiring the 16-bit tier for Illumina data (measured via the pair-dump hook on HG002 WGS: 16-bit tier share 7.84% → 0.17%, the residual being exactly the `len1 < len2` pairs the envelope still excludes).

## Correctness — byte-identical on every tier

Since this changes *which* kernel computes ~7.4% of pairs, byte-identity was re-established at the SAM level, per tier, over a 1M-read-pair WGS slice (HG002, hg38), fixed `-t`, md5 excluding `@PG`, against the base commit:

| tier | host | result |
|---|---|---|
| NEON (arm64) | Graviton4 + Apple Silicon | byte-identical |
| AVX2 | Sapphire Rapids | byte-identical |
| AVX-512BW | Sapphire Rapids | byte-identical |

`test/bandedswa_high_h0_zdrop_test.cpp` is extended with harsh gap/mismatch parameter sets (`-B9 -O16 -E3`, `-A2 -B20 -O30 -E5`) that exercise the newly-admitted `h0 > zdrop+1` region against `scalarBandedSWA` — 0 diffs across all 10 parameter sets (200,000 pairs).

## Performance — whole-aligner wall A/B (same slice, `-t16`, warm index, each run validated for exit code + full record count)

| tier | host | Δ wall |
|---|---|---|
| AVX-512BW | Sapphire Rapids | **~16% faster** |
| NEON | Graviton4 | neutral (~0.3%) |
| AVX2 | Sapphire Rapids | neutral (noisy) |

The AVX-512 gain is frequency-management driven: the baseline sends the 7.4% of high-`h0` pairs through the zmm-heavy 16-bit AVX-512 kernel, whose license-based downclock drags the whole run; retiring that tier keeps the core at a higher frequency. NEON has no such penalty (hence neutral), and AVX2 uses ymm (less downclock, hence neutral/noisy). No tier regresses.

## Validation notes

Both the SAM byte-identity and the wall-clock numbers were taken from runs confirmed to exit 0 and emit the full record count; the 8-bit vs 16-bit routing shift was confirmed non-vacuous before trusting the byte-identity result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 8-bit envelope gating and alignment extension routing for high-score and high-`h0` cases, enabling more scenarios to use the 8-bit fast path while maintaining score-safety guarantees.

* **Tests**
  * Expanded the HIGH-`h0`/high-`zdrop` regression matrix with additional harsh scoring-parameter probes.
  * Refined the seeded-`h0` regression to match the unsigned seeding behavior and corrected mismatch accounting for the verified score byte.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->