### PR TITLE
refactor(chain): fuse mem_chain_weight's two seed sweeps into one

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -869,22 +869,24 @@ int mem_seed_sw(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
 
 int mem_chain_weight(const mem_chain_t *c)
 {
-    int64_t end;
-    int j, w = 0, tmp;
-    for (j = 0, end = 0; j < c->n; ++j) {
+    /* CL-1: fused query- and reference-axis coverage into a single seed sweep.
+     * The two accumulations are independent (query coverage keys off qbeg/len,
+     * reference coverage off rbeg/len), so interleaving them in one pass with a
+     * separate running end per axis is byte-identical to the former two sweeps
+     * -- it only halves the loop iterations (the second sweep re-read the same
+     * L1-resident seeds), a tidy-up rather than a speedup. */
+    int64_t qend, rend;
+    int j, wq = 0, wr = 0, w;
+    for (j = 0, qend = 0, rend = 0; j < c->n; ++j) {
         const mem_seed_t *s = &c->seeds[j];
-        if (s->qbeg >= end) w += s->len;
-        else if (s->qbeg + s->len > end) w += s->qbeg + s->len - end;
-        end = end > s->qbeg + s->len? end : s->qbeg + s->len;
+        if (s->qbeg >= qend) wq += s->len;
+        else if (s->qbeg + s->len > qend) wq += s->qbeg + s->len - qend;
+        qend = qend > s->qbeg + s->len? qend : s->qbeg + s->len;
+        if (s->rbeg >= rend) wr += s->len;
+        else if (s->rbeg + s->len > rend) wr += s->rbeg + s->len - rend;
+        rend = rend > s->rbeg + s->len? rend : s->rbeg + s->len;
     }
-    tmp = w; w = 0;
-    for (j = 0, end = 0; j < c->n; ++j) {
-        const mem_seed_t *s = &c->seeds[j];
-        if (s->rbeg >= end) w += s->len;
-        else if (s->rbeg + s->len > end) w += s->rbeg + s->len - end;
-        end = end > s->rbeg + s->len? end : s->rbeg + s->len;
-    }
-    w = w < tmp? w : tmp;
+    w = wq < wr? wq : wr;
     return w < 1<<30? w : (1<<30)-1;
 }
 


### PR DESCRIPTION
## What

`mem_chain_weight` swept a chain's seed array **twice** — once accumulating query-axis coverage (keyed off `qbeg`/`len`), once reference-axis coverage (keyed off `rbeg`/`len`) — then took `min` of the two. The two accumulations are independent, so this fuses them into a **single pass** with a running end and partial sum per axis, taking `min(query, reference)` at the end. The `1<<30` clamp is unchanged.

## Why

Tidy-up: the second sweep re-read the same seeds that were already L1-resident from the first, so halving the iteration count is not expected to move wall-clock — this is a readability/redundancy cleanup, **not** a perf change. No perf claim is made.

## Correctness

Byte-identical: each per-axis accumulation is preserved exactly (only interleaved), and `min(wq, wr)` equals the former `min(w, tmp)`. Verified at the SAM level — whole-aligner output md5 (excluding `@PG`) is identical to the base commit over a 1M-read-pair WGS slice (HG002/hg38) at fixed `-t`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal chain coverage calculations while preserving existing results and behavior.
  * Reduced redundant processing when evaluating query and reference coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->