### PR TITLE
ci(meth): gate the batched OT/OB mate rescue and collapsed scoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,13 +517,21 @@ jobs:
         # OT/OB x strand placement; original-alphabet output integrity (Bismark
         # four-strand XR/XG); and the reverse-strand-conversion matrix flip
         # (meth_strand_hyp) — a reverse read that is unmapped under the unflipped
-        # matrix and full-length under the fix.
+        # matrix and full-length under the fix; the batched OT/OB-partition mate
+        # rescue being byte-identical to the scalar rescue; and the `collapsed`
+        # --meth-scoring model.
         env:
           BWA_MEM3: ${{ github.workspace }}/bwa-mem3
         run: |
+          # All but meth_seed_index `exit 0` with "SKIP: samtools not on PATH"
+          # when samtools is missing, so without this assertion a runner that
+          # lost the apt package would turn the whole step into a green no-op.
+          command -v samtools >/dev/null 2>&1 \
+            || { echo "FAIL: samtools not on PATH; the --meth regressions would all SKIP"; exit 1; }
           for t in meth_seed_index meth_mixed_pe_asym meth_pe_placement \
                    meth_output_integrity meth_reverse_strand_conversion \
-                   meth_seed_unpacked_ref_not_loaded; do
+                   meth_seed_unpacked_ref_not_loaded \
+                   meth_rescue_batched_identical meth_collapsed_scoring; do
             echo "::group::$t"; bash "test/regression/$t.sh"; echo "::endgroup::"
           done
 


### PR DESCRIPTION
The self-contained `--meth` regression loop in `ci.yml` ran six of the eight meth tests in `test/regression/`. The two it skipped were the two with no other coverage anywhere in CI. This adds them, and makes the step fail rather than silently no-op when its one external dependency is missing.

## `meth_rescue_batched_identical`

This is the one that matters. It asserts that mate rescue routed through the **batched OT/OB-partition `kswv` kernel** emits a BAM byte-identical to the legacy scalar `ksw_align2` rescue, toggling between them with the `BWAMEM3_METH_BATCHED_RESCUE` escape hatch — same binary on both legs, so the diff isolates the routing.

That kernel is roughly 38% of compute CPU on a whole-genome run and is under active optimisation (#324 modified it; more is queued behind it). Nothing in CI covered it. It has been passing because people touching the kernel chose to run it by hand, which is not a guarantee that the next person does.

Scope note, already documented in the test's header: this is a no-regression guard for the *routing*, not the kernel-correctness oracle. The rescue candidate's `kswv` score is re-derived downstream by `mem_sort_dedup_patch` and the asymmetric `mem_reg2aln` re-scoring, so a SIMD-vs-scalar score difference would not surface in the final BAM. The authoritative per-field byte-identity gate for the mat-aware OT/OB rescue kernel remains the standalone sw-kernel-bench self-check (`sw_bench --mode rescue --meth ot|ob`).

## `meth_collapsed_scoring`

Covers the `collapsed` `--meth-scoring` model, whose siblings the loop already runs. It exercises `bandedSWA`'s general (>=2 freed cell) matrix path by checking that a single ref-T → read-C substitution — the conversion *mirror* cell — is free under `collapsed` and a real mismatch under `genomic`, while `NM` preserves the literal mismatch either way.

## samtools assertion

Seven of the eight tests `exit 0` with `SKIP: samtools not on PATH` when samtools is missing. Today it arrives via the apt step, but if that ever stops delivering it, the entire step becomes a green no-op instead of a failure. The three added lines assert it up front. A gate that can silently no-op is not a gate.

## Cost

Both additions are self-contained: each generates a deterministic 1500 bp reference and its reads inline, needs no committed fixtures, and finishes in seconds. No new dependencies beyond `samtools` and `python3`, both already required by the loop.

## Verification

Built from this branch and ran the loop exactly as the step spells it, with an absolute `BWA_MEM3`. All eight pass:

```
meth_seed_index                        PASS
meth_mixed_pe_asym                     PASS
meth_pe_placement                      PASS
meth_output_integrity                  PASS
meth_reverse_strand_conversion         PASS
meth_seed_unpacked_ref_not_loaded      PASS
meth_rescue_batched_identical          PASS  (batched OT/OB-partition rescue == scalar rescue, byte-identical BAM)
meth_collapsed_scoring                 OK    (genomic: AS=55 NM=1   collapsed: AS=60 NM=1)
```

That run was on arm64/NEON; neither test is tier-sensitive, since both compare two legs of the same binary on the same host. The guard was checked separately under a stripped `PATH` and exits 1 as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded meth regression coverage to include additional rescue and collapsed-scoring scenarios.
  * Added a pre-flight check to ensure `samtools` is available before running regressions, preventing false skips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->