### PR TITLE
perf(kswv): recover the query end after the row, via block checkpoints

### DIFF
--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -34,6 +34,21 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "kswv.h"
 #include "limits.h"
 
+/* Column blocking for the u8 kernels' post-row query-end recovery. The row's
+ * running max is checkpointed every QE_BLK columns, so the recovery scans only
+ * the block(s) holding the max instead of the whole row. Measured on wgs-5M at
+ * 64 lanes: 68.1 % of the rows that need a query end resolve inside a single
+ * block and 89.6 % within two (mean 1.50), cutting the scan from 160 columns to
+ * ~34 -- 4.7x. QE_BLK=16 is the flat part of that curve; 8 is a wash and 32 is
+ * worse, because halving the block-index sweep doubles the block being scanned.
+ *
+ * QE_MAXBLK bounds the checkpoint array. ncol cannot exceed 255 in the 8-bit
+ * kernels -- the width guard (l_ms * a < 250) caps it, and the u8 column index
+ * the kernel records would wrap otherwise -- so 256/QE_BLK blocks plus one for
+ * a partial tail is always enough. */
+#define QE_BLK    16
+#define QE_MAXBLK (256 / QE_BLK + 1)
+
 /* ARM/NEON support */
 #if defined(__ARM_NEON) || defined(__aarch64__) || defined(APPLE_SILICON)
 #include "neon_utils.h"
@@ -178,21 +193,9 @@ static inline int compute_jdummy(const SeqPair *p, int width, int ncol, int cap)
         m11 = _mm512_subs_epu8(m11, sft512);                            \
         h11 = _mm512_max_epu8(m11, e11);                                \
         h11 = _mm512_max_epu8(h11, f11);                                \
-        /* AVX-512 deliberately KEEPS the per-cell query-end tracking    \
-         * that NEON and AVX2 defer to a post-row rescan. Measured on    \
-         * c7i/wgs-5M: deferring is worth -6.69 % here (the largest gain \
-         * of any tier) but recovering qe by rescanning costs ~7 pp on   \
-         * top, for a net +1.23 % REGRESSION. The rescan is dearer at 64 \
-         * lanes because its trigger is "did ANY lane advance", so it    \
-         * fires on 39.9 % of rows versus 18.9 % at 16 lanes. Masking    \
-         * the scan to the active lanes and exiting once they are all    \
-         * found recovers only ~1 pp (+0.24 %), because a firing row     \
-         * usually has many active lanes and the last match tends to sit \
-         * late in the row. Capturing the -6.69 % needs a cheaper way to \
-         * obtain qe, not a cheaper scan. */                             \
-        __mmask64 cmp0 = _mm512_cmpgt_epu8_mask(h11, imax512);          \
+        /* Row max only; the query-end column is recovered after the row \
+         * from the QE_BLK checkpoints. See kswv_neon_u8_impl. */        \
         imax512 = _mm512_max_epu8(imax512, h11);                        \
-        iqe512 = _mm512_mask_blend_epi8(cmp0, iqe512, l512);            \
         __m512i gapE512 = _mm512_subs_epu8(h11, oe_ins512);             \
         e11 = _mm512_subs_epu8(e11, e_ins512);                          \
         e11 = _mm512_max_epu8(gapE512, e11);                            \
@@ -568,6 +571,11 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
 
     uint8x16_t zero_vec = vdupq_n_u8(0);
 
+    /* Per-row running-max checkpoints, one vector per QE_BLK columns. Rewritten
+     * every row, so no clearing is needed; a few hundred bytes of stack, hot in
+     * L1 beside H0/H1/F. */
+    alignas(64) uint8_t blockMax[QE_MAXBLK * SIMD_WIDTH8];
+
     m_b = n_b = 0; b = 0;
 
     int8_t temp[SIMD_WIDTH8] __attribute((aligned(128))) = {0};
@@ -860,8 +868,19 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
                                                                                 \
             vst1q_u8(H1 + (j + 1) * SIMD_WIDTH8, h11);                          \
             vst1q_u8(F + (j + 1) * SIMD_WIDTH8, f21);                           \
+            /* Checkpoint the running row max once per QE_BLK columns, so the   \
+             * post-row query-end recovery can find the block holding the max   \
+             * without rescanning the whole row. One vector store per QE_BLK    \
+             * cells, on a branch taken 1-in-QE_BLK with a fixed stride -- the  \
+             * predictor sees a regular pattern, and the four unswitched column \
+             * loops stay intact. */                                            \
+            if (j == qeNext) {                                                  \
+                vst1q_u8(blockMax + qeBlk * SIMD_WIDTH8, imax_vec);             \
+                qeBlk++; qeNext += QE_BLK;                                      \
+            }                                                                   \
         }
 
+        int qeNext = QE_BLK - 1, qeBlk = 0;
         j = 0;
         if (i < minLen1) {
             /* No lane has begun reference padding and no column below jsplit
@@ -881,6 +900,13 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
         for (; j < ncol; j++)
             KSWV_NEON_U8_CELL(true, vtstq_u8(vorrq_u8(s1, s2), highbit_vec), true)
 #undef KSWV_NEON_U8_CELL
+
+        /* Close the final (possibly partial) block. imax_vec is now the row max,
+         * so this entry always compares equal below, which is what guarantees
+         * the block walk terminates with every active lane found. When ncol is a
+         * multiple of QE_BLK this rewrites the last complete block with the same
+         * value. */
+        vst1q_u8(blockMax + ((ncol - 1) / QE_BLK) * SIMD_WIDTH8, imax_vec);
 
         /* Block I - row max tracking */
         if (i > 0)
@@ -942,9 +968,12 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
          * seventeen SIMD ALU ops -- on every cell of every row. But qe is only
          * ever CONSUMED on a row that advances some lane's global max, which
          * instrumenting wgs-5M puts at 18.9 % of rows. So recover it here
-         * instead, by rescanning this row's H1 for the first column equal to
-         * the row max. At 4 ops per scanned column the amortised cost is
-         * 0.19 * 4 = 0.76 ops per cell against 3 removed.
+         * instead, from the QE_BLK checkpoints: take the first block whose
+         * running max equals the row max, and scan only that block's columns
+         * for the first H1 cell equal to it. Restricting the scan to the
+         * block(s) that can hold the max cuts it to a fraction of the row
+         * (QE_BLK's comment carries the measured factor), which is what keeps
+         * the amortised cost well under the 3 ops per cell removed above.
          *
          * Identical by construction. The per-cell form blended iqe on a STRICT
          * `h11 > running row max`, so what it computed was
@@ -959,13 +988,31 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
         if (neon_movemask_u8(cmp0_active))
         {
             uint8x16_t iqe_vec = vdupq_n_u8(0xFF);
-            uint8x16_t found = zero_vec;
+            uint8x16_t foundBlk = zero_vec;
             const uint8_t *colIdx = this->colIdx8;
-            for (int j2 = 0; j2 < ncol; j2++) {
-                uint8x16_t eq = vceqq_u8(vld1q_u8(H1 + (j2 + 1) * SIMD_WIDTH8), imax_vec);
-                uint8x16_t first = vbicq_u8(eq, found);
-                iqe_vec = vbslq_u8(first, vld1q_u8(colIdx + j2 * SIMD_WIDTH8), iqe_vec);
-                found = vorrq_u8(found, eq);
+            const int nblocks = (ncol + QE_BLK - 1) / QE_BLK;
+            for (int b = 0; b < nblocks; b++) {
+                /* blockMax[b] is the running row max after block b, so it is
+                 * non-decreasing in b. `reached` marks lanes whose max was
+                 * already attained by the end of this block; `newly` narrows
+                 * that to active lanes seeing it for the FIRST time, whose
+                 * first occurrence of the max therefore lies inside block b. */
+                uint8x16_t reached = vceqq_u8(vld1q_u8(blockMax + b * SIMD_WIDTH8), imax_vec);
+                uint8x16_t newly = vandq_u8(vbicq_u8(reached, foundBlk), cmp0_active);
+                foundBlk = vorrq_u8(foundBlk, reached);
+                if (neon_movemask_u8(newly)) {
+                    const int j0 = b * QE_BLK;
+                    const int j1 = (j0 + QE_BLK < ncol) ? (j0 + QE_BLK) : ncol;
+                    uint8x16_t got = zero_vec;
+                    for (int j2 = j0; j2 < j1; j2++) {
+                        uint8x16_t eq = vandq_u8(
+                            vceqq_u8(vld1q_u8(H1 + (j2 + 1) * SIMD_WIDTH8), imax_vec), newly);
+                        uint8x16_t first = vbicq_u8(eq, got);
+                        iqe_vec = vbslq_u8(first, vld1q_u8(colIdx + j2 * SIMD_WIDTH8), iqe_vec);
+                        got = vorrq_u8(got, eq);
+                    }
+                }
+                if (!vmaxvq_u8(vbicq_u8(cmp0_active, foundBlk))) break;
             }
             qe_vec = vbslq_u8(cmp0_active, iqe_vec, qe_vec);
         }
@@ -1777,6 +1824,9 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
 
     const __m256i zero_vec = _mm256_setzero_si256();
 
+    /* Per-row running-max checkpoints; see kswv_neon_u8_impl. */
+    alignas(64) uint8_t blockMax[QE_MAXBLK * SIMD_WIDTH8];
+
     /* Score lookup table (16 bytes). Indexed by (s1 ^ s2). */
     int8_t temp[SIMD_WIDTH8] __attribute__((aligned(64))) = {0};
 
@@ -1966,11 +2016,20 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
  \
             _mm256_storeu_si256((__m256i*)(H1 + (j + 1) * SIMD_WIDTH8), h11); \
             _mm256_storeu_si256((__m256i*)(F  + (j + 1) * SIMD_WIDTH8), f21); \
+            if (j == qeNext) { \
+                _mm256_store_si256((__m256i*)(blockMax + qeBlk * SIMD_WIDTH8), imax_vec); \
+                qeBlk++; qeNext += QE_BLK; \
+            } \
 }
+        int qeNext = QE_BLK - 1, qeBlk = 0;
         int j = 0;
         for (; j < jdummy_a2; j++) KSWV_AVX2_U8_CELL(false)
         for (; j < ncol; j++)      KSWV_AVX2_U8_CELL(true)
 #undef KSWV_AVX2_U8_CELL
+
+        /* Close the final (possibly partial) block; see kswv_neon_u8_impl. */
+        _mm256_store_si256((__m256i*)(blockMax + ((ncol - 1) / QE_BLK) * SIMD_WIDTH8),
+                           imax_vec);
 
         /* Block I - rowMax tracking. Same shape as NEON. */
         if (i > 0) {
@@ -2012,21 +2071,37 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
 
         /* Deferred query-end recovery; see the rescan in kswv_neon_u8_impl for
          * the full derivation of why this is identical to the per-cell form. */
-        if (_mm256_movemask_epi8(cmp0_active))
+        const int active_msk = _mm256_movemask_epi8(cmp0_active);
+        if (active_msk)
         {
             __m256i iqe_vec = _mm256_set1_epi8((char)0xFF);
-            __m256i found = zero_vec;
+            __m256i foundBlk = zero_vec;
             const uint8_t *colIdx = this->colIdx8;
-            for (int j2 = 0; j2 < ncol; j2++) {
-                __m256i eq = _mm256_cmpeq_epi8(
-                    _mm256_loadu_si256((const __m256i*)(H1 + (j2 + 1) * SIMD_WIDTH8)),
-                    imax_vec);
-                __m256i first = _mm256_andnot_si256(found, eq);
-                iqe_vec = avx2_blendv_u8(
-                    first,
-                    _mm256_loadu_si256((const __m256i*)(colIdx + j2 * SIMD_WIDTH8)),
-                    iqe_vec);
-                found = _mm256_or_si256(found, eq);
+            const int nblocks = (ncol + QE_BLK - 1) / QE_BLK;
+            for (int b = 0; b < nblocks; b++) {
+                __m256i reached = _mm256_cmpeq_epi8(
+                    _mm256_load_si256((const __m256i*)(blockMax + b * SIMD_WIDTH8)), imax_vec);
+                __m256i newly = _mm256_and_si256(
+                    _mm256_andnot_si256(foundBlk, reached), cmp0_active);
+                foundBlk = _mm256_or_si256(foundBlk, reached);
+                if (_mm256_movemask_epi8(newly)) {
+                    const int j0 = b * QE_BLK;
+                    const int j1 = (j0 + QE_BLK < ncol) ? (j0 + QE_BLK) : ncol;
+                    __m256i got = zero_vec;
+                    for (int j2 = j0; j2 < j1; j2++) {
+                        __m256i eq = _mm256_and_si256(
+                            _mm256_cmpeq_epi8(
+                                _mm256_loadu_si256((const __m256i*)(H1 + (j2 + 1) * SIMD_WIDTH8)),
+                                imax_vec),
+                            newly);
+                        iqe_vec = avx2_blendv_u8(
+                            _mm256_andnot_si256(got, eq),
+                            _mm256_loadu_si256((const __m256i*)(colIdx + j2 * SIMD_WIDTH8)),
+                            iqe_vec);
+                        got = _mm256_or_si256(got, eq);
+                    }
+                }
+                if ((_mm256_movemask_epi8(foundBlk) & active_msk) == active_msk) break;
             }
             qe_vec = avx2_blendv_u8(cmp0_active, iqe_vec, qe_vec);
         }
@@ -2933,6 +3008,9 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
 
     __m512i zero512 = _mm512_setzero_si512();
     __m512i one512  = _mm512_set1_epi8(1);
+
+    /* Per-row running-max checkpoints; see kswv_neon_u8_impl. */
+    alignas(64) uint8_t blockMax[QE_MAXBLK * SIMD_WIDTH8];
     
     m_b = n_b = 0; b = 0;
 
@@ -3065,7 +3143,6 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
         s1 = _mm512_load_si512((__m512i *)(seq1SoA + (i + 0) * SIMD_WIDTH8));
         h10 = zero512;
         imax512 = zero512;
-        __m512i iqe512 = _mm512_set1_epi8(-1);
 
         /* Freed-cell override (issue 173, bisulfite OT/OB + TAPS neutral). s1 is
          * loop-invariant across the inner j loop, so hoist the per-row fr_ref
@@ -3109,10 +3186,14 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
                                                                                     \
             _mm512_store_si512((__m512i *)(H1 + (j + 1) * SIMD_WIDTH8), h11);       \
             _mm512_store_si512((__m512i *)(F + (j + 1)* SIMD_WIDTH8), f21);         \
-            l512 = _mm512_add_epi8(l512, one512);                                   \
+            if (j == qeNext) {                                                      \
+                _mm512_store_si512((__m512i *)(blockMax + qeBlk * SIMD_WIDTH8),      \
+                                   imax512);                                        \
+                qeBlk++; qeNext += QE_BLK;                                          \
+            }                                                                       \
         }
 
-        __m512i l512 = zero512;
+        int qeNext = QE_BLK - 1, qeBlk = 0;
         /* Below jsplit the two forms are equal, so the meth (HasFreed)
          * instantiation keeps the per-cell one: hoisting there pins a third
          * live k-reg against the two freed masks and measured slightly slower.
@@ -3130,6 +3211,10 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
         for (; j < ncol; j++)
             KSWV_AVX512_U8_CELL(rowboundary512 | _mm512_movepi8_mask(s2), true)
 #undef KSWV_AVX512_U8_CELL
+
+        /* Close the final (possibly partial) block; see kswv_neon_u8_impl. */
+        _mm512_store_si512((__m512i *)(blockMax + ((ncol - 1) / QE_BLK) * SIMD_WIDTH8),
+                           imax512);
 
         // Block I
         if (i > 0)
@@ -3153,7 +3238,39 @@ int kswv::kswv512_u8_impl(uint8_t seq1SoA[],
         gmax512 = _mm512_mask_blend_epi8(cmp0, gmax512, imax512);
         te512 = _mm512_mask_blend_epi16((__mmask32)cmp0, te512,  i512);
         te512_ = _mm512_mask_blend_epi16((__mmask32) (cmp0 >> SIMD_WIDTH16), te512_,  i512);
-        qe512 = _mm512_mask_blend_epi8(cmp0, qe512,  iqe512);
+        /* Deferred query-end recovery over the QE_BLK checkpoints; see
+         * kswv_neon_u8_impl for the derivation. `found` and the per-block
+         * masks are k-regs here, so a block that holds no active lane's max
+         * costs one compare, one kandn and one kor. */
+        if (cmp0)
+        {
+            __m512i iqe512 = _mm512_set1_epi8(-1);
+            __mmask64 foundBlk = 0;
+            const uint8_t *colIdx = this->colIdx8;
+            const int nblocks = (ncol + QE_BLK - 1) / QE_BLK;
+            for (int b = 0; b < nblocks; b++) {
+                __mmask64 reached = _mm512_cmpeq_epu8_mask(
+                    _mm512_load_si512((__m512i *)(blockMax + b * SIMD_WIDTH8)), imax512);
+                __mmask64 newly = reached & ~foundBlk & cmp0;
+                foundBlk |= reached;
+                if (newly) {
+                    const int j0 = b * QE_BLK;
+                    const int j1 = (j0 + QE_BLK < ncol) ? (j0 + QE_BLK) : ncol;
+                    __mmask64 got = 0;
+                    for (int j2 = j0; j2 < j1; j2++) {
+                        __mmask64 eq = _mm512_cmpeq_epu8_mask(
+                            _mm512_load_si512((__m512i *)(H1 + (j2 + 1) * SIMD_WIDTH8)),
+                            imax512) & newly;
+                        iqe512 = _mm512_mask_blend_epi8(
+                            eq & ~got, iqe512,
+                            _mm512_loadu_si512((const __m512i *)(colIdx + j2 * SIMD_WIDTH8)));
+                        got |= eq;
+                    }
+                }
+                if ((foundBlk & cmp0) == cmp0) break;
+            }
+            qe512 = _mm512_mask_blend_epi8(cmp0, qe512, iqe512);
+        }
         
         cmp0 = _mm512_cmpge_epu8_mask(gmax512, endsc512);
         cmp0 &= endsc_msk_a;

--- a/src/kswv.cpp
+++ b/src/kswv.cpp
@@ -178,6 +178,18 @@ static inline int compute_jdummy(const SeqPair *p, int width, int ncol, int cap)
         m11 = _mm512_subs_epu8(m11, sft512);                            \
         h11 = _mm512_max_epu8(m11, e11);                                \
         h11 = _mm512_max_epu8(h11, f11);                                \
+        /* AVX-512 deliberately KEEPS the per-cell query-end tracking    \
+         * that NEON and AVX2 defer to a post-row rescan. Measured on    \
+         * c7i/wgs-5M: deferring is worth -6.69 % here (the largest gain \
+         * of any tier) but recovering qe by rescanning costs ~7 pp on   \
+         * top, for a net +1.23 % REGRESSION. The rescan is dearer at 64 \
+         * lanes because its trigger is "did ANY lane advance", so it    \
+         * fires on 39.9 % of rows versus 18.9 % at 16 lanes. Masking    \
+         * the scan to the active lanes and exiting once they are all    \
+         * found recovers only ~1 pp (+0.24 %), because a firing row     \
+         * usually has many active lanes and the last match tends to sit \
+         * late in the row. Capturing the -6.69 % needs a cheaper way to \
+         * obtain qe, not a cheaper scan. */                             \
         __mmask64 cmp0 = _mm512_cmpgt_epu8_mask(h11, imax512);          \
         imax512 = _mm512_max_epu8(imax512, h11);                        \
         iqe512 = _mm512_mask_blend_epi8(cmp0, iqe512, l512);            \
@@ -260,6 +272,15 @@ kswv::kswv(const int o_del, const int e_del, const int o_ins,
     H8_0 = (uint8_t*) H16_0;
     H8_1 = (uint8_t*) H16_1;
     rowMax8 = (uint8_t*) rowMax16;
+
+    /* Column-index broadcast table for the u8 kernels' post-row query-end
+     * rescan; see kswv.h. Shared by all threads and never written after
+     * construction. */
+    colIdx8 = (uint8_t *)_mm_malloc((size_t) this->maxQerLen * SIMD_WIDTH8
+                                    * sizeof(uint8_t), 64);
+    for (int32_t j = 0; j < this->maxQerLen; ++j)
+        for (int k = 0; k < SIMD_WIDTH8; ++k)
+            colIdx8[(size_t) j * SIMD_WIDTH8 + k] = (uint8_t) j;
 }
 
 // Mat-aware constructor (issue 173). Delegates to the 9-arg ctor (identical
@@ -369,6 +390,7 @@ kswv::kswv(const int o_del, const int e_del, const int o_ins,
 kswv::~kswv() {
     _mm_free(F16); _mm_free(H16_0); _mm_free(H16_1);
     _mm_free(rowMax16);
+    _mm_free(colIdx8);
 }
 
 
@@ -545,7 +567,6 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
     uint64_t *b;
 
     uint8x16_t zero_vec = vdupq_n_u8(0);
-    uint8x16_t one_vec = vdupq_n_u8(1);
 
     m_b = n_b = 0; b = 0;
 
@@ -733,7 +754,6 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
         s1 = vld1q_u8(seq1SoA + (i + 0) * SIMD_WIDTH8);
         h10 = zero_vec;
         imax_vec = zero_vec;
-        uint8x16_t iqe_vec = vdupq_n_u8(0xFF);
 
         /* Freed-cell override (issue 173, bisulfite OT/OB + TAPS neutral). The
          * freed cell (s1==fr_ref, s2==fr_read) scores fr_val. s1 is
@@ -769,8 +789,6 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
             active_frread = vbslq_u8(rowfreed,  vdupq_n_u8((uint8_t)fr_read),
                                      active_frread);
         }
-
-        uint8x16_t l_vec = zero_vec;
 
         /* One DP cell. BND is the boundary mask -- bit 7 set in the reference
          * base (rows past len1) or the query base (columns past this lane's
@@ -820,10 +838,10 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
             uint8x16_t hme = vmaxq_u8(m11, e11);                                \
             h11 = vmaxq_u8(hme, f11);                                           \
                                                                                 \
-            /* Update imax tracking */                                          \
-            uint8x16_t cmp0 = vcgtq_u8(h11, imax_vec);                          \
+            /* Row max only. The COLUMN at which it sits (the query end) is    \
+             * recovered after the row, and only on the rows that actually     \
+             * advance a lane's global max -- see the rescan below. */         \
             imax_vec = vmaxq_u8(imax_vec, h11);                                 \
-            iqe_vec = vbslq_u8(cmp0, l_vec, iqe_vec);                           \
                                                                                 \
             /* Reassociate BOTH gap recurrences off h11 (Daily-scan algebra).   \
              * e uses max(m11,f11), f uses max(m11,e11) — each drops the term   \
@@ -842,7 +860,6 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
                                                                                 \
             vst1q_u8(H1 + (j + 1) * SIMD_WIDTH8, h11);                          \
             vst1q_u8(F + (j + 1) * SIMD_WIDTH8, f21);                           \
-            l_vec = vaddq_u8(l_vec, one_vec);                                    \
         }
 
         j = 0;
@@ -918,7 +935,40 @@ int kswv::kswv_neon_u8_impl(uint8_t seq1SoA[],
         /* Update te/qe only for active lanes (imax > gmax AND not frozen) */
         te_vec_lo = vbslq_s16(cmp_lo_16, i_vec, te_vec_lo);
         te_vec_hi = vbslq_s16(cmp_hi_16, i_vec, te_vec_hi);
-        qe_vec = vbslq_u8(cmp0_active, iqe_vec, qe_vec);
+
+        /* Query end (qe) of this row's max. The inner loop used to carry it
+         * cell by cell -- a compare against the running row max, a blend of
+         * the column index, and the counter feeding that blend, three of the
+         * seventeen SIMD ALU ops -- on every cell of every row. But qe is only
+         * ever CONSUMED on a row that advances some lane's global max, which
+         * instrumenting wgs-5M puts at 18.9 % of rows. So recover it here
+         * instead, by rescanning this row's H1 for the first column equal to
+         * the row max. At 4 ops per scanned column the amortised cost is
+         * 0.19 * 4 = 0.76 ops per cell against 3 removed.
+         *
+         * Identical by construction. The per-cell form blended iqe on a STRICT
+         * `h11 > running row max`, so what it computed was
+         * min{ j : H1[j+1] == imax } -- exactly what this scan returns. Every
+         * column in [0, ncol) is written to H1 on every row (the jsplit ranges
+         * partition the width, they do not skip any of it), so the scan never
+         * reads a cell left over from an earlier row. Pad columns participate
+         * in column order in both forms, so a row max attained only by a
+         * carried-forward pad column still reports that pad column. Lanes that
+         * did not advance get a garbage index, discarded by the same vbsl the
+         * per-cell form already relied on. */
+        if (neon_movemask_u8(cmp0_active))
+        {
+            uint8x16_t iqe_vec = vdupq_n_u8(0xFF);
+            uint8x16_t found = zero_vec;
+            const uint8_t *colIdx = this->colIdx8;
+            for (int j2 = 0; j2 < ncol; j2++) {
+                uint8x16_t eq = vceqq_u8(vld1q_u8(H1 + (j2 + 1) * SIMD_WIDTH8), imax_vec);
+                uint8x16_t first = vbicq_u8(eq, found);
+                iqe_vec = vbslq_u8(first, vld1q_u8(colIdx + j2 * SIMD_WIDTH8), iqe_vec);
+                found = vorrq_u8(found, eq);
+            }
+            qe_vec = vbslq_u8(cmp0_active, iqe_vec, qe_vec);
+        }
 
         /* Check end score threshold */
         uint8x16_t cmp_end = vcgeq_u8(gmax_vec, endsc_vec);
@@ -1726,7 +1776,6 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
     uint8_t endsc[SIMD_WIDTH8] __attribute__((aligned(64))) = {0};
 
     const __m256i zero_vec = _mm256_setzero_si256();
-    const __m256i one_vec  = _mm256_set1_epi8(1);
 
     /* Score lookup table (16 bytes). Indexed by (s1 ^ s2). */
     int8_t temp[SIMD_WIDTH8] __attribute__((aligned(64))) = {0};
@@ -1830,8 +1879,6 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
         __m256i e11 = zero_vec;
         __m256i s1  = _mm256_loadu_si256((const __m256i*)(seq1SoA + i * SIMD_WIDTH8));
         imax_vec    = zero_vec;
-        __m256i iqe_vec = _mm256_set1_epi8((char)0xFF);
-        __m256i l_vec = zero_vec;
         __m256i i_vec_s16 = _mm256_set1_epi16((int16_t)i);
 
         /* Freed-cell override (issue 173, bisulfite OT/OB + TAPS neutral). The
@@ -1905,9 +1952,9 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
             __m256i h11 = _mm256_max_epu8(m11, e11); \
             h11 = _mm256_max_epu8(h11, f11); \
  \
-            __m256i cmp0 = avx2_cmpgt_u8(h11, imax_vec); \
+            /* Row max only; the query-end column is recovered after the row. \
+             * See the rescan below kswv_neon_u8_impl's equivalent. */ \
             imax_vec = _mm256_max_epu8(imax_vec, h11); \
-            iqe_vec  = avx2_blendv_u8(cmp0, l_vec, iqe_vec); \
  \
             __m256i gapE = _mm256_subs_epu8(h11, oe_ins_vec); \
             e11 = _mm256_subs_epu8(e11, e_ins_vec); \
@@ -1919,7 +1966,6 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
  \
             _mm256_storeu_si256((__m256i*)(H1 + (j + 1) * SIMD_WIDTH8), h11); \
             _mm256_storeu_si256((__m256i*)(F  + (j + 1) * SIMD_WIDTH8), f21); \
-            l_vec = _mm256_add_epi8(l_vec, one_vec); \
 }
         int j = 0;
         for (; j < jdummy_a2; j++) KSWV_AVX2_U8_CELL(false)
@@ -1963,7 +2009,27 @@ int kswv::kswv256_u8_impl(uint8_t seq1SoA[],
 
         te_vec_lo = avx2_blendv_u8(cmp_lo_16, i_vec_s16, te_vec_lo);
         te_vec_hi = avx2_blendv_u8(cmp_hi_16, i_vec_s16, te_vec_hi);
-        qe_vec    = avx2_blendv_u8(cmp0_active, iqe_vec, qe_vec);
+
+        /* Deferred query-end recovery; see the rescan in kswv_neon_u8_impl for
+         * the full derivation of why this is identical to the per-cell form. */
+        if (_mm256_movemask_epi8(cmp0_active))
+        {
+            __m256i iqe_vec = _mm256_set1_epi8((char)0xFF);
+            __m256i found = zero_vec;
+            const uint8_t *colIdx = this->colIdx8;
+            for (int j2 = 0; j2 < ncol; j2++) {
+                __m256i eq = _mm256_cmpeq_epi8(
+                    _mm256_loadu_si256((const __m256i*)(H1 + (j2 + 1) * SIMD_WIDTH8)),
+                    imax_vec);
+                __m256i first = _mm256_andnot_si256(found, eq);
+                iqe_vec = avx2_blendv_u8(
+                    first,
+                    _mm256_loadu_si256((const __m256i*)(colIdx + j2 * SIMD_WIDTH8)),
+                    iqe_vec);
+                found = _mm256_or_si256(found, eq);
+            }
+            qe_vec = avx2_blendv_u8(cmp0_active, iqe_vec, qe_vec);
+        }
 
         /* End-score check + freeze update. */
         __m256i cmp_end = avx2_cmpge_u8(gmax_vec, endsc_vec);

--- a/src/kswv.h
+++ b/src/kswv.h
@@ -567,7 +567,23 @@ private:
 	uint8_t *F8;
 	uint8_t *H8_0, *H8_1;
 	uint8_t *rowMax8;
-	
+
+	/* Column index broadcast across all lanes: colIdx8[j*W + k] == (uint8_t) j.
+	 * The NEON and AVX2 u8 kernels' post-row query-end rescan needs the scanned
+	 * column index in every lane; reading it from this table costs one load,
+	 * where deriving it would cost a broadcast or a running vector add.
+	 * maxQerLen * SIMD_WIDTH8 bytes -- 8 KB at 16 lanes, 33 KB at 64 -- swept in
+	 * column order, so it stays L1-resident alongside H0/H1/F. Unused by the
+	 * AVX-512 u8 kernel, which keeps the per-cell form (see MAIN_SAM_CODE8_OPT
+	 * for why), so on an AVX-512 build this is built once and never read; it is
+	 * left unconditional rather than #ifdef'd because 33 KB of one-time setup
+	 * does not earn another preprocessor branch through the constructor.
+	 *
+	 * Only the low byte matters: the 8-bit kernels' width guard (l_ms * a <
+	 * 250) caps ncol well under 255, and the per-cell counter this replaced was
+	 * itself a u8 that wrapped identically. */
+	uint8_t *colIdx8;
+
 	int16_t *F16;
 	int16_t *H16_0, *H16_1;
 	int16_t *rowMax16;

--- a/src/kswv.h
+++ b/src/kswv.h
@@ -569,19 +569,19 @@ private:
 	uint8_t *rowMax8;
 
 	/* Column index broadcast across all lanes: colIdx8[j*W + k] == (uint8_t) j.
-	 * The NEON and AVX2 u8 kernels' post-row query-end rescan needs the scanned
-	 * column index in every lane; reading it from this table costs one load,
-	 * where deriving it would cost a broadcast or a running vector add.
-	 * maxQerLen * SIMD_WIDTH8 bytes -- 8 KB at 16 lanes, 33 KB at 64 -- swept in
-	 * column order, so it stays L1-resident alongside H0/H1/F. Unused by the
-	 * AVX-512 u8 kernel, which keeps the per-cell form (see MAIN_SAM_CODE8_OPT
-	 * for why), so on an AVX-512 build this is built once and never read; it is
-	 * left unconditional rather than #ifdef'd because 33 KB of one-time setup
-	 * does not earn another preprocessor branch through the constructor.
+	 * All three u8 kernels -- NEON, AVX2 and AVX-512BW -- read it when they
+	 * recover the query end after the row: the scan needs the scanned column
+	 * index in every lane, and one load is cheaper there than a broadcast or a
+	 * running vector add.
 	 *
-	 * Only the low byte matters: the 8-bit kernels' width guard (l_ms * a <
-	 * 250) caps ncol well under 255, and the per-cell counter this replaced was
-	 * itself a u8 that wrapped identically. */
+	 * maxQerLen * SIMD_WIDTH8 bytes -- 8 KB at 16 lanes, 33 KB at 64 -- but a
+	 * row only touches the block(s) the QE_BLK checkpoints select, so the live
+	 * working set is a fraction of that and stays L1-resident alongside H0/H1/F.
+	 *
+	 * Only the low byte matters: ncol cannot exceed 255 in the 8-bit kernels,
+	 * capped by the width guard (l_ms * a < 250). That is the same bound
+	 * QE_MAXBLK sizes the checkpoint array against -- see the QE_BLK comment in
+	 * kswv.cpp. */
 	uint8_t *colIdx8;
 
 	int16_t *F16;


### PR DESCRIPTION
Now rebased onto `main` (thanks for the retarget and the `compute_jdummy` extraction) and extended with a **second commit that supersedes the first commit's mechanism**. Read them in order — the first establishes *why* the query end can be deferred, the second makes the deferral cheap.

Three of the u8 rescue kernel's per-cell SIMD ALU ops exist only to record *where* in the query the row max sat: a compare against the running row max, a blend of the column index into `iqe`, and the counter feeding that blend. But `qe` is only ever *consumed* on a row that advances some lane's global max. So drop those three from the inner loop and recover `qe` afterwards.

- **`recover the query end after the row`** — recovers it by rescanning the row's `H1`.
- **`find the query end via block checkpoints`** — checkpoints the running row max every 16 columns and scans only the block holding it. Better on every tier; this is the mechanism to review.

## Results

wgs-5M, arms interleaved, **every arm warmed**, every run's records and digest checked before its timing was read. Each host's arms were all measured in one session, so the two columns are directly comparable.

| tier | host | full-row rescan | **block checkpoints** |
|---|---|---:|---:|
| avx2 `-t 16` | c7i.4xlarge | −3.31 % | **−5.63 %** |
| neon `-t 16` | c8g.16xlarge | −2.54 % | **−4.37 %** |
| neon `-t 64` | c8g.16xlarge | −0.65 % | **−2.15 %** |
| avx512bw `-t 16` | c7i.4xlarge | +1.23 % | **−1.23 %** |

Block checkpoints win everywhere, and they turn `avx512bw` from a regression into a small win — which is why the first commit's AVX-512 arm, which kept the per-cell form, is re-enabled by the second.

Reps are tight: NEON base 80.565/80.527 against blocked-max 77.042/77.014 at `-t 16`. Note these are all *within-session* deltas — the same binary drifted 4–7 % across sessions on the same host, so cross-session absolute times are not comparable and I haven't quoted any.

## Why blocking works

The rescan's trigger is *"did **any** lane advance its global max"*, so its fire rate climbs with lane count — 18.9 % of rows at 16 lanes, 31.7 % at 32, 39.9 % at 64 (counter over wgs-5M). At 64 lanes the full-row rescan therefore runs more than twice as often as the 18.9 % that originally motivated deferring at all, which is exactly why it regressed there.

But the *argmax columns cluster*. Instrumenting wgs-5M at 64 lanes: an average firing row has 21.2 active lanes, yet their argmax columns fall into a mean of **1.50 distinct 16-column blocks** — 68.1 % into a single block, 89.6 % within two. So scanning only the block(s) that matter cuts the scan from ~160 columns to ~34, a **4.7×** reduction.

`QE_BLK = 16` is the flat part of that curve: 8 is a wash, 32 is worse because halving the block-index sweep doubles the block being scanned.

## Correctness

Identical by construction, argued in the code:

- The per-cell form blended `iqe` on a **strict** `h11 > running row max`, so it computed `min{ j : H1[j+1] == imax }`.
- `blockMax[b]` is the running row max after block b and is non-decreasing in b, so the **first** block whose checkpoint equals the row max holds the max's first occurrence; scanning that block in column order returns the same index.
- Lanes are resolved the first time their checkpoint matches and masked out of later blocks; the final block is closed with the row max itself, so the walk always terminates with every active lane resolved.
- Every column in `[0, ncol)` is written to `H1` on every row, so no scan can read a cell left from an earlier row.
- The one case where an equality scan could disagree — an all-zero row, where the strict `>` never fires and `iqe` stays `0xFF` while a scan returns column 0 — is unreachable on an active lane, since `imax == 0` cannot satisfy the unsigned `imax > gmax` that puts a lane in `cmp0_active`.

Verified, not asserted:

- wgs-5M digests `5774c6ef` at `-t 16` on **neon, avx2 and avx512bw** and `b9c1e797` at `-t 64` on neon — 10,030,558 records on every run, every arm.
- sw-kernel-bench's rescue padding gate passes at **neon, avx2 and avx512bw** across all three `--meth-scoring` models, 8-bit and 16-bit, against the scalar oracle, with its own negative controls firing.
- Local PE fixture `1787274d6818` / 300000; `meth_rescue_batched_identical` passes (now a CI gate via #325); `make test` green.
- No new compiler warnings at either x86 tier — counts identical to base.

## What is left on the table

`avx512bw` is still well short of what deferring makes available there. A probe that removes the per-cell tracking and omits the recovery entirely — wrong `qe`, perf isolation only — runs **−7.54 %** in the same session. Block checkpoints claim ~1.2 of those 7.5 points.

Since cutting the scan 4.7× recovered so little, the dominant remaining cost at 64 lanes is **not** the scan but the per-cell checkpoint branch, which I added deliberately to avoid restructuring the column loops. Removing it means blocking the loops themselves so the checkpoint falls at a loop boundary. That's follow-up, not in this PR.

## Measurement caveat

The timings above were taken on the pre-rebase base, i.e. before the `compute_jdummy` extraction landed on this branch. That refactor is a pure extraction of an existing computation, so I expect the deltas to carry unchanged, but I have not re-measured on top of it and am not claiming I have.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved SIMD processing around query-tail padding.
  * Reduced redundant work during sequence analysis.
  * Optimized query-end recovery for faster execution while keeping output the same across supported hardware acceleration paths.
* **Bug Fixes**
  * Improved correctness of query-end position handling in deferred recovery logic across NEON, AVX2, and AVX-512BW implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->