### PR TITLE
ci: reject NDEBUG gates and build the opt-in debug macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,27 @@ permissions:
   contents: read
 
 jobs:
+  # Source-only lint; no toolchain, no build. Kept as its own job so the
+  # failure reads as "you wrote an NDEBUG gate" rather than being buried in a
+  # matrix row, and so it reports in seconds instead of after a full build.
+  ndebug-gate-lint:
+    name: NDEBUG gate lint (src/)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      # Runs first: the lint's PASS is indistinguishable from the PASS a lint
+      # whose matcher has stopped matching prints, so the step below only means
+      # something once the matcher has been shown to still reject real gates.
+      - name: NDEBUG gate lint still detects gates
+        run: bash test/regression/ndebug_gate_lint_selftest.sh
+
+      - name: No NDEBUG preprocessor gates in src/
+        run: bash test/regression/ndebug_gate_lint.sh
+
   build-and-test:
     strategy:
       fail-fast: false
@@ -632,6 +653,43 @@ jobs:
                    meth_rescue_batched_identical meth_collapsed_scoring; do
             echo "::group::$t"; bash "test/regression/$t.sh"; echo "::endgroup::"
           done
+
+      - name: Opt-in debug/instrumentation macro build (chr22 parity)
+        if: matrix.canonical == true
+        # The expensive debug checks and instrumentation in this tree sit behind
+        # opt-in macros rather than `#ifndef NDEBUG`, because nothing here
+        # defines NDEBUG (see test/regression/ndebug_gate_lint.sh). That is
+        # correct, but it means no CI row compiles them, so they can rot
+        # unnoticed until the dead code is deleted -- or, worse, until someone
+        # enables one to debug a live problem and finds it no longer builds.
+        #
+        # One rebuild with every such macro on at once, then the same chr22
+        # parity check the row already runs against the normal binary. This
+        # asserts two things: the guarded code still compiles, and every check
+        # it enables holds on real data. Five of the six are pure assertions or
+        # scratch poisoning and the sixth (BWAMEM3_UGP_PROFILE) is profiling
+        # counters that never feed the alignment result, so output must be
+        # unchanged -- a failure here is a genuine invariant violation, not a
+        # debug-build artifact.
+        #
+        # BWA_MEM3_DEBUG_CHN_FLT_XCHECK, BWA_MEM3_DEBUG_RID_CHECK and
+        # BWA_MEM3_DEBUG_UNGAPPED_XCHECK are defined ahead of the changes that
+        # introduce them; until those land the flags are simply unused, which
+        # costs nothing and avoids a follow-up CI edit.
+        #
+        # Placed immediately before the ASAN step because both replace
+        # $GITHUB_WORKSPACE/bwa-mem3 with a differently-configured binary; the
+        # ASAN step does its own `make clean` and so is unaffected by this one.
+        run: |
+          make clean
+          make -j"$(nproc)" arch=${{ matrix.arch_flag }} \
+            CXX=${{ matrix.cxx || 'g++' }} \
+            EXTRA_CXXFLAGS="-DBWA_MEM3_DEBUG_CHN_FLT_XCHECK -DBWA_MEM3_DEBUG_RID_CHECK -DBWA_MEM3_DEBUG_UNGAPPED_XCHECK -DBSW8_ASSERT_ENVELOPE -DBWA_MEM3_DEBUG_POISON -DBWAMEM3_UGP_PROFILE=1"
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          CHR22_FA=/tmp/chr22/chr22.fa \
+          BWA_CHR22_FA=/tmp/chr22/bwa_chr22.fa \
+          CHR22_SIM_DIR=/tmp/chr22-sim \
+          bash test/regression/chr22_parity.sh
 
       - name: Short-read SE smoke (chr22, ASAN, dense+variable-length)
         if: matrix.canonical == true

--- a/Makefile
+++ b/Makefile
@@ -848,6 +848,8 @@ test: test-binaries $(STANDALONE_TESTS_IN_TEST_TARGET) bwa-mem3
 	for t in $(STANDALONE_TESTS_IN_TEST_TARGET); do echo "./$$t"; ./$$t || exit 1; done
 	BWA_MEM3=./bwa-mem3 ./test/regression/version_banner.sh
 	BWA_MEM3=./bwa-mem3 ./test/regression/meth_rescue_batched_identical.sh
+	./test/regression/ndebug_gate_lint_selftest.sh
+	./test/regression/ndebug_gate_lint.sh
 
 # Regression test that requires a binary built with TESTING_BUILD=1
 # (enables BWAMEM3_TESTING_HOST_TIER env-var injection). Not invoked by

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -2,8 +2,9 @@
 
 End-to-end parity and invariant checks. `chr22_parity.sh` runs on every
 matrix row; the rest run on the canonical AVX2 row only, except
-`profile_slice_cpu.sh`, which runs from the `profiling-build` job (see below).
-Each script:
+`profile_slice_cpu.sh`, which runs from the `profiling-build` job (see below),
+and the two `ndebug_gate_lint*` scripts, which need no binary at all and run
+from the `ndebug-gate-lint` job. Each script:
 
 - is self-contained (set -euo pipefail; explicit env-var contract)
 - emits `PASS:` on success and `FAIL:` on failure
@@ -22,6 +23,8 @@ Each script:
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
 | `cohort_ramp_validation.sh`  | `--cohort-ramp-first`/`-ratio` reject malformed values; env warns and falls back | "Cohort ramp values are validated (flag and environment alike)" |
 | `profile_slice_cpu.sh`       | `--profile` accounts for a partial cohort slice's compute CPU (needs `STAGE_PROF=1`) | "Partial cohort slices report their compute CPU"    |
+| `ndebug_gate_lint.sh`        | no `#if`/`#ifdef`/`#ifndef`/`#elif` NDEBUG gates in `src/` — nothing here defines NDEBUG, so they never compile out | "No NDEBUG preprocessor gates in src/"              |
+| `ndebug_gate_lint_selftest.sh` | the lint above still flags real gates, so its `PASS` means something | "NDEBUG gate lint still detects gates"              |
 
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is
 the authoritative list, and `ci.yml` is where each one is actually wired up.

--- a/test/regression/ndebug_gate_lint.sh
+++ b/test/regression/ndebug_gate_lint.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Reject NDEBUG preprocessor gates in production sources under src/ -- any
+# `#if`, `#ifdef`, `#ifndef` or `#elif` directive that tests NDEBUG.
+#
+# Why this is a hard error rather than a style preference: no target in this
+# build system has ever defined NDEBUG -- not the Makefile, not any workflow in
+# .github/, including the release build. So a gate written as
+#
+#     #ifndef NDEBUG
+#         ... expensive debug-only work ...
+#     #endif
+#
+# never compiles out of anything this repository produces. The work runs in
+# every shipped binary while the surrounding comment claims it does not. That
+# has bitten this codebase repeatedly:
+#
+#   - the pac-fetch poison in bntseq.cpp, which memset whole buffers on every
+#     fetch of a production run before it was converted to BWA_MEM3_DEBUG_POISON;
+#   - a chaining cross-check that ran the O(n^2) reference pass -- the exact work
+#     its own optimization existed to skip -- on every read.
+#
+# The idiom that actually works here is a dedicated opt-in macro, off by
+# default and named in the comment so it can be turned on deliberately:
+#
+#     #ifdef BWA_MEM3_DEBUG_MY_CHECK
+#         ... expensive debug-only work ...
+#     #endif
+#
+# built with `make EXTRA_CXXFLAGS=-DBWA_MEM3_DEBUG_MY_CHECK`. Existing examples:
+# BSW8_ASSERT_ENVELOPE, BWA_MEM3_DEBUG_POISON, BWAMEM3_UGP_PROFILE.
+#
+# Scope is src/ only. test/ is exempt: test/unit/test_xassert_macro.cpp gates on
+# NDEBUG deliberately, because asserting on assert-vs-xassert semantics is the
+# whole point of that test.
+#
+# Note this lint says nothing about plain `assert()` calls, which are live in
+# every build here and are fine. `xassert()` (utils.h) remains the right guard
+# for a check that must survive a hypothetical -DNDEBUG build.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+if (( $# > 1 )); then
+    echo "usage: ${BASH_SOURCE[0]##*/} [directory-to-scan]" >&2
+    exit 2
+fi
+
+# The directory to scan. Defaults to this repository's src/; the optional
+# argument exists so ndebug_gate_lint_selftest.sh can aim the same matcher at a
+# fixture tree of known-good and known-bad directives, which is the only way to
+# tell "no gates in src/" apart from "the matcher stopped matching".
+scan_root="${1:-src}"
+
+# Every way this lint can end up scanning nothing has to be a failure, not a
+# PASS. A lint that silently checks nothing is the same class of bug as the
+# NDEBUG gate it exists to catch: it reads as green while doing no work.
+if [[ ! -d $scan_root ]]; then
+    echo "FAIL: no $scan_root/ directory under $repo_root -- nothing was linted" >&2
+    exit 1
+fi
+
+# Select by extension rather than scanning every regular file: in a working
+# tree src/ also holds untracked build artifacts (.o and friends), and feeding
+# those to a text scanner is a hard error, not a lint finding. The list is
+# deliberately wider than the extensions the tree uses today so adding a .cc or
+# a .inc does not quietly fall outside the lint.
+sources=()
+while IFS= read -r -d '' file; do
+    sources+=("$file")
+done < <(find "$scan_root" -type f \( \
+    -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.cxx' -o \
+    -name '*.h' -o -name '*.hh' -o -name '*.hpp' -o -name '*.hxx' -o \
+    -name '*.inc' -o -name '*.ipp' -o -name '*.tcc' \) -print0)
+
+if (( ${#sources[@]} == 0 )); then
+    echo "FAIL: no C/C++ sources under $scan_root/ -- nothing was linted" >&2
+    exit 1
+fi
+
+# Flag only real preprocessor conditionals: a line whose first non-blank
+# character is `#`, an if/ifdef/ifndef/elif directive, mentioning NDEBUG as a
+# whole word. Prose inside block comments (` * ... #ifndef NDEBUG ...`) does not
+# start with `#` and so does not match -- bntseq.cpp documents the historical
+# bug in exactly that shape and must keep passing.
+#
+# Two details this gets right that a plain `grep -E` does not:
+#
+#   - Word boundaries are spelled out as explicit character classes. `\b` is a
+#     GNU extension, not POSIX ERE; an implementation without it treats `\b` as
+#     a literal `b`, so `(if|ifdef|ifndef|elif)\b` matches nothing at all and
+#     the lint passes everything -- silently, on exactly the machines whose
+#     grep differs from CI's.
+#
+#   - A trailing backslash splices the next physical line onto this one before
+#     the compiler sees a directive, so `#if \` / `defined(NDEBUG)` is one
+#     `#if defined(NDEBUG)`. grep matches physical lines and would miss it;
+#     this joins continuations first and reports the line the directive starts
+#     on.
+# shellcheck disable=SC2016  # single quotes are deliberate: $0 is awk's, not the shell's
+scan_file='
+{
+    line = $0
+    start = FNR
+    while (line ~ /\\[ \t]*$/) {
+        sub(/\\[ \t]*$/, "", line)
+        spliced = (getline continuation)
+        # getline returns 0 at end of file and -1 on a read error. Treating the
+        # error as end of file would abandon the rest of the file and still let
+        # the lint print PASS.
+        if (spliced < 0) {
+            print "awk: read error while splicing a continued line" > "/dev/stderr"
+            exit 2
+        }
+        if (spliced == 0) break
+        line = line continuation
+    }
+    if (line ~ /^[ \t]*#[ \t]*(ifndef|ifdef|elif|if)([^A-Za-z0-9_]|$)/ &&
+        line ~ /(^|[^A-Za-z0-9_])NDEBUG([^A-Za-z0-9_]|$)/) {
+        printf "%s:%d:%s\n", FILENAME, start, line
+    }
+}'
+
+# One awk per file so a continuation at end-of-file cannot splice across into
+# the next one, and so a read error on any single file fails the whole lint
+# instead of being mistaken for "that file had no matches".
+hits=""
+for file in "${sources[@]}"; do
+    if ! file_hits="$(awk "$scan_file" "$file")"; then
+        echo "FAIL: unable to scan $file -- lint did not complete" >&2
+        exit 1
+    fi
+    if [[ -n $file_hits ]]; then
+        hits+="$file_hits"$'\n'
+    fi
+done
+
+if [[ -n $hits ]]; then
+    echo "FAIL: NDEBUG preprocessor gate(s) found in $scan_root/:" >&2
+    echo >&2
+    printf '%s' "$hits" >&2
+    echo >&2
+    echo "This build never defines NDEBUG, so the guarded code runs in every" >&2
+    echo "binary produced here -- including the release build. Replace the gate" >&2
+    echo "with a dedicated opt-in macro (see BWA_MEM3_DEBUG_POISON in" >&2
+    echo "src/bntseq.cpp) and document how to enable it." >&2
+    exit 1
+fi
+
+echo "PASS: ndebug_gate_lint (no NDEBUG preprocessor gates in $scan_root/)"

--- a/test/regression/ndebug_gate_lint_selftest.sh
+++ b/test/regression/ndebug_gate_lint_selftest.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# test/regression/ndebug_gate_lint_selftest.sh
+#
+# Regression: ndebug_gate_lint.sh still recognises an NDEBUG gate.
+#
+# The lint it tests has exactly one observable behaviour on a healthy tree --
+# it prints PASS -- and that is also what it prints when its matcher has
+# stopped matching anything at all. Those two states are indistinguishable from
+# CI, which is the same "green while doing no work" failure the lint itself
+# exists to catch upstream. The only way to tell them apart is to hand it
+# directives it must flag and check that it does.
+#
+# That is not hypothetical. The matcher spells its word boundaries as explicit
+# character classes because `\b` is a GNU extension, not POSIX ERE: an
+# implementation that treats `\b` as a literal `b` makes the whole pattern
+# unmatchable, so the lint reports PASS on a tree full of gates -- silently,
+# and only on the machines whose tools differ from CI's. A single wrong
+# character in the pattern reproduces that by hand.
+#
+# Fixtures are generated here rather than committed: each case is one line, and
+# a file of one-line fixtures away from the expectations that name them is
+# harder to read than the table below.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+lint="test/regression/ndebug_gate_lint.sh"
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+
+failures=0
+
+# Run the lint over a fixture directory holding a single source line, and
+# check the verdict. `expected` is FLAG (the lint must reject it, exit 1) or
+# PASS (the lint must accept it, exit 0).
+check_line() {
+    local description="$1" expected="$2" content="$3"
+    local dir="$fixture_root/case"
+
+    rm -rf "$dir"
+    mkdir -p "$dir"
+    printf '%s\n' "$content" > "$dir/fixture.cpp"
+
+    local output status verdict
+    output="$(bash "$lint" "$dir" 2>&1)" && status=0 || status=$?
+    case "$status" in
+        0) verdict=PASS ;;
+        1) verdict=FLAG ;;
+        *) verdict="ERROR(exit $status)" ;;
+    esac
+
+    if [[ "$verdict" == "$expected" ]]; then
+        echo "  ok   $description -> $verdict"
+    else
+        echo "  FAIL $description: expected $expected, got $verdict" >&2
+        printf '%s\n' "$output" | sed 's/^/       /' >&2
+        failures=$((failures + 1))
+    fi
+}
+
+echo "== gates the lint must reject =="
+check_line "plain #ifndef"              FLAG '#ifndef NDEBUG'
+check_line "plain #ifdef"               FLAG '#ifdef NDEBUG'
+check_line "#if !defined()"             FLAG '#if !defined(NDEBUG)'
+check_line "space between # and elif"   FLAG '#  elif defined NDEBUG'
+check_line "leading tab"                FLAG $'\t#ifndef NDEBUG'
+check_line "NDEBUG last on the line"    FLAG '#if defined(FOO) && !defined NDEBUG'
+# The compiler splices a backslash-continued line before it sees a directive,
+# so this is one `#if defined(NDEBUG)`. A physical-line matcher misses it.
+check_line "backslash continuation"     FLAG '#if \
+defined(NDEBUG)'
+check_line "continuation mid-expression" FLAG '#if defined(FOO) || \
+    defined(NDEBUG)'
+
+echo "== non-gates the lint must accept =="
+# bntseq.cpp documents the historical bug in exactly this shape; a matcher that
+# flags prose makes the lint unusable in the file that motivated it.
+check_line "NDEBUG in block comment"    PASS ' * this was once gated on #ifndef NDEBUG and never compiled out'
+check_line "NDEBUG in line comment"     PASS '// see the #ifndef NDEBUG note above'
+check_line "unrelated directive"        PASS '#define NDEBUG_FOO 1'
+check_line "NDEBUG as a name prefix"    PASS '#ifndef NDEBUG_TRACE'
+check_line "NDEBUG as a name suffix"    PASS '#ifdef MY_NDEBUG'
+check_line "#endif trailing comment"    PASS '#endif // NDEBUG'
+check_line "ordinary code"              PASS 'int main(void) { return 0; }'
+
+echo "== a lint that scanned nothing must not report PASS =="
+empty_dir="$fixture_root/empty"
+mkdir -p "$empty_dir"
+if bash "$lint" "$empty_dir" >/dev/null 2>&1; then
+    echo "  FAIL directory with no sources reported PASS" >&2
+    failures=$((failures + 1))
+else
+    echo "  ok   directory with no sources -> FAIL"
+fi
+
+if bash "$lint" "$fixture_root/does-not-exist" >/dev/null 2>&1; then
+    echo "  FAIL missing directory reported PASS" >&2
+    failures=$((failures + 1))
+else
+    echo "  ok   missing directory -> FAIL"
+fi
+
+# Exit 2 rather than 1, so a caller that mis-invokes the lint cannot read the
+# result as "gates found" -- or, worse, as a clean run.
+bash "$lint" one two >/dev/null 2>&1 && usage_status=0 || usage_status=$?
+if (( usage_status == 2 )); then
+    echo "  ok   too many arguments -> usage error (exit 2)"
+else
+    echo "  FAIL too many arguments: expected exit 2, got $usage_status" >&2
+    failures=$((failures + 1))
+fi
+
+# Build artifacts share src/ with the sources in a working tree. Feeding a .o
+# to a text scanner is an error, not a finding, so they must be skipped rather
+# than aborting the run.
+artifact_dir="$fixture_root/artifacts"
+mkdir -p "$artifact_dir"
+printf '%s\n' 'int main(void) { return 0; }' > "$artifact_dir/fixture.cpp"
+head -c 4096 /dev/urandom > "$artifact_dir/fixture.o"
+if bash "$lint" "$artifact_dir" >/dev/null 2>&1; then
+    echo "  ok   binary artifact alongside sources -> PASS"
+else
+    echo "  FAIL binary artifact alongside sources aborted the lint" >&2
+    failures=$((failures + 1))
+fi
+
+if (( failures > 0 )); then
+    echo "FAIL: ndebug_gate_lint_selftest ($failures case(s))" >&2
+    exit 1
+fi
+
+echo "PASS: ndebug_gate_lint_selftest"


### PR DESCRIPTION
## The problem

No target in this build system has ever defined `NDEBUG` — not the `Makefile`, not any workflow in `.github/`, including the release build. That is true all the way back to the initial import: `-DNDEBUG` has never appeared in either file, in any commit.

So a gate written as

```c
#ifndef NDEBUG
    ... expensive debug-only work ...
#endif
```

never compiles out of anything this repository produces. The work runs in every shipped binary, while the comment above it states the opposite. There is no build configuration in which the claim is true.

This has now landed three times:

| where | what ran in production |
|---|---|
| pac-fetch poison, `bntseq.cpp` | `memset` of whole high-water buffers on every fetch, immediately overwritten — tens of GB of stores on a 5M-pair run. Fixed by converting to `BWA_MEM3_DEBUG_POISON`. |
| chaining cross-check | the O(n²) reference pass — precisely the work the accompanying optimization existed to skip — on every read. |
| a third instance | currently in review. |

Each was caught by hand, after the fact, and only because someone went looking. The failure is silent by construction: the code is correct, the tests pass, and the only symptom is that a perf change quietly delivers nothing.

Worth noting where the assumption came from, since it explains why it keeps recurring. `NDEBUG` entered this codebase in a review comment on #57 pointing out that `assert`-based *tests* would be elided under `-DNDEBUG` — and that comment said explicitly that the build does not define it and the risk was latent. The tests were fixed. What propagated was the phrasing, minus the caveat, into production comments two days later, and from there into perf gates where it became load-bearing.

## What this adds

**1. A lint — `test/regression/ndebug_gate_lint.sh`.** Fails on any `#if(n)def NDEBUG` / `#elif ... NDEBUG` preprocessor directive under `src/`, and points at the idiom that does work here: a dedicated opt-in macro, off by default, named in the comment so it can be enabled deliberately. The existing examples are `BSW8_ASSERT_ENVELOPE`, `BWA_MEM3_DEBUG_POISON`, `BWAMEM3_UGP_PROFILE`.

Scope is `src/` only — `test/unit/test_xassert_macro.cpp` gates on `NDEBUG` deliberately, since assert-vs-`xassert` semantics is what it tests. Prose describing the bug does not match the pattern, so `bntseq.cpp`'s historical comment still passes.

Verified against all three real instances — it flags each one and passes clean `main`:

```
--- pac-fetch poison, as originally written ---
FAIL: src/bntseq.cpp:585:#ifndef NDEBUG
--- chaining cross-check, as originally submitted ---
FAIL: src/bwamem.cpp:1420:#ifndef NDEBUG
--- the instance currently in review ---
FAIL: src/bwamem.cpp:3231:#ifndef NDEBUG
--- main ---
PASS: ndebug_gate_lint (no NDEBUG preprocessor gates in src/)
```

It runs as its own CI job — checkout and grep, seconds, no toolchain — so the failure reads as "you wrote an NDEBUG gate" instead of being buried in a matrix row. Also wired into `make test`.

**2. A build step that compiles the opt-in macros.** The lint pushes expensive checks behind opt-in macros, which opens the second gap: nothing compiles them, so they rot until the dead code gets deleted, or until someone enables one to debug a live problem and finds it no longer builds. **None of the four has ever been built by CI.**

One step in the canonical row rebuilds with all of them enabled and reruns the chr22 parity check the row already runs against the normal binary. Three are pure assertions or scratch poisoning and the fourth is profiling counters that never reach the alignment result, so output must be unchanged — a failure here is a genuine invariant violation, not a debug-build artifact. It sits immediately before the ASAN step, since both replace the workspace binary and the ASAN step does its own `make clean`.

`BWA_MEM3_DEBUG_CHN_FLT_XCHECK` is included ahead of the chaining cross-check that introduces it; until that lands the flag is simply unused, which costs nothing and saves a follow-up CI edit.

## Validation

Local, arm64:

- Four-macro build compiles clean, and aligns 400k read pairs (HG002/hg38) with **zero assertion failures** and output **byte-identical** to the normal build — same md5, 803,947 records each, both exit 0.
- `make test` green with the lint wired in.
- Lint red/green demonstrated against all three historical instances above.

The x86 rows are what this PR's own CI run validates: the AVX2 and AVX-512 variants of `BSW8_ASSERT_ENVELOPE` have never been compiled by anyone, so if one of them has rotted, this run is where it surfaces — which is the point of the step.

## Cost

One extra full rebuild in one matrix row, plus a seconds-long lint job. The rebuild is the price of the anti-rot coverage; the lint is what actually catches the bug class.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added checks to detect unsupported `NDEBUG` preprocessor gating.
  * Added validation for debug and instrumented builds while preserving chromosome 22 parity.

* **Tests**
  * Extended the default test suite with `NDEBUG` gating checks and self-tests.
  * Added dedicated continuous integration coverage for debug, assertion, poisoning, and profiling configurations.
  * Improved regression documentation for the new validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->