### PR TITLE
fix(sam): make the SAM-A9 rid check opt-in so the recompute is skipped

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -3368,11 +3368,19 @@ mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *
     }
     /* SAM-A9: the region already carries its rid and bns_pos2rid(bns, pos) is
      * provably equal to it (the original code asserted exactly this). Use the
-     * known value and keep the equality as a debug-only check against the
-     * recompute, so NDEBUG builds skip the bns_pos2rid scan entirely. Output is
-     * byte-identical: a.rid == ar->rid == old bns_pos2rid result. */
+     * known value rather than recomputing. Output is byte-identical:
+     * a.rid == ar->rid == old bns_pos2rid result.
+     *
+     * The equality is kept as a cross-check, but opt-in rather than under a
+     * bare `assert`. Nothing in this build system defines NDEBUG, so an assert
+     * here is live in every shipped binary -- meaning the recompute this
+     * optimization exists to avoid ran on every emitted alignment, and the
+     * saving the comment claimed was never realized anywhere. Enable with
+     *   make EXTRA_CXXFLAGS=-DBWA_MEM3_DEBUG_RID_CHECK */
     a.rid = ar->rid;
+#ifdef BWA_MEM3_DEBUG_RID_CHECK
     assert(a.rid == bns_pos2rid(bns, pos));
+#endif
     a.pos = pos - bns->anns[a.rid].offset;
     a.score = ar->score; a.sub = ar->sub > ar->csub? ar->sub : ar->csub;
     a.is_alt = ar->is_alt; a.alt_sc = ar->alt_sc;


### PR DESCRIPTION
## The defect

SAM-A9 replaced a `bns_pos2rid(bns, pos)` call in `mem_reg2aln` with the rid the region already carries, keeping the equality as an assert against the recompute. The comment on `main` today:

```c
/* SAM-A9: ... Use the known value and keep the equality as a debug-only
 * check against the recompute, so NDEBUG builds skip the bns_pos2rid scan
 * entirely. ... */
a.rid = ar->rid;
assert(a.rid == bns_pos2rid(bns, pos));
```

Nothing in this build system defines `NDEBUG` — not the `Makefile`, not any workflow, including the release build, and never has in the repository's history. So the assert is live in every binary produced here, the `bns_pos2rid` call it wraps runs on every emitted alignment, and the saving the comment describes has never been realized in any build anyone ships.

This is the same class of defect as the pac-fetch poison in `bntseq.cpp` and the chaining cross-check: an optimization whose benefit is predicated on a build configuration that does not exist. Note that a lint for `#if(n)def NDEBUG` gates does **not** catch this one — it is a bare `assert`, not a preprocessor gate, so it needs fixing on its own.

## The change

Gate the equality behind `BWA_MEM3_DEBUG_RID_CHECK`, matching the opt-in idiom already used for the other expensive checks in this tree (`BWA_MEM3_DEBUG_POISON`, `BSW8_ASSERT_ENVELOPE`), and correct the comment to describe what the code actually does. The invariant is unchanged and still checkable on demand:

```
make EXTRA_CXXFLAGS=-DBWA_MEM3_DEBUG_RID_CHECK
```

## No performance claim, and why not

The removed work is one bucket-bracket lookup per emitted alignment — on the order of **0.01%** of run time for a WGS input, well below what this or any host can resolve.

An A/B against the parent commit did measure the candidate cheaper, and I do not believe it:

| arm | rep 1 | rep 2 | mean |
|---|---|---|---|
| base (`main`) | 204.75s | 209.30s | 207.03s |
| candidate | 201.59s | 200.97s | 201.28s |

That is −2.8% with non-overlapping ranges, which looks like a result until you check whether it could be one. Reproducing it would require roughly 3µs per removed call, against a function that costs tens of nanoseconds — two orders of magnitude apart. The baseline's own rep-to-rep spread is 4.55s (2.2%), nearly the size of the claimed effect, and the two arms are separately-linked binaries, so code layout alone covers a difference this size. More reps would tighten the interval without touching the confound.

Recorded here so the number is not mistaken for a result later. What this PR fixes is a comment describing a build nobody has, and a shipped binary doing work it was changed to stop doing.

## Validation

1M WGS read pairs (HG002/hg38), `mem -t8`, arm64, 2 interleaved reps per arm:

- All four runs exit 0 with **identical SAM md5** (excluding `@PG`), equal to the parent commit — byte-identity holds in both directions.
- Default build and `BWA_MEM3_DEBUG_RID_CHECK` build both compile clean.
- `make test` green.

## Related

Pairs with the CI work that rejects `#if(n)def NDEBUG` gates under `src/` and builds the opt-in debug macros so they cannot rot. That lint would not have caught this instance, for the reason above; `BWA_MEM3_DEBUG_RID_CHECK` is worth adding to that PR's macro list once this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment reference ID handling for more reliable results.
  * Removed an unnecessary consistency check from normal operation while retaining it for diagnostic builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->