### PR TITLE
fix(meth): derive NM/MD from the scoring matrix so bisulfite conversions are not counted

### DIFF
--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -117,11 +117,14 @@ Methylation (--meth) options:
                  collapsed: C/T (and G/A) interchangeable, bwameth-compatible
                  placement (sets -B 2).
                  genomic: free only the conversion direction, scored as a full
-                 match, keep variants as mismatches (variant-aware, truthful
-                 NM/MD; -B 4).
+                 match, keep variants as mismatches (variant-aware: variants
+                 outside the conversion direction visible in NM/MD; -B 4).
                  neutral: free only the conversion direction but score it 0
-                 (tolerated, not rewarded); best for TAPS (variant-aware,
-                 truthful NM/MD; -B 4).
+                 (tolerated, not rewarded); best for TAPS (variant-aware:
+                 variants visible in NM/MD as in genomic; -B 4).
+                 In genomic/neutral a real variant in the conversion direction
+                 itself (C->T at a reference C) is indistinguishable from a
+                 conversion and stays hidden in NM/MD.
    --set-as-failed f|r
                  flag alignments to the matching strand ('f' or 'r') as QC-fail (0x200)
    --chimera-qc

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -580,10 +580,14 @@ See [Methylation Reference](../methylation/overview.md) for the full treatment.
 Selects how the 4-letter matrix treats converted bases. `collapsed` (the
 `--meth`/`--meth=emseq` default) frees C↔T and G↔A both ways (bwameth-compatible
 placement, sets `-B 2`); `genomic` frees only the conversion direction scored as
-a full match, keeping real variants as mismatches (variant-aware, truthful
-`NM`/`MD`, keeps `-B 4`); `neutral` (the `--meth=taps` default) frees only the
-conversion direction but scores it `0` — tolerated, not rewarded — best for the
-sparse conversions of TAPS (keeps `-B 4`, truthful `NM`/`MD`). Only meaningful
+a full match, keeping real variants as mismatches (variant-aware: variants outside
+the conversion direction stay visible in `NM`/`MD`, keeps `-B 4`); `neutral` (the
+`--meth=taps` default) frees only the conversion direction but scores it `0` —
+tolerated, not rewarded — best for the sparse conversions of TAPS (keeps `-B 4`;
+variants stay visible in `NM`/`MD` as in `genomic`). In both, a genuine variant in
+the conversion direction itself (a C→T at a reference `C`) shares the freed cell
+with a conversion and stays hidden
+([why](../methylation/overview.md#which-real-variants-stay-visible)). Only meaningful
 with `--meth`.
 See [Flags → --meth-scoring](../methylation/flags.md#--meth-scoring-collapsedgenomicneutral).
 

--- a/docs/src/getting-started/quick-meth.md
+++ b/docs/src/getting-started/quick-meth.md
@@ -12,9 +12,13 @@ postprocessing step are required.
 > of records (~1% on typical WGBS/EM-seq) still differ in `POS`/`CIGAR`/`MAPQ`, so re-validate if you
 > are pinned to a specific bwameth release (see
 > [bwameth.py drop-in mapping](../methylation/bwameth-mapping.md)). Add
-> `--meth-scoring genomic` to opt into variant-aware scoring (truthful `NM`/`MD`; one BAM for both
-> methylation and variant calling), or `--meth-scoring neutral` — the `--meth=taps` default — which
-> is variant-aware too but scores the conversion `0` instead of a match.
+> `--meth-scoring genomic` to opt into variant-aware scoring (variants outside the conversion
+> direction visible in `NM`/`MD` — a genuine C→T at a reference `C` is indistinguishable from a
+> conversion and stays hidden, see
+> [which real variants stay visible](../methylation/overview.md#which-real-variants-stay-visible);
+> one BAM for both methylation and variant calling), or `--meth-scoring neutral` — the
+> `--meth=taps` default — which is variant-aware too but scores the conversion `0` instead of a
+> match.
 
 ## Index the reference for methylation
 

--- a/docs/src/methylation/bwameth-mapping.md
+++ b/docs/src/methylation/bwameth-mapping.md
@@ -17,9 +17,9 @@ differs, and where the two approaches diverge by design.
 > WGBS/EM-seq, with true mapped-position (`POS`) changes affecting a smaller
 > subset (a few tenths of a percent). The 4-letter scoring path **widens** this
 > versus a pure collapsed-space aligner — and versus the older 3-letter `--meth`
-> releases — and the opt-in `genomic` mode diverges further on purpose (it
-> penalizes real variants). The tag schema is also Bismark (`XR`/`XG`/`XM`), not
-> bwameth (`YS`/`YC`/`YD`).
+> releases — and the variant-aware modes (`genomic`, `neutral`) diverge further
+> on purpose (they penalize real variants). The tag schema is also Bismark
+> (`XR`/`XG`/`XM`), not bwameth (`YS`/`YC`/`YD`).
 >
 > **If you are pinned to a specific bwameth release** (e.g. a clinical pipeline
 > validated against a bwameth version), treat `collapsed` as a *new aligner* and
@@ -70,10 +70,13 @@ environment, no bwameth.py version pinning.
 is applied in-memory to the seeding copy of each read.
 
 **Variant-aware options.** `--meth-scoring genomic` and `--meth-scoring neutral`
-(the `--meth=taps` default) both score real C/T and G/A variants as mismatches, so
-a single BAM supports both methylation calling and variant calling — something a
-collapsed-space aligner cannot produce. They differ only in what the *conversion*
-cell scores: a full match under `genomic`, `0` under `neutral`.
+(the `--meth=taps` default) both score a real C/T or G/A variant on the mirror cell
+as a mismatch, so a single BAM supports both methylation calling and variant
+calling — something a collapsed-space aligner cannot produce. (A variant in the
+conversion direction itself remains hidden; see
+[which real variants stay visible](overview.md#which-real-variants-stay-visible).)
+They differ only in what the *conversion* cell scores: a full match under
+`genomic`, `0` under `neutral`.
 
 **Inline BAM post-processing.** Header rewriting, Bismark `XR`/`XG`/`XM` tags,
 opt-in chimera QC (`--chimera-qc`), and QC-fail propagation happen in the same
@@ -89,7 +92,7 @@ has no option that unsets them, so `--meth` applies them unconditionally.
 These constants are quoted at bwa's default match score (`-A 1`, what bwameth
 runs). Like every other score-derived default, they scale with `-A`: under
 `-A 2` the effective values are `-L 20 -U 200 -T 80` and `-B 4` (collapsed) /
-`-B 8` (genomic).
+`-B 8` (genomic and neutral).
 
 ## What stays the same (collapsed mode)
 
@@ -109,7 +112,16 @@ differ:
 | Chimera QC threshold | Longest M < 44% of read | Same (44%), opt-in via `--chimera-qc` |
 | Chimera QC flags | `0x200`, clear `0x2`, MAPQ ≤ 1 | Same |
 | SEQ field | Pre-conversion bases (RC-flipped when `is_rev`) | Same |
-| `NM`/`MD` | Collapsed (conversions and real variants both hidden) | Conversions hidden; real variants hidden in `collapsed`, **shown in `genomic`** |
+| `NM`/`MD` | Collapsed (conversions and real variants both hidden) | Conversions hidden; real variants hidden in `collapsed`, **shown in `genomic` and `neutral`**[^nmmd] |
+
+[^nmmd]: `genomic` and `neutral` both free only the conversion direction — they
+    differ solely in what that cell scores (a full match vs. `0`) and both leave
+    the *mirror* cell penalised — so both keep a real variant in the *opposite*
+    direction (ref `T` × read `C` on OT) visible. A real variant in the
+    conversion direction itself (a genuine C→T SNP at a reference C) is
+    indistinguishable from a conversion in a single read under any mode — that
+    aliasing is resolved downstream at the pileup, not by the aligner. See
+    [which real variants stay visible](overview.md#which-real-variants-stay-visible).
 
 bwa-mem3 emits the **Bismark-compatible** `XR:Z` / `XG:Z` / `XM:Z` tag set rather
 than bwameth's `YS:Z` / `YC:Z` / `YD:Z`, so output is directly consumable by
@@ -123,7 +135,8 @@ If your workflow requires bwameth.py-specific features (e.g. `bwameth.py
 markduplicates` or non-standard post-processors), or strict byte-for-byte
 reproduction of a bwameth release, continue using bwameth.py. `bwa-mem3 --meth`
 targets the indexing + alignment + standard post-processing path, with
-bwameth-compatible placement (`collapsed`) or variant-aware scoring (`genomic`).
+bwameth-compatible placement (`collapsed`) or variant-aware scoring (`genomic`,
+`neutral`).
 
 ---
 

--- a/docs/src/methylation/conversion.md
+++ b/docs/src/methylation/conversion.md
@@ -65,8 +65,11 @@ the conversion direction is freed, scored as a full match. Under
 `--meth-scoring neutral` (the `--meth=taps` default) only the conversion direction
 is freed as well, but it scores `0` rather than a match: a converted base is
 tolerated, not rewarded. Both `genomic` and `neutral` leave the mirror cell a real
-mismatch, so a genuine variant stays a mismatch and `NM`/`MD` remain variant-aware.
-See [Overview → `--meth-scoring`](overview.md#three-scoring-modes---meth-scoring).
+mismatch, so a genuine variant *in that direction* stays a mismatch and `NM`/`MD`
+remain variant-aware; a variant in the conversion direction itself shares the freed
+cell with a conversion and is hidden in every mode. See
+[Overview → `--meth-scoring`](overview.md#three-scoring-modes---meth-scoring) and
+[which real variants stay visible](overview.md#which-real-variants-stay-visible).
 
 The seed's own ungapped score is recomputed in the same matrix (not assumed to be
 a perfect `len × match`), so under `--meth-scoring genomic` a seed-internal C/T or

--- a/docs/src/methylation/flags.md
+++ b/docs/src/methylation/flags.md
@@ -70,13 +70,17 @@ conversion (bwameth-style), keep it variant-aware, or merely tolerate it.
   Use this when you need bwameth-compatible read placement (the drop-in default).
 - `genomic` — free **only** the conversion direction (a one-cell matrix), scored
   as a full match (`+A`), so the mirror cell stays a real mismatch. A genuine C/T
-  or G/A variant is penalized, making `NM`/`MD` truthful and the BAM usable for
-  variant calling. Keeps bwa's default `-B 4`.
+  or G/A variant on that mirror cell (ref `T` × read `C` on OT, ref `A` × read
+  `G` on OB) is penalized and stays visible in `NM`/`MD`, making the BAM usable
+  for variant calling; a variant in the conversion direction itself shares the
+  freed cell with a conversion and stays hidden
+  ([why](overview.md#which-real-variants-stay-visible)). Keeps bwa's default `-B 4`.
 - `neutral` (**default for `--meth=taps`**) — free only the conversion direction,
   but score it `0` rather than `+A`: tolerated but not rewarded. Best for TAPS,
   whose conversions are sparse, where a full-match reward over-credits spurious
   C→T alignments (see the measurement above). Keeps `-B 4`; the mirror cell stays
-  a mismatch, so `NM`/`MD` remain truthful.
+  a mismatch, so real variants remain visible in `NM`/`MD` on the same terms as
+  `genomic`.
 
 > **Important — `collapsed` is a placement drop-in, not byte-identical to bwameth**
 >
@@ -104,8 +108,8 @@ Keep `collapsed` for methylation-only workflows that must match bwameth placemen
 when you want one BAM that serves both methylation *and* variant calling, or want
 the aligner to distinguish real variants from conversions. Prefer `neutral` for
 TAPS (its default), where conversions are sparse and rewarding them as matches
-costs placement specificity — it is truthful for variant calling like `genomic`
-while placing sparse-conversion reads more accurately.
+costs placement specificity — it keeps variants visible for variant calling on the
+same terms as `genomic` while placing sparse-conversion reads more accurately.
 
 > **Note — `-B` follows the mode, but you can override it**
 >

--- a/docs/src/methylation/overview.md
+++ b/docs/src/methylation/overview.md
@@ -20,10 +20,56 @@ it then extends, scores, and reports every alignment against the **original
 4-letter reference** using a per-strand asymmetric substitution matrix. The
 output is in the original alphabet with Bismark-compatible `XR`/`XG`/`XM` tags,
 so one BAM serves both methylation calling and — in the variant-aware scoring
-mode — variant calling, because real C/T and G/A variants stay literal
-mismatches in `NM`/`MD`.
+modes — variant calling, because a real variant the matrix penalises stays a
+mismatch in `NM`/`MD` while a bisulfite conversion does not. The exception is a
+variant in the conversion direction itself (a genuine C→T at a reference `C`),
+which no single read can tell apart from a conversion — see
+[how `NM`/`MD` are computed](#how-nmmd-are-computed-under---meth).
 
 The non-`--meth` code path is byte-for-byte unchanged.
+
+## How `NM`/`MD` are computed under `--meth`
+
+Under `--meth`, a column counts as a mismatch **iff the scoring matrix penalises
+it** — the same matrix that drives the DP. Because the per-strand asymmetric
+matrix scores the conversion cell (ref `C` × read `T` on OT, ref `G` × read `A`
+on OB) as a match, a bisulfite conversion is a match for `NM`/`MD` exactly as it
+already is for the alignment score. A perfectly converted read is `NM:i:0` with
+a plain `MD:Z:<len>`, and `MD` no longer enumerates every reference C.
+
+There is no bisulfite special case in the `NM`/`MD` code: one definition —
+"a mismatch is what the scoring model penalises" — produces both the score and
+the tags, so `NM`/`MD` automatically track whatever `--meth-scoring` selects.
+
+### Which real variants stay visible
+
+The same rule decides that too. Under the variant-aware modes (`genomic`,
+`neutral`) the matrix frees *only* the conversion cell, so every penalised
+substitution stays a mismatch in `NM`/`MD` — including a C/T or G/A variant in
+the **opposite** direction (ref `T` × read `C` on OT, ref `A` × read `G` on OB),
+which is what makes the BAM usable for variant calling. But a variant in the
+**conversion direction itself** — a genuine C→T SNP at a reference `C` on OT, or
+G→A at a reference `G` on OB — lands on that same freed cell and is therefore
+*absent* from `NM`/`MD`: it is byte-indistinguishable from a conversion in a
+single read, so no aligner can separate the two. Under `collapsed` the mirror
+cell is freed as well, so C/T and G/A variants are hidden in both directions.
+
+> **This is a deliberate deviation from the SAM specification**, which defines
+> `NM` as the edit distance to the reference and `MD` as the mismatching
+> reference bases. Under `--meth` neither is literal: a converted base is
+> reported as matching a reference base it differs from, so `CIGAR` + `SEQ` +
+> `MD` reconstructs the *converted* reference, not the real one. This is the
+> same convention every mainstream bisulfite aligner uses — bwameth.py and
+> Bismark get it structurally by aligning in collapsed space, and BISCUIT
+> defines `NM` as "non-cytosine-conversion mismatches" — and it exists because a
+> literal `NM` makes an error-free bisulfite library look ~25 % divergent to
+> every downstream `NM` filter and QC metric. The non-`--meth` path is
+> unaffected and remains spec-literal.
+>
+> A single read cannot distinguish a bisulfite C→T from a real C→T SNP; that
+> aliasing is resolved downstream at the pileup. The aligner reports what its
+> scoring model treats as divergence rather than adjudicating chemistry against
+> genotype base by base.
 
 ## Three scoring modes: `--meth-scoring`
 
@@ -33,8 +79,8 @@ about converted bases. This is controlled by `--meth-scoring`:
 | Mode | Default? | Matrix | `-B` | Behavior |
 |------|----------|--------|------|----------|
 | **`collapsed`** | **`--meth` / `--meth=emseq`** | frees C↔T *and* G↔A both ways (two cells), each scored as a full match | `2` | bwameth-compatible **placement** — C/T and G/A are interchangeable, so it closely tracks bwameth's collapsed-space mapping. A close approximation, **not** exact: ~1% of records differ in `POS`/`CIGAR`/`MAPQ`, so re-validate if pinned to a bwameth release. |
-| **`genomic`** | no (opt-in) | frees only the conversion direction (one cell), scored as a full match | `4` | **variant-aware** — a real C/T or G/A variant scores as a mismatch, so `NM`/`MD` are truthful and the BAM is usable for variant calling. |
-| **`neutral`** | **`--meth=taps`** | frees only the conversion direction (one cell), scored `0` | `4` | **variant-aware and conservative** — a conversion is tolerated but not rewarded, so a sparse TAPS conversion no longer over-credits a spurious C→T alignment. `NM`/`MD` stay truthful; measured +0.24–0.28 pp placement over `genomic` on simulated TAPS. |
+| **`genomic`** | no (opt-in) | frees only the conversion direction (one cell), scored as a full match | `4` | **variant-aware** — the mirror cell stays penalised, so a real C/T or G/A variant scores as a mismatch and stays visible in `NM`/`MD`, making the BAM usable for variant calling. A variant in the conversion direction itself is still hidden ([why](#which-real-variants-stay-visible)). |
+| **`neutral`** | **`--meth=taps`** | frees only the conversion direction (one cell), scored `0` | `4` | **variant-aware and conservative** — a conversion is tolerated but not rewarded, so a sparse TAPS conversion no longer over-credits a spurious C→T alignment. Real variants stay visible in `NM`/`MD` on the same terms as `genomic`; measured +0.24–0.28 pp placement over `genomic` on simulated TAPS. |
 
 The default follows the chemistry: `--meth` and `--meth=emseq` default to
 `collapsed`, so existing methylation pipelines see bwameth-compatible read
@@ -108,7 +154,8 @@ bwa-mem3 mem --meth -t 16 ref.fa R1.fq.gz R2.fq.gz \
   | samtools sort -o out.bam
 samtools index out.bam
 
-# Opt into variant-aware scoring (truthful NM/MD; BAM usable for variant calling).
+# Opt into variant-aware scoring (variants outside the conversion direction stay
+# visible in NM/MD; BAM usable for variant calling).
 bwa-mem3 mem --meth --meth-scoring genomic -t 16 ref.fa R1.fq.gz R2.fq.gz \
   | samtools sort -o out.bam
 

--- a/docs/src/related-projects/bwameth.md
+++ b/docs/src/related-projects/bwameth.md
@@ -30,9 +30,11 @@ there, bwa-mem3 uses the 3-letter projection only to **find seeds**, then extend
 and scores against the **original 4-letter reference**. That enables two further
 variant-aware modes — `--meth-scoring genomic`, which scores the conversion cell as
 a full match, and `--meth-scoring neutral` (the `--meth=taps` default), which scores
-it `0` so a sparse conversion is tolerated but not rewarded. Both keep real C/T and
-G/A variants as mismatches (truthful `NM`/`MD`), something a collapsed-space aligner
-cannot do.
+it `0` so a sparse conversion is tolerated but not rewarded. Both keep a real C/T or
+G/A variant in the direction *opposite* the conversion as a mismatch (visible in
+`NM`/`MD`), something a collapsed-space aligner cannot do; a variant in the conversion
+direction itself is indistinguishable from a conversion under either design
+([why](../methylation/overview.md#which-real-variants-stay-visible)).
 
 It rewrites the `@SQ` headers to consolidate the per-strand contig pairs back to
 canonical chromosome names, emits Bismark-compatible `XR:Z` / `XG:Z` / `XM:Z`

--- a/src/bwa.cpp
+++ b/src/bwa.cpp
@@ -287,8 +287,23 @@ void bwa_fill_scmat(int a, int b, int8_t mat[25])
     for (j = 0; j < 5; ++j) mat[k++] = -1;   // DEFAULT AMBIG
 }
 
-// Generate CIGAR when the alignment end points are known
-uint32_t *bwa_gen_cigar2(const int8_t mat[25], int o_del, int e_del, int o_ins, int e_ins, int w_, int64_t l_pac, const uint8_t *pac, int l_query, uint8_t *query, int64_t rb, int64_t re, int *score, int *n_cigar, int *NM)
+/* Generate CIGAR when the alignment end points are known.
+ *
+ * `nm_from_mat` selects how the NM/MD pass classifies an aligned column:
+ *   0 (default, non-meth): a column is a mismatch iff the bases differ literally
+ *     (`query != rseq`) -- the historical bwa behaviour, byte-for-byte.
+ *   1 (--meth): a column is a mismatch iff the SCORING MATRIX penalises it
+ *     (`mat[ref*5 + query] < 0`). Under --meth `mat` is the per-hypothesis
+ *     asymmetric matrix whose bisulfite-conversion cell is set to the match
+ *     score (mem_opt_fill_meth_mat), so a C->T (OT) / G->A (OB) conversion is a
+ *     match for NM/MD exactly as it already is for the DP. See the policy note
+ *     in mem_reg2aln().
+ *
+ * The matrix is safe to reuse here because the NM/MD pass and the DP share BOTH
+ * buffers and frame: on the reverse strand (rb >= l_pac) `query`/`rseq` are
+ * reversed in place above and the caller has already flipped the OT/OB
+ * hypothesis to match, so `mat` indexes the same way in both passes. */
+uint32_t *bwa_gen_cigar3(const int8_t mat[25], int o_del, int e_del, int o_ins, int e_ins, int w_, int64_t l_pac, const uint8_t *pac, int l_query, uint8_t *query, int64_t rb, int64_t re, int *score, int *n_cigar, int *NM, int nm_from_mat)
 {
     uint32_t *cigar = 0;
     uint8_t tmp, *rseq;
@@ -353,7 +368,11 @@ uint32_t *bwa_gen_cigar2(const int8_t mat[25], int o_del, int e_del, int o_ins, 
             op  = cigar[k]&0xf, len = cigar[k]>>4;
             if (op == 0) { // match
                 for (i = 0; i < len; ++i) {
-                    if (query[x + i] != rseq[y + i]) {
+                    /* loop-invariant select; see the nm_from_mat contract above */
+                    const int is_mm = nm_from_mat
+                        ? (mat[rseq[y + i] * 5 + query[x + i]] < 0)
+                        : (query[x + i] != rseq[y + i]);
+                    if (is_mm) {
                         kputw(u, &str);
                         kputc(int2base[rseq[y+i]], &str);
                         ++n_mm; u = 0;
@@ -381,6 +400,11 @@ uint32_t *bwa_gen_cigar2(const int8_t mat[25], int o_del, int e_del, int o_ins, 
 ret_gen_cigar:
     /* rseq aliases thread-local kvec scratch in this function; do not free. */
     return cigar;
+}
+
+uint32_t *bwa_gen_cigar2(const int8_t mat[25], int o_del, int e_del, int o_ins, int e_ins, int w_, int64_t l_pac, const uint8_t *pac, int l_query, uint8_t *query, int64_t rb, int64_t re, int *score, int *n_cigar, int *NM)
+{
+    return bwa_gen_cigar3(mat, o_del, e_del, o_ins, e_ins, w_, l_pac, pac, l_query, query, rb, re, score, n_cigar, NM, 0);
 }
 
 uint32_t *bwa_gen_cigar(const int8_t mat[25], int q, int r, int w_, int64_t l_pac, const uint8_t *pac, int l_query, uint8_t *query, int64_t rb, int64_t re, int *score, int *n_cigar, int *NM)

--- a/src/bwa.h
+++ b/src/bwa.h
@@ -130,6 +130,16 @@ extern "C" {
 							 int64_t rb, int64_t re, int *score,
 							 int *n_cigar, int *NM);
 
+	/* As bwa_gen_cigar2, plus `nm_from_mat`: 0 derives NM/MD from literal base
+	 * inequality (bwa default); 1 derives them from the scoring matrix, so a
+	 * cell the matrix does not penalise is a match. --meth uses 1 so bisulfite
+	 * conversions are matches for NM/MD as well as for the DP. */
+	uint32_t *bwa_gen_cigar3(const int8_t mat[25], int o_del, int e_del,
+							 int o_ins, int e_ins, int w_, int64_t l_pac,
+							 const uint8_t *pac, int l_query, uint8_t *query,
+							 int64_t rb, int64_t re, int *score,
+							 int *n_cigar, int *NM, int nm_from_mat);
+
 	/* emit_unpacked_ref=0 (the default) skips writing `<prefix>.0123`. `mem`
 	 * pac-fetches the original reference from `<prefix>.pac` on demand
 	 * (bns_get_seq_v2), so the unpacked `.0123` (~8x the `.pac`) is never read

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -3167,7 +3167,7 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
     int *HN = 0;
 
     if (!(opt->flag & MEM_F_ALL))
-        XA = mem_gen_alt(opt, bns, pac, a, s->l_seq, s->seq, &HN);
+        XA = mem_gen_alt(opt, bns, pac, a, s->l_seq, s->seq, &HN, s->meth_orig_seq);
 
     kv_init(aa);
     str.l = str.m = 0; str.s = 0;
@@ -3475,12 +3475,12 @@ mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *
     qb = ar->qb, qe = ar->qe;
     rb = ar->rb, re = ar->re;
     /* D3 (--meth, PR-5): output CIGAR/NM/MD must reflect the ORIGINAL read vs the
-     * ORIGINAL reference in the original alphabet, so a real (non-converting) SNP
-     * shows as a mismatch and the bisulfite C→T/G→A conversion shows as read-T at
-     * ref-C (the substrate a downstream double-masking step like Revelio expects;
-     * plan §4 / spec §6.1). When `meth_orig_query` is supplied, regen from the
-     * original bases; else fall back to the projected `query_` (non-meth path,
-     * byte-for-byte identical to legacy). */
+     * ORIGINAL reference in the original alphabet, so placement and gap shape are
+     * expressed in real coordinates and a real (non-converting) SNP stays a
+     * mismatch. When `meth_orig_query` is supplied, regen from the original
+     * bases; else fall back to the projected `query_` (non-meth path,
+     * byte-for-byte identical to legacy). How conversions themselves are treated
+     * in NM/MD is governed by the policy note below, not here. */
     const int use_meth_orig = (opt->meth_mode && meth_orig_query != NULL
                                && ar->meth_hypothesis >= 0);
     const char *regen_query = use_meth_orig ? meth_orig_query : query_;
@@ -3513,19 +3513,31 @@ mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *
      *     re-penalize every conversion as a mismatch and can shift gaps); for
      *     non-meth it is the symmetric opt->mat (legacy, unchanged).
      *
-     * NOTE (--meth NM/MD-vs-conversion policy, RESOLVED — plan §4): bwa_gen_cigar2
-     * computes NM/MD by LITERAL base comparison (query[x+i] != rseq[y+i]),
-     * independent of `regen_mat`. So a bisulfite C→T (OT) / G→A (OB) at a
-     * ref-C/ref-G is COUNTED as one mismatch in NM and emitted in MD, exactly like
-     * a real SNP — it is NOT hidden. This is deliberate: it is the substrate a
-     * downstream Revelio-style double-mask + conventional caller expects (the
-     * conversion is visible as read-T at ref-C, then BQ-masked downstream; the
-     * aligner does no masking). The conversion is NOT double-counted against the
-     * alignment SCORE: the asymmetric `regen_mat` frees the conversion cell to a
-     * match (+a) for the DP, while NM/MD count it once as a literal mismatch — two
-     * separate concerns. Hiding conversions from NM/MD (e.g. a Bismark-style
-     * XM-only consumer) would be a different, explicit choice and must be made
-     * here, not assumed. */
+     * NOTE (--meth NM/MD-vs-conversion policy): under --meth, NM/MD are derived
+     * from `regen_mat`, not from literal base inequality — a column is a mismatch
+     * iff the matrix penalises it (`bwa_gen_cigar3(..., nm_from_mat=1)`). Because
+     * the asymmetric matrix scores the conversion cell as a match, a bisulfite
+     * C→T (OT) / G→A (OB) at a ref-C/ref-G is a MATCH for NM/MD exactly as it
+     * already is for the DP. One definition drives both; there is no bisulfite
+     * special case in the NM/MD pass itself.
+     *
+     * Consequences, by design and by scoring mode:
+     *   - Conversions never reach NM/MD. A perfectly converted read is NM:i:0,
+     *     and MD does not enumerate every ref-C (which otherwise dominates the
+     *     record; see issue #327).
+     *   - `genomic` frees only the conversion direction, so a real variant in the
+     *     opposite direction stays a mismatch and remains visible.
+     *   - `collapsed` frees the mirror cell too, so C/T (and G/A) are fully
+     *     interchangeable and real variants in that class are hidden as well —
+     *     the documented cost of bwameth-compatible placement.
+     *
+     * A read alone cannot distinguish a bisulfite C→T from a real C→T SNP; that
+     * aliasing is resolved downstream at the pileup, not here. The aligner
+     * therefore reports what its scoring model treats as divergence rather than
+     * adjudicating chemistry-vs-genotype per base. NOTE: this makes NM/MD
+     * deliberately non-conformant with the SAM spec's "edit distance to the
+     * reference" under --meth (the same divergence class as BISCUIT's NM and
+     * bwameth's collapsed-space NM); the non-meth path is unchanged. */
     /* D3 (--meth, fix): the CIGAR regen must use the SAME strand-adjusted matrix
      * as the extension (see mem_alnreg_t.meth_strand_hyp). ar->rb is final here,
      * so derive is_rev directly (rb in doubled-pac; >= l_pac = reverse) and flip
@@ -3538,7 +3550,7 @@ mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *
     do {
         free(a.cigar);
         w2 = w2 < opt->w<<2? w2 : opt->w<<2;
-        a.cigar = bwa_gen_cigar2(regen_mat, opt->o_del, opt->e_del, opt->o_ins, opt->e_ins, w2, bns->l_pac, pac, qe - qb, (uint8_t*)&query[qb], rb, re, &score, &a.n_cigar, &NM);
+        a.cigar = bwa_gen_cigar3(regen_mat, opt->o_del, opt->e_del, opt->o_ins, opt->e_ins, w2, bns->l_pac, pac, qe - qb, (uint8_t*)&query[qb], rb, re, &score, &a.n_cigar, &NM, use_meth_orig);
         if (bwa_verbose >= 4) fprintf(stderr, "* Final alignment: w2=%d, global_sc=%d, local_sc=%d\n", w2, score, ar->truesc);
         if (score == last_sc || w2 == opt->w<<2) break; // it is possible that global alignment and local alignment give different scores
         last_sc = score;

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -157,11 +157,12 @@ typedef struct mem_opt_t {
      *   GENOMIC: that cell alone is freed, to a MATCH (+a); the mirror
      *     (mat[T][C], mat[A][G]) STAYS at −b so genuine variants score as
      *     mismatches → one freed cell at +a ⇒ the SIMD rank-1 fast path.
-     *     Variant-aware, truthful NM/MD.
+     *     Variant-aware: real variants stay visible in NM/MD.
      *   NEUTRAL: that cell alone is freed, to 0 (tolerated, not rewarded); the
      *     mirror STAYS at −b. One freed cell, but NOT rank-1 (the value is
      *     neither match nor mismatch) → bandedSWA's general path; the kswv
-     *     freed-cell blend expresses it directly. Variant-aware, truthful NM/MD.
+     *     freed-cell blend expresses it directly. Variant-aware: real variants
+     *     stay visible in NM/MD.
      *   COLLAPSED: the mirror cell is ALSO freed (two cells, both to +a) so C/T
      *     and G/A are interchangeable → reproduces bwameth; uses bandedSWA's
      *     general path.
@@ -485,9 +486,13 @@ int mem_mark_primary_se(const mem_opt_t *opt, int n, mem_alnreg_t *a, int64_t id
 
 static void mem_mark_primary_se_core(const mem_opt_t *opt, int n, mem_alnreg_t *a, int_v *z);
 
+/* ONLY work after mem_mark_primary_se(); out_hn may be NULL.
+ * `meth_orig_query` is forwarded to mem_reg2aln for each XA sub-entry so they
+ * regenerate under the same NM/MD policy as the primary record (see
+ * mem_reg2aln). NULL (the default) keeps the legacy literal regen. */
 char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
                    const mem_alnreg_v *a, int l_query, const char *query,
-                   int **out_hn); // ONLY work after mem_mark_primary_se(); out_hn may be NULL
+                   int **out_hn, const char *meth_orig_query = NULL);
 void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str, bseq1_t *s,
                  int n, const mem_aln_t *list, int which, const mem_aln_t *m_);
 

--- a/src/bwamem_extra.cpp
+++ b/src/bwamem_extra.cpp
@@ -129,7 +129,7 @@ static inline int get_pri_idx(double XA_drop_ratio, const mem_alnreg_t *a, int i
 // Okay, returning strings is bad, but this has happened a lot elsewhere. If I have time, I need serious code cleanup.
 // When out_hn is non-NULL, it is set to a newly-allocated int[a->n] of per-primary
 // hit counts (cnt[r]) so callers can emit the HN:i tag; caller owns the buffer.
-char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, const mem_alnreg_v *a, int l_query, const char *query, int **out_hn) // ONLY work after mem_mark_primary_se()
+char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, const mem_alnreg_v *a, int l_query, const char *query, int **out_hn, const char *meth_orig_query) // ONLY work after mem_mark_primary_se()
 {
 	int i, k, r, *cnt, tot;
 	kstring_t *aln = 0, str = {0,0,0};
@@ -168,7 +168,11 @@ char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 		mem_aln_t t;
 		if ((r = get_pri_idx(opt->XA_drop_ratio, a->a, i)) < 0) continue;
 		if (cnt[r] > opt->max_XA_hits_alt || (!has_alt[r] && cnt[r] > opt->max_XA_hits)) continue;
-		t = mem_reg2aln(opt, bns, pac, l_query, query, &a->a[i]);
+		/* Pass meth_orig_query so each XA sub-entry regenerates under the SAME
+		 * NM/MD policy as the primary record. Omitting it silently falls back to
+		 * the literal predicate, so one record would report matrix-derived NM:i:
+		 * on the primary and conversion-counting NM inside its own XA:Z. */
+		t = mem_reg2aln(opt, bns, pac, l_query, query, &a->a[i], meth_orig_query);
 		str.l = 0;
 		kputs(bns->anns[t.rid].name, &str);
 		kputc(',', &str); kputc("+-"[t.is_rev], &str); kputl(t.pos + 1, &str);

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -684,7 +684,7 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns,
                uint64_t id, bseq1_t s[2], mem_alnreg_v a[2])
 {
     extern void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, bseq1_t *s, mem_alnreg_v *a, int extra_flag, const mem_aln_t *m);
-    extern char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, const mem_alnreg_v *a, int l_query, const char *query, int **out_hn);
+    extern char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, const mem_alnreg_v *a, int l_query, const char *query, int **out_hn, const char *meth_orig_query);
 
     int i, j, z[2], extra_flag, n_pri[2], q_se[2], n_aa[2], paired;
     kstring_t str;
@@ -703,7 +703,7 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns,
         int *HN[2] = { 0, 0 };
         if (!(opt->flag & MEM_F_ALL)) {
             for (i = 0; i < 2; ++i)
-                XA[i] = mem_gen_alt(opt, bns, pac, &a[i], s[i].l_seq, s[i].seq, &HN[i]);
+                XA[i] = mem_gen_alt(opt, bns, pac, &a[i], s[i].l_seq, s[i].seq, &HN[i], s[i].meth_orig_seq);
         } else XA[0] = XA[1] = 0;
         // write SAM
         for (i = 0; i < 2; ++i) {
@@ -1119,7 +1119,7 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
                             bseq1_t *s, mem_alnreg_v *a, int extra_flag, const mem_aln_t *m);
     extern char **mem_gen_alt(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
                               const mem_alnreg_v *a, int l_query, const char *query,
-                              int **out_hn);
+                              int **out_hn, const char *meth_orig_query);
     #if MATE_SORT
     extern void sort_alnreg_re(int n, mem_alnreg_t* a);
     extern void sort_alnreg_score(int n, mem_alnreg_t* a);
@@ -1291,7 +1291,7 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
         int *HN[2] = { 0, 0 };
         if (!(opt->flag & MEM_F_ALL)) {
             for (i = 0; i < 2; ++i)
-                XA[i] = mem_gen_alt(opt, bns, pac, &a[i], s[i].l_seq, s[i].seq, &HN[i]);
+                XA[i] = mem_gen_alt(opt, bns, pac, &a[i], s[i].l_seq, s[i].seq, &HN[i], s[i].meth_orig_seq);
         } else XA[0] = XA[1] = 0;
         // write SAM
         for (i = 0; i < 2; ++i) {

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1542,11 +1542,14 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                 collapsed: C/T (and G/A) interchangeable, bwameth-compatible\n");
     fprintf(stderr, "                 placement (sets -B 2).\n");
     fprintf(stderr, "                 genomic: free only the conversion direction, scored as a full\n");
-    fprintf(stderr, "                 match, keep variants as mismatches (variant-aware, truthful\n");
-    fprintf(stderr, "                 NM/MD; -B 4).\n");
+    fprintf(stderr, "                 match, keep variants as mismatches (variant-aware: variants\n");
+    fprintf(stderr, "                 outside the conversion direction visible in NM/MD; -B 4).\n");
     fprintf(stderr, "                 neutral: free only the conversion direction but score it 0\n");
-    fprintf(stderr, "                 (tolerated, not rewarded); best for TAPS (variant-aware,\n");
-    fprintf(stderr, "                 truthful NM/MD; -B 4).\n");
+    fprintf(stderr, "                 (tolerated, not rewarded); best for TAPS (variant-aware:\n");
+    fprintf(stderr, "                 variants visible in NM/MD as in genomic; -B 4).\n");
+    fprintf(stderr, "                 In genomic/neutral a real variant in the conversion direction\n");
+    fprintf(stderr, "                 itself (C->T at a reference C) is indistinguishable from a\n");
+    fprintf(stderr, "                 conversion and stays hidden in NM/MD.\n");
     fprintf(stderr, "   --set-as-failed f|r\n");
     fprintf(stderr, "                 flag alignments to the matching strand ('f' or 'r') as QC-fail (0x200)\n");
     fprintf(stderr, "   --chimera-qc\n");
@@ -2418,6 +2421,28 @@ int main_mem(int argc, char *argv[])
          * -A (bwameth's constants assume a==1) and can be unit-tested. */
         mem_opt_apply_meth_defaults(opt, &opt0);
         aux.copy_comment = 1;          /* -C, needed for YS:Z/YC:Z passthrough */
+    }
+
+    /* Under --meth, NM/MD are derived from the scoring matrix (a column is a
+     * mismatch iff the matrix penalizes it), so a non-positive -B makes every
+     * substitution cell non-negative and silently collapses NM to 0 and MD to
+     * a bare match run -- hiding real variants, not just conversions. Refuse it
+     * rather than emit output that looks clean because scoring is degenerate.
+     * The bound is `<= 0`, not `== 0`: bwa_fill_scmat stores -b, so a NEGATIVE
+     * -B turns every substitution into a positive reward, which hides real
+     * variants at least as thoroughly as -B 0 does.
+     * The message reports the EFFECTIVE penalty rather than echoing "-B":
+     * update_a() scales b by -A when -B was not given, so `-A 0` reaches b == 0
+     * without the user ever passing -B, and naming -B there would misdirect.
+     * The non-meth path keeps the literal comparison and is unaffected. */
+    if (opt->meth_mode && opt->b <= 0) {
+        fprintf(stderr, "ERROR: --meth requires a positive mismatch penalty, but the "
+                        "effective penalty is %d; a non-positive penalty makes every "
+                        "substitution free or rewarded, which collapses NM/MD to zero "
+                        "and hides real variants (check -B and -A)\n", opt->b);
+        free(opt);
+        if (out_opened) fclose(aux.fp);
+        return 1;
     }
 
     /* Matrix for SWA */

--- a/test/regression/meth_collapsed_scoring.sh
+++ b/test/regression/meth_collapsed_scoring.sh
@@ -9,9 +9,17 @@
 # modes; the MIRROR cell ref-T x read-C is a real mismatch under `genomic`
 # (variant-aware) but freed under `collapsed` (C/T interchangeable). So a read
 # that differs from the reference only by a single ref-T -> read-C substitution
-# scores (a+b) higher under collapsed than under genomic, while the literal
-# mismatch is preserved in NM either way. This exercises bandedSWA's general
-# (>=2 freed cell) matrix path that collapsed mode uses.
+# scores (a+b) higher under collapsed than under genomic. NM is derived from the
+# same matrix, so the variant is a mismatch under genomic (NM=1) and hidden under
+# collapsed (NM=0) -- the observable cost of bwameth-compatible placement. This
+# exercises bandedSWA's general (>=2 freed cell) matrix path that collapsed uses.
+#
+# The mirror cell alone cannot separate `neutral` from `genomic` -- both leave it
+# at -b -- so a second read exercises the CONVERSION cell itself, which genomic
+# scores +a and neutral scores 0. There NM must be 0 in both (neither penalizes
+# it, and NM is "mismatch iff the matrix penalizes"), while AS differs by exactly
+# one match score. Without that case a regression collapsing neutral into genomic
+# would pass this fixture.
 
 set -euo pipefail
 : "${BWA_MEM3:?BWA_MEM3 must be set}"
@@ -42,6 +50,21 @@ done
 Q=$(printf 'I%.0s' $(seq 1 $LEN))
 printf '@m\n%s\n+\n%s\n' "$READ" "$Q" > r.fq
 
+# Same window, but flip one internal ref-C to T: a pure OT conversion, the only
+# off-diagonal column, and the cell whose SCORE differs between genomic (+a) and
+# neutral (0).
+CONV=""; CONVERTED=0
+for ((i=0; i<LEN; i++)); do
+    b=${SUB:i:1}
+    if [ "$CONVERTED" -eq 0 ] && [ "$b" = "C" ] && [ "$i" -ge 18 ] && [ "$i" -le 42 ]; then
+        CONV+="T"; CONVERTED=1
+    else
+        CONV+="$b"
+    fi
+done
+[ "$CONVERTED" -eq 1 ] || fail "no internal ref-C found to convert in window"
+printf '@c\n%s\n+\n%s\n' "$CONV" "$Q" > c.fq
+
 tag() { mawk -v k="$2" '{for(i=12;i<=NF;i++) if(substr($i,1,5)==k":i:"){print substr($i,6); exit}}' <<<"$1"; }
 as_of() { # $1 = scoring mode -> echoes "AS NM" of the primary alignment
     "$BWA_MEM3" mem --meth --meth-scoring "$1" -t 1 ref.fa r.fq > o.bam 2>/dev/null || fail "$1 mem --meth nonzero exit"
@@ -58,19 +81,92 @@ echo "[meth_collapsed] genomic: AS=$AS_G NM=$NM_G   collapsed: AS=$AS_C NM=$NM_C
 
 # a=1, b=4 (collapsed default sets b=2, but we want a fixed delta: pin -B 4 in
 # BOTH so the only variable is the matrix). Re-run with explicit -B 4.
-as_of_b4() {
-    "$BWA_MEM3" mem --meth --meth-scoring "$1" -B 4 -t 1 ref.fa r.fq > o.bam 2>/dev/null || fail "$1 -B4 nonzero exit"
+as_of_b4() { # $1 = scoring mode, $2 = fastq -> echoes "AS NM" of the primary alignment
+    "$BWA_MEM3" mem --meth --meth-scoring "$1" -B 4 -t 1 ref.fa "$2" > o.bam 2>/dev/null || fail "$1 -B4 nonzero exit on $2"
     local line; line=$(samtools view -F 0x104 o.bam | mawk 'NR==1')
+    [ -n "$line" ] || fail "$1 -B4: no primary alignment for $2"
     echo "$(tag "$line" AS) $(tag "$line" NM)"
 }
-read -r AS_Gb NM_Gb <<<"$(as_of_b4 genomic)"
-read -r AS_Cb NM_Cb <<<"$(as_of_b4 collapsed)"
+read -r AS_Gb NM_Gb <<<"$(as_of_b4 genomic r.fq)"
+read -r AS_Cb NM_Cb <<<"$(as_of_b4 collapsed r.fq)"
 
 # The mirror cell is a mismatch under genomic, a match under collapsed:
 #   collapsed AS - genomic AS == a + b == 1 + 4 == 5.
 [ $((AS_Cb - AS_Gb)) -eq 5 ] || fail "collapsed should free the ref-T x read-C mirror: AS_collapsed=$AS_Cb AS_genomic=$AS_Gb (want diff 5)"
-# Literal mismatch preserved in NM regardless of scoring mode.
-[ "$NM_Gb" = "$NM_Cb" ] || fail "NM should be identical across modes (literal mismatch preserved): genomic=$NM_Gb collapsed=$NM_Cb"
-[ "$NM_Cb" = "1" ] || fail "expected exactly one literal mismatch (the flipped base): NM=$NM_Cb"
+# NM follows the same matrix, so the mirror cell is visible in NM too: a real
+# ref-T x read-C variant is a mismatch under genomic and hidden under collapsed.
+# This is the observable cost of bwameth-compatible placement (issue #327).
+[ "$NM_Gb" = "1" ] || fail "genomic should keep the ref-T x read-C variant as a mismatch: NM=$NM_Gb, want 1"
+[ "$NM_Cb" = "0" ] || fail "collapsed should hide the ref-T x read-C variant (C/T interchangeable): NM=$NM_Cb, want 0"
+
+# `neutral` (the --meth=taps default) is the third mode and the only one whose
+# conversion cell is 0 rather than +a, so it exercises a distinct edge of the
+# "mismatch iff the matrix penalizes it" predicate. Like `genomic` it leaves the
+# mirror cell at -b, so the real ref-T x read-C variant must stay visible.
+read -r AS_Nb NM_Nb <<<"$(as_of_b4 neutral r.fq)"
+[ "$NM_Nb" = "1" ] || fail "neutral should keep the ref-T x read-C variant as a mismatch: NM=$NM_Nb, want 1"
+# This read has no conversion column, so the one cell where neutral and genomic
+# differ is never exercised: their scores must agree exactly. (The conversion
+# read below is what separates them.)
+[ "$AS_Nb" = "$AS_Gb" ] || fail "neutral and genomic must score the mirror cell identically: AS_neutral=$AS_Nb AS_genomic=$AS_Gb"
+
+# ---------------------------------------------------------------------------
+# Conversion cell (ref-C x read-T), the one cell genomic and neutral score
+# DIFFERENTLY: +a under genomic, 0 under neutral. Neither value is negative, so
+# "mismatch iff the matrix penalizes it" makes it a match for NM in both -- the
+# NM=0 the whole issue is about. The scores must still diverge by exactly one
+# match score, which is what pins neutral apart from genomic.
+read -r AS_Gc NM_Gc <<<"$(as_of_b4 genomic c.fq)"
+read -r AS_Nc NM_Nc <<<"$(as_of_b4 neutral c.fq)"
+
+echo "[meth_collapsed] conversion read -> genomic: AS=$AS_Gc NM=$NM_Gc   neutral: AS=$AS_Nc NM=$NM_Nc"
+
+[ "$NM_Gc" = "0" ] || fail "genomic should not count the ref-C x read-T conversion: NM=$NM_Gc, want 0"
+[ "$NM_Nc" = "0" ] || fail "neutral should not count the ref-C x read-T conversion (cell scores 0, not < 0): NM=$NM_Nc, want 0"
+# a=1: genomic credits the conversion +1, neutral credits it 0, and the read has
+# no other off-diagonal column, so the whole AS difference is that one cell.
+[ $((AS_Gc - AS_Nc)) -eq 1 ] || fail "neutral must score the conversion 0 where genomic scores +a=1: AS_genomic=$AS_Gc AS_neutral=$AS_Nc (want diff 1)"
+
+# ---------------------------------------------------------------------------
+# Degenerate -B under --meth. "Mismatch iff the matrix penalizes it" only says
+# something while SOME cell is penalized: bwa_fill_scmat stores -b, so -B 0
+# makes every substitution free and -B <0 makes it a positive reward. Either
+# way NM collapses to 0 and MD to a bare match run for REAL variants, not just
+# conversions -- output that looks clean because scoring is degenerate. Both
+# must be refused, so the bound is `<= 0` rather than `== 0`.
+#
+# Assert the guard's own message, not merely a non-zero exit: `mem` exits 1 for
+# plenty of unrelated reasons (missing index, bad path), so an exit-code-only
+# check would pass with the guard never firing.
+reject_meth() { # $1 = human label, $2... = args before the positional operands
+    local label="$1"; shift
+    local rc=0
+    "$BWA_MEM3" mem --meth "$@" -t 1 ref.fa r.fq > /dev/null 2> badB.err || rc=$?
+    [ "$rc" -eq 1 ] || fail "$label must be rejected with exit 1, got exit $rc"
+    grep -q 'requires a positive mismatch penalty' badB.err \
+        || fail "$label must be rejected by the mismatch-penalty guard, but stderr was: $(cat badB.err)"
+}
+# Explicit -B: bwa_fill_scmat stores -b, so 0 frees every substitution and a
+# negative -B rewards it.
+for badB in 0 -1; do
+    reject_meth "--meth -B $badB" -B "$badB"
+done
+# ...and the -A route, which is why the message reports the EFFECTIVE penalty
+# rather than echoing "-B": update_a() scales b by -A when -B was not given, so
+# -A 0 drives b to 0 without the user ever passing -B.
+reject_meth "--meth -A 0 (b scaled to 0 by update_a)" -A 0
+
+# ...and the rejection is scoped to --meth: the non-meth path keeps the literal
+# base comparison, where -B 0 only affects placement, never NM/MD truthfulness.
+# A separate non-doubled index is required -- `index --meth` builds the doubled
+# per-strand reference, which plain `mem` must not be pointed at.
+cp ref.fa ref_nonmeth.fa
+"$BWA_MEM3" index ref_nonmeth.fa >/dev/null 2>&1 || fail "index (non-meth) nonzero exit"
+"$BWA_MEM3" mem -B 0 -t 1 ref_nonmeth.fa r.fq > nm.sam 2>/dev/null \
+    || fail "non-meth -B 0 must still be accepted (the --meth guard must not leak into the default path)"
+NM_LIT=$(mawk '!/^@/{for(i=12;i<=NF;i++) if(substr($i,1,5)=="NM:i:"){print substr($i,6); exit}}' nm.sam)
+# The read carries one real ref-T x read-C substitution; literal NM must see it
+# even at -B 0, which is exactly why -B 0 is harmless off the --meth path.
+[ "$NM_LIT" = "1" ] || fail "non-meth -B 0 should keep literal NM: NM=$NM_LIT, want 1"
 
 echo "OK"

--- a/test/regression/meth_mixed_pe_asym.sh
+++ b/test/regression/meth_mixed_pe_asym.sh
@@ -8,12 +8,13 @@
 # matrix for the batched-SIMD placement scorer, so bisulfite conversions were
 # penalized as mismatches (deflated AS/MAPQ). After A1's per-hypothesis partition
 # pass each mate is scored against its OT/OB object, so conversions are FREE in
-# scoring (AS == perfect) while remaining literal mismatches in NM/MD (for
-# downstream Revelio-style masking).
+# scoring (AS == perfect). Since NM/MD are derived from that same matrix, the
+# conversions are hidden from NM/MD as well (issue #327).
 #
-# The decisive assertion per mate: AS == read length (60) AND NM == #conversions
-# (> 0). A symmetric-scored conversion would cost (a + b) per event, dropping AS
-# well below 60.
+# The decisive assertion per mate: AS == read length (60) AND NM == 0, with the
+# lowercase call count in XM:Z proving the read really carries #conversions > 0
+# (otherwise NM == 0 would pass vacuously). A symmetric-scored conversion would
+# cost (a + b) per event, dropping AS well below 60.
 #
 # Inputs:
 #   BWA_MEM3 — path to the bwa-mem3 binary under test
@@ -31,9 +32,9 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 # Deterministic 1500 bp reference (PRNG seed 4242; see test generation notes).
 REF=TCATTGGCTATCCTAACCCGACCCTAGGAGCGGTTGGCGTGTATGCCGTGAATTTTCTCATTTCCGCTAGACATAATCGTTCTGCCTATATCTGGACAACATCCCGGCGACTTAGGCGACCCACAGAATCGTCCCTTCTAACGTAGTTCGCATAGTTCCCGTCCGTAGCCGGACTATTCGAACACCCAGTATTCGATTAACTCGGGCTTGACGTATTAGAGGCGTTAGTGTGCCAGGTAAGATACGCCAACGGAATTAACCTCTGTGACACTCCGCGGAGCCTTCGGACATATAAGTGATCGGGTCTACGTTTGTTAGACTTGAGACGTCTGTTAAGAGTTGGGTCTAATAAATCGCCTACACGTGGAGTCTAACGGGGAAGCGTCGAATCCTGATACATCATATAATGGAGCGTGTTATGAAAAAAGAGCATTCCATTGTACGAGCCGTGCCAGAAACGGCTTGACTACGTGAGCGTAGTGTTAGATAAACAGGAAACACTGACGCGGTTAGAAGGCGGATTGCCGGTAGGTTTTGGAAACATAAATACACACGGTATCATGTTGGGTCACGATTCCTATCACCGCACAGGGCCAACCATAGAAGAACTGAAAGAACTAATCTGGCGGCGGGCTCGGTGCTTATATTTTCCACCCAACATCGTGCACATTAGGCTCACCGCGCCCTACGGGCGAAGGGTGCGTACGGTGTTTATAAGGCGTGACGGCCCCAAGTAGAGGGTAATTCTGTGAAAGAATCTCAGGACGGTGGCATGAATTCAATTCCTTTTAAACCTATCGTTCCGACCTTATGCAATCCTTCAATGAAGATCGTCAACGACCATCGTTCTTCTGCTTTAAGTGTGAGTTCTCTCTTACAAGCTAATACACCCCAGCGTTCTCCGTACTCTTCACTGCCCAAGCGAGGCTAACCTTTTGAAATGTCACAGTCGAAGCATATCTCCCGTACATCTTTTTCGGAGATCGCAGCTCGCGGAGCTATAAGCGACTTAAGCCCTTGTGTCGGTGATCCCAAGGGTCTGACTCCTGTACCAGGGTTACTGTTTCGCTTTACGGAGTAGCCTGTGAGGTGAACTGAAAGGAGCATATTTGAGATCTAAGATAGGGTCCTCCTCTGCGTCTACGTTCTCTCCGTTACGTACGGCTTCGCACCGGAGTGCATCTTGGCCCCGAAACGCACTGTGTGTGCTGATACAGCGTCCCTGGCCGGCCATGGGTTCAGAACTCCCGGGAACGCTTTTCAACTTAGAGGAACCCCGTCATGGAAGTAGATCGCGTCGAATGAGGGAGTTAGTCCTCGTTCCAGCTGGTAATTGTTTTACCGCTTGGGACCACTATAGGCCGCGGGTAGAAGTTGCTGGGTGTTGATTCCAACCCTCGAACCACGATACGACCTGCCATTTATGGCACAGTAAGGTTCAAACAGCATAATGAATACAGTTATAGTAACTTCCTCACGTACGATTAGGACGCAGCCTTG
 
-# R1: OT (C->T) read over chrA[100:160] (1-based pos 101), forward.  NM == 10 conversions.
+# R1: OT (C->T) read over chrA[100:160] (1-based pos 101), forward.  10 C->T conversions.
 R1=ATTCTGGCGATTTAGGTGACTCACAGAATCGTTCTTTCTAACGTAGTTTGTATAGTTCTC
-# R2: OB (G->A) read, reverse mate over chrA[300:360] (1-based pos 301).  NM == 5 conversions.
+# R2: OB (G->A) read, reverse mate over chrA[300:360] (1-based pos 301).  5 G->A conversions.
 R2=TAAGCGATTTATTAAACCCAACTCTTAACAAACGTCTCAAATCTAACAAACGTAAACCCG
 
 printf '>chrA\n%s\n' "$REF" > ref.fa
@@ -46,34 +47,43 @@ printf '@p\n%s\n+\n%s\n' "$R2" "$Q" > r2.fq
 samtools quickcheck pe.bam || fail "mem --meth produced an invalid BAM"
 
 # Extract one decoded line per mate (READ1 = flag&64, READ2 = flag&128).
-get() { # $1 = mate-flag-bit (64=READ1, 128=READ2)  -> echo "RNAME POS MAPQ rev CIGAR AS NM XR"
+get() { # $1 = mate-flag-bit (64=READ1, 128=READ2)  -> echo "RNAME POS MAPQ rev CIGAR AS NM XR NCONV"
     # mawk has no bitwise and(); extract a flag bit via integer arithmetic.
+    # NCONV = count of lowercase methylation calls in XM:Z, i.e. the number of
+    # bases that were actually bisulfite-converted in this read. The lowercase
+    # classes are z (CpG), x (CHG), h (CHH) and u (context unresolvable -- e.g.
+    # a read at a contig edge, where meth_xm.cpp defaults the context to N).
     samtools view pe.bam | mawk -v bit="$1" '
         (int($2/bit) % 2) == 1 {
-            rev = (int($2/16) % 2) == 1 ? 1 : 0; as=""; nm=""; xr="";
-            for (i=12;i<=NF;i++){ if($i~/^AS:i:/){as=substr($i,6)} if($i~/^NM:i:/){nm=substr($i,6)} if($i~/^XR:Z:/){xr=substr($i,6)} }
-            print $3, $4, $5, rev, $6, as, nm, xr; exit
+            rev = (int($2/16) % 2) == 1 ? 1 : 0; as=""; nm=""; xr=""; nconv=0;
+            for (i=12;i<=NF;i++){ if($i~/^AS:i:/){as=substr($i,6)} if($i~/^NM:i:/){nm=substr($i,6)} if($i~/^XR:Z:/){xr=substr($i,6)} if($i~/^XM:Z:/){xm=substr($i,6); nconv=gsub(/[zxhu]/,"",xm)} }
+            print $3, $4, $5, rev, $6, as, nm, xr, nconv; exit
         }'
 }
 
-check_mate() { # $1=label $2=mateflag $3=want_pos $4=want_rev $5=want_as $6=want_nm $7=want_xr
-    read -r rn pos mapq rev cig as nm xr < <(get "$2")
+check_mate() { # $1=label $2=mateflag $3=want_pos $4=want_rev $5=want_as $6=want_nconv $7=want_xr
+    read -r rn pos mapq rev cig as nm xr nconv < <(get "$2")
     [ "$rn" = "chrA" ]      || fail "$1: RNAME $rn, want chrA"
     [ "$pos" = "$3" ]       || fail "$1: POS $pos, want $3"
     [ "$rev" = "$4" ]       || fail "$1: strand rev=$rev, want $4"
     [ "$cig" = "60M" ]      || fail "$1: CIGAR $cig, want 60M"
     [ "$mapq" = "60" ]      || fail "$1: MAPQ $mapq, want 60 (asym scoring must not deflate MAPQ)"
     [ "$xr" = "$7" ]        || fail "$1: XR $xr, want $7"
-    # The A1 contract: conversions are FREE in scoring (AS == full length) yet
-    # appear as literal mismatches in NM (> 0). A symmetric fallback would give AS < $5.
+    # The A1 contract: conversions are FREE in scoring (AS == full length). A
+    # symmetric fallback would give AS < $5.
     [ "$as" = "$5" ]        || fail "$1: AS $as, want $5 (conversions must be scored free under the per-hypothesis matrix)"
-    [ "$nm" = "$6" ]        || fail "$1: NM $nm, want $6 (conversions must remain literal mismatches for downstream masking)"
-    [ "$nm" -gt 0 ]         || fail "$1: NM must be > 0 (test must actually exercise conversions)"
+    # NM is derived from the same matrix, so a read whose only differences are
+    # conversions is NM:i:0. XM's lowercase call count is the independent witness
+    # that the read really does carry conversions -- without it, NM==0 would also
+    # pass on a read with none, making this test vacuous.
+    [ "$nconv" = "$6" ]     || fail "$1: XM shows $nconv converted bases, want $6 (fixture must actually exercise conversions)"
+    [ "$nconv" -gt 0 ]      || fail "$1: converted-base count must be > 0 (test must actually exercise conversions)"
+    [ "$nm" = "0" ]         || fail "$1: NM $nm, want 0 ($nconv conversions are matrix-freed, so they are matches for NM/MD)"
 }
 
-# R1 OT forward @101, AS 60 (10 C->T free), NM 10, XR CT.
+# R1 OT forward @101, AS 60 (10 C->T free), 10 conversions in XM, NM 0, XR CT.
 check_mate "R1/OT" 64  101 0 60 10 CT
-# R2 OB reverse @301, AS 60 (5 G->A free), NM 5, XR GA.
+# R2 OB reverse @301, AS 60 (5 G->A free), 5 conversions in XM, NM 0, XR GA.
 check_mate "R2/OB" 128 301 1 60 5  GA
 
-echo "PASS: meth_mixed_pe_asym (mixed OT+OB PE batch scored per-hypothesis; conversions free in AS, literal in NM)"
+echo "PASS: meth_mixed_pe_asym (mixed OT+OB PE batch scored per-hypothesis; conversions free in AS and hidden in NM)"

--- a/test/regression/meth_output_integrity.sh
+++ b/test/regression/meth_output_integrity.sh
@@ -4,13 +4,17 @@
 # Regression (D3 B6): the --meth BAM is original-alphabet and Bismark-compatible.
 # Five invariants downstream methylation + variant callers depend on:
 #
-#  1. Real-SNP vs bisulfite-conversion. The asymmetric matrix frees conversions
-#     in SCORING but NM/MD count every literal mismatch. An OT read with 10 C->T
-#     conversions plus one real A->G SNP must score AS = 60 - (a+b) (only the SNP
-#     penalized, conversions free), NM = 11, and an MD string with ten ref-C
-#     mismatches (the conversions, the Revelio masking substrate) and exactly one
-#     ref-A mismatch (the real variant) -- so a downstream caller sees the SNP and
-#     a Revelio double-mask hides the conversions.
+#  1. Real-SNP vs bisulfite-conversion. Under --meth, NM/MD are derived from the
+#     per-hypothesis asymmetric matrix rather than from literal base inequality,
+#     so a column is a mismatch iff the matrix penalizes it. An OT read with 10
+#     C->T conversions plus one real A->G SNP must score AS = 60 - (a+b) (only the
+#     SNP penalized, conversions free), NM = 1, and an MD string with exactly one
+#     ref-A mismatch (the real variant) and NO ref-C entries -- the conversions
+#     are matches for NM/MD exactly as they already are for the DP (issue #327).
+#
+#     (The complementary case -- that `collapsed` additionally hides a real T->C
+#     variant while `genomic` keeps it -- is covered by meth_collapsed_scoring.sh,
+#     which owns that fixture.)
 #
 #  2. Bismark four-strand XR/XG. XR is the per-read conversion (R1=CT, R2=GA); XG
 #     is the genome strand shared by both mates of a fragment. A top-strand
@@ -62,12 +66,13 @@ as=$(tag "$line" AS); nm=$(tag "$line" NM); md=$(tag "$line" MD)
 # --meth keeps the bwa default mismatch penalty b=4 (not bwameth's b=2), so the single real SNP costs -4
 # (conversions free): 59 match/freed columns (+59) - 1 SNP (-4) = 55.
 [ "$as" = "55" ] || fail "SNP/conv: AS $as, want 55 (only the real SNP penalized at b=4; conversions free)"
-[ "$nm" = "11" ] || fail "SNP/conv: NM $nm, want 11 (10 conversions + 1 SNP)"
-# MD reference-base mismatch letters: ten ref-C (conversions) + exactly one ref-A (SNP).
+[ "$nm" = "1" ]  || fail "SNP/conv: NM $nm, want 1 (the real SNP only; conversions are matches for NM/MD)"
+# MD reference-base mismatch letters: exactly one ref-A (the SNP), no ref-C (the
+# conversions must not appear at all).
 nC=$(printf '%s' "$md" | tr -cd 'C' | wc -c | tr -d ' ')
 nA=$(printf '%s' "$md" | tr -cd 'A' | wc -c | tr -d ' ')
 nG=$(printf '%s' "$md" | tr -cd 'G' | wc -c | tr -d ' ')
-[ "$nC" = "10" ] || fail "SNP/conv: MD has $nC ref-C mismatches, want 10 (conversions); MD=$md"
+[ "$nC" = "0" ]  || fail "SNP/conv: MD has $nC ref-C mismatches, want 0 (conversions must be hidden); MD=$md"
 [ "$nA" = "1" ]  || fail "SNP/conv: MD has $nA ref-A mismatches, want 1 (the real SNP); MD=$md"
 [ "$nG" = "0" ]  || fail "SNP/conv: MD has $nG ref-G mismatches, want 0; MD=$md"
 

--- a/test/regression/meth_pe_placement.sh
+++ b/test/regression/meth_pe_placement.sh
@@ -12,9 +12,12 @@
 #   Reverse fragment:  R1 OT reverse @701,  R2 OB forward @501
 #
 # Directional contract: R1 -> OT (XR:CT), R2 -> OB (XR:GA), regardless of which
-# genomic strand the mate maps to. Conversions are scored free (AS == 60) but
-# remain literal mismatches (NM == #conversions), confirming placement and
-# original-alphabet scoring are jointly correct on every strand/hypothesis.
+# genomic strand the mate maps to. Conversions are scored free (AS == 60), and
+# because NM/MD are derived from the same matrix they are hidden from NM too
+# (NM == 0; issue #327) -- with XM's lowercase call count proving the read really
+# carries #conversions > 0, so NM == 0 cannot pass vacuously. Together these
+# confirm placement and original-alphabet scoring are jointly correct on every
+# strand/hypothesis.
 #
 # Inputs:
 #   BWA_MEM3 — path to the bwa-mem3 binary under test
@@ -44,12 +47,12 @@ emit() { printf '@%s\n%s\n+\n%s\n' "$1" "$2" "$Q" > "$3"; }
 # Decode one mate (mate-flag bit 64=READ1, 128=READ2) from $1.bam.
 get() { samtools view "$1" | mawk -v bit="$2" '
     (int($2/bit) % 2) == 1 {
-        rev = (int($2/16) % 2); as=""; nm=""; xr="";
-        for (i=12;i<=NF;i++){ if($i~/^AS:i:/)as=substr($i,6); if($i~/^NM:i:/)nm=substr($i,6); if($i~/^XR:Z:/)xr=substr($i,6) }
-        print $3, $4, $5, rev, $6, as, nm, xr; exit }'
+        rev = (int($2/16) % 2); as=""; nm=""; xr=""; nconv=0;
+        for (i=12;i<=NF;i++){ if($i~/^AS:i:/)as=substr($i,6); if($i~/^NM:i:/)nm=substr($i,6); if($i~/^XR:Z:/)xr=substr($i,6); if($i~/^XM:Z:/){xm=substr($i,6); nconv=gsub(/[zxhu]/,"",xm)} }
+        print $3, $4, $5, rev, $6, as, nm, xr, nconv; exit }'
 }
-check() { # $1 bam  $2 mateflag  $3 label  $4 pos  $5 rev  $6 xr  $7 as  $8 nm
-    read -r rn pos mapq rev cig as nm xr < <(get "$1" "$2")
+check() { # $1 bam  $2 mateflag  $3 label  $4 pos  $5 rev  $6 xr  $7 as  $8 nconv
+    read -r rn pos mapq rev cig as nm xr nconv < <(get "$1" "$2")
     [ "$rn" = "chrA" ]  || fail "$3: RNAME $rn, want chrA"
     [ "$pos" = "$4" ]   || fail "$3: POS $pos, want $4 (remap placement)"
     [ "$rev" = "$5" ]   || fail "$3: strand rev=$rev, want $5 (reverse-strand re-encode)"
@@ -57,7 +60,9 @@ check() { # $1 bam  $2 mateflag  $3 label  $4 pos  $5 rev  $6 xr  $7 as  $8 nm
     [ "$mapq" = "60" ]  || fail "$3: MAPQ $mapq, want 60"
     [ "$xr" = "$6" ]    || fail "$3: XR $xr, want $6 (hypothesis label)"
     [ "$as" = "$7" ]    || fail "$3: AS $as, want $7 (conversions scored free)"
-    [ "$nm" = "$8" ]    || fail "$3: NM $nm, want $8 (conversions remain literal mismatches)"
+    [ "$nconv" = "$8" ] || fail "$3: XM shows $nconv converted bases, want $8 (fixture must actually exercise conversions)"
+    [ "$nconv" -gt 0 ]  || fail "$3: converted-base count must be > 0 (test must actually exercise conversions)"
+    [ "$nm" = "0" ]     || fail "$3: NM $nm, want 0 ($nconv conversions are matrix-freed, so they are matches for NM/MD)"
 }
 
 # --- forward fragment ---

--- a/test/regression/meth_reverse_strand_conversion.sh
+++ b/test/regression/meth_reverse_strand_conversion.sh
@@ -71,7 +71,7 @@ read -r rn pos mapq rev cig as nm xr unm < <(get pe.bam 64)
 [ "$cig" = "75M" ] || fail "R1: CIGAR $cig, want 75M (no soft-clip — conversions freed by strand-adjusted matrix)"
 [ "$mapq" = "60" ] || fail "R1: MAPQ $mapq, want 60"
 [ "$xr" = "CT" ]   || fail "R1: XR $xr, want CT (OT hypothesis)"
-[ "$nm" = "25" ]   || fail "R1: NM $nm, want 25 (24 conversions + 1 real mismatch; all literal in NM)"
+[ "$nm" = "1" ]    || fail "R1: NM $nm, want 1 (the real mismatch only; the 24 conversions are matrix-freed, so they are matches for NM/MD as well as for the DP)"
 # Conversions are scored free; the 1 real mismatch costs the bwa default penalty b=4 (--meth keeps b=4):
 # 74 match/freed columns (+74) - 1 real mismatch (-4) = 70.
 [ "$as" = "70" ]   || fail "R1: AS $as, want 70 (conversions free; 1 real mismatch at b=4)"


### PR DESCRIPTION
Closes #327.

## The report

An error-free bisulfite read came back `NM:i:78` with an `MD:Z` string enumerating every reference C. The reporter called this "non-methyl-aware", and the effect is real even though the aligner is methyl-aware everywhere else: a fully converted read already scores a perfect `AS`, picks the right OT/OB hypothesis, and emits correct `XR`/`XG`/`XM`.

## Root cause

`NM`/`MD` were the one output that ignored the methylation model. `bwa_gen_cigar2` classified a column by literal base inequality (`query[x+i] != rseq[y+i]`), independent of the per-hypothesis asymmetric matrix passed in the same call and used for the DP. So the matrix freed the conversion for *scoring* while the tag pass re-charged it, and every C→T (OT) / G→A (OB) landed in `NM` and `MD` indistinguishable from a real SNP.

This arrived with the switch from a collapsed-space overlay to native 4-letter alignment (first released in v0.4.0). Before that, `--meth` aligned against the converted doubled reference, so conversions were structurally invisible and `NM` was small — which is what the reporter was comparing against.

## The fix

Let the scoring model define what a mismatch is. A column is a mismatch iff the matrix penalises it:

```c
- if (query[x + i] != rseq[y + i]) {
+ const int is_mm = nm_from_mat ? (mat[rseq[y + i] * 5 + query[x + i]] < 0)
+                               : (query[x + i] != rseq[y + i]);
+ if (is_mm) {
```

Because the asymmetric matrix already scores the conversion cell as a match (or `0` under `neutral`), conversions become matches for `NM`/`MD` exactly as they are for `AS`. **There is no bisulfite special case in the `NM`/`MD` code** — one definition produces both the score and the tags, so `NM`/`MD` now automatically track whatever `--meth-scoring` selects.

No frame special-casing was needed either: the tag pass and the DP share both the buffers and the matrix, and `mem_reg2aln` already flips the OT/OB hypothesis when `rb >= l_pac`, so the reverse strand indexes identically. Verified directly on a reverse-strand OB read (`NM:i:41` → `NM:i:0`, flag 16).

## This is what the docs already promised

`docs/src/methylation/bwameth-mapping.md` has said since `--meth` landed:

> `NM`/`MD` — Conversions hidden; real variants hidden in `collapsed`, **shown in `genomic`**

That was never true of the code. It is now — including the second half, which falls out for free: `collapsed` frees the mirror cell, so a real T→C variant is hidden there (`NM:i:0`) and visible under `genomic` (`NM:i:1`). This PR is the implementation catching up to its own documented contract, not a new policy.

## Measured effect

5,000 simulated 151 bp reads carrying only bisulfite conversions — no SNPs, no sequencing errors:

| | before | after |
|---|---|---|
| mean `NM` | 36.0 | **0.0** |
| reads with `NM:i:0` | 0 / 5000 | **5000 / 5000** |
| mean `MD` length | 75.3 chars | **3.0 chars** |
| `MD` cost (BGZF) | 35.6 B/read | **0.4 B/read** |
| BAM size | — | **−23.5 %** |

## Two further fixes found while reviewing this change

**`XA:Z` carried the other NM semantics.** `mem_gen_alt` called `mem_reg2aln` without `meth_orig_query`, so it took the `= NULL` default and every `XA:Z` sub-entry regenerated with the *literal* predicate while the primary record used the matrix. One record reported two different NM semantics with nothing to distinguish them. On a reference with an exact 600 bp duplicated segment and a fully-converted OT read:

```
primary NM:i:0
XA:Z:chrD,+2101,151M,40;     <- same locus, byte-identical, reported as 40 mismatches worse
```

A tool ranking XA candidates by NM would systematically reject the alternative hit. `mem_gen_alt` now takes `meth_orig_query` and forwards it, so both agree. (`SA:Z` was already correct — it is built from `mem_aln_t` values that came through the path which does pass `meth_orig_seq`.)

**`-B 0` is now rejected under `--meth`.** `bwa_fill_scmat` writes off-diagonal cells as `-b`, so `-B 0` makes every substitution cell exactly `0`; under the new predicate that is not a penalty, and `NM`/`MD` collapse to zero for *real variants* as well as conversions. Confirmed on a single-real-SNP fixture (`-B 0` → `NM:i:0 MD:Z:151`; `-B 4` → `NM:i:1 MD:Z:13A137`). It now exits with an explicit error. Non-`--meth` `-B 0` keeps the literal comparison and is unaffected.

## Spec deviation — deliberate, and called out

Under `--meth` this makes `NM`/`MD` non-conformant with the SAM spec's "edit distance to the reference": a converted base is reported as matching a reference base it differs from, so `CIGAR` + `SEQ` + `MD` reconstructs the *converted* reference. This is the same divergence class as BISCUIT's `NM` ("non-cytosine-conversion mismatches") and bwameth's collapsed-space `NM`, and for the same reason — a literal `NM` makes an error-free bisulfite library look ~25 % divergent to every downstream `NM` filter and QC metric.

The deviation is documented prominently in a new "How `NM`/`MD` are computed under `--meth`" section rather than left implicit. The underlying argument: a single read cannot distinguish a bisulfite C→T from a real C→T SNP; that aliasing is resolved at the pileup. The aligner reports what its scoring model treats as divergence rather than adjudicating chemistry against genotype base by base.

**The non-`--meth` path is spec-literal and unchanged.**

## Non-meth byte-identity

`bwa_gen_cigar2` now delegates to a new `bwa_gen_cigar3` with `nm_from_mat=0`, preserving the literal comparison exactly, and `mem_gen_alt`'s new parameter defaults to `NULL`. The existing public signatures are untouched. Verified against a build of the base commit: records-only md5 identical for single-end, paired-end, **and** XA-bearing non-meth output (only the `@PG` `VN`/`CL` line differs).

The matrix predicate is applied **only** under `--meth`, deliberately: `mat[N][N]` is `-1`, so the matrix rule would classify a ref-N/read-N column as a mismatch where the literal rule calls it a match. That is believed unreachable (the `.pac` fills N with pseudo-random bases), but "believed unreachable" is not a basis for risking byte-identity.

## Tests

All `--meth` regression gates updated to the new contract and passing; `make test` green.

Two of them needed more than a constant change. `meth_pe_placement` and `meth_mixed_pe_asym` used `NM > 0` as the evidence that a fixture genuinely contained conversions — with `NM` now `0` by design, that guard would have silently disappeared and the tests could have passed on a read with no conversions at all. They now assert the conversion count via `XM:Z`'s lowercase call count (`z`/`x`/`h` **plus `u`**, the unresolvable-context class `meth_xm.cpp` emits at contig edges), which is a direct witness, so `NM == 0` cannot pass vacuously.

`meth_collapsed_scoring` gains the mode differences newly observable in `NM`: a real T→C variant is `NM:i:1` under `genomic`, `NM:i:0` under `collapsed`, and `NM:i:1` under `neutral`.

## Review notes

- `src/bwa.cpp` is the core functional change; `src/bwamem_extra.cpp` + the `mem_gen_alt` signature carry the XA fix.
- The policy note in `mem_reg2aln` (`src/bwamem.cpp`) is rewritten — it documented the old contract and its rationale, both of which are now obsolete. The stale "conversion shows as read-T at ref-C … Revelio expects" block above it is also gone; Revelio masks from the reference FASTA and `SEQ` and consumes neither `NM` nor `MD`, so it never justified the literal policy.
- Doc prose that called `NM`/`MD` "truthful" has been softened to "real variants stay visible", which is what those passages actually meant and is still accurate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Methylation-aware alignment now reports real variants in `NM`/`MD` tags while excluding configured conversion matches.
  * Added validation to reject methylation mode with zero or negative mismatch penalties.
  * Alternate alignments now apply the same methylation-aware mismatch reporting as primary alignments.
* **Documentation**
  * Expanded guidance on `NM`/`MD` behavior, conversion ambiguity, and genomic/neutral scoring modes.
* **Tests**
  * Updated regression coverage for mismatch reporting, conversion handling, paired-end reads, and alternate alignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->