### PR TITLE
feat(meth): add --meth-tags to select which Bismark tags are emitted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,8 +637,10 @@ jobs:
         # four-strand XR/XG); and the reverse-strand-conversion matrix flip
         # (meth_strand_hyp) — a reverse read that is unmapped under the unflipped
         # matrix and full-length under the fix; the batched OT/OB-partition mate
-        # rescue being byte-identical to the scalar rescue; and the `collapsed`
-        # --meth-scoring model.
+        # rescue being byte-identical to the scalar rescue; the `collapsed`
+        # --meth-scoring model; and --meth-tags spec resolution (all|none|list|
+        # ^exclusion) plus its guarantee that tag selection leaves the alignment
+        # untouched.
         env:
           BWA_MEM3: ${{ github.workspace }}/bwa-mem3
         run: |
@@ -650,7 +652,8 @@ jobs:
           for t in meth_seed_index meth_mixed_pe_asym meth_pe_placement \
                    meth_output_integrity meth_reverse_strand_conversion \
                    meth_seed_unpacked_ref_not_loaded \
-                   meth_rescue_batched_identical meth_collapsed_scoring; do
+                   meth_rescue_batched_identical meth_collapsed_scoring \
+                   meth_tags; do
             echo "::group::$t"; bash "test/regression/$t.sh"; echo "::endgroup::"
           done
 

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -125,6 +125,17 @@ Methylation (--meth) options:
                  In genomic/neutral a real variant in the conversion direction
                  itself (C->T at a reference C) is indistinguishable from a
                  conversion and stays hidden in NM/MD.
+   --meth-tags SPEC
+                 which Bismark tags to emit: 'all' (default), 'none', a
+                 comma-separated list (XR,XG), or ^-prefixed exclusions (^XM).
+                 Comma-separated, NOT space-separated (a second word becomes
+                 the reference). Quote ^ specs: '^XM' -- bare ^ is a negated
+                 glob in zsh with EXTENDED_GLOB.
+                 Unselected tags are not computed. XM:Z is a read-length string
+                 and dominates the BAM's aux payload; '^XM' drops it for callers
+                 that recompute from the reference (MethylDackel, biscuit).
+                 Keep XM for Bismark-family tools (bismark_methylation_extractor,
+                 methylKit, methtuple, DMRfinder, epialleleR).
    --set-as-failed f|r
                  flag alignments to the matching strand ('f' or 'r') as QC-fail (0x200)
    --chimera-qc

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -591,6 +591,16 @@ with a conversion and stays hidden
 with `--meth`.
 See [Flags → --meth-scoring](../methylation/flags.md#--meth-scoring-collapsedgenomicneutral).
 
+#### `--meth-tags SPEC` — select which Bismark tags are emitted
+
+`all` (default), `none`, a comma-separated inclusion list (`XR,XG`), or
+`^`-prefixed exclusions (`^XM`). Inclusion and exclusion forms cannot be mixed.
+A deselected tag is not computed, so `^XM` skips the per-read methylation-call
+pass as well as its bytes — `XM:Z` is a read-length string and is ~33% of the
+BAM. Keep it for Bismark-family tools; drop it for MethylDackel/biscuit, which
+recompute from the reference. Only meaningful with `--meth`.
+See [Flags → --meth-tags](../methylation/flags.md#--meth-tags-spec).
+
 #### `--set-as-failed {f|r}` — strand QC-fail flag
 
 Forces the QC-fail bit (`0x200`) on all alignments to the forward (`f`) or

--- a/docs/src/methylation/flags.md
+++ b/docs/src/methylation/flags.md
@@ -1,7 +1,8 @@
-# Flags: --meth chemistry, --meth-scoring, --set-as-failed, --chimera-qc
+# Flags: --meth chemistry, --meth-scoring, --meth-tags, --set-as-failed, --chimera-qc
 
 `--meth` itself takes an optional chemistry argument. Alongside it,
-`--meth-scoring` selects the scoring model; `--set-as-failed` and `--chimera-qc`
+`--meth-scoring` selects the scoring model and `--meth-tags` selects which
+Bismark tags are emitted; `--set-as-failed` and `--chimera-qc`
 control QC behavior during BAM post-processing (both affect the chimera QC and
 strand-filtering logic inside `meth_mem_aln_to_bam`, `src/meth_bam.cpp`).
 
@@ -117,6 +118,65 @@ same terms as `genomic` while placing sparse-conversion reads more accurately.
 > explicit `-B` overrides the mode default and still reaches the per-strand
 > matrices, whether it appears before or after `--meth`. The other `--meth`
 > defaults (`-L 10 -U 100 -T 40 -M -C`) are the same across modes.
+
+## `--meth-tags SPEC`
+
+Selects which of the Bismark tags — [`XR:Z`, `XG:Z`, `XM:Z`](tags.md) — are
+emitted. **Default: `all`.** A tag that is not selected is never computed, so
+deselecting `XM` skips its per-read pass as well as its bytes.
+
+| Spec | Meaning |
+|------|---------|
+| `all` | emit `XR`, `XG`, `XM` (the default) |
+| `none` | emit none of the three |
+| `XR,XG` | inclusion list — emit exactly these |
+| `^XM` | exclusion — everything except `XM` |
+
+A spec is either an inclusion list or a set of `^` exclusions; mixing the two
+(`XR,^XM`) is rejected rather than given an arbitrary reading. Tag names are
+case-insensitive.
+
+```bash
+# Drop the methylation call string; keep the strand labels.
+bwa-mem3 mem --meth --meth-tags '^XM' ref.fa r1.fq r2.fq > out.bam
+
+# Identical, spelled as an inclusion list (no quoting needed).
+bwa-mem3 mem --meth --meth-tags XR,XG ref.fa r1.fq r2.fq > out.bam
+```
+
+> **Quote `^`-prefixed specs.** In `zsh` with `EXTENDED_GLOB` enabled — the
+> default under oh-my-zsh and prezto — a bare `^XM` is a *negated glob* and
+> expands to every file in the working directory except `XM`. The aligner then
+> receives a filename as the tag spec and the remaining filenames as positional
+> arguments. `bash` and stock `zsh` leave `^` alone, so this bites only some
+> users; quoting it (`'^XM'`) is always safe, and `XR,XG` sidesteps it entirely.
+
+> **The list is comma-separated, not space-separated.** `--meth-tags XR XG`
+> passes only `XR` to the flag; `XG` becomes the next positional argument, i.e.
+> the reference. The failure surfaces as a confusing
+> `--meth seed index 'XG.meth.*' not found` rather than a flag error. This is the
+> same shape as the `--meth taps` trap above, though the cause differs:
+> `--meth` takes an *optional* argument and so requires `=`, whereas
+> `--meth-tags` takes a *required* argument and happily consumes the first word
+> but not the second.
+
+**Why you would drop `XM`.** It is a read-length string, so it dominates the
+aux payload: on a 151 bp EM-seq-style library it is **~33 % of the BAM**
+(~155 B/read uncompressed, ~42 B/read at BGZF level 6), while `XR` and `XG`
+together cost ~1 B/read. The alignments themselves are unaffected either way —
+same records, positions, CIGARs, and scores — but dropping `XM` removes both its
+bytes and the per-read methylation-call pass that produces them.
+
+**Why the default keeps it.** `XM` is what makes the BAM directly consumable by
+the Bismark family — `bismark_methylation_extractor`, methylKit, methtuple,
+DMRfinder, epialleleR. Those tools cannot reconstruct it. Callers that work
+from the reference FASTA instead — **MethylDackel** and **biscuit**, the most
+common pairing for a bwameth-style BAM — never read `XM`, so `^XM` is free for
+them.
+
+The asymmetry is why `all` remains the default: a pipeline that needed `XM` and
+silently lost it produces empty or wrong methylation calls, whereas a pipeline
+that did not need it merely carries a larger BAM and can opt out with one flag.
 
 ## `--set-as-failed {f|r}`
 

--- a/docs/src/methylation/tags.md
+++ b/docs/src/methylation/tags.md
@@ -1,5 +1,10 @@
 # SAM Tags: XR, XG, XM (Bismark-compatible)
 
+> All three are emitted by default. Use [`--meth-tags`](flags.md#--meth-tags-spec)
+> to select a subset — e.g. `--meth-tags ^XM` drops the read-length call
+> string (~33 % of the BAM) for callers that recompute from the reference,
+> such as MethylDackel and biscuit. A deselected tag is not computed.
+
 `bwa-mem3 mem --meth` emits three Bismark-compatible auxiliary tags on
 each output record: `XR:Z`, `XG:Z`, and `XM:Z`. These tags are read by
 `bismark_methylation_extractor`, `deduplicate_bismark`, methylKit

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -38,6 +38,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include "kvec.h"          /* kvec_t/kv_push/kv_resize used directly below */
 #include "pdqsort_wrap.h"
 #include <inttypes.h>      /* PRId64 for int64_t fprintf format strings */
+#include <strings.h>       /* strcasecmp in mem_opt_parse_meth_tags */
 #include <mutex>           /* BWAMEM3_DUMP_PAIRS append lock */
 #include <string>          /* BWAMEM3_DUMP_PAIRS per-batch row buffer */
 
@@ -389,6 +390,7 @@ mem_opt_t *mem_opt_init()
     o->mapQ_coef_len = 50; o->mapQ_coef_fac = log(o->mapQ_coef_len);
     o->meth_scoring = MEM_METH_SCORING_COLLAPSED;  /* --meth default: bwameth-compatible */
     o->meth_chem    = METH_CHEM_EMSEQ;             /* --meth default chemistry: bisulfite/em-seq */
+    o->meth_tags    = MEM_METH_TAGS_ALL;           /* --meth default: emit XR/XG/XM (Bismark set) */
     o->compat       = &COMPAT_TARGET_OFF;          /* --compat off: bwa-mem3's native output */
     bwa_fill_scmat(o->a, o->b, o->mat);
     mem_opt_fill_meth_mat(o);
@@ -413,6 +415,56 @@ mem_opt_t *mem_opt_init()
  * rebuild of opt->mat (mem_opt_init AND after main_mem parses -A/-B/-x and
  * re-runs bwa_fill_scmat) — otherwise the meth matrices keep the default
  * match/mismatch and silently ignore the user's scoring options. */
+/* Map one tag name to its MEM_METH_TAG_* bit; 0 if unknown. Case-insensitive. */
+static int meth_tag_bit(const char *name, size_t len)
+{
+    if (len != 2 || (name[0] != 'X' && name[0] != 'x')) return 0;
+    switch (name[1]) {
+        case 'R': case 'r': return MEM_METH_TAG_XR;
+        case 'G': case 'g': return MEM_METH_TAG_XG;
+        case 'M': case 'm': return MEM_METH_TAG_XM;
+        default:            return 0;
+    }
+}
+
+int mem_opt_parse_meth_tags(const char *spec, int *out, const char **err)
+{
+    if (spec == NULL || *spec == '\0') { *err = "empty tag spec"; return -1; }
+    if (strcasecmp(spec, "all")  == 0) { *out = MEM_METH_TAGS_ALL; return 0; }
+    if (strcasecmp(spec, "none") == 0) { *out = 0;                 return 0; }
+
+    /* A spec is either all-inclusion (`XR,XG`) or all-exclusion (`^XM`).
+     * Mixing the two has no obvious reading -- is `XR,^XM` "only XR" or
+     * "everything but XM"? -- so reject it rather than pick a meaning. */
+    int included = 0, excluded = 0, n_inc = 0, n_exc = 0;
+    const char *p = spec;
+    while (*p != '\0') {
+        const char *comma = strchr(p, ',');
+        size_t len = comma != NULL ? (size_t)(comma - p) : strlen(p);
+        /* Separate from the unknown-tag case below: in `,XR` or `XR,,XG` there
+         * is no tag name to be unknown, and saying so sends the user hunting
+         * for a misspelling that isn't there. `XR,` is caught as a trailing
+         * comma at the bottom of the loop. */
+        if (len == 0) { *err = "empty tag in list"; return -1; }
+        int is_exclusion = (*p == '^');
+        const char *name = is_exclusion ? p + 1 : p;
+        size_t name_len  = is_exclusion ? len - 1 : len;
+        int bit = meth_tag_bit(name, name_len);
+        if (bit == 0) { *err = "unknown tag (expected XR, XG or XM)"; return -1; }
+        if (is_exclusion) { excluded |= bit; ++n_exc; }
+        else              { included |= bit; ++n_inc; }
+        if (comma == NULL) break;
+        p = comma + 1;
+        if (*p == '\0') { *err = "trailing comma"; return -1; }
+    }
+    if (n_inc > 0 && n_exc > 0) {
+        *err = "cannot mix included and ^excluded tags in one spec";
+        return -1;
+    }
+    *out = n_exc > 0 ? (MEM_METH_TAGS_ALL & ~excluded) : included;
+    return 0;
+}
+
 void mem_opt_fill_meth_mat(mem_opt_t *o) {
     memcpy(o->mat_ot, o->mat, sizeof(o->mat));
     memcpy(o->mat_ob, o->mat, sizeof(o->mat));

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -104,6 +104,24 @@ typedef struct __smem_i smem_i;
 enum mem_meth_scoring { MEM_METH_SCORING_COLLAPSED = 0, MEM_METH_SCORING_GENOMIC = 1,
                         MEM_METH_SCORING_NEUTRAL = 2 };
 
+/* Bismark tag selection under --meth (--meth-tags). XR:Z and XG:Z are two-byte
+ * strand labels; XM:Z is a read-length methylation-call string and dominates the
+ * BAM's aux payload, so it is the one worth being able to turn off. */
+#define MEM_METH_TAG_XR   0x1
+#define MEM_METH_TAG_XG   0x2
+#define MEM_METH_TAG_XM   0x4
+#define MEM_METH_TAGS_ALL (MEM_METH_TAG_XR | MEM_METH_TAG_XG | MEM_METH_TAG_XM)
+
+/* Parse a --meth-tags spec into a MEM_METH_TAG_* bitmask.
+ *
+ * Grammar: `all` | `none` | a comma-separated list of tag names, either all
+ * plain (an inclusion set: `XR,XG`) or all `^`-prefixed (subtracted from the
+ * full set: `^XM`). Mixing plain and `^` terms is rejected. Tag names are
+ * case-insensitive. Returns 0 on success and writes *out; returns -1 on a
+ * malformed spec and writes a human-readable reason to *err (a static string).
+ * Exposed for unit testing. */
+int mem_opt_parse_meth_tags(const char *spec, int *out, const char **err);
+
 typedef enum {
     SEED_ORDER_OFF = 0,
     SEED_ORDER_GLOBAL_LONGEST,
@@ -180,6 +198,10 @@ typedef struct mem_opt_t {
                             // converted index and the scoring matrices are shared,
                             // because both chemistries produce the same C->T /
                             // G->A base change as far as the aligner can see.
+    int    meth_tags;       // bitmask of Bismark tags to emit (--meth-tags):
+                            // MEM_METH_TAG_{XR,XG,XM}. Tags not selected are
+                            // neither computed nor emitted -- clearing XM skips
+                            // the per-read meth_build_xm() pass entirely.
     char   meth_set_as_failed;// 'f', 'r', or 0 — flag reads on that strand 0x200
     int    meth_chimera_qc; // 1 to enable bwameth.py-style longest-M <44% chimera heuristic (default off; not in Bismark)
     int    supp_rep_hard_cap; // supp alnregs whose chain's seeds share >=this many genome hits are forced to MAPQ=0; 0 disables

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1550,6 +1550,17 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                 In genomic/neutral a real variant in the conversion direction\n");
     fprintf(stderr, "                 itself (C->T at a reference C) is indistinguishable from a\n");
     fprintf(stderr, "                 conversion and stays hidden in NM/MD.\n");
+    fprintf(stderr, "   --meth-tags SPEC\n");
+    fprintf(stderr, "                 which Bismark tags to emit: 'all' (default), 'none', a\n");
+    fprintf(stderr, "                 comma-separated list (XR,XG), or ^-prefixed exclusions (^XM).\n");
+    fprintf(stderr, "                 Comma-separated, NOT space-separated (a second word becomes\n");
+    fprintf(stderr, "                 the reference). Quote ^ specs: '^XM' -- bare ^ is a negated\n");
+    fprintf(stderr, "                 glob in zsh with EXTENDED_GLOB.\n");
+    fprintf(stderr, "                 Unselected tags are not computed. XM:Z is a read-length string\n");
+    fprintf(stderr, "                 and dominates the BAM's aux payload; '^XM' drops it for callers\n");
+    fprintf(stderr, "                 that recompute from the reference (MethylDackel, biscuit).\n");
+    fprintf(stderr, "                 Keep XM for Bismark-family tools (bismark_methylation_extractor,\n");
+    fprintf(stderr, "                 methylKit, methtuple, DMRfinder, epialleleR).\n");
     fprintf(stderr, "   --set-as-failed f|r\n");
     fprintf(stderr, "                 flag alignments to the matching strand ('f' or 'r') as QC-fail (0x200)\n");
     fprintf(stderr, "   --chimera-qc\n");
@@ -1771,6 +1782,7 @@ int main_mem(int argc, char *argv[])
         OPT_BAM = 1000,
         OPT_METH,
         OPT_METH_SCORING,
+        OPT_METH_TAGS,
         OPT_METH_SET_AS_FAILED,
         OPT_METH_CHIMERA_QC,
         OPT_SUPP_REP_HARD_CAP,
@@ -1808,6 +1820,7 @@ int main_mem(int argc, char *argv[])
         {"cohort-ramp-first",        required_argument, 0, OPT_COHORT_RAMP_FIRST},
         {"meth",                     optional_argument, 0, OPT_METH},
         {"meth-scoring",             required_argument, 0, OPT_METH_SCORING},
+        {"meth-tags",                required_argument, 0, OPT_METH_TAGS},
         {"set-as-failed",            required_argument, 0, OPT_METH_SET_AS_FAILED},
         {"chimera-qc",               no_argument,       0, OPT_METH_CHIMERA_QC},
         {"supp-rep-hard-cap",        required_argument, 0, OPT_SUPP_REP_HARD_CAP},
@@ -1993,6 +2006,19 @@ int main_mem(int argc, char *argv[])
                 if (out_opened) fclose(aux.fp);
                 return 1;
             }
+        }
+        else if (c == OPT_METH_TAGS) {
+            const char *tag_err = NULL;
+            if (mem_opt_parse_meth_tags(optarg, &opt->meth_tags, &tag_err) != 0) {
+                fprintf(stderr, "ERROR: --meth-tags '%s': %s\n"
+                                "       expected 'all', 'none', a comma-separated list "
+                                "(e.g. XR,XG), or ^-prefixed exclusions (e.g. ^XM)\n",
+                        optarg != NULL ? optarg : "", tag_err);
+                free(opt);
+                if (out_opened) fclose(aux.fp);
+                return 1;
+            }
+            opt0.meth_tags = 1;
         }
         else if (c == OPT_METH_SET_AS_FAILED) {
             if (optarg == NULL || !(optarg[0] == 'f' || optarg[0] == 'r') || optarg[1] != '\0') {

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -485,7 +485,8 @@ int meth_mem_aln_to_bam(bam1_t *b,
      * the original rid); meth_build_xm reads the original read-C-vs-T at ref-C
      * from `seq_text`, which is restored from meth_orig_seq above. */
     char *xm = NULL;
-    if (mapped && seq_text != NULL && bam_cigar != NULL && l_emit > 0) {
+    if ((opt->meth_tags & MEM_METH_TAG_XM)
+        && mapped && seq_text != NULL && bam_cigar != NULL && l_emit > 0) {
         /* Match the XG `direction` guard at line ~322: a -1 hypothesis maps to
          * XG:Z:GA (bottom strand), so treat it as bottom here too. ((-1)&1)==1
          * would otherwise mislabel a -1-hypothesis record (e.g. mate rescued off
@@ -629,12 +630,15 @@ int meth_mem_aln_to_bam(bam1_t *b,
     }
     /* Bismark-compatible XR:Z (read conversion) emitted on every record;
      * XG:Z (genome strand) and XM:Z (methylation call string) only on
-     * mapped records. The YC:Z payload in s->comment carries the (CT|GA)
+     * mapped records. Each is additionally gated on its --meth-tags bit, and
+     * the gate wraps the value's derivation rather than just the append, so a
+     * deselected tag costs nothing to compute -- the contract --help and the
+     * methylation docs state. The YC:Z payload in s->comment carries the (CT|GA)
      * value (the comment buffer is "YS:Z:<seq>\tYC:Z:<dir>", see
      * src/fastmap.cpp:415-425). Locate it with a marker search rather
      * than l_seq arithmetic so any future YS framing change (alternate
      * prefix length, prior FASTQ comments folded in) stays detectable. */
-    {
+    if (opt->meth_tags & MEM_METH_TAG_XR) {
         const char *xr = NULL;
         if (s->comment != NULL) {
             const char *yc = strstr(s->comment, "\tYC:Z:");
@@ -649,10 +653,12 @@ int meth_mem_aln_to_bam(bam1_t *b,
         }
     }
     if (mapped) {
-        /* XG:Z genome strand from the winning hypothesis: OT→CT, OB→GA
-         * (direction is the 'f'/'r' encoding of p.meth_hypothesis above). */
-        const char *xg = (direction == 'f') ? "CT" : "GA";
-        bam_aux_append(b, "XG", 'Z', 3, (const uint8_t *)xg);
+        if (opt->meth_tags & MEM_METH_TAG_XG) {
+            /* XG:Z genome strand from the winning hypothesis: OT→CT, OB→GA
+             * (direction is the 'f'/'r' encoding of p.meth_hypothesis above). */
+            const char *xg = (direction == 'f') ? "CT" : "GA";
+            bam_aux_append(b, "XG", 'Z', 3, (const uint8_t *)xg);
+        }
         if (xm != NULL) {
             /* xm aliases thread-local scratch in meth_xm.cpp; do not free. */
             bam_aux_append(b, "XM", 'Z', (int)l_emit + 1,

--- a/test/regression/meth_tags.sh
+++ b/test/regression/meth_tags.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# test/regression/meth_tags.sh
+#
+# Regression (issue #331): --meth-tags selects which Bismark tags reach the BAM.
+#
+#  1. The default is the full set -- a bare `--meth` emits XR:Z, XG:Z and XM:Z,
+#     so existing methylation pipelines are unaffected by the flag's addition.
+#  2. Every spec form resolves to the right set: `all`, `none`, an inclusion
+#     list (`XR,XG`), and `^`-prefixed exclusions (`^XM`, the motivating case).
+#  3. Deselecting a tag removes ONLY that tag. The alignment itself is
+#     untouched: fields 1-11 plus NM/MD/AS are byte-identical between a default
+#     run and a `--meth-tags none` run, so the flag is an emission filter and
+#     not an alignment-affecting knob.
+#  4. Malformed specs are rejected with a non-zero exit rather than silently
+#     falling back to a default -- a typo'd `--meth-tags ^XN` must not quietly
+#     emit everything.
+#
+# Inputs:
+#   BWA_MEM3 — path to the bwa-mem3 binary under test
+set -euo pipefail
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+command -v samtools >/dev/null 2>&1 || { echo "SKIP: samtools not on PATH (--meth emits BAM)"; exit 0; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT; cd "$WORK"
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Deterministic 1500 bp reference (same generator as meth_output_integrity).
+REF=TCATTGGCTATCCTAACCCGACCCTAGGAGCGGTTGGCGTGTATGCCGTGAATTTTCTCATTTCCGCTAGACATAATCGTTCTGCCTATATCTGGACAACATCCCGGCGACTTAGGCGACCCACAGAATCGTCCCTTCTAACGTAGTTCGCATAGTTCCCGTCCGTAGCCGGACTATTCGAACACCCAGTATTCGATTAACTCGGGCTTGACGTATTAGAGGCGTTAGTGTGCCAGGTAAGATACGCCAACGGAATTAACCTCTGTGACACTCCGCGGAGCCTTCGGACATATAAGTGATCGGGTCTACGTTTGTTAGACTTGAGACGTCTGTTAAGAGTTGGGTCTAATAAATCGCCTACACGTGGAGTCTAACGGGGAAGCGTCGAATCCTGATACATCATATAATGGAGCGTGTTATGAAAAAAGAGCATTCCATTGTACGAGCCGTGCCAGAAACGGCTTGACTACGTGAGCGTAGTGTTAGATAAACAGGAAACACTGACGCGGTTAGAAGGCGGATTGCCGGTAGGTTTTGGAAACATAAATACACACGGTATCATGTTGGGTCACGATTCCTATCACCGCACAGGGCCAACCATAGAAGAACTGAAAGAACTAATCTGGCGGCGGGCTCGGTGCTTATATTTTCCACCCAACATCGTGCACATTAGGCTCACCGCGCCCTACGGGCGAAGGGTGCGTACGGTGTTTATAAGGCGTGACGGCCCCAAGTAGAGGGTAATTCTGTGAAAGAATCTCAGGACGGTGGCATGAATTCAATTCCTTTTAAACCTATCGTTCCGACCTTATGCAATCCTTCAATGAAGATCGTCAACGACCATCGTTCTTCTGCTTTAAGTGTGAGTTCTCTCTTACAAGCTAATACACCCCAGCGTTCTCCGTACTCTTCACTGCCCAAGCGAGGCTAACCTTTTGAAATGTCACAGTCGAAGCATATCTCCCGTACATCTTTTTCGGAGATCGCAGCTCGCGGAGCTATAAGCGACTTAAGCCCTTGTGTCGGTGATCCCAAGGGTCTGACTCCTGTACCAGGGTTACTGTTTCGCTTTACGGAGTAGCCTGTGAGGTGAACTGAAAGGAGCATATTTGAGATCTAAGATAGGGTCCTCCTCTGCGTCTACGTTCTCTCCGTTACGTACGGCTTCGCACCGGAGTGCATCTTGGCCCCGAAACGCACTGTGTGTGCTGATACAGCGTCCCTGGCCGGCCATGGGTTCAGAACTCCCGGGAACGCTTTTCAACTTAGAGGAACCCCGTCATGGAAGTAGATCGCGTCGAATGAGGGAGTTAGTCCTCGTTCCAGCTGGTAATTGTTTTACCGCTTGGGACCACTATAGGCCGCGGGTAGAAGTTGCTGGGTGTTGATTCCAACCCTCGAACCACGATACGACCTGCCATTTATGGCACAGTAAGGTTCAAACAGCATAATGAATACAGTTATAGTAACTTCCTCACGTACGATTAGGACGCAGCCTTG
+
+printf '>chrA\n%s\n' "$REF" > ref.fa
+"$BWA_MEM3" index --meth ref.fa >/dev/null 2>&1 || fail "index --meth nonzero exit"
+
+# OT read over chrA[100:160] with 10 C->T conversions -- carries all three tags.
+READ=ATTCTGGCGATTTAGGTGACTCACAGAATCGTTCTTTCTAACGTAGTTTGTATAGTTCTC
+Q=$(printf 'I%.0s' $(seq 1 60))
+printf '@t\n%s\n+\n%s\n' "$READ" "$Q" > r.fq
+
+# Echo the meth tags present on the first record, space-separated and sorted,
+# so the assertion does not depend on aux emission order.
+tags_of() { # $1 = bam -> e.g. "XG XM XR"
+    samtools view "$1" | mawk 'NR==1{for(i=12;i<=NF;i++) if($i~/^X[RGM]:Z:/) print substr($i,1,2)}' \
+        | sort | tr '\n' ' ' | sed 's/ $//'
+}
+run() { # $1 = out.bam, rest = extra args
+    local out="$1"; shift
+    "$BWA_MEM3" mem --meth "$@" -t 1 ref.fa r.fq > "$out" 2>/dev/null \
+        || fail "mem --meth $* nonzero exit"
+    samtools quickcheck "$out" || fail "mem --meth $* produced an invalid BAM"
+}
+
+# --- 1. default is the full Bismark set ------------------------------------
+run default.bam
+got=$(tags_of default.bam)
+[ "$got" = "XG XM XR" ] || fail "default: tags '$got', want 'XG XM XR' (a bare --meth must emit all three)"
+
+# --- 2. every spec form resolves correctly ---------------------------------
+check_spec() { # $1 = spec, $2 = expected sorted tag list
+    run "spec.bam" --meth-tags "$1"
+    local g; g=$(tags_of spec.bam)
+    [ "$g" = "$2" ] || fail "--meth-tags $1: tags '$g', want '$2'"
+}
+check_spec all       "XG XM XR"
+check_spec none      ""
+check_spec "^XM"     "XG XR"          # the motivating case from issue #331
+check_spec "XR,XG"   "XG XR"          # equivalent inclusion spelling
+check_spec "XM"      "XM"
+check_spec "^XR,^XG" "XM"
+check_spec "xr,xg"   "XG XR"          # case-insensitive
+
+# --- 3. tag selection does not perturb the alignment ------------------------
+# Fields 1-11 plus the alignment-bearing tags must match the default run; only
+# the meth tags may differ.
+run none.bam --meth-tags none
+core() { samtools view "$1" | mawk '{o=$1;for(i=2;i<=11;i++)o=o"\t"$i;
+    for(i=12;i<=NF;i++) if($i~/^(NM:i:|MD:Z:|AS:i:)/) o=o"\t"$i; print o}'; }
+core default.bam > core.default
+core none.bam    > core.none
+cmp -s core.default core.none \
+    || fail "--meth-tags none changed the alignment: fields 1-11/NM/MD/AS differ from the default run"
+[ -s core.default ] || fail "core comparison was vacuous (no records extracted)"
+
+# --- 4. malformed specs are rejected, not silently defaulted ----------------
+for bad in "XR,^XM" "XZ" "XR," ",XR" "XR,,XG" "" "^" "XRX"; do
+    if "$BWA_MEM3" mem --meth --meth-tags "$bad" -t 1 ref.fa r.fq >/dev/null 2>/dev/null; then
+        fail "--meth-tags '$bad' exited 0; a malformed spec must be rejected"
+    fi
+done
+
+echo "PASS: meth_tags (default emits XR/XG/XM; all|none|list|^exclusion resolve correctly; selection does not perturb the alignment; malformed specs rejected)"

--- a/test/unit/test_meth_tags_parse.cpp
+++ b/test/unit/test_meth_tags_parse.cpp
@@ -1,0 +1,124 @@
+// Unit tests for mem_opt_parse_meth_tags (--meth-tags).
+//
+// Grammar: `all` | `none` | a comma-separated list of tag names that is either
+// all plain (an inclusion set) or all `^`-prefixed (subtracted from the full
+// set). Mixing the two forms is rejected rather than given an arbitrary
+// meaning. Tag names are case-insensitive.
+
+#include "doctest/doctest.h"
+#include "bwamem.h"
+
+#include <string>
+
+namespace {
+
+// Parse `spec` and require success; returns the resulting bitmask.
+int parse_ok(const char *spec)
+{
+    int bits = -1;
+    const char *err = nullptr;
+    REQUIRE(mem_opt_parse_meth_tags(spec, &bits, &err) == 0);
+    return bits;
+}
+
+// Parse `spec` and require failure; returns the reason string.
+const char *parse_err(const char *spec)
+{
+    int bits = -1;
+    const char *err = nullptr;
+    REQUIRE(mem_opt_parse_meth_tags(spec, &bits, &err) == -1);
+    REQUIRE(err != nullptr);
+    return err;
+}
+
+}  // namespace
+
+TEST_CASE("all and none are the two extremes" * doctest::description("--meth-tags"))
+{
+    CHECK(parse_ok("all") == MEM_METH_TAGS_ALL);
+    CHECK(parse_ok("none") == 0);
+    // The whole point of `none` is that it is distinguishable from a parse
+    // failure: it must succeed and yield an empty mask, not error.
+    CHECK(parse_ok("ALL") == MEM_METH_TAGS_ALL);
+    CHECK(parse_ok("None") == 0);
+}
+
+TEST_CASE("inclusion lists select exactly the named tags")
+{
+    CHECK(parse_ok("XR") == MEM_METH_TAG_XR);
+    CHECK(parse_ok("XG") == MEM_METH_TAG_XG);
+    CHECK(parse_ok("XM") == MEM_METH_TAG_XM);
+    CHECK(parse_ok("XR,XG") == (MEM_METH_TAG_XR | MEM_METH_TAG_XG));
+    CHECK(parse_ok("XM,XR,XG") == MEM_METH_TAGS_ALL);
+    // Order and repetition are immaterial -- it is a set.
+    CHECK(parse_ok("XG,XR") == parse_ok("XR,XG"));
+    CHECK(parse_ok("XR,XR") == MEM_METH_TAG_XR);
+}
+
+TEST_CASE("exclusions subtract from the full set")
+{
+    // The issue's motivating case: keep the cheap strand labels, drop the
+    // read-length call string.
+    CHECK(parse_ok("^XM") == (MEM_METH_TAG_XR | MEM_METH_TAG_XG));
+    CHECK(parse_ok("^XR") == (MEM_METH_TAG_XG | MEM_METH_TAG_XM));
+    CHECK(parse_ok("^XR,^XG") == MEM_METH_TAG_XM);
+    CHECK(parse_ok("^XR,^XG,^XM") == 0);
+    // An exclusion spec and the equivalent inclusion spec agree.
+    CHECK(parse_ok("^XM") == parse_ok("XR,XG"));
+}
+
+TEST_CASE("tag names are case-insensitive")
+{
+    CHECK(parse_ok("xr,xg") == parse_ok("XR,XG"));
+    CHECK(parse_ok("^xm") == parse_ok("^XM"));
+    CHECK(parse_ok("Xm") == MEM_METH_TAG_XM);
+}
+
+TEST_CASE("malformed specs are rejected with a reason")
+{
+    // Mixing forms has no obvious reading -- is "XR,^XM" only-XR or
+    // everything-but-XM? Reject rather than pick one silently.
+    CHECK(parse_err("XR,^XM") != nullptr);
+    CHECK(parse_err("^XM,XR") != nullptr);
+    // Unknown or malformed tag names.
+    CHECK(parse_err("XZ") != nullptr);
+    CHECK(parse_err("NM") != nullptr);
+    CHECK(parse_err("XRX") != nullptr);
+    CHECK(parse_err("X") != nullptr);
+    CHECK(parse_err("^") != nullptr);
+    // Empty and trailing-comma specs.
+    CHECK(parse_err("") != nullptr);
+    CHECK(parse_err("XR,") != nullptr);
+    CHECK(parse_err(",XR") != nullptr);
+    CHECK(parse_err("XR,,XG") != nullptr);
+}
+
+TEST_CASE("an empty list element is not diagnosed as an unknown tag")
+{
+    // A missing element and a misspelled one are different mistakes and must
+    // read differently: there is no tag name in ",XR" to be unknown, and
+    // saying so sends the user hunting for a typo that isn't there.
+    using std::string;
+    const string misspelled = parse_err("XZ");
+    CHECK(misspelled.find("unknown") != string::npos);
+    for (const char *empty_elem : {",XR", "XR,,XG", "XR,"}) {
+        const string reason = parse_err(empty_elem);
+        CHECK(reason != misspelled);
+        CHECK(reason.find("unknown") == string::npos);
+    }
+}
+
+TEST_CASE("a NULL spec is rejected rather than dereferenced")
+{
+    int bits = -1;
+    const char *err = nullptr;
+    CHECK(mem_opt_parse_meth_tags(nullptr, &bits, &err) == -1);
+    CHECK(err != nullptr);
+}
+
+TEST_CASE("the default opt emits the full Bismark set")
+{
+    mem_opt_t *o = mem_opt_init();
+    CHECK(o->meth_tags == MEM_METH_TAGS_ALL);
+    free(o);
+}


### PR DESCRIPTION
Closes #331. **Stacked on #332** — base is `fix/issue-327-meth-matrix-derived-nm-md`, so review that first and this diff shows only the new commit. Retarget to `main` once #332 merges.

## Why

`XM:Z` is a read-length string, so it dominates the aux payload. Measured on 100k simulated 151 bp EM-seq-style reads, same writer both sides:

| | all tags | `^XM` | XM's share |
|---|---|---|---|
| uncompressed (aligner default) | 47.6 MB | 32.1 MB | **32.6 %** (155 B/read) |
| BGZF level 6 | 12.2 MB | 8.1 MB | **34.0 %** (41.6 B/read) |

`XR` + `XG` together are ~1 B/read — effectively free.

Alignment throughput is unaffected either way (0.20–0.23 s per 100k reads with and without, i.e. inside run-to-run spread). **The cost of `XM` is bytes, not cycles** — which matches how the issue framed it ("don't want to pay the cost of a read-length string downstream").

## What

```
--meth-tags all | none | XR,XG | ^XM
```

- `all` (default), `none`, a comma-separated inclusion list, or `^`-prefixed exclusions.
- Inclusion and exclusion forms cannot be mixed. `XR,^XM` has no obvious reading — is it "only XR" or "everything but XM"? — so it is rejected rather than silently assigned one.
- Tag names are case-insensitive.
- **Comma-separated, not space-separated.** The issue sketched `--meth-tags XR XG`; `getopt` would parse `XG` as the first FASTQ. This is the same footgun `--meth` already documents for its optional argument, so the flag avoids it by construction.
- A deselected tag is **not computed**, not merely suppressed — clearing `XM` skips the per-read `meth_build_xm()` pass as well as its bytes.

## On the default

`all`, and a bare `--meth` is byte-identical to before (verified against the parent commit on a 5k-read library).

This is an asymmetry-of-harm call rather than a cost call. The Bismark family — `bismark_methylation_extractor`, methylKit, methtuple, DMRfinder, epialleleR — consumes `XM` as its input contract and **cannot reconstruct it**. A pipeline that needed the tag and silently lost it produces empty or wrong methylation calls, and may not notice. A pipeline that never needed it carries a larger BAM and opts out with one flag.

MethylDackel and biscuit — the usual pairing for a bwameth-style BAM — work from the reference FASTA and never read `XM`, so `^XM` is free for them.

Two secondary considerations pointed the same way: `--meth` output semantics already change in the PR this is stacked on, and two consecutive releases silently changing `--meth` output is how a tool loses trust. Flipping the default later is a one-line change if the balance shifts.

## Tests

- **`test/unit/test_meth_tags_parse.cpp`** — `mem_opt_parse_meth_tags()` is exposed so the grammar is unit tested directly: every spec form, set semantics (order/repetition immaterial, `^XM` ≡ `XR,XG`), case-insensitivity, the mixed-form rejection, malformed inputs, and a NULL spec.
- **`test/regression/meth_tags.sh`** — end-to-end emission for every spec form; asserts tag selection leaves fields 1-11 and `NM`/`MD`/`AS` byte-identical to a default run (the flag is an emission filter, not an alignment knob); asserts malformed specs exit non-zero rather than falling back to a default.

Full `--meth` regression suite and `make test` green. Non-`--meth` output byte-identical to the parent.

## Review notes

- `src/meth_bam.cpp` has the three gates; the `XM` one wraps the `meth_build_xm()` call, not the `bam_aux_append`, so the compute is genuinely skipped.
- `mem_opt_parse_meth_tags()` lives in `src/bwamem.cpp` next to `mem_opt_fill_meth_mat()` and is declared in `bwamem.h` for testability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--meth-tags` to control which Bismark methylation tags (`XR`, `XG`, and `XM`) are generated.
  - Supports selecting all tags, no tags, specific tags, or excluding selected tags.
  - Unselected tags are not computed or emitted.

- **Documentation**
  - Added command-line usage details, validation rules, examples, and payload-size guidance.

- **Bug Fixes**
  - Invalid tag specifications now produce clear errors without proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->