### PR TITLE
fix(meth): diagnose orphaned --meth/--meth-tags values instead of aligning to them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,9 +638,12 @@ jobs:
         # (meth_strand_hyp) — a reverse read that is unmapped under the unflipped
         # matrix and full-length under the fix; the batched OT/OB-partition mate
         # rescue being byte-identical to the scalar rescue; the `collapsed`
-        # --meth-scoring model; and --meth-tags spec resolution (all|none|list|
+        # --meth-scoring model; --meth-tags spec resolution (all|none|list|
         # ^exclusion) plus its guarantee that tag selection leaves the alignment
-        # untouched.
+        # untouched; and the --meth-family flag footguns (a value orphaned by
+        # `--meth taps` / `--meth-tags XR XG` is diagnosed by name instead of
+        # being aligned to as the reference, a reference genuinely named after
+        # one of those values still works, and `-XM` == `^XM`).
         env:
           BWA_MEM3: ${{ github.workspace }}/bwa-mem3
         run: |
@@ -653,7 +656,7 @@ jobs:
                    meth_output_integrity meth_reverse_strand_conversion \
                    meth_seed_unpacked_ref_not_loaded \
                    meth_rescue_batched_identical meth_collapsed_scoring \
-                   meth_tags; do
+                   meth_tags meth_flag_footguns; do
             echo "::group::$t"; bash "test/regression/$t.sh"; echo "::endgroup::"
           done
 

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -129,8 +129,8 @@ Methylation (--meth) options:
                  which Bismark tags to emit: 'all' (default), 'none', a
                  comma-separated list (XR,XG), or ^-prefixed exclusions (^XM).
                  Comma-separated, NOT space-separated (a second word becomes
-                 the reference). Quote ^ specs: '^XM' -- bare ^ is a negated
-                 glob in zsh with EXTENDED_GLOB.
+                 the reference). An exclusion may be written ^XM or -XM; prefer
+                 -XM in scripts (bare ^ is a negated glob in zsh EXTENDED_GLOB).
                  Unselected tags are not computed. XM:Z is a read-length string
                  and dominates the BAM's aux payload; '^XM' drops it for callers
                  that recompute from the reference (MethylDackel, biscuit).

--- a/docs/src/methylation/flags.md
+++ b/docs/src/methylation/flags.md
@@ -130,11 +130,11 @@ deselecting `XM` skips its per-read pass as well as its bytes.
 | `all` | emit `XR`, `XG`, `XM` (the default) |
 | `none` | emit none of the three |
 | `XR,XG` | inclusion list — emit exactly these |
-| `^XM` | exclusion — everything except `XM` |
+| `^XM` or `-XM` | exclusion — everything except `XM` (`-` needs no shell quoting) |
 
-A spec is either an inclusion list or a set of `^` exclusions; mixing the two
-(`XR,^XM`) is rejected rather than given an arbitrary reading. Tag names are
-case-insensitive.
+A spec is either an inclusion list or a set of exclusions (`^XM`, or its `-XM`
+synonym below); mixing the two (`XR,^XM`) is rejected rather than given an
+arbitrary reading. Tag names are case-insensitive.
 
 ```bash
 # Drop the methylation call string; keep the strand labels.
@@ -144,21 +144,30 @@ bwa-mem3 mem --meth --meth-tags '^XM' ref.fa r1.fq r2.fq > out.bam
 bwa-mem3 mem --meth --meth-tags XR,XG ref.fa r1.fq r2.fq > out.bam
 ```
 
-> **Quote `^`-prefixed specs.** In `zsh` with `EXTENDED_GLOB` enabled — the
-> default under oh-my-zsh and prezto — a bare `^XM` is a *negated glob* and
-> expands to every file in the working directory except `XM`. The aligner then
-> receives a filename as the tag spec and the remaining filenames as positional
-> arguments. `bash` and stock `zsh` leave `^` alone, so this bites only some
-> users; quoting it (`'^XM'`) is always safe, and `XR,XG` sidesteps it entirely.
+An exclusion may be written `^XM` **or** `-XM`. Prefer `-XM` in scripts: a bare
+`^XM` is a *negated glob* in `zsh` with `EXTENDED_GLOB` enabled (the oh-my-zsh
+and prezto default), where it expands to every file in the working directory
+except `XM`. `bash` and stock `zsh` leave `^` alone, so this bites only some
+users — but `-XM` and `XR,XG` need no quoting anywhere.
 
 > **The list is comma-separated, not space-separated.** `--meth-tags XR XG`
-> passes only `XR` to the flag; `XG` becomes the next positional argument, i.e.
-> the reference. The failure surfaces as a confusing
-> `--meth seed index 'XG.meth.*' not found` rather than a flag error. This is the
-> same shape as the `--meth taps` trap above, though the cause differs:
-> `--meth` takes an *optional* argument and so requires `=`, whereas
-> `--meth-tags` takes a *required* argument and happily consumes the first word
-> but not the second.
+> passes only `XR` to the flag; `XG` then becomes the next positional argument,
+> i.e. the reference. This is the same *shape* as the `--meth taps` trap above,
+> though the cause differs: `--meth` takes an *optional* argument and so
+> requires `=`, whereas `--meth-tags` takes a *required* argument and binds the
+> first word but not the second.
+>
+> Both spellings are detected and reported by name:
+>
+> ```text
+> ERROR: 'XG' was taken as a positional argument (the <idxbase> reference), but it looks like
+>        the value for --meth-tags and no such file exists.
+>        --meth-tags takes ONE comma-separated list, not a space-separated one:
+>        write --meth-tags XR,XG (or --meth-tags '^XM'), not --meth-tags XR XG.
+> ```
+>
+> The check fires only when the orphaned token names nothing on disk, so a
+> reference genuinely called `taps` or `all` still works.
 
 **Why you would drop `XM`.** It is a read-length string, so it dominates the
 aux payload: on a 151 bp EM-seq-style library it is **~33 % of the BAM**

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -446,7 +446,11 @@ int mem_opt_parse_meth_tags(const char *spec, int *out, const char **err)
          * for a misspelling that isn't there. `XR,` is caught as a trailing
          * comma at the bottom of the loop. */
         if (len == 0) { *err = "empty tag in list"; return -1; }
-        int is_exclusion = (*p == '^');
+        /* '-' is accepted as a synonym for '^' because a bare ^XM is a negated
+         * glob in zsh with EXTENDED_GLOB (the oh-my-zsh/prezto default), where
+         * it silently expands to every file in the directory except XM. '-XM'
+         * needs no quoting in any common shell. */
+        int is_exclusion = (*p == '^' || *p == '-');
         const char *name = is_exclusion ? p + 1 : p;
         size_t name_len  = is_exclusion ? len - 1 : len;
         int bit = meth_tag_bit(name, name_len);

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -115,8 +115,9 @@ enum mem_meth_scoring { MEM_METH_SCORING_COLLAPSED = 0, MEM_METH_SCORING_GENOMIC
 /* Parse a --meth-tags spec into a MEM_METH_TAG_* bitmask.
  *
  * Grammar: `all` | `none` | a comma-separated list of tag names, either all
- * plain (an inclusion set: `XR,XG`) or all `^`-prefixed (subtracted from the
- * full set: `^XM`). Mixing plain and `^` terms is rejected. Tag names are
+ * plain (an inclusion set: `XR,XG`) or all exclusions (subtracted from the full
+ * set: `^XM`). An exclusion may be written `^XM` or `-XM`; the latter needs no
+ * shell quoting. Mixing plain and excluded terms is rejected. Tag names are
  * case-insensitive. Returns 0 on success and writes *out; returns -1 on a
  * malformed spec and writes a human-readable reason to *err (a static string).
  * Exposed for unit testing. */

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1413,6 +1413,61 @@ static void update_a(mem_opt_t *opt, const mem_opt_t *opt0)
     }
 }
 
+/* True if `p` names something on disk, or is the base of a bwa index (the
+ * <idxbase> argument is a prefix, not a file: "ref.fa" with "ref.fa.amb"
+ * alongside it). Used only to decide whether a positional that *looks* like an
+ * option value is in fact a real path the user meant. */
+static int path_exists(const char *p)
+{
+    char buf[PATH_MAX];
+    if (p == NULL || *p == '\0') return 0;
+    if (access(p, F_OK) == 0) return 1;
+    /* Probe one index sidecar rather than all of them: .amb is written by every
+     * index variant (plain and --meth) and is the smallest. */
+    if (snprintf(buf, sizeof(buf), "%s.amb", p) < (int)sizeof(buf)
+        && access(buf, F_OK) == 0) return 1;
+    return 0;
+}
+
+/* If `s` is a value that belongs to one of the --meth family's options rather
+ * than a path, return the flag it belongs to; else NULL. Deliberately narrow:
+ * every token here is a closed-vocabulary keyword no one would name a reference
+ * after, and the caller additionally requires that no such path exists. */
+static const char *stray_option_value_flag(const char *s)
+{
+    static const struct { const char *value, *flag; } known[] = {
+        { "taps",      "--meth"         }, { "emseq",     "--meth" },
+        { "em-seq",    "--meth"         }, { "bisulfite", "--meth" },
+        { "collapsed", "--meth-scoring" }, { "genomic",   "--meth-scoring" },
+        { "neutral",   "--meth-scoring" },
+        { "XR",        "--meth-tags"    }, { "XG",        "--meth-tags" },
+        { "XM",        "--meth-tags"    }, { "all",       "--meth-tags" },
+        { "none",      "--meth-tags"    },
+    };
+    if (s == NULL) return NULL;
+    /* A `^`-prefixed exclusion can only have come from --meth-tags. Its `-XM`
+     * synonym needs no case here: `X` takes an argument in the short optstring,
+     * so getopt binds `-XM` as `-X M` and it never reaches a positional slot. */
+    if (s[0] == '^') return "--meth-tags";
+    for (size_t i = 0; i < sizeof(known) / sizeof(known[0]); ++i)
+        if (strcasecmp(s, known[i].value) == 0) return known[i].flag;
+    return NULL;
+}
+
+/* The corrective spelling for a stray value, tailored to how it got orphaned. */
+static const char *stray_option_value_advice(const char *s)
+{
+    const char *flag = stray_option_value_flag(s);
+    if (flag == NULL) return "";
+    if (strcmp(flag, "--meth") == 0)
+        return "       --meth takes an OPTIONAL argument, which getopt only binds with '=':\n"
+               "       write --meth=taps, not --meth taps.";
+    if (strcmp(flag, "--meth-tags") == 0)
+        return "       --meth-tags takes ONE comma-separated list, not a space-separated one:\n"
+               "       write --meth-tags XR,XG (or --meth-tags '^XM'), not --meth-tags XR XG.";
+    return "       Pass it as the argument to that flag, e.g. --meth-scoring genomic.";
+}
+
 static void usage(const mem_opt_t *opt)
 {
     fprintf(stderr, "Usage: bwa-mem3 mem [options] <idxbase> <in1.fq> [in2.fq]\n");
@@ -1554,8 +1609,8 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                 which Bismark tags to emit: 'all' (default), 'none', a\n");
     fprintf(stderr, "                 comma-separated list (XR,XG), or ^-prefixed exclusions (^XM).\n");
     fprintf(stderr, "                 Comma-separated, NOT space-separated (a second word becomes\n");
-    fprintf(stderr, "                 the reference). Quote ^ specs: '^XM' -- bare ^ is a negated\n");
-    fprintf(stderr, "                 glob in zsh with EXTENDED_GLOB.\n");
+    fprintf(stderr, "                 the reference). An exclusion may be written ^XM or -XM; prefer\n");
+    fprintf(stderr, "                 -XM in scripts (bare ^ is a negated glob in zsh EXTENDED_GLOB).\n");
     fprintf(stderr, "                 Unselected tags are not computed. XM:Z is a read-length string\n");
     fprintf(stderr, "                 and dominates the BAM's aux payload; '^XM' drops it for callers\n");
     fprintf(stderr, "                 that recompute from the reference (MethylDackel, biscuit).\n");
@@ -2203,6 +2258,29 @@ int main_mem(int argc, char *argv[])
     }
 
     if (opt->n_threads < 1) opt->n_threads = 1;
+    /* A stray word on the command line slides silently into a positional slot.
+     * Two spellings invite it:
+     *   --meth taps        (optional argument: getopt_long only binds it with '=')
+     *   --meth-tags XR XG  (required argument: 'XR' binds, 'XG' does not)
+     * In both cases the orphan lands in <idxbase>, and with a single-end read
+     * file the result still has three positionals -- a perfectly well-formed
+     * paired-end invocation whose reference happens to be "taps" or "XG". The
+     * user then gets a missing-index error naming a token they never meant as a
+     * path. Diagnose it here, before any index work, whenever a positional
+     * matches a known option-value vocabulary and is not an actual path. */
+    for (int pos = optind; pos < argc; ++pos) {
+        const char *flag = stray_option_value_flag(argv[pos]);
+        if (flag == NULL || path_exists(argv[pos])) continue;
+        fprintf(stderr,
+                "ERROR: '%s' was taken as a positional argument (%s), but it looks like\n"
+                "       the value for %s and no such file exists.\n"
+                "%s\n",
+                argv[pos], pos == optind ? "the <idxbase> reference" : "a read file",
+                flag, stray_option_value_advice(argv[pos]));
+        free(opt);
+        if (out_opened) fclose(aux.fp);
+        return 1;
+    }
     if (optind + 2 != argc && optind + 3 != argc) {
         usage(opt);
         free(opt);

--- a/test/regression/meth_flag_footguns.sh
+++ b/test/regression/meth_flag_footguns.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# test/regression/meth_flag_footguns.sh
+#
+# Regression: a stray word from a mis-spelled --meth-family flag must be
+# diagnosed, not silently consumed as the reference.
+#
+# Two spellings orphan their value on the command line:
+#   --meth taps        -- an OPTIONAL argument; getopt_long only binds it with '='
+#   --meth-tags XR XG  -- a REQUIRED argument; 'XR' binds, 'XG' does not
+#
+# The orphan lands in the <idxbase> slot. With a single-end read file the
+# invocation still has three positionals, which is a well-formed paired-end
+# call whose reference happens to be named "taps" or "XG" -- so the arity check
+# passes and the user gets a missing-index error naming a token they never
+# meant as a path (previously: "--meth seed index 'XG.meth.*' not found. Run:
+# bwa-mem3 index --meth XG").
+#
+# Asserted here:
+#  1. Both spellings are rejected with a message that names the offending token
+#     AND the flag it belongs to, so the fix is readable off the error.
+#  2. The check is gated on the token not existing: a reference genuinely named
+#     `taps` (a value in the vocabulary) still aligns normally. A guard that
+#     blocks a legitimate filename would be worse than the footgun.
+#  3. `-XM` is accepted as a synonym for `^XM`, so the exclusion form needs no
+#     shell quoting (a bare ^XM is a negated glob under zsh EXTENDED_GLOB).
+#
+# Inputs:
+#   BWA_MEM3 — path to the bwa-mem3 binary under test
+set -euo pipefail
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+command -v samtools >/dev/null 2>&1 || { echo "SKIP: samtools not on PATH (--meth emits BAM)"; exit 0; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT; cd "$WORK"
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+REF=TCATTGGCTATCCTAACCCGACCCTAGGAGCGGTTGGCGTGTATGCCGTGAATTTTCTCATTTCCGCTAGACATAATCGTTCTGCCTATATCTGGACAACATCCCGGCGACTTAGGCGACCCACAGAATCGTCCCTTCTAACGTAGTTCGCATAGTTCCCGTCCGTAGCCGGACTATTCGAACACCCAGTATTCGATTAACTCGGGCTTGACGTATTAGAGGCGTTAGTGTGCCAGGTAAGATACGCCAACGGAATTAACCTCTGTGACACTCCGCGGAGCCTTCGGACATATAAGTGATCGGGTCTACGTTTGTTAGACTTGAGACGTCTGTTAAGAGTTGGGTCTAATAAATCGCCTACACGTGGAGTCTAACGGGGAAGCGTCGAATCCTGATACATCATATAATGGAGCGTGTTATGAAAAAAGAGCATTCCATTGTACGAGCCGTGCCAGAAACGGCTTGACTACGTGAGCGTAGTGTTAGATAAACAGGAAACACTGACGCGGTTAGAAGGCGGATTGCCGGTAGGTTTTGGAAACATAAATACACACGGTATCATGTTGGGTCACGATTCCTATCACCGCACAGGGCCAACCATAGAAGAACTGAAAGAACTAATCTGGCGGCGGGCTCGGTGCTTATATTTTCCACCCAACATCGTGCACATTAGGCTCACCGCGCCCTACGGGCGAAGGGTGCGTACGGTGTTTATAAGGCGTGACGGCCCCAAGTAGAGGGTAATTCTGTGAAAGAATCTCAGGACGGTGGCATGAATTCAATTCCTTTTAAACCTATCGTTCCGACCTTATGCAATCCTTCAATGAAGATCGTCAACGACCATCGTTCTTCTGCTTTAAGTGTGAGTTCTCTCTTACAAGCTAATACACCCCAGCGTTCTCCGTACTCTTCACTGCCCAAGCGAGGCTAACCTTTTGAAATGTCACAGTCGAAGCATATCTCCCGTACATCTTTTTCGGAGATCGCAGCTCGCGGAGCTATAAGCGACTTAAGCCCTTGTGTCGGTGATCCCAAGGGTCTGACTCCTGTACCAGGGTTACTGTTTCGCTTTACGGAGTAGCCTGTGAGGTGAACTGAAAGGAGCATATTTGAGATCTAAGATAGGGTCCTCCTCTGCGTCTACGTTCTCTCCGTTACGTACGGCTTCGCACCGGAGTGCATCTTGGCCCCGAAACGCACTGTGTGTGCTGATACAGCGTCCCTGGCCGGCCATGGGTTCAGAACTCCCGGGAACGCTTTTCAACTTAGAGGAACCCCGTCATGGAAGTAGATCGCGTCGAATGAGGGAGTTAGTCCTCGTTCCAGCTGGTAATTGTTTTACCGCTTGGGACCACTATAGGCCGCGGGTAGAAGTTGCTGGGTGTTGATTCCAACCCTCGAACCACGATACGACCTGCCATTTATGGCACAGTAAGGTTCAAACAGCATAATGAATACAGTTATAGTAACTTCCTCACGTACGATTAGGACGCAGCCTTG
+printf '>chrA\n%s\n' "$REF" > ref.fa
+READ=ATTCTGGCGATTTAGGTGACTCACAGAATCGTTCTTTCTAACGTAGTTTGTATAGTTCTC
+printf '@t\n%s\n+\n%s\n' "$READ" "$(printf 'I%.0s' $(seq 1 60))" > r.fq
+"$BWA_MEM3" index --meth ref.fa >/dev/null 2>&1 || fail "index --meth nonzero exit"
+
+# --- 1. both orphan spellings are diagnosed --------------------------------
+# Single-end read file, so the stray token makes exactly three positionals and
+# the arity check cannot catch it -- this is the case that used to slip through.
+expect_diagnosed() { # $1 = label, $2 = stray token, $3 = flag it belongs to, rest = argv
+    local label="$1" token="$2" flag="$3"; shift 3
+    if "$BWA_MEM3" "$@" >/dev/null 2>err.txt; then
+        fail "$label: exited 0; the stray '$token' must be rejected"
+    fi
+    grep -q "'$token' was taken as a positional argument" err.txt \
+        || fail "$label: error does not name the stray token '$token'; got: $(head -2 err.txt | tr '\n' ' ')"
+    # Match the whole clause, not just the flag: a bare "--meth" would also be
+    # satisfied by "--meth-tags", so a value attributed to the wrong member of
+    # the family would slip through.
+    grep -Fq -- "the value for $flag and no such file exists" err.txt \
+        || fail "$label: error does not attribute '$token' to $flag; got: $(head -2 err.txt | tr '\n' ' ')"
+    # The old, misleading advice must be gone: it told the user to build an
+    # index for the stray token.
+    if grep -q "index --meth $token" err.txt; then
+        fail "$label: error still advises building an index for the stray token '$token'"
+    fi
+}
+expect_diagnosed "--meth-tags space-separated" XG      --meth-tags    mem --meth --meth-tags XR XG ref.fa r.fq
+expect_diagnosed "--meth separated argument"   taps    --meth         mem --meth taps ref.fa r.fq
+expect_diagnosed "--meth-scoring orphan"       genomic --meth-scoring mem --meth --meth-scoring collapsed genomic ref.fa r.fq
+
+# --- 2. no false positive on a real file with a vocabulary name -------------
+# A reference genuinely named `taps` must still work: the guard fires only when
+# the token names nothing on disk.
+cp ref.fa taps
+"$BWA_MEM3" index --meth taps >/dev/null 2>&1 || fail "index --meth taps nonzero exit"
+"$BWA_MEM3" mem --meth taps r.fq > real.bam 2>/dev/null \
+    || fail "a reference genuinely named 'taps' was blocked by the stray-value guard"
+[ "$(samtools view -c real.bam)" = "1" ] || fail "reference named 'taps': expected 1 record"
+# Same file, this time with the chemistry actually selected.
+"$BWA_MEM3" mem --meth=taps taps r.fq > real2.bam 2>/dev/null \
+    || fail "--meth=taps with a reference named 'taps' was rejected"
+[ "$(samtools view -c real2.bam)" = "1" ] || fail "--meth=taps + ref 'taps': expected 1 record"
+
+# --- 3. '-XM' is a shell-safe synonym for '^XM' -----------------------------
+tags_of() { samtools view "$1" | mawk 'NR==1{for(i=12;i<=NF;i++) if($i~/^X[RGM]:Z:/) print substr($i,1,2)}' \
+    | sort | tr '\n' ' ' | sed 's/ $//'; }
+"$BWA_MEM3" mem --meth --meth-tags -XM -t 1 ref.fa r.fq > dash.bam 2>/dev/null \
+    || fail "--meth-tags -XM nonzero exit"
+"$BWA_MEM3" mem --meth --meth-tags '^XM' -t 1 ref.fa r.fq > caret.bam 2>/dev/null \
+    || fail "--meth-tags ^XM nonzero exit"
+d=$(tags_of dash.bam); c=$(tags_of caret.bam)
+[ "$d" = "XG XR" ] || fail "--meth-tags -XM: tags '$d', want 'XG XR'"
+[ "$d" = "$c" ]    || fail "-XM and ^XM disagree: '$d' vs '$c'"
+
+echo "PASS: meth_flag_footguns (orphaned --meth/--meth-tags/--meth-scoring values diagnosed by name; real files with vocabulary names unaffected; -XM == ^XM)"

--- a/test/unit/test_meth_tags_parse.cpp
+++ b/test/unit/test_meth_tags_parse.cpp
@@ -67,6 +67,24 @@ TEST_CASE("exclusions subtract from the full set")
     CHECK(parse_ok("^XM") == parse_ok("XR,XG"));
 }
 
+TEST_CASE("'-' is a shell-safe synonym for '^'")
+{
+    // A bare ^XM is a negated glob in zsh with EXTENDED_GLOB (the oh-my-zsh
+    // default), so it expands to every file in the directory except XM. '-XM'
+    // needs no quoting in any common shell and must mean the same thing.
+    CHECK(parse_ok("-XM") == parse_ok("^XM"));
+    CHECK(parse_ok("-XR,-XG") == parse_ok("^XR,^XG"));
+    CHECK(parse_ok("-xm") == parse_ok("^XM"));
+    // The two prefixes may be freely intermixed -- both are exclusions, so
+    // there is no ambiguity to guard against.
+    CHECK(parse_ok("^XR,-XG") == MEM_METH_TAG_XM);
+    // But an exclusion still cannot be mixed with an inclusion.
+    CHECK(parse_err("XR,-XM") != nullptr);
+    CHECK(parse_err("-XR,XM") != nullptr);
+    // A lone prefix is not a tag.
+    CHECK(parse_err("-") != nullptr);
+}
+
 TEST_CASE("tag names are case-insensitive")
 {
     CHECK(parse_ok("xr,xg") == parse_ok("XR,XG"));


### PR DESCRIPTION
Refs #331. **Stacked on #333** (which is itself stacked on #332). Base is `feat/issue-331-meth-tags`; retarget as the stack merges.

## The problem

Two `--meth`-family spellings orphan their value on the command line:

| spelling | argument type | what happens |
|---|---|---|
| `--meth taps` | **optional** | `getopt_long` only binds an optional argument with `=`, so `taps` is never consumed |
| `--meth-tags XR XG` | **required** | `XR` binds fine; `XG` is simply the next word |

Either way the orphan slides into the next positional slot — which is `<idxbase>`.

With a **paired-end** pair that makes four positionals, and the existing arity check catches it — but answers with a 200-line usage dump that buries the cause. With a **single-end** read file it makes exactly three: a perfectly well-formed paired-end invocation whose reference happens to be named `taps` or `XG`. The arity check passes and you get

```
ERROR: --meth seed index 'XG.meth.*' not found. Run: bwa-mem3 index --meth XG
```

which names a token the user never meant as a path — and then advises them to build an index for it.

## The fix

Check the positionals before any index work. If one matches the closed vocabulary of a `--meth`-family option value **and** names nothing on disk, say which flag it belongs to and how to spell it:

```
ERROR: 'XG' was taken as a positional argument (the <idxbase> reference), but it looks like
       the value for --meth-tags and no such file exists.
       --meth-tags takes ONE comma-separated list, not a space-separated one:
       write --meth-tags XR,XG (or --meth-tags '^XM'), not --meth-tags XR XG.
```

```
ERROR: 'taps' was taken as a positional argument (the <idxbase> reference), but it looks like
       the value for --meth and no such file exists.
       --meth takes an OPTIONAL argument, which getopt only binds with '=':
       write --meth=taps, not --meth taps.
```

Covers `--meth`, `--meth-tags`, and `--meth-scoring` values.

**The disk check is what keeps this from becoming a footgun of its own.** A guard that rejected a legitimately-named file would be worse than the problem it solves, so the check fires only when the token names nothing on disk. A reference genuinely called `taps` still aligns normally — asserted in the regression, including under `--meth=taps` where the chemistry keyword and the filename are the same string.

## Also: `-XM` as a shell-safe exclusion

A bare `^XM` is a **negated glob** in zsh with `EXTENDED_GLOB` — the oh-my-zsh and prezto default — where it expands to every file in the working directory except `XM`, silently handing the aligner a filename as its tag spec:

```
stock zsh / bash:      ^XM  ->  ^XM
zsh + EXTENDED_GLOB:   ^XM  ->  a.bam all.bam b.bam ...
```

`--meth-tags -XM` is now accepted as a synonym and needs no quoting in any common shell. Both prefixes are exclusions so they may be intermixed (`^XR,-XG`); neither may be mixed with an inclusion, exactly as before.

## Output is unchanged

Non-`--meth` and default `--meth` output are byte-identical to the parent commit (records-only md5, SE and PE). This turns three confusing failures into readable ones and adds a spelling that does not depend on shell options — it changes no alignment behavior.

## Tests

- **`test/regression/meth_flag_footguns.sh`** — asserts all three orphan spellings are rejected with a message naming the offending token *and* its flag; asserts the old misleading "build an index for it" advice is gone; asserts a reference genuinely named `taps` still works both with and without `--meth=taps`; asserts `-XM` ≡ `^XM`.
- **`test/unit/test_meth_tags_parse.cpp`** — new cases for the `-` prefix, intermixing `^` and `-`, and that `-` still cannot be mixed with an inclusion.

Full `--meth` suite and `make test` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `--meth-tags` now supports `-TAG` as a shell-safe alternative to `^TAG` for exclusions.
  * Updated help text documents both exclusion formats and recommended usage.
* **Bug Fixes**
  * Improved detection and reporting of misplaced or space-separated methylation option values.
  * Valid reference paths that match recognized option values continue to work correctly.
* **Tests**
  * Added coverage for exclusion syntax, invalid inputs, mixed inclusion/exclusion tags, and positional-argument diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->