### PR TITLE
feat(mem): band mate rescue to a k-mer anchor diagonal (--rescue-kmer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,6 +505,18 @@ jobs:
           FIXTURES="$GITHUB_WORKSPACE/test/fixtures" \
           bash test/regression/chunk_cap_optin.sh
 
+      - name: --rescue-kmer/--rescue-band reject malformed values
+        if: matrix.canonical == true
+        # Both were parsed with atoi(), which maps unparseable text to 0. For
+        # --rescue-kmer 0 means "off" and counts as explicitly set, so a typo
+        # would silently disable the largest lever in --fast; for --rescue-band
+        # the kernel's `band > 0 ? band : 50` guard turned a bad value back into
+        # the default. Neither is visible in the output.
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          FIXTURES="$GITHUB_WORKSPACE/test/fixtures" \
+          bash test/regression/rescue_kmer_options.sh
+
       - name: --supp-rep-hard-cap repetitive-seed regression
         if: matrix.canonical == true
         run: |

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -19,9 +19,14 @@ Options:
     -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [0.50]
     -W INT        discard a chain if seeded bases shorter than INT [0]
     -m INT        perform at most INT rounds of mate rescues for each read [50]
+    --rescue-kmer[=K]  band the mate-rescue Smith-Waterman to a K-mer exact-match anchor
+                  diagonal, falling back to the full insert window when no anchor. K is
+                  1..16 (bare = 6, =0 = off); the value must be attached with '='.
+                  Opt-in speedup, NOT byte-identical; enabled by --fast [off]
+    --rescue-band INT  half-width (bp) of the band around the anchor diagonal, 1..1000000 [50]
     -S            skip mate rescue
     -P            skip pairing; mate rescue performed unless -S also in use
-    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup
+    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup --rescue-kmer=6
                   --skip-contained-ext --max-extend-chains 20 --adaptive-band
                   --extend-mate-concordant (under --meth: --max-extend-chains 10,
                   -s 2). Opt-in; explicit

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -348,6 +348,40 @@ on data where the default (50) wastes time on unrescuable pairs. See
 [Settings profiles](../best-practices/settings-profiles.md) for the benchmarked
 `-m 10` recommendation.
 
+#### `--rescue-kmer[=K]` / `--rescue-band INT` — banded mate rescue (opt-in, not byte-identical)
+
+Mate rescue Smith-Watermans a read against a reference window sized by the insert
+distribution — on the order of a kilobase for a ~150 bp read — and that unbanded
+window is the single largest kernel in the aligner on paired WGS. `--rescue-kmer`
+finds the read's dominant K-mer exact-match diagonal within the window and bands the
+rescue SW to that diagonal ± `--rescue-band` (default 50 bp), falling back to the full
+window when no anchor is found — or when the banded window would come out shorter than
+the read, which cannot host a full-length rescue alignment. The `kswv` kernel is
+unchanged — it is simply handed a shorter reference window — so the speedup comes from
+doing far less DP.
+
+`K` ranges over `1…16` — a K-mer code has to fit the `uint32` the anchor index packs it
+into, so larger values are rejected rather than silently treated as `K=16`. Bare
+`--rescue-kmer` selects `K=6`. Smaller K makes the anchor scan degenerate and slow (the
+diagonal vote's hash chains grow as `read_length / alphabet^K`); larger K lowers the
+fraction of rescues that find an anchor. K=6 is the measured wall-time peak (~−22% on the
+rescue-heavy WGS tail). `--rescue-band` takes `1…1000000` bp; the default 50 bp band means
+the narrowed window is the read length plus 100 bp, against the ~kilobase full window.
+Under `--meth` the anchor scan collapses to three letters on each pair's bisulfite strand
+(C→T for OT, G→A for OB) so exact K-mers survive the conversion; the SW still scores the
+real bases with the methylation matrix.
+
+The value must be attached with `=`: `--rescue-kmer` takes an *optional* argument, so
+`--rescue-kmer 6` selects the bare default and leaves `6` as a positional argument. Write
+`--rescue-kmer=6`.
+
+**Off by default and NOT byte-identical.** A narrowed window computes a different
+suboptimal alignment score, so a rescued read's `csub` — and therefore its MAPQ — can
+change; ~0.2% of records move. Truth-based ROC (holodeck simulated hg38 WGS, and
+bisulfite chr20) shows accuracy neutral-to-positive and confident (MAPQ ≥ 60) mismaps
+unchanged across `K = 1…16`. Enabled by [`--fast`](#--fast--speed-preset-opt-in-not-byte-identical);
+use `--rescue-kmer=0` to force it off even under `--fast`.
+
 #### `-S` — skip mate rescue
 
 Disables mate rescue entirely. Faster but may reduce sensitivity for
@@ -500,7 +534,7 @@ the alignment score and mapping quality for each secondary hit.
 `--fast` is a one-flag shorthand for the characterized speed levers:
 
 ```text
-bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 20 --adaptive-band --extend-mate-concordant
+bwa-mem3 mem --fast  ≡  -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 20 --adaptive-band --extend-mate-concordant --rescue-kmer=6
 ```
 
 `--skip-contained-ext` is byte-identical to the default on non-meth short- and
@@ -522,6 +556,13 @@ not run at default settings regardless of this flag (see
 mate-concordant chain the cap would otherwise drop — and is included for both non-meth and `--meth`
 `--fast` (see
 [Settings profiles → `--extend-mate-concordant`](../best-practices/settings-profiles.md#mate-concordant-chain-retention---extend-mate-concordant)).
+
+`--rescue-kmer=6` (see
+[`--rescue-kmer`](#--rescue-kmerk----rescue-band-int--banded-mate-rescue-opt-in-not-byte-identical))
+bands the mate-rescue Smith-Waterman to a 6-mer anchor diagonal. It is the largest single
+lever in `--fast` on paired WGS (mate rescue is the biggest kernel there) and is validated
+accuracy-neutral by truth-based ROC in both non-meth and `--meth` modes. Pass `--rescue-kmer=0`
+to opt back out while keeping the rest of `--fast`.
 
 `--fast` also flips one lever that has **no flag of its own**: the sort that orders alignment
 regions by reference end position before the order-sensitive dedup/patch pass. The default

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -383,6 +383,8 @@ mem_opt_t *mem_opt_init()
     o->max_XA_hits = 5;
     o->max_XA_hits_alt = 200;
     o->max_matesw = 50;
+    o->rescue_kmer = 0;      /* off by default (opt-in, not byte-identical) */
+    o->rescue_band = MEM_RESCUE_BAND_DEFAULT;
     o->mask_level_redun = 0.95;
     o->min_chain_weight = 0;
     o->max_chain_extend = 1<<30;

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -61,6 +61,23 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #define MEM_MAPQ_COEF 30.0
 #define MEM_MAPQ_MAX  60
 
+/* Bounds on the --rescue-kmer / --rescue-band options (mem_opt_t::rescue_kmer,
+ * ::rescue_band below). K is capped where a k-mer code stops fitting the uint32
+ * the anchor index packs it into; beyond that every K would behave as K=16, so
+ * the CLI rejects it rather than silently clamping. The band is capped well past
+ * any insert-sized rescue window -- a wider band already covers the whole window,
+ * so asking for one is a mistake worth naming -- and the cap also keeps the
+ * `anchor_diagonal + read_length + band` arithmetic clear of int overflow. */
+#define MEM_RESCUE_KMER_MAX 16
+#define MEM_RESCUE_BAND_MAX 1000000
+/* K used by both bare `--rescue-kmer` and the --fast preset (the measured
+ * wall-time optimum); named so the two parse sites and the help text cannot
+ * drift apart. The band default is named for the same reason: mem_opt_init sets
+ * it and matesw_kmer_narrow repeats it as a defensive fallback for a caller that
+ * sets the field directly, and those two must not drift. */
+#define MEM_RESCUE_KMER_DEFAULT 6
+#define MEM_RESCUE_BAND_DEFAULT 50
+
 struct __smem_i;
 typedef struct __smem_i smem_i;
 
@@ -147,6 +164,8 @@ typedef struct mem_opt_t {
     int mapQ_coef_fac;
     int max_ins;            // when estimating insert size distribution, skip pairs with insert longer than this value
     int max_matesw;         // perform maximally max_matesw rounds of mate-SW for each end
+    int rescue_kmer;        // k-mer-anchored banded mate rescue: 0=off, else anchor k-mer length in [1,MEM_RESCUE_KMER_MAX] (opt-in, not byte-identical)
+    int rescue_band;        // half-width (bp) of the band around the k-mer anchor diagonal, in [1,MEM_RESCUE_BAND_MAX]
     int max_XA_hits, max_XA_hits_alt; // if there are max_hits or fewer, output them all
     int8_t mat[25];         // scoring matrix; mat[0] == 0 if unset
     /* D3 (--meth): per-hypothesis substitution matrices, built from `mat` by

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -48,6 +48,159 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #  include "malloc_wrap.h"
 #endif
 
+/* ---- k-mer-anchored banded mate rescue (opt->rescue_kmer) --------------------
+ * Mate rescue Smith-Watermans a read against a ~kilobase reference window chosen
+ * by insert size (mem_matesw_batch_pre/post). With --rescue-kmer set, find the
+ * read's dominant k-mer exact-match diagonal within that window and band the SW
+ * to that diagonal +/- rescue_band, falling back to the full window when no
+ * anchor gathers enough votes. Opt-in and NOT byte-identical: the narrowed
+ * window yields a different suboptimal score (csub -> MAPQ), so it is off by
+ * default and enabled by --fast. The kswv kernel is unchanged -- narrowing just
+ * hands it a shorter reference window. */
+#include <vector>
+#include <cstdint>
+#include <algorithm>
+namespace {
+
+/* Find the dominant k-mer exact-match diagonal of the (oriented) read within the
+ * reference window ref[0..M) and return the window sub-range [ob,oe) a band of
+ * half-width opt->rescue_band around it covers. Returns false (=> full window)
+ * when no diagonal gathers >= 3 votes, or when the banded span would come out
+ * shorter than the query. Only mem_matesw_batch_pre calls this: it runs the scan
+ * once per enqueued pair and stores the resulting offset in g_rescue_narrow_off
+ * (keyed by regid) for mem_matesw_batch_post to read back, so _post never
+ * re-derives the window. `collapse` reduces the alphabet for the anchor scan only
+ * (1 = C->T / OT, 2 = G->A / OB, 0 = none) so exact k-mers survive the bisulfite
+ * conversion under --meth; the SW still sees the real bases. */
+static bool matesw_kmer_narrow(const mem_opt_t *opt, const uint8_t *ref, int M,
+                               const uint8_t *ms, int l_ms, int is_rev, int collapse,
+                               int *ob, int *oe)
+{
+    /* The CLI rejects K outside [1,MEM_RESCUE_KMER_MAX]; clamp defensively so a
+     * caller that sets opt->rescue_kmer directly cannot overflow the uint32 code. */
+    int k = opt->rescue_kmer;
+    if (k < 1) k = 1;
+    if (k > MEM_RESCUE_KMER_MAX) k = MEM_RESCUE_KMER_MAX;
+    if (M < k || l_ms < k) return false;
+
+    auto col = [collapse](uint8_t b) -> uint8_t {
+        if (b > 3) return b;
+        if (collapse == 1 && b == 1) return 3;   /* C -> T */
+        if (collapse == 2 && b == 2) return 0;   /* G -> A */
+        return b;
+    };
+
+    /* oriented (RC for is_rev), collapsed query bases */
+    static thread_local std::vector<uint8_t> q;
+    if ((int)q.size() < l_ms) q.resize(l_ms);
+    if (is_rev) for (int i = 0; i < l_ms; ++i) { uint8_t c = ms[l_ms-1-i]; q[i] = col((c < 4)? 3-c : 4); }
+    else        for (int i = 0; i < l_ms; ++i) q[i] = col(ms[i]);
+
+    /* index the read's k-mers in a fixed open-addressing hash (O(read) build,
+     * O(1) lookup); reset only the touched slots each call.
+     *
+     * HMAX caps occupancy so both probe loops below always terminate on an empty
+     * slot: a read offers up to l_ms - k + 1 distinct k-mers, which exceeds the
+     * HS slots for a mate of ~1 kb or longer (the K=6 code space is 4096), and a
+     * full table would make linear probing spin forever. touched.size() IS the
+     * occupancy -- every insert pushes exactly one slot and the reset loop below
+     * empties exactly those -- so no separate counter is needed. Stopping early
+     * leaves a partial index, which is safe: the vote scan then sees fewer
+     * anchors and falls back to the full window if votes stay under threshold. */
+    constexpr int HS = 1024, HMASK = HS - 1;
+    constexpr int HMAX = HS - (HS >> 2);                   /* stop inserting at 75% load */
+    static_assert(HMAX < HS, "the table must retain empty slots or linear probing cannot terminate");
+    static thread_local std::vector<uint32_t> slot_code;   /* 0xFFFFFFFF = empty */
+    static thread_local std::vector<int>      slot_head;
+    static thread_local std::vector<int>      nxt;         /* read-pos chain */
+    static thread_local std::vector<int>      touched;
+    if ((int)slot_code.size() < HS) { slot_code.assign(HS, 0xFFFFFFFFu); slot_head.assign(HS, -1); }
+    if ((int)nxt.size() < l_ms) nxt.resize(l_ms);
+    touched.clear();
+
+    uint32_t mask = (k >= 16) ? 0xffffffffu : ((1u << (2*k)) - 1);
+    { uint32_t code = 0; int valid = 0;
+      for (int i = 0; i < l_ms; ++i) {
+          uint8_t c = q[i];
+          if (c > 3) { valid = 0; code = 0; continue; }
+          code = ((code << 2) | c) & mask;
+          if (++valid >= k) {
+              int pos = i - k + 1;
+              uint32_t h = (code * 2654435761u) >> (32 - 10);   /* HS = 1<<10 */
+              while (slot_code[h] != 0xFFFFFFFFu && slot_code[h] != code) h = (h + 1) & HMASK;
+              if (slot_code[h] == 0xFFFFFFFFu) {
+                  if ((int)touched.size() >= HMAX) break;   /* table full enough: stop indexing */
+                  slot_code[h] = code; slot_head[h] = -1; touched.push_back((int)h);
+              }
+              nxt[pos] = slot_head[h]; slot_head[h] = pos;
+          }
+      } }
+    if (touched.empty()) return false;
+
+    /* vote diagonals d = (ref k-mer start) - (read k-mer start), index by d+l_ms */
+    int span = M + l_ms + 1;
+    static thread_local std::vector<int> dv;
+    if ((int)dv.size() < span) dv.resize(span);
+    std::fill(dv.begin(), dv.begin() + span, 0);
+    int best_d = 0, best_v = 0;
+    { uint32_t code = 0; int valid = 0;
+      for (int o = 0; o < M; ++o) {
+          uint8_t c = col(ref[o]);
+          if (c > 3) { valid = 0; code = 0; continue; }
+          code = ((code << 2) | c) & mask;
+          if (++valid >= k) {
+              int opos = o - k + 1;
+              uint32_t h = (code * 2654435761u) >> (32 - 10);
+              while (slot_code[h] != 0xFFFFFFFFu && slot_code[h] != code) h = (h + 1) & HMASK;
+              if (slot_code[h] == code) {
+                  for (int p = slot_head[h]; p >= 0; p = nxt[p]) {
+                      int idx = (opos - p) + l_ms;
+                      if (idx < 0 || idx >= span) continue;
+                      int v = ++dv[idx];
+                      if (v > best_v) { best_v = v; best_d = opos - p; }
+                  }
+              }
+          }
+      } }
+    for (int h : touched) slot_code[h] = 0xFFFFFFFFu;
+
+    if (best_v < 3) return false;
+    int W = opt->rescue_band > 0 ? opt->rescue_band : MEM_RESCUE_BAND_DEFAULT;
+    int lo_off = best_d - W;             /* read-0 maps to window offset best_d */
+    int hi_off = best_d + l_ms + W;
+    if (lo_off < 0) lo_off = 0;
+    if (hi_off > M) hi_off = M;
+    /* An anchor diagonal near a window edge clamps to a span that can be far
+     * shorter than the query (down to ~k + W when the read hangs off the left
+     * edge). Such a window cannot host a full-length rescue alignment, so the
+     * SW would return a truncated, low score that the caller's
+     * `score >= min_seed_len` gate is liable to reject -- a rescue the full
+     * window might have kept. Keep the full window in that case. */
+    if (hi_off - lo_off < l_ms) return false;
+    *ob = lo_off; *oe = hi_off;
+    return true;
+}
+
+/* mem_matesw_batch_pre stores the narrowing offset per enqueued pair (keyed by
+ * regid, stable under the batch's sort_classify / length-sort reorder) so
+ * mem_matesw_batch_post reads it back instead of re-running the anchor scan. */
+static thread_local std::vector<int> g_rescue_narrow_off;
+
+/* --rescue-kmer: length-sort each SIMD-width partition of `sp[0,pcnt)` (8-bit
+ * below pcnt8, 16-bit above) so the narrowed short windows group together --
+ * getScores8/16 runs each SIMD-lane group out to the group's longest len1, so a
+ * full fallback window mixed into a narrowed group wastes the saving. The
+ * 8/16-bit split at pcnt8 is preserved by sorting each side independently.
+ * Result-safe: aln[] and g_rescue_narrow_off are keyed by regid and seqBuf* by
+ * idr/idq, so every key travels with the SeqPair it belongs to. */
+static void matesw_sort_partitions_by_len(SeqPair *sp, int64_t pcnt8, int64_t pcnt)
+{
+    auto by_len1 = [](const SeqPair &x, const SeqPair &y) { return x.len1 < y.len1; };
+    std::sort(sp, sp + pcnt8, by_len1);
+    if (pcnt > pcnt8) std::sort(sp + pcnt8, sp + pcnt, by_len1);
+}
+} // namespace
+
 /* File-scope forward declaration of the dedup/patch entry point defined in
  * src/bwamem.cpp (kept default-free there). The `mat = NULL` default lives
  * here only, so [dcl.fct.default]/4 (no redefining a default in one TU) is
@@ -1077,6 +1230,13 @@ int mem_sam_pe_batch(const mem_opt_t *opt, mem_cache *mmc,
             scored += group_pcnt;
             if (group_pcnt == 0) continue;
 
+            /* --rescue-kmer: same length sort as the non-meth path below, applied
+             * per OT/OB partition -- otherwise --fast --meth would enqueue narrowed
+             * windows but leave them mixed with full ones inside each SIMD group,
+             * paying the scan cost without collecting the saving. */
+            if (opt->rescue_kmer)
+                matesw_sort_partitions_by_len(scratch, group_pcnt8, group_pcnt);
+
             Ikswv *pwsw = (hyp == 1) ? pwsw_ot.get() : pwsw_ob.get();
             mem_sam_pe_batch_run(pwsw, scratch, seqBufRef, seqBufQer,
                                  aln, group_pcnt, group_pcnt8, nthreads);
@@ -1098,6 +1258,8 @@ int mem_sam_pe_batch(const mem_opt_t *opt, mem_cache *mmc,
     auto pwsw = make_kswv(opt->o_del, opt->e_del, opt->o_ins, opt->e_ins,
                           opt->a, -1*opt->b, nthreads,
                           maxRefLen, maxQerLen);
+
+    if (opt->rescue_kmer) matesw_sort_partitions_by_len(seqPairArray, pcnt8, pcnt);
 
     mem_sam_pe_batch_run(pwsw.get(), seqPairArray, seqBufRef, seqBufQer,
                          aln, pcnt, pcnt8, nthreads);
@@ -1517,6 +1679,19 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
                 gar[gcnt + r] = -1;
                 continue;
             }
+            /* --rescue-kmer: band this window to the anchor diagonal before enqueue
+             * (meth collapses the anchor scan to 3 letters on this pair's strand).
+             * mem_matesw_batch_post applies the same offset, so coords stay
+             * consistent; narrow_ob (0 = full window) is recorded at enqueue. */
+            int narrow_ob = 0;
+            if (opt->rescue_kmer) {
+                int collapse = 0;
+                if (opt->meth_mode) { int hyp = (mate_meth_ot ^ is_rev) & 1; collapse = hyp ? 1 : 2; }
+                int ob, oe;
+                if (matesw_kmer_narrow(opt, ref, (int)(re - rb), ms, l_ms, is_rev, collapse, &ob, &oe)) {
+                    int64_t rb_full = rb; ref += ob; rb = rb_full + ob; re = rb_full + oe; narrow_ob = ob;
+                }
+            }
             //kswr_t aln;
             //mem_alnreg_t b;
             int xtra = KSW_XSUBO | KSW_XSTART | (l_ms * opt->a < 250? KSW_XBYTE : 0) | (opt->min_seed_len * opt->a);
@@ -1658,6 +1833,11 @@ int mem_matesw_batch_pre(const mem_opt_t *opt, const bntseq_t *bns,
                 /* gar[gcnt+r] points at this rescue's single enqueued regid. */
                 if (hi == 0) gar[gcnt + r] = pcnt;
                 sp.regid = pcnt;
+                if (opt->rescue_kmer) {   /* record narrow offset by regid for _post */
+                    if ((int)g_rescue_narrow_off.size() <= pcnt)
+                        g_rescue_narrow_off.resize(pcnt + 1024, 0);
+                    g_rescue_narrow_off[pcnt] = narrow_ob;
+                }
                 seqPairArray[pcnt++] = sp;
             }
         }
@@ -1779,6 +1959,11 @@ int mem_matesw_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
             //aln = **myaln;
             //(*myaln)++;
             int index = gar[gcnt + r];
+            /* --rescue-kmer: apply the same narrowing offset _pre stored for this
+             * regid, so aln.tb/te map against the narrowed window start (batched
+             * pairs only; index==-1 scalar-fallback pairs were never narrowed). */
+            if (opt->rescue_kmer && index >= 0)
+                rb += g_rescue_narrow_off[index];
             if (index == -1) {
                 // fprintf(stderr, "Re-routing: Encountered -ve index for "
                 // "gcnt: %d, look into pre.\n", gcnt + r);

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -1436,9 +1436,16 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "    -D FLOAT      drop chains shorter than FLOAT fraction of the longest overlapping chain [%.2f]\n", opt->drop_ratio);
     fprintf(stderr, "    -W INT        discard a chain if seeded bases shorter than INT [0]\n");
     fprintf(stderr, "    -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
+    fprintf(stderr, "    --rescue-kmer[=K]  band the mate-rescue Smith-Waterman to a K-mer exact-match anchor\n");
+    fprintf(stderr, "                  diagonal, falling back to the full insert window when no anchor. K is\n");
+    fprintf(stderr, "                  1..%d (bare = %d, =0 = off); the value must be attached with '='.\n",
+            MEM_RESCUE_KMER_MAX, MEM_RESCUE_KMER_DEFAULT);
+    fprintf(stderr, "                  Opt-in speedup, NOT byte-identical; enabled by --fast [off]\n");
+    fprintf(stderr, "    --rescue-band INT  half-width (bp) of the band around the anchor diagonal, 1..%d [%d]\n",
+            MEM_RESCUE_BAND_MAX, opt->rescue_band);
     fprintf(stderr, "    -S            skip mate rescue\n");
     fprintf(stderr, "    -P            skip pairing; mate rescue performed unless -S also in use\n");
-    fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup\n");
+    fprintf(stderr, "    --fast        speed preset: -m 10 -y 0 --min-ext-len 30 --smem-dedup --rescue-kmer=6\n");
     fprintf(stderr, "                  --skip-contained-ext --max-extend-chains 20 --adaptive-band\n");
     fprintf(stderr, "                  --extend-mate-concordant (under --meth: --max-extend-chains 10,\n");
     fprintf(stderr, "                  -s 2). Opt-in; explicit\n");
@@ -1783,6 +1790,8 @@ int main_mem(int argc, char *argv[])
         OPT_COMPAT,
         OPT_CHUNK_CAP,
         OPT_COHORT_SLICES,
+        OPT_RESCUE_KMER,
+        OPT_RESCUE_BAND,
         OPT_COHORT_RAMP_RATIO,
         OPT_COHORT_RAMP_FIRST,
 #ifdef STAGE_PROF
@@ -1801,6 +1810,8 @@ int main_mem(int argc, char *argv[])
         {"extend-mate-concordant",   optional_argument, 0, OPT_EXTEND_MATE_CONCORDANT},
         {"chunk-cap",                required_argument, 0, OPT_CHUNK_CAP},
         {"cohort-slices",            required_argument, 0, OPT_COHORT_SLICES},
+        {"rescue-kmer",              optional_argument, 0, OPT_RESCUE_KMER},
+        {"rescue-band",              required_argument, 0, OPT_RESCUE_BAND},
         {"cohort-ramp-ratio",        required_argument, 0, OPT_COHORT_RAMP_RATIO},
         {"cohort-ramp-first",        required_argument, 0, OPT_COHORT_RAMP_FIRST},
         {"meth",                     optional_argument, 0, OPT_METH},
@@ -2063,6 +2074,42 @@ int main_mem(int argc, char *argv[])
         }
         else if (c == OPT_SMEM_DEDUP) opt->smem_dedup = 1;
         else if (c == OPT_FAST) fast = 1;
+        else if (c == OPT_RESCUE_KMER) {
+            /* Validated rather than atoi'd for the same reason as --chunk-cap
+             * below: atoi maps every unparseable value to 0, and 0 here means
+             * "off" -- so `--rescue-kmer=x` would silently disable the option it
+             * was meant to configure, and would keep it disabled under --fast
+             * (which defers to any explicitly-set value). K above the uint32 code
+             * width is rejected rather than clamped so `--rescue-kmer=20` cannot
+             * masquerade as a distinct setting from K=16. */
+            int64_t k = MEM_RESCUE_KMER_DEFAULT;   /* bare --rescue-kmer */
+            if (optarg && parse_bounded_i64(optarg, 0, MEM_RESCUE_KMER_MAX, &k) != 0) {
+                fprintf(stderr, "ERROR: --rescue-kmer requires an integer in "
+                                "0..%d (0 = off), got '%s'\n",
+                        MEM_RESCUE_KMER_MAX, optarg);
+                free(opt);
+                if (out_opened) fclose(aux.fp);
+                return 1;
+            }
+            opt->rescue_kmer = (int)k;
+            opt0.rescue_kmer = 1;
+        }
+        else if (c == OPT_RESCUE_BAND) {
+            /* Validated like --rescue-kmer above. A bare atoi accepted both
+             * unparseable text and negatives, and the kernel's `band > 0 ? band
+             * : 50` guard then turned either into the default -- so a typo read
+             * as a deliberate band width but silently ran the default one. */
+            int64_t band = 0;
+            if (parse_bounded_i64(optarg, 1, MEM_RESCUE_BAND_MAX, &band) != 0) {
+                fprintf(stderr, "ERROR: --rescue-band requires an integer in "
+                                "1..%d bp, got '%s'\n",
+                        MEM_RESCUE_BAND_MAX, optarg);
+                free(opt);
+                if (out_opened) fclose(aux.fp);
+                return 1;
+            }
+            opt->rescue_band = (int)band;
+        }
         else if (c == OPT_CHUNK_CAP) {
             /* Validated the same way as --supp-rep-hard-cap below rather than via
              * a bare atoll, which maps every unparseable value to 0 -- and 0 here
@@ -2322,6 +2369,12 @@ int main_mem(int argc, char *argv[])
         if (!opt0.max_matesw)   opt->max_matesw   = 10;  /* -m 10 */
         if (!opt0.max_mem_intv) opt->max_mem_intv = 0;   /* -y 0  */
         if (!opt0.min_ext_len)  opt->min_ext_len  = 30;  /* --min-ext-len 30 */
+        /* Band mate rescue to a 6-mer anchor diagonal (--rescue-kmer=6). Opt-in,
+         * not byte-identical, but truth-based ROC (holodeck, hg38 + bisulfite
+         * chr20) shows accuracy neutral-to-positive and confident (MAPQ>=60)
+         * mismaps unchanged; k=6 is the measured wall-time peak (~-22% on the
+         * rescue-heavy WGS tail). */
+        if (!opt0.rescue_kmer)  opt->rescue_kmer  = MEM_RESCUE_KMER_DEFAULT;
         /* --max-extend-chains: 5 for non-meth; 10 under --meth. A 7-point ablation
          * ({0,5,10,20,50,100,1000}) on 1M sim-meth PE pairs (with mate-concordant
          * rescue on, below) shows chr-accuracy flat (0.9908) at every cap but the
@@ -2508,15 +2561,20 @@ int main_mem(int argc, char *argv[])
          * grep for, this line is the only record a run leaves of a lever that
          * changes output (see the comparator commentary in src/bwamem.cpp). It is
          * not meth-gated, so it appears on both branches. */
+        /* --rescue-kmer reports its RESOLVED K, and reports `=0` when the user opted
+         * back out, because 0 is the one --fast lever whose off-state is invisible
+         * anywhere else in the run -- it changes MAPQ on rescued reads, so which way
+         * it resolved has to be on the record. It applies under --meth too (the
+         * anchor scan collapses to 3 letters there), so it is on both branches. */
         if (opt->meth_mode)
             /* --skip-contained-ext is set but no-ops under --meth (internal gate), so it is
              * intentionally omitted from the meth audit line to reflect the effective levers.
              * --adaptive-band is set unconditionally and applies under --meth, so it stays. */
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --max-extend-chains %d --adaptive-band -s %d --extend-mate-concordant alnreg-sort=fast\n",
-                    __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains, opt->split_width);
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --max-extend-chains %d --adaptive-band -s %d --extend-mate-concordant --rescue-kmer=%d alnreg-sort=fast\n",
+                    __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains, opt->split_width, opt->rescue_kmer);
         else
-            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d --adaptive-band --extend-mate-concordant alnreg-sort=fast\n",
-                    __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains);
+            fprintf(stderr, "[M::%s] --fast: -m %d -y %ld --min-ext-len %d --smem-dedup --skip-contained-ext --max-extend-chains %d --adaptive-band --extend-mate-concordant --rescue-kmer=%d alnreg-sort=fast\n",
+                    __func__, opt->max_matesw, (long)opt->max_mem_intv, opt->min_ext_len, opt->max_extend_chains, opt->rescue_kmer);
         /* --fast also caps the batch size, which keeps the read/compute/write
          * pipeline overlapped at high -t. It re-partitions the input and so is not
          * byte-identical -- which --fast already is not -- hence it rides here

--- a/test/fast_preset_test.sh
+++ b/test/fast_preset_test.sh
@@ -3,8 +3,8 @@
 #
 # Asserts that `bwa-mem3 mem --fast` resolves the characterized speed levers
 # (-m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext
-# --max-extend-chains 20 --extend-mate-concordant, plus -s 2 and a lower
-# --max-extend-chains 10 under --meth), that explicit user flags override the
+# --max-extend-chains 20 --extend-mate-concordant --rescue-kmer=6, plus -s 2 and a
+# lower --max-extend-chains 10 under --meth), that explicit user flags override the
 # preset, and that the default path is untouched when --fast is absent.
 # --skip-contained-ext no-ops under --meth (internal gate), so it is omitted from
 # the meth audit line; --max-extend-chains applies under --meth too but at a
@@ -53,11 +53,12 @@ line="$(fast_line --fast)"
    && "$line" == *"--max-extend-chains 20"* \
    && "$line" == *"--adaptive-band"* \
    && "$line" == *"--extend-mate-concordant"* \
+   && "$line" == *"--rescue-kmer=6"* \
    && "$line" == *"alnreg-sort=fast"* ]] \
     || { echo "FAIL: --fast bundle wrong: '$line'" >&2; exit 1; }
 [[ "$line" != *"-s "* ]] \
     || { echo "FAIL: non-meth --fast must not set -s: '$line'" >&2; exit 1; }
-echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 20 --adaptive-band --extend-mate-concordant alnreg-sort=fast (no -s)"
+echo "OK:   --fast bundle resolves -m 10 -y 0 --min-ext-len 30 --smem-dedup --skip-contained-ext --max-extend-chains 20 --adaptive-band --extend-mate-concordant --rescue-kmer=6 alnreg-sort=fast (no -s)"
 
 # 2. Override precedence: an explicit flag wins *only* for its own field; the
 #    rest of the preset (including the unconditional --smem-dedup) must survive.
@@ -96,6 +97,22 @@ line="$(fast_line --fast --max-extend-chains 8)"
     || { echo "FAIL: explicit --max-extend-chains 8 should only override that lever: '$line'" >&2; exit 1; }
 echo "OK:   explicit -m/-y/--min-ext-len/--max-extend-chains override only their field; rest of preset (--adaptive-band, --extend-mate-concordant, alnreg-sort=fast, ...) survives"
 
+# --rescue-kmer is overridable both ways under --fast. The `=0` case is the one
+# that matters: 0 means "off", so a parser that treated an explicitly-set 0 as
+# "unset" would silently re-enable the preset's K=6 -- and since --rescue-kmer
+# changes MAPQ on rescued reads, that is an invisible output change. The value
+# must be attached with `=`: the option takes an OPTIONAL argument, so a
+# space-separated `--rescue-kmer 0` would leave 0 as a positional instead.
+line="$(fast_line --fast --rescue-kmer=0)"
+[[ "$line" == *"-m 10"* && "$line" == *"--smem-dedup"* \
+   && "$line" == *"--rescue-kmer=0"* \
+   && "$line" == *"alnreg-sort=fast"* ]] \
+    || { echo "FAIL: explicit --rescue-kmer=0 should opt out of just that lever: '$line'" >&2; exit 1; }
+line="$(fast_line --fast --rescue-kmer=11)"
+[[ "$line" == *"--rescue-kmer=11"* && "$line" == *"--max-extend-chains 20"* ]] \
+    || { echo "FAIL: explicit --rescue-kmer=11 should override the preset K: '$line'" >&2; exit 1; }
+echo "OK:   explicit --rescue-kmer=0/=11 overrides the preset K without disturbing the rest"
+
 # 3. Default contract: no --fast => no audit line at all.
 "$bin" mem "$ref" "$reads" >/dev/null 2>"$err" || { echo "FAIL: plain mem nonzero" >&2; exit 1; }
 ! grep -qE '^\[M::main_mem\] --fast:' "$err" \
@@ -117,6 +134,10 @@ if "$bin" index --meth "$mdir/ref.fa" >/dev/null 2>&1; then
         || { echo "FAIL: --max-extend-chains applies under --meth (cap 10); must be in audit line: '$line'" >&2; exit 1; }
     [[ "$line" == *"--extend-mate-concordant"* ]] \
         || { echo "FAIL: --fast --meth must enable --extend-mate-concordant: '$line'" >&2; exit 1; }
+    # --rescue-kmer applies under --meth as well (the anchor scan collapses to the
+    # pair's bisulfite alphabet there), so the meth audit line must report it too.
+    [[ "$line" == *"--rescue-kmer=6"* ]] \
+        || { echo "FAIL: --fast --meth must enable --rescue-kmer=6: '$line'" >&2; exit 1; }
     # The dedup-sort lever is not meth-gated; it must be reported under --meth too.
     [[ "$line" == *"alnreg-sort=fast"* ]] \
         || { echo "FAIL: --fast --meth must enable alnreg-sort=fast: '$line'" >&2; exit 1; }

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -21,6 +21,7 @@ Each script:
 | `default_hd_parity.sh`       | default `@HD` byte-identical across SAM/`--bam`/`--meth` (#288)        | "default @HD parity across output paths"            |
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
 | `cohort_ramp_validation.sh`  | `--cohort-ramp-first`/`-ratio` reject malformed values; env warns and falls back | "Cohort ramp values are validated (flag and environment alike)" |
+| `rescue_kmer_options.sh`     | `--rescue-kmer`/`--rescue-band` reject malformed and out-of-range values; the `=` form is required | "--rescue-kmer/--rescue-band reject malformed values" |
 | `profile_slice_cpu.sh`       | `--profile` accounts for a partial cohort slice's compute CPU (needs `STAGE_PROF=1`) | "Partial cohort slices report their compute CPU"    |
 
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is

--- a/test/regression/rescue_kmer_options.sh
+++ b/test/regression/rescue_kmer_options.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# test/regression/rescue_kmer_options.sh
+#
+# Regression: --rescue-kmer / --rescue-band must reject malformed and
+# out-of-range values instead of silently substituting a working default.
+#
+# Both options were originally parsed with atoi(), which maps every unparseable
+# string to 0. For --rescue-kmer, 0 means "off" AND counts as an explicitly-set
+# value, so `--fast --rescue-kmer=x` would disable the single largest lever in
+# --fast while looking accepted. For --rescue-band, both unparseable text and a
+# negative value produced a number the kernel's `band > 0 ? band : 50` guard
+# then turned back into the default -- so a typo read as a deliberate band width
+# but quietly ran the default one. Neither failure is visible in the output:
+# --rescue-kmer only moves MAPQ on rescued reads.
+#
+# This test pins the contract:
+#   * --rescue-kmer  -> integer in 0..16 (0 = off); anything else is a hard error
+#   * --rescue-band  -> integer in 1..1000000 bp; anything else is a hard error
+#   * the K bound matches the uint32 k-mer encoder, so K=17.. is REJECTED rather
+#     than silently clamped to 16 and reported as a distinct setting
+#   * the value must be attached with `=`: --rescue-kmer takes an *optional*
+#     argument, so `--rescue-kmer 6` selects the bare default and leaves 6 as a
+#     positional argument. This is the whole reason the docs and --help spell the
+#     --fast expansion as --rescue-kmer=6.
+#
+# Inputs:
+#   BWA_MEM3 — path to bwa-mem3 binary
+#   FIXTURES — directory containing phix.fa and reads.fa (default: test/fixtures)
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+FIXTURES="${FIXTURES:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../fixtures" && pwd)}"
+
+src_ref="$FIXTURES/phix.fa"
+reads="$FIXTURES/reads.fa"
+[[ -x "$BWA_MEM3" ]] || { echo "FAIL: binary not executable: $BWA_MEM3" >&2; exit 1; }
+[[ -s "$src_ref" ]]  || { echo "FAIL: phix.fa missing: $src_ref" >&2; exit 1; }
+[[ -s "$reads" ]]    || { echo "FAIL: reads.fa missing: $reads" >&2; exit 1; }
+
+# Index a private copy so the test never writes into the fixtures tree.
+mdir="$(mktemp -d)"; err="$mdir/err.log"
+trap 'rm -rf "$mdir"' EXIT
+ref="$mdir/phix.fa"
+cp "$src_ref" "$ref"
+"$BWA_MEM3" index "$ref" >/dev/null 2>&1 || { echo "FAIL: index phix.fa" >&2; exit 1; }
+
+fails=0
+
+# $1 = full option word (e.g. --rescue-kmer=abc), $2 = expected diagnostic substring.
+# Always uses the `=` form so a leading '-' in the value is not taken for another
+# option.
+reject() {
+    local optword="$1" want="$2" rc
+    set +e
+    "$BWA_MEM3" mem "$optword" "$ref" "$reads" >/dev/null 2>"$err"
+    rc=$?
+    set -e
+    if [[ "$rc" -eq 0 ]]; then
+        echo "FAIL: '$optword' was accepted; expected a non-zero exit"
+        fails=$((fails + 1))
+    elif ! grep -q "$want" "$err"; then
+        echo "FAIL: '$optword' exited $rc but without the expected diagnostic ('$want')"
+        fails=$((fails + 1))
+    else
+        echo "  ok: '$optword' rejected"
+    fi
+}
+
+# $1 = full option word that must be ACCEPTED (the run itself must succeed).
+accept() {
+    local optword="$1"
+    if "$BWA_MEM3" mem "$optword" "$ref" "$reads" >/dev/null 2>"$err"; then
+        echo "  ok: '$optword' accepted"
+    else
+        echo "FAIL: '$optword' was rejected; expected it to run"
+        cat "$err" >&2
+        fails=$((fails + 1))
+    fi
+}
+
+kmer_err='ERROR: --rescue-kmer requires an integer in 0..16'
+band_err='ERROR: --rescue-band requires an integer in 1..1000000 bp'
+
+# --- --rescue-kmer -----------------------------------------------------------
+reject "--rescue-kmer=abc" "$kmer_err"   # not a number at all -> would have meant "off"
+reject "--rescue-kmer=6x"  "$kmer_err"   # trailing junk: partial parse must not pass
+reject "--rescue-kmer=-1"  "$kmer_err"   # negative
+# Above the uint32 k-mer code width. Rejected rather than clamped: a clamped K=20
+# behaves exactly as K=16, so accepting it would report a setting that does not
+# exist. This is also what the documented 1..16 range promises.
+reject "--rescue-kmer=17"  "$kmer_err"
+reject "--rescue-kmer=20"  "$kmer_err"
+
+accept "--rescue-kmer"     # bare: selects the default K
+accept "--rescue-kmer=0"   # explicit off
+accept "--rescue-kmer=1"   # low edge
+accept "--rescue-kmer=16"  # high edge -- must be INSIDE the accepted range
+
+# --- --rescue-band -----------------------------------------------------------
+reject "--rescue-band=abc"     "$band_err"
+reject "--rescue-band=50bp"    "$band_err"   # trailing suffix: the option takes plain bp
+reject "--rescue-band=-5"      "$band_err"   # negative
+# 0 is rejected rather than accepted-and-ignored: it reads as "no band" but the
+# kernel's `band > 0 ? band : 50` guard would have silently run the 50 bp default.
+reject "--rescue-band=0"       "$band_err"
+reject "--rescue-band=1000001" "$band_err"   # above the documented cap
+
+accept "--rescue-band=1"
+accept "--rescue-band=1000000"
+
+# --- the value must be attached with `=` -------------------------------------
+# --rescue-kmer takes an optional argument, so getopt_long never consumes a
+# following word: `mem --rescue-kmer 6 ref reads` leaves THREE positionals, and
+# `6` is taken as the index base. Pinning this keeps the docs and the --help
+# --fast expansion honest about the `=` form.
+set +e
+"$BWA_MEM3" mem --rescue-kmer 6 "$ref" "$reads" >/dev/null 2>"$err"
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+    echo "FAIL: '--rescue-kmer 6' (space-separated) unexpectedly succeeded;"
+    echo "      it should leave 6 as a positional argument"
+    fails=$((fails + 1))
+elif ! grep -q '6\.bwt\.2bit\.64' "$err"; then
+    echo "FAIL: '--rescue-kmer 6' should have tried to open '6' as the index base"
+    cat "$err" >&2
+    fails=$((fails + 1))
+else
+    echo "  ok: '--rescue-kmer 6' leaves 6 as a positional (the '=' form is required)"
+fi
+
+if [[ "$fails" -ne 0 ]]; then
+    echo "FAIL: rescue-kmer option validation ($fails failure(s))"
+    exit 1
+fi
+echo "PASS: --rescue-kmer/--rescue-band reject malformed and out-of-range values"


### PR DESCRIPTION
## What

`--rescue-kmer[=K]` (off by default, enabled by `--fast`, default K=6) bands the mate-rescue Smith-Waterman to a K-mer exact-match anchor diagonal instead of scanning the full insert-size window. On paired WGS this is the largest single speed lever in the aligner.

## Why

Mate rescue SW-aligns a read against a reference window sized by the insert distribution — ~1 kb for a 150 bp read — and that window is **unbanded** (unlike seed extension, there's no known diagonal). A call-graph profile on WGS PE puts the rescue kernel (`kswv`, reached via `worker_sam → mem_sam_pe_batch → mem_sam_pe_batch_run`) at **~36% of compute** — bigger than seed extension. The window is huge precisely because the diagonal is unknown.

## How

Give the kernel a **diagonal**. A K-mer exact-match vote over the window is a cross-correlation: the true diagonal collects a vote at every matching base (~majority of the read) and towers over the ~`1/alphabet` background, so even small K lands on the right diagonal. Band the window to that diagonal ± `--rescue-band` (default 50 bp) and hand the *shorter* window to `kswv` — **the kernel is unchanged**, the win is fewer DP cells.

Three pieces:
- **Anchor scan** (`matesw_kmer_narrow`): open-addressing hash of the read's K-mers, O(read+window), fixed vote floor + full-window fallback.
- **Compute-once**: the narrowing offset is computed in `mem_matesw_batch_pre` and stored per `regid`; `mem_matesw_batch_post` reads it back (no re-scan).
- **Length-sort**: narrowed pairs are sorted by window length before the batched kernel so short windows group together (`getScores8` runs each 16-lane group to the group's longest window; a stray full window would otherwise negate the saving). Result-safe — `aln[]`/offsets are `regid`-keyed and `seqBuf*` by `idr/idq`, all travel with the `SeqPair`.

Under `--meth` the anchor scan collapses to three letters on each pair's bisulfite strand (C→T for OT, G→A for OB) so exact K-mers survive the conversion; the SW still scores the real bases with the methylation matrix.

## Not byte-identical — off by default

A narrowed window computes a different suboptimal score, so a rescued read's `csub` → MAPQ can change (~0.2% of records move). So it is **off by default** and enabled by `--fast` (the accuracy-tradeoff preset). `--rescue-kmer 0` opts back out even under `--fast`.

## Validation

**Byte-identity (off):** full-run SAM md5 (excl `@PG`) equals the parent commit at fixed `-t`, WGS 1M pairs. PASS.

**Accuracy (truth-based ROC, holodeck):** swept K = 1…20.

| | non-meth (sim hg38 WGS, 2.14M pairs) | meth (bisulfite chr20, 644k pairs) |
|---|---|---|
| correct vs baseline (K=0) | −5 … −53 reads (≤0.001%) | **0 … +24 reads** |
| **confident mismap (MAPQ ≥ 60)** | **272 at every K (unchanged)** | **37 at every K (unchanged)** |

MAPQ calibration holds — the reads that move all land in the MAPQ=0 bin (correctly flagged low-confidence). Meth is neutral-to-*positive*.

**Wall (Graviton4, arm64/NEON, `mem -t16`, 1M WGS pairs):** U-shaped in K —

| K | 1 | 2 | 4 | **6** | 8 | 12 | 16–20 |
|---|---|---|---|---|---|---|---|
| vs base | +45% (slower) | −5% | −20% | **−22%** | −19% | −17% | −17% |

k=1 is slower because the vote's hash chains grow as `read_length / alphabet^K`; the peak is **k=6**, hence the `--fast` default.

## Docs

`docs/src/cli/mem.md` gets a `--rescue-kmer` / `--rescue-band` section and the `--fast` preset is updated (equivalence line + rationale). Generated CLI help regenerated.

## Honest gaps (follow-ups)

- **Meth *wall* not measured on a box** (accuracy + 99.7% fire rate + the scan-cost argument support k=6; a meth wall-vs-K curve would confirm). The length-sort currently applies to the non-meth batch driver only, so meth perf is un-optimized.
- ROC is **simulated** (holodeck); a real-data concordance spot-check is the ideal final gate.

## Reading order

1. `matesw_kmer_narrow` (the anchor scan) in `src/bwamem_pair.cpp`.
2. The `mem_matesw_batch_pre` narrowing + offset store, then `mem_matesw_batch_post` offset read.
3. The length-sort in `mem_sam_pe_batch`.
4. `src/fastmap.cpp` (knob + `--fast` wiring) and `src/bwamem.{h,cpp}`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional k-mer-anchored mate rescue to improve alignment efficiency while retaining full-window fallback.
  * Added `--rescue-kmer[=K]` and `--rescue-band` command-line options.
  * Updated `--fast` to enable k-mer rescue with a default value of 6.
  * Added support for disabling or overriding rescue settings explicitly.

* **Bug Fixes**
  * Added validation and clear rejection of malformed or out-of-range rescue option values.

* **Documentation**
  * Documented defaults, methylation handling, fallback behavior, performance, accuracy, and output differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->