### PR TITLE
ci: check the opt-in debug macro list against the macros in src/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,26 @@ jobs:
       - name: No NDEBUG preprocessor gates in src/
         run: bash test/regression/ndebug_gate_lint.sh
 
+  # Same shape and rationale as the job above, kept separate so the failure
+  # reads as "the opt-in macro list drifted" rather than as an NDEBUG finding.
+  debug-macro-flag-lint:
+    name: Opt-in debug macro list (ci.yml <-> src/)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      # Runs first, for the same reason as the NDEBUG job: an empty flag set
+      # satisfies every check over it, so PASS only means something once the
+      # extraction has been shown to still detect a drifted list.
+      - name: Macro list lint still detects drift
+        run: bash test/regression/debug_macro_flag_lint_selftest.sh
+
+      - name: Opt-in macro -D list matches the macros in src/
+        run: bash test/regression/debug_macro_flag_lint.sh
+
   build-and-test:
     strategy:
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -850,6 +850,8 @@ test: test-binaries $(STANDALONE_TESTS_IN_TEST_TARGET) bwa-mem3
 	BWA_MEM3=./bwa-mem3 ./test/regression/meth_rescue_batched_identical.sh
 	./test/regression/ndebug_gate_lint_selftest.sh
 	./test/regression/ndebug_gate_lint.sh
+	./test/regression/debug_macro_flag_lint_selftest.sh
+	./test/regression/debug_macro_flag_lint.sh
 
 # Regression test that requires a binary built with TESTING_BUILD=1
 # (enables BWAMEM3_TESTING_HOST_TIER env-var injection). Not invoked by

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -25,6 +25,8 @@ from the `ndebug-gate-lint` job. Each script:
 | `profile_slice_cpu.sh`       | `--profile` accounts for a partial cohort slice's compute CPU (needs `STAGE_PROF=1`) | "Partial cohort slices report their compute CPU"    |
 | `ndebug_gate_lint.sh`        | no `#if`/`#ifdef`/`#ifndef`/`#elif` NDEBUG gates in `src/` — nothing here defines NDEBUG, so they never compile out | "No NDEBUG preprocessor gates in src/"              |
 | `ndebug_gate_lint_selftest.sh` | the lint above still flags real gates, so its `PASS` means something | "NDEBUG gate lint still detects gates"              |
+| `debug_macro_flag_lint.sh`   | the opt-in macro build's `-D` list and the `BWA_MEM3_DEBUG_*` macros in `src/` still name each other | "Opt-in macro -D list matches the macros in src/"   |
+| `debug_macro_flag_lint_selftest.sh` | the lint above still detects a drifted list, so its `PASS` means something | "Macro list lint still detects drift"               |
 
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is
 the authoritative list, and `ci.yml` is where each one is actually wired up.

--- a/test/regression/debug_macro_flag_lint.sh
+++ b/test/regression/debug_macro_flag_lint.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# Keep the opt-in debug/instrumentation macro list in ci.yml and the macros in
+# src/ pointing at each other.
+#
+# ci.yml has one step that rebuilds with every opt-in debug macro enabled and
+# reruns the chr22 parity check, so the guarded code is compiled and exercised
+# rather than left to rot (see the "Opt-in debug/instrumentation macro build"
+# step). That step is only worth anything if its `-D` flags name macros that
+# actually exist. Two ways it silently stops being worth anything:
+#
+#   - A flag names no macro. The build compiles it into nothing, the parity
+#     check passes, and the check the flag was supposed to enable never runs.
+#     This is not hypothetical: the flags for three checks were added ahead of
+#     the PRs introducing them, so for a while the step really was enabling
+#     nothing for those three. Two have since landed and matched; one has not.
+#     A rename of one character during review would have been invisible.
+#
+#   - A macro exists but no flag names it. A new BWA_MEM3_DEBUG_* check added
+#     to src/ without a corresponding -D is never compiled by any CI row --
+#     the exact gap the step was added to close, reopened one macro at a time.
+#
+# So this lint checks both directions. It is the same failure this repository
+# keeps rediscovering: a check that reads as green while doing no work. See
+# test/regression/ndebug_gate_lint.sh for the sibling case.
+#
+# Scope note: the reverse direction is restricted to the BWA_MEM3_DEBUG_ prefix
+# because that is the one unambiguous naming convention for this family. Build
+# mode switches (STAGE_PROF, DISABLE_OUTPUT, COVERAGE) have their own CI rows
+# and are deliberately not in scope here.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+if (( $# > 1 )); then
+    echo "usage: ${BASH_SOURCE[0]##*/} [repo-root-to-check]" >&2
+    exit 2
+fi
+
+# Optional argument so debug_macro_flag_lint_selftest.sh can aim the same
+# checks at a fixture tree; there is no other way to tell "the lists agree"
+# apart from "the extraction stopped extracting".
+if (( $# == 1 )); then
+    cd "$1"
+fi
+
+workflow=".github/workflows/ci.yml"
+src_dir="src"
+
+for required in "$workflow" "$src_dir"; do
+    if [[ ! -e $required ]]; then
+        echo "FAIL: $required missing under $PWD -- nothing was checked" >&2
+        exit 1
+    fi
+done
+
+# Existing is not the same as usable, and the type errors do not announce
+# themselves: `grep` over a directory named ci.yml reads nothing, so the flag
+# list looks absent and the failure below blames a restructured step; `find`
+# over a regular file named src finds no sources, so the failure blames an empty
+# preprocessor set. Both exit nonzero either way, but both name the wrong bug.
+if [[ ! -f $workflow ]]; then
+    echo "FAIL: $workflow is not a regular file -- nothing was checked" >&2
+    exit 1
+fi
+if [[ ! -d $src_dir ]]; then
+    echo "FAIL: $src_dir is not a directory -- nothing was checked" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Deliberately-ahead-of-the-code flags.
+#
+# A flag may name a macro that does not exist yet when it is added ahead of the
+# PR introducing the check, which avoids a follow-up CI edit. That is fine, but
+# it has to be stated here with a reason, so the exemption is a line a reviewer
+# sees rather than silence. Delete the entry when the check lands.
+# ---------------------------------------------------------------------------
+pending_flags=(
+    # Enabled ahead of the ungapped-CIGAR fast-path change that introduces it.
+    BWA_MEM3_DEBUG_UNGAPPED_XCHECK
+)
+
+# ---------------------------------------------------------------------------
+# Fold `\`-continued lines into one logical line.
+#
+# Every match below is line-oriented, and both of the constructs they match --
+# a preprocessor conditional and a shell assignment -- can be split across
+# physical lines. src/ already splits conditions that way today. A grep that
+# reads only the first physical line silently drops what the rest carries,
+# which is the same set-shrinking failure the `\b` note further down guards
+# against: the dropped macro is never required to have a -D, so the reverse
+# check stops covering it and says nothing.
+#
+# A file whose last line ends in `\` would join across a file boundary below,
+# but that is undefined behaviour in C anyway, and the only consequence here is
+# one spurious identifier in the set -- which fails loudly rather than quietly.
+# ---------------------------------------------------------------------------
+join_continuations() {
+    sed -e ':a' -e '/\\$/{$!{N;s/\\\n/ /;ba' -e '}' -e '}'
+}
+
+# ---------------------------------------------------------------------------
+# The -D flags the opt-in macro build passes.
+#
+# Anchored on the single EXTRA_CXXFLAGS line carrying the family prefix rather
+# than on a step name or line number, either of which drifts silently. Zero or
+# several matches means the step was restructured and this extraction no longer
+# describes it -- a hard error, not a quiet empty list.
+#
+# Comment lines are dropped first, then both terms are required. Requiring both
+# terms alone is not enough: a comment that quotes the assignment carries both,
+# and would count as a second "flag list" -- a spurious restructured-step failure
+# pointing at the wrong cause. Dropping comments is right under either reading of
+# such a line, since `#` opens a comment in YAML and in the shell of a `run: |`
+# block alike. A trailing `# ...` on a real flag line is untouched; only a line
+# whose first character is `#` is one.
+#
+# Comments are dropped before joining, not after. A `#` comment runs to the end
+# of its physical line in both languages -- a trailing `\` inside one continues
+# nothing -- so joining first would let a comment absorb the real flag list and
+# then discard both, reporting the list as absent.
+#
+# Numbered before either step: the number a wrapped list reports has to be the
+# line the reader can go and look at, and numbering the joined stream would count
+# logical lines the file does not have. The comment filter therefore has to skip
+# that `N:` prefix to find the line's first real character.
+# ---------------------------------------------------------------------------
+flag_lines="$(grep -n '' "$workflow" \
+    | grep -vE '^[0-9]+:[[:space:]]*#' \
+    | join_continuations \
+    | grep 'EXTRA_CXXFLAGS' | grep 'DBWA_MEM3_DEBUG' || true)"
+flag_line_count="$(printf '%s' "$flag_lines" | grep -c . || true)"
+
+if [[ $flag_line_count -ne 1 ]]; then
+    echo "FAIL: expected exactly one -DBWA_MEM3_DEBUG flag list in $workflow," >&2
+    echo "found $flag_line_count. The opt-in macro build step was restructured;" >&2
+    echo "update the extraction in ${BASH_SOURCE[0]##*/} to match." >&2
+    [[ -n $flag_lines ]] && printf '%s\n' "$flag_lines" >&2
+    exit 1
+fi
+
+ci_flags="$(printf '%s' "$flag_lines" \
+    | grep -oE '\-D[A-Za-z_][A-Za-z0-9_]*' \
+    | sed 's/^-D//' | sort -u)"
+
+if [[ -z $ci_flags ]]; then
+    echo "FAIL: no -D flags parsed out of $workflow -- nothing was checked" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Macro names that appear in a real preprocessor conditional under src/.
+#
+# Identifiers are pulled with an explicit character class, never `\b` -- that
+# is a GNU extension an implementation may read as a literal `b`, which would
+# empty this set and make every check below vacuously pass.
+#
+# C comments are stripped off the directive line first, the same way YAML
+# comments are stripped off the flag line above. A trailing `// see also
+# BWA_MEM3_DEBUG_X` is routine, and without this the name lands in the set as
+# though a conditional tested it -- so the reverse check demands a -D for a macro
+# that gates nothing, reporting that src/ gates code on it when src/ does not.
+# The obvious way to silence that is to add the flag, which then enables a macro
+# no conditional tests: the forward-direction hole this lint exists to close,
+# reopened by its own false alarm.
+#
+# Stripped after the directive-line match, not before, so a commented-out
+# directive stays excluded rather than becoming eligible once its `//` is gone.
+#
+# Only comments that run to the end of the line are stripped: a `//` tail, a
+# `/* ... */` that ends the line, and an unterminated `/*` tail. A closed
+# `/* ... */` with code after it is deliberately left alone, because no portable
+# BRE distinguishes it from the trailing case without risking the code that
+# follows -- and getting that wrong drops a real macro, which is silent, while
+# leaving a comment in only ever keeps an extra identifier, which is loud. Bias
+# the residual case toward the failure a reader will see.
+#
+# No `\|` alternation, for the reason the `\b` note gives: it is a GNU extension
+# that BSD sed reads as a literal `|`, and here that silently dropped the second
+# macro of a two-macro condition. The `[[:space:]]*$` anchor and the negated
+# `/\*\//` address below are portable BRE and behave identically on both.
+# ---------------------------------------------------------------------------
+src_macros="$(find "$src_dir" -type f \( \
+        -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.cxx' -o \
+        -name '*.h' -o -name '*.hh' -o -name '*.hpp' -o -name '*.hxx' \) \
+        -exec cat {} + 2>/dev/null \
+    | join_continuations \
+    | grep -E '^[[:space:]]*#[[:space:]]*(if|ifdef|ifndef|elif)' \
+    | sed -e 's://.*::' \
+          -e 's:/\*.*\*/[[:space:]]*$: :' \
+          -e '/\*\//!s:/\*.*$: :' \
+    | grep -oE '[A-Za-z_][A-Za-z0-9_]*' | sort -u || true)"
+
+if [[ -z $src_macros ]]; then
+    echo "FAIL: no preprocessor conditionals found under $src_dir/ -- nothing was checked" >&2
+    exit 1
+fi
+
+# Membership tests use a herestring rather than `printf ... | grep -q`. Under
+# `set -o pipefail`, `grep -q` exits on its first match, printf is killed by
+# SIGPIPE, and the pipeline reports 141 -- so a match reads as a miss. It only
+# bites once the text outgrows the pipe buffer, which is exactly the kind of
+# bug that lies dormant until the list it scans gets longer.
+failures=0
+
+# Forward: every flag the CI step passes must name a macro src/ actually tests.
+while IFS= read -r flag; do
+    [[ -z $flag ]] && continue
+    if grep -qx -- "$flag" <<< "$src_macros"; then
+        continue
+    fi
+    exempt=0
+    # `${a[@]+"${a[@]}"}` rather than `"${a[@]}"`: the pending_flags block above
+    # tells the maintainer to delete the entry when the check lands, and bash
+    # before 4.4 (3.2 ships on macOS, and this script runs under `#!/bin/bash`)
+    # treats the plain expansion of an empty array under `set -u` as an unbound
+    # variable and aborts.
+    for pending in ${pending_flags[@]+"${pending_flags[@]}"}; do
+        [[ $flag == "$pending" ]] && exempt=1 && break
+    done
+    if (( exempt )); then
+        echo "note: $flag names no macro in $src_dir/ yet (listed as pending)"
+    else
+        echo "FAIL: $workflow passes -D$flag, but no preprocessor conditional in" >&2
+        echo "      $src_dir/ tests it. The opt-in build compiles it into nothing," >&2
+        echo "      so whatever check it was meant to enable never runs. Fix the" >&2
+        echo "      name, or add it to pending_flags with a reason if the check" >&2
+        echo "      has not landed yet." >&2
+        failures=$((failures + 1))
+    fi
+done <<< "$ci_flags"
+
+# Reverse: every BWA_MEM3_DEBUG_* macro in src/ must be enabled by that step.
+while IFS= read -r macro; do
+    [[ -z $macro ]] && continue
+    case "$macro" in BWA_MEM3_DEBUG_*) ;; *) continue ;; esac
+    if grep -qx -- "$macro" <<< "$ci_flags"; then
+        continue
+    fi
+    echo "FAIL: $src_dir/ gates code on $macro, but the opt-in macro build in" >&2
+    echo "      $workflow does not pass -D$macro. No CI row compiles that code," >&2
+    echo "      so it can rot unnoticed. Add it to the EXTRA_CXXFLAGS list." >&2
+    failures=$((failures + 1))
+done <<< "$src_macros"
+
+if (( failures > 0 )); then
+    echo "FAIL: debug_macro_flag_lint ($failures problem(s))" >&2
+    exit 1
+fi
+
+echo "PASS: debug_macro_flag_lint (ci.yml -D list and src/ macros agree)"

--- a/test/regression/debug_macro_flag_lint_selftest.sh
+++ b/test/regression/debug_macro_flag_lint_selftest.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# test/regression/debug_macro_flag_lint_selftest.sh
+#
+# Regression: debug_macro_flag_lint.sh still detects a list that has drifted.
+#
+# The lint prints PASS when the two lists agree -- and also when its extraction
+# has quietly stopped extracting, because an empty flag set trivially satisfies
+# every check over it. Those two states are indistinguishable from CI, which is
+# the same "green while doing no work" failure the lint exists to catch. The
+# only way to separate them is to hand it lists that have drifted and confirm
+# it says so.
+#
+# Fixtures are generated per case: a minimal .github/workflows/ci.yml carrying
+# an EXTRA_CXXFLAGS line, plus a src/ holding preprocessor conditionals.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+lint="$PWD/test/regression/debug_macro_flag_lint.sh"
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+
+failures=0
+case_seq=0
+
+# Build a fixture repo: $1 = the EXTRA_CXXFLAGS line body, $2 = src/ content,
+# $3 = optional text appended after the assignment's closing quote.
+#
+# Each call gets its own directory rather than reusing one path. Several cases
+# below build a fixture and then append to its ci.yml; sharing a path would make
+# those mutations survive only as long as no other case is built in between, and
+# a clobbered fixture still reports `ok` against whatever replaced it.
+#
+# The flags body goes through printf, not echo: some of it carries a literal
+# backslash-newline to exercise a wrapped assignment, and echo may interpret it.
+build_fixture() {
+    local flags="$1" src_body="$2" line_suffix="${3-}" dir
+
+    case_seq=$((case_seq + 1))
+    dir="$fixture_root/case-$case_seq"
+    mkdir -p "$dir/.github/workflows" "$dir/src"
+    {
+        printf 'jobs:\n  build:\n    steps:\n      - run: |\n'
+        printf '          make EXTRA_CXXFLAGS="%s"%s\n' "$flags" "$line_suffix"
+    } > "$dir/.github/workflows/ci.yml"
+    printf '%s\n' "$src_body" > "$dir/src/fixture.cpp"
+    printf '%s' "$dir"
+}
+
+# $1 = description, $2 = PASS|FAIL, $3 = flags line, $4 = src content,
+# $5 = optional substring the output must contain.
+#
+# The exit status alone is not discriminating: the lint exits 1 from several
+# distinct checks, and it also exits 1 when it aborts outright (an unbound
+# variable under `set -u`, say). Without $5 a case that means to exercise one
+# branch is satisfied by any other -- including a crash -- so each drift case
+# below pins the message that names its own branch.
+check_case() {
+    local description="$1" expected="$2" expect_text="${5-}" dir
+    dir="$(build_fixture "$3" "$4")"
+
+    local output status verdict
+    output="$(bash "$lint" "$dir" 2>&1)" && status=0 || status=$?
+    case "$status" in
+        0) verdict=PASS ;;
+        1) verdict=FAIL ;;
+        *) verdict="ERROR(exit $status)" ;;
+    esac
+
+    if [[ "$verdict" == "$expected" ]] \
+        && [[ -z $expect_text || "$output" == *"$expect_text"* ]]; then
+        echo "  ok   $description -> $verdict"
+    else
+        echo "  FAIL $description: expected $expected${expect_text:+ matching \"$expect_text\"}, got $verdict" >&2
+        printf '%s\n' "$output" | sed 's/^/       /' >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# $1 = description, $2 = fixture dir, $3 = expected exit status,
+# $4 = optional substring the output must contain.
+#
+# Sibling of check_case for the cases that have to mutate a fixture after
+# build_fixture returns, which check_case cannot express. Same reason for
+# pinning the message: "nonzero" alone is satisfied by a syntax error or by an
+# unrelated early guard firing first, neither of which is the branch under test.
+check_dir() {
+    local description="$1" dir="$2" expect_status="$3" expect_text="${4-}"
+
+    local output status
+    output="$(bash "$lint" "$dir" 2>&1)" && status=0 || status=$?
+
+    if (( status == expect_status )) \
+        && [[ -z $expect_text || "$output" == *"$expect_text"* ]]; then
+        echo "  ok   $description -> exit $status"
+    else
+        echo "  FAIL $description: expected exit $expect_status${expect_text:+ matching \"$expect_text\"}, got exit $status" >&2
+        printf '%s\n' "$output" | sed 's/^/       /' >&2
+        failures=$((failures + 1))
+    fi
+}
+
+echo "== lists that agree =="
+check_case "flag names a real macro" PASS \
+    '-DBWA_MEM3_DEBUG_ALPHA' \
+    '#ifdef BWA_MEM3_DEBUG_ALPHA
+int alpha;
+#endif'
+check_case "several flags, all matched" PASS \
+    '-DBWA_MEM3_DEBUG_ALPHA -DBWA_MEM3_DEBUG_BETA' \
+    '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif
+#if defined(BWA_MEM3_DEBUG_BETA)
+#endif'
+check_case "non-family macro needs no flag" PASS \
+    '-DBWA_MEM3_DEBUG_ALPHA' \
+    '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif
+#ifdef STAGE_PROF
+#endif'
+
+echo "== forward drift: a flag that enables nothing =="
+check_case "flag names no macro" FAIL \
+    '-DBWA_MEM3_DEBUG_ALPHA -DBWA_MEM3_DEBUG_TYPO' \
+    '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif' \
+    'passes -DBWA_MEM3_DEBUG_TYPO'
+# The whole point: a mention in prose is not a compiled gate. The unrelated
+# conditional keeps the src/ macro set non-empty, so this reaches the
+# forward-drift branch instead of stopping at the "nothing was checked" guard.
+check_case "macro only named in a comment" FAIL \
+    '-DBWA_MEM3_DEBUG_ALPHA' \
+    '// BWA_MEM3_DEBUG_ALPHA would guard this, if anything did
+int alpha;
+#ifdef STAGE_PROF
+#endif' \
+    'passes -DBWA_MEM3_DEBUG_ALPHA'
+# The same rule on the directive line itself, which the case above does not
+# reach. A trailing comment there is not a gate either, so it must not be
+# demanded of the flag list: reporting that src/ gates code on it would be false,
+# and adding the -D to silence that would enable a macro nothing tests.
+check_case "macro named in a comment on the #ifdef line" PASS \
+    '-DBWA_MEM3_DEBUG_ALPHA' \
+    '#ifdef BWA_MEM3_DEBUG_ALPHA  // see also BWA_MEM3_DEBUG_BETA, not yet used
+#endif
+#if defined(BWA_MEM3_DEBUG_ALPHA) /* not BWA_MEM3_DEBUG_GAMMA */
+#endif
+#ifdef BWA_MEM3_DEBUG_ALPHA /* a * inside must not defeat the strip: BWA_MEM3_DEBUG_DELTA */
+#endif' \
+    'PASS: debug_macro_flag_lint'
+# The other half of the same rule, and the half that matters more: stripping a
+# comment must never take real code with it. A closed comment mid-condition is
+# left in place precisely so the macro after it survives -- getting this wrong
+# drops a gate silently, which is the failure mode this lint exists to catch.
+check_case "macro after a mid-condition comment still counts" PASS \
+    '-DBWA_MEM3_DEBUG_ALPHA -DBWA_MEM3_DEBUG_BETA' \
+    '#if defined(BWA_MEM3_DEBUG_ALPHA) /* 2*3 */ || defined(BWA_MEM3_DEBUG_BETA)
+#endif' \
+    'PASS: debug_macro_flag_lint'
+
+# The exempt macro is read out of the lint's own pending_flags array rather than
+# hardcoded: that array is documented as something to empty once the pending
+# check lands, and a hardcoded name would turn that deletion into a spurious
+# failure here. No entries left means there is nothing to exercise.
+#
+# No `| head -1` on the end: under `set -o pipefail` head exits after the first
+# line, the upstream stage dies of SIGPIPE, and the pipeline reports 141 -- so
+# the assignment fails and `set -e` kills this script. That is the same trap the
+# lint documents above its membership tests. Take the first line in the shell
+# instead, and `|| true` for the no-entries case, where grep exits 1.
+# Strip the indent with sed rather than `tr -d '[:space:]'`: tr would delete the
+# newlines too, collapsing a multi-entry array into one concatenated token that
+# the first-line split below cannot separate.
+pending_flags_in_lint="$(sed -n '/^pending_flags=(/,/^)/p' "$lint" \
+    | sed -n 's/^[[:space:]]*\(BWA_MEM3_DEBUG_[A-Za-z0-9_]*\).*/\1/p')"
+pending_flag="${pending_flags_in_lint%%$'\n'*}"
+if [[ -n $pending_flag ]]; then
+    check_case "pending flag is exempt" PASS \
+        "-DBWA_MEM3_DEBUG_ALPHA -D$pending_flag" \
+        '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif' \
+        "note: $pending_flag names no macro"
+else
+    echo "  skip pending flag is exempt (lint has no pending_flags entries)"
+fi
+
+# The deletion the array documents, exercised now rather than discovered later:
+# an empty pending_flags must still reach the FAIL branch. Bash before 4.4
+# aborts on the plain expansion of an empty array under `set -u`, and that abort
+# also exits 1 -- so this case only means something because it pins the message
+# rather than the status.
+#
+# Run through the shebang instead of `bash "$lint"`. The lint declares
+# `#!/bin/bash`, which is 3.2 on macOS, while `bash` on PATH is whatever the
+# developer installed -- and under a 4.4+ bash this case cannot observe the
+# abort it exists to catch.
+empty_pending_lint="$fixture_root/lint_no_pending.sh"
+sed '/^pending_flags=(/,/^)/{ /^pending_flags=(/!{ /^)/!d; }; }' \
+    "$lint" > "$empty_pending_lint"
+chmod +x "$empty_pending_lint"
+remaining="$(sed -n '/^pending_flags=(/,/^)/p' "$empty_pending_lint" \
+    | grep -cE '^[[:space:]]*BWA_MEM3_DEBUG_' || true)"
+empty_dir="$(build_fixture '-DBWA_MEM3_DEBUG_ALPHA -DBWA_MEM3_DEBUG_TYPO' \
+    '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif')"
+empty_out="$("$empty_pending_lint" "$empty_dir" 2>&1)" \
+    && empty_status=0 || empty_status=$?
+if (( remaining != 0 )); then
+    echo "  FAIL could not empty pending_flags; the empty-array case checked nothing" >&2
+    failures=$((failures + 1))
+elif (( empty_status == 1 )) \
+    && [[ "$empty_out" == *'passes -DBWA_MEM3_DEBUG_TYPO'* ]]; then
+    echo "  ok   empty pending_flags -> FAIL (no unbound-variable abort)"
+else
+    echo "  FAIL empty pending_flags: expected the forward-drift message, got exit $empty_status" >&2
+    printf '%s\n' "$empty_out" | sed 's/^/       /' >&2
+    failures=$((failures + 1))
+fi
+
+echo "== reverse drift: a macro no CI row compiles =="
+check_case "src macro missing from flag list" FAIL \
+    '-DBWA_MEM3_DEBUG_ALPHA' \
+    '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif
+#ifdef BWA_MEM3_DEBUG_ORPHAN
+#endif' \
+    'gates code on BWA_MEM3_DEBUG_ORPHAN'
+
+echo "== a backslash continuation is one logical line =="
+# Both extractions are line-oriented, and both of the constructs they read can
+# be split across physical lines. Reading only the first one drops whatever the
+# continuation carries, and drops it silently -- the same "green while doing no
+# work" failure the lint exists to catch, reopened inside the lint itself.
+#
+# src/ already splits preprocessor conditions this way today, so the reverse
+# direction is the live risk: a continued condition's second macro would never
+# be required to have a -D.
+check_case "macro on a continued #if line" FAIL \
+    '-DBWA_MEM3_DEBUG_ALPHA' \
+    '#if defined(BWA_MEM3_DEBUG_ALPHA) || \
+    defined(BWA_MEM3_DEBUG_CONTINUED)
+#endif' \
+    'gates code on BWA_MEM3_DEBUG_CONTINUED'
+# Forward direction, same shape. The flag list is one long line today; wrapping
+# it is the natural next edit, and a continuation keeps the single-line anchor's
+# count at 1 -- so the trailing flags would go unchecked while every guard in the
+# script still reported success.
+check_case "flag on a continued EXTRA_CXXFLAGS line" FAIL \
+    '-DBWA_MEM3_DEBUG_ALPHA \
+            -DBWA_MEM3_DEBUG_WRAPPED' \
+    '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif' \
+    'passes -DBWA_MEM3_DEBUG_WRAPPED'
+
+echo "== extraction that stopped extracting must not report PASS =="
+check_case "no flag list in the workflow" FAIL \
+    '-DSTAGE_PROF' \
+    '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif' \
+    'expected exactly one -DBWA_MEM3_DEBUG flag list'
+check_case "src with no preprocessor conditionals" FAIL \
+    '-DBWA_MEM3_DEBUG_ALPHA' \
+    'int main(void) { return 0; }' \
+    'no preprocessor conditionals found under'
+echo "== the anchor is scoped to the flag line, not the whole workflow =="
+# Two independent mechanisms keep prose out of the flag set -- requiring
+# EXTRA_CXXFLAGS on the line, and dropping comment lines outright -- so there is
+# a case per mechanism. One fixture carrying both would let either mechanism
+# cover for the other's absence.
+#
+# Mechanism 1: a comment that names only a macro is filtered by the missing
+# EXTRA_CXXFLAGS. The macro is one that appears nowhere else, not the one on the
+# flag line: repeating the flag-line macro would leave this blind to an extractor
+# that scans the whole workflow, since it would `sort -u` both mentions back into
+# the same one-flag set and still print PASS. A distinct name lands in the flag
+# set only if the comment was read, and then names no macro in src/, so the
+# forward-drift branch fails the case.
+prefix_comment_dir="$(build_fixture '-DBWA_MEM3_DEBUG_ALPHA' '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif')"
+echo '      # note: -DBWA_MEM3_DEBUG_COMMENT_ONLY is deliberately not enabled' \
+    >> "$prefix_comment_dir/.github/workflows/ci.yml"
+check_dir "comment naming only a macro" "$prefix_comment_dir" 0 \
+    'PASS: debug_macro_flag_lint'
+
+# Mechanism 2: a comment that quotes the whole assignment carries EXTRA_CXXFLAGS
+# too, so requiring both terms does not filter it -- it would count as a second
+# flag list and fail claiming the step was restructured. Only the comment filter
+# catches this one.
+full_comment_dir="$(build_fixture '-DBWA_MEM3_DEBUG_ALPHA' '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif')"
+echo '      # was: EXTRA_CXXFLAGS="-DBWA_MEM3_DEBUG_ALPHA" before the rename' \
+    >> "$full_comment_dir/.github/workflows/ci.yml"
+check_dir "comment quoting the whole assignment" "$full_comment_dir" 0 \
+    'PASS: debug_macro_flag_lint'
+
+# A trailing comment on the real flag line is part of that line, not a comment
+# line, so the filter must leave it alone. Filtering on "contains #" rather than
+# "starts with #" would take the flag list with it and report an absent list.
+trailing_comment_dir="$(build_fixture '-DBWA_MEM3_DEBUG_ALPHA' '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif' '  # keep this list in sync with src/')"
+check_dir "trailing comment on the flag line survives" "$trailing_comment_dir" 0 \
+    'PASS: debug_macro_flag_lint'
+
+# A `#` comment ends at its own newline in YAML and in shell alike, so a trailing
+# backslash inside one continues nothing. Dropping comments only after joining
+# would let this comment absorb the flag list below it and discard both, leaving
+# the list looking absent.
+comment_backslash_dir="$fixture_root/comment-backslash"
+mkdir -p "$comment_backslash_dir/.github/workflows" "$comment_backslash_dir/src"
+{
+    printf 'jobs:\n  build:\n    steps:\n      - run: |\n'
+    printf '      # a note that happens to end in a backslash \\\n'
+    printf '          make EXTRA_CXXFLAGS="-DBWA_MEM3_DEBUG_ALPHA"\n'
+} > "$comment_backslash_dir/.github/workflows/ci.yml"
+printf '#ifdef BWA_MEM3_DEBUG_ALPHA\n#endif\n' \
+    > "$comment_backslash_dir/src/fixture.cpp"
+check_dir "comment ending in a backslash keeps the next line" \
+    "$comment_backslash_dir" 0 'PASS: debug_macro_flag_lint'
+
+# Two flag lines means the step was restructured and the single-line anchor no
+# longer describes it; guessing which one is authoritative would be the bug.
+two_line_dir="$(build_fixture '-DBWA_MEM3_DEBUG_ALPHA' '#ifdef BWA_MEM3_DEBUG_ALPHA
+#endif')"
+echo '          make EXTRA_CXXFLAGS="-DBWA_MEM3_DEBUG_ALPHA"' \
+    >> "$two_line_dir/.github/workflows/ci.yml"
+check_dir "two flag lines" "$two_line_dir" 1 \
+    'expected exactly one -DBWA_MEM3_DEBUG flag list'
+
+missing_dir="$fixture_root/missing"
+mkdir -p "$missing_dir/src"
+check_dir "missing workflow" "$missing_dir" 1 \
+    '.github/workflows/ci.yml missing under'
+
+# A path of the right name but the wrong type exists, so the existence check
+# above passes it through. Both of these already exited nonzero before the type
+# checks were added -- but blaming a restructured step and an empty preprocessor
+# set respectively, which is the wrong bug. These cases pin the diagnostic, not
+# just the status.
+wrong_workflow_dir="$fixture_root/wrong-type-workflow"
+mkdir -p "$wrong_workflow_dir/.github/workflows/ci.yml" "$wrong_workflow_dir/src"
+check_dir "workflow path is a directory" "$wrong_workflow_dir" 1 \
+    '.github/workflows/ci.yml is not a regular file'
+
+wrong_src_dir="$fixture_root/wrong-type-src"
+mkdir -p "$wrong_src_dir/.github/workflows"
+printf 'jobs:\n          make EXTRA_CXXFLAGS="-DBWA_MEM3_DEBUG_ALPHA"\n' \
+    > "$wrong_src_dir/.github/workflows/ci.yml"
+printf '#ifdef BWA_MEM3_DEBUG_ALPHA\n#endif\n' > "$wrong_src_dir/src"
+check_dir "src path is a regular file" "$wrong_src_dir" 1 \
+    'src is not a directory'
+
+# The expected text is derived from $lint rather than spelled out: the lint
+# prints its own basename, so a hardcoded name would make this case fail for a
+# renamed copy of the script instead of for the behaviour under test.
+usage_out="$(bash "$lint" one two 2>&1)" && usage_status=0 || usage_status=$?
+if (( usage_status == 2 )) && [[ "$usage_out" == *"usage: ${lint##*/}"* ]]; then
+    echo "  ok   too many arguments -> usage error (exit 2)"
+else
+    echo "  FAIL too many arguments: expected the usage message and exit 2, got exit $usage_status" >&2
+    printf '%s\n' "$usage_out" | sed 's/^/       /' >&2
+    failures=$((failures + 1))
+fi
+
+if (( failures > 0 )); then
+    echo "FAIL: debug_macro_flag_lint_selftest ($failures case(s))" >&2
+    exit 1
+fi
+
+echo "PASS: debug_macro_flag_lint_selftest"


### PR DESCRIPTION
The opt-in macro build step added in #329 rebuilds with every debug and
instrumentation macro enabled and reruns the chr22 parity check, so the
guarded code is compiled and exercised rather than left to rot. That is
only worth anything if its `-D` flags name macros that exist, and nothing
checked that they did.

Both directions can drift silently. A flag that names no macro compiles
into nothing: the build succeeds, parity passes, and the check the flag
was meant to enable never runs. A macro that no flag names is compiled by
no CI row at all -- the exact gap the step was added to close, reopened
one macro at a time. Neither shows up as a failure; both read as green.

This is not hypothetical in either direction. Three flags were added
ahead of the changes introducing them, so for a while the step really was
enabling nothing for those three. Two have since landed (#326, #330) and
their names happened to match; BWA_MEM3_DEBUG_UNGAPPED_XCHECK still names
nothing and is listed as pending here, with the reason, so the exemption
is a line a reviewer sees rather than silence. A one-character rename
during review of any of them would have been invisible.

Add test/regression/debug_macro_flag_lint.sh, which parses the `-D` list
out of the step and cross-checks it against the macros src/ actually
tests in a preprocessor conditional, in both directions. The reverse
check is scoped to the BWA_MEM3_DEBUG_ prefix, the one unambiguous naming
convention for this family; build-mode switches like STAGE_PROF have
their own rows and are deliberately out of scope.

The flag list is located by anchoring on the single EXTRA_CXXFLAGS line
carrying the family prefix rather than on a step name or line number,
either of which drifts silently. Zero or several matches is a hard error:
the step was restructured and the extraction no longer describes it.
Every other way the check can end up covering nothing -- no flags parsed,
no conditionals under src/, a missing workflow -- exits nonzero too,
rather than passing vacuously over an empty set.

A lint whose extraction has stopped extracting prints exactly what a
healthy tree prints, so debug_macro_flag_lint_selftest.sh runs the lint
over generated fixture repositories that have drifted each way and
confirms it says so. Neutering either direction of the check fails it.

Runs as its own CI job (seconds, no toolchain) and from `make test`.

## Validation

- Passes on `main` today: five of the six flags name live macros; `BWA_MEM3_DEBUG_UNGAPPED_XCHECK` names nothing and is reported as pending.
- Self-test: 13 cases (agreeing lists, forward drift, reverse drift, comment-only mention, pending exemption, and five ways the extraction can cover nothing).
- Mutation-tested: neutering the forward check or the reverse check each fails the self-test.
- `shellcheck -S style` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression checks to keep debug build flags synchronized with source macros.
  * Added self-tests covering matching configurations, drift detection, pending flags, invalid inputs, and missing configuration.
  * Included these checks in the standard test target and documented regression test matrix.

* **Chores**
  * Added a CI validation job to automatically detect debug flag inconsistencies and help prevent configuration drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->