### PR TITLE
refactor(meth): name the native-regen decision and document the hypothesis invariant

### DIFF
--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -3513,6 +3513,36 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
     str->s[str->l] = 0;  /* single trailing NUL — unsafe writers skipped this */
 }
 
+/* Does this region's CIGAR/NM/MD regeneration run in NATIVE (--meth) mode?
+ *
+ * One predicate, because it selects THREE things at once and they must never
+ * disagree: the query bases (original vs projected), the scoring matrix
+ * (per-hypothesis asymmetric vs symmetric), and the NM/MD predicate
+ * (matrix-derived vs literal). A caller that satisfies two of the three inputs
+ * but not the third silently produces a record with the OTHER tag semantics and
+ * no diagnostic — which is exactly how XA:Z sub-entries ended up reporting
+ * conversion-counting NM alongside a conversion-hiding primary (fixed by
+ * threading meth_orig_query through mem_gen_alt). Keeping the decision in one
+ * named place is what makes that class of mistake reviewable.
+ *
+ * On the `meth_hypothesis >= 0` term: for a MAPPED region under --meth this is
+ * always true, so the term is defensive rather than a real branch.
+ *   - Chain seeds that cannot be remapped to an OT/OB hypothesis are DROPPED,
+ *     not carried with -1 (mem_chain_seeds -> meth_seed_to_orig returns
+ *     non-zero and the seed is skipped).
+ *   - meth_orig_bns is NULL only if the reference prefix overflowed PATH_MAX,
+ *     which warns loudly at startup.
+ *   - Every mem_matesw call site passes `opt->meth_mode ? i : -1`, so a rescued
+ *     mate under --meth inherits 0 or 1, never -1.
+ * Were it ever false, the fallback is still self-consistent rather than mixed:
+ * the symmetric opt->mat has every off-diagonal at -b < 0 (--meth rejects
+ * -B 0), so the matrix-derived and literal NM/MD predicates agree on it. */
+static int mem_use_native_regen(const mem_opt_t *opt, const mem_alnreg_t *ar,
+                                const char *meth_orig_query)
+{
+    return opt->meth_mode && meth_orig_query != NULL && ar->meth_hypothesis >= 0;
+}
+
 mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, int l_query, const char *query_, const mem_alnreg_t *ar, const char *meth_orig_query)
 {
     mem_aln_t a;
@@ -3537,8 +3567,7 @@ mem_aln_t mem_reg2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *
      * bases; else fall back to the projected `query_` (non-meth path,
      * byte-for-byte identical to legacy). How conversions themselves are treated
      * in NM/MD is governed by the policy note below, not here. */
-    const int use_meth_orig = (opt->meth_mode && meth_orig_query != NULL
-                               && ar->meth_hypothesis >= 0);
+    const int use_meth_orig = mem_use_native_regen(opt, ar, meth_orig_query);
     const char *regen_query = use_meth_orig ? meth_orig_query : query_;
     /* Reuse a per-thread nt4 scratch instead of a malloc/free per region. The
      * buffer is consumed within this call (copied into a.cigar via the DP), so

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -347,6 +347,20 @@ int meth_mem_aln_to_bam(bam1_t *b,
      * existing encoding. */
     int32_t tid = (p.rid >= 0 && p.rid < bns->n_seqs) ? p.rid : -1;
     int32_t mtid = (mp && mp->rid >= 0 && mp->rid < bns->n_seqs) ? mp->rid : -1;
+    /* The `meth_hypothesis >= 0` term is DEFENSIVE, not a reachable branch: a
+     * mapped record under --meth always carries 0 or 1. The value reaches `p`
+     * through mem_reg2aln, which defaults it to -1 and then copies the region's
+     * hypothesis over that default. A region (mem_alnreg_t) gets its hypothesis
+     * in exactly three places, all of which supply 0 or 1 under --meth:
+     *   - mem_chain2aln_across_reads_V2 (bwamem.cpp), copying the chain's
+     *     hypothesis (itself set in chain_add_one_seed) -- chain seeds that
+     *     cannot be remapped to an OT/OB hypothesis are dropped rather than
+     *     carried as -1;
+     *   - mem_matesw and mem_matesw_batch_post (bwamem_pair.cpp), the two
+     *     mate-rescue paths.
+     * The term is kept so an unmapped or non-meth record, which does keep the
+     * -1 default, cannot index off ((-1)&1)==1 and be labelled top-strand. Do
+     * not read it as evidence that -1 reaches a mapped record. */
     char direction = 0;
     if (tid >= 0 && p.meth_hypothesis >= 0)
         direction = (p.meth_hypothesis & 1) ? 'f' : 'r';
@@ -487,10 +501,18 @@ int meth_mem_aln_to_bam(bam1_t *b,
     char *xm = NULL;
     if ((opt->meth_tags & MEM_METH_TAG_XM)
         && mapped && seq_text != NULL && bam_cigar != NULL && l_emit > 0) {
-        /* Match the XG `direction` guard at line ~322: a -1 hypothesis maps to
-         * XG:Z:GA (bottom strand), so treat it as bottom here too. ((-1)&1)==1
-         * would otherwise mislabel a -1-hypothesis record (e.g. mate rescued off
-         * a -1 anchor) as top strand, emitting XG:GA with a top-strand XM. */
+        /* The `>= 0` term cannot fire here: this block is gated on `mapped`,
+         * which requires `direction != 0`, and `direction` is only set when
+         * meth_hypothesis >= 0. So -1 is already excluded before this line --
+         * the term is redundant under the current control flow, not a guard
+         * against something that happens.
+         *
+         * It is kept for symmetry with the XG `direction` guard above, and so
+         * the two stay consistent if `mapped` is ever loosened: should a -1
+         * reach here then, it is treated as bottom strand, matching the
+         * XG:Z:GA that guard would emit. Dropping the term instead would let
+         * ((-1)&1)==1 mislabel such a record top-strand and pair XG:GA with a
+         * top-strand XM. */
         int is_top_strand = (p.meth_hypothesis >= 0 && (p.meth_hypothesis & 1)) ? 1 : 0;
         xm = meth_build_xm(bns, pac, tid, (int64_t)p.pos,
                            is_top_strand,


### PR DESCRIPTION
**Stacked on #334.** Retarget as the stack merges.

## What this is not

I opened this expecting to fix a bug: `mem_reg2aln` gates native `--meth` regeneration on `ar->meth_hypothesis >= 0`, so a mapped record with a `-1` hypothesis would fall back to the literal NM/MD predicate while its neighbours used the matrix-derived one — the same two-semantics-in-one-BAM defect fixed for `XA:Z` in #332.

**It isn't reachable, and it wouldn't matter if it were.** Both halves verified:

*Not reachable* for a mapped record under `--meth`:
- Chain seeds that cannot be remapped to an OT/OB hypothesis are **dropped**, not carried with `-1` — `mem_chain_seeds` → `meth_seed_to_orig` returns non-zero and the seed is skipped (`bwamem.cpp:2257`).
- `meth_remap` is false only when `meth_orig_bns == NULL`, which needs `meth_orig_ref_prefix == NULL` — reachable only through a `PATH_MAX` overflow that warns loudly at startup (`fastmap.cpp:2578`).
- All five `mem_matesw` call sites pass `opt->meth_mode ? i : -1`, so a rescued mate under `--meth` inherits 0 or 1 (`bwamem_pair.cpp:571,594,832,1173,1197`).

*Wouldn't matter*: with `-1` the regen uses the symmetric `opt->mat`, whose off-diagonals are all `-b < 0` — and `--meth` now rejects `-B 0` (#332). Matrix-derived and literal therefore **agree** on that matrix. The fallback is self-consistent, not mixed.

## What this is

Two changes, both non-behavioral.

**1. Name the decision.** The gate is one inline conjunction that silently selects *three* coupled things: the query bases, the scoring matrix, and the NM/MD predicate. A caller satisfying two of the three inputs but not the third gets the other tag semantics with no diagnostic.

That is not hypothetical — it is precisely how `XA:Z` sub-entries came to report conversion-counting `NM` next to a conversion-hiding primary in #332: `mem_gen_alt` omitted `meth_orig_query` and silently took the literal path. Extracting `mem_use_native_regen()` makes the coupling visible at the point of decision, so the next omission is reviewable instead of invisible.

**2. Label the defensive guards.** `meth_bam.cpp` has two `meth_hypothesis >= 0` guards whose comments read as evidence that `-1` reaches the output layer — one even cites "e.g. mate rescued off a -1 anchor". They are worth keeping (an unmapped or non-meth record must not index off `((-1)&1)==1` and be labelled top-strand) but they are defensive, not reachable. They cost me a full reachability investigation; the comments now say so, with a pointer to the argument.

## Verification

Pure no-op. Non-`--meth` and `--meth` output byte-identical to the parent commit (records-only md5, SE and PE). Full `--meth` regression suite and `make test` green.

## Why bother, if there's no bug

The value is in the second-order effect. #332 shipped with a real defect of exactly this shape, found only because a review pass happened to check the `XA` path. The fix there was to thread one argument; the fix for the *class* is to stop spelling the policy out inline at each site. This is the smaller, boring half of that — and it records the reachability argument so nobody spends another twenty minutes deriving it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized methylation alignment regeneration logic without changing existing behavior.

- **Documentation**
  - Clarified handling of invalid methylation hypotheses during strand-direction and methylation annotation generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->