### PR TITLE
ci: require every regression script to actually be run by CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,23 @@ jobs:
       - name: Tracked shell scripts are shellcheck-clean and shfmt-formatted
         run: bash test/regression/shell_lint.sh
 
+  # Fourth source-only lint, same shape as the three above. Kept separate so the
+  # failure reads as "a regression script runs nowhere" on its own line.
+  regression-coverage-lint:
+    name: Regression scripts are run by CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Coverage lint still detects an unrun script
+        run: bash test/regression/regression_coverage_lint_selftest.sh
+
+      - name: Every regression script is run by CI
+        run: bash test/regression/regression_coverage_lint.sh
+
   build-and-test:
     strategy:
       fail-fast: false
@@ -252,6 +269,15 @@ jobs:
 
       - name: Verify binary
         run: ./bwa-mem3 version
+
+      # `./bwa-mem3 version` above only proves the binary runs. The regression
+      # script asserts what the banner actually says -- the SIMD floor and
+      # runtime tier lines, and that BWAMEM3_FORCE_TIER downgrades the runtime
+      # line. It was wired only into `make test`, which no workflow invokes, so
+      # until now it ran nowhere in CI. Every row rather than the canonical one:
+      # the lines it checks are exactly what differs across arch and floor.
+      - name: Version banner regression
+        run: BWA_MEM3=./bwa-mem3 bash test/regression/version_banner.sh
 
       - name: Build doctest framework and unit binary
         # Invoke via the parent `test-binaries` target so ARCH_FLAGS

--- a/Makefile
+++ b/Makefile
@@ -854,6 +854,8 @@ test: test-binaries $(STANDALONE_TESTS_IN_TEST_TARGET) bwa-mem3
 	./test/regression/debug_macro_flag_lint.sh
 	./test/regression/shell_lint_selftest.sh
 	./test/regression/shell_lint.sh
+	./test/regression/regression_coverage_lint_selftest.sh
+	./test/regression/regression_coverage_lint.sh
 
 # Shell lint on its own, and its autofix. Separate from `test` because the
 # whole point is to run them without a build: both are source-only and finish
@@ -870,8 +872,9 @@ shell-fix:
 # Regression test that requires a binary built with TESTING_BUILD=1
 # (enables BWAMEM3_TESTING_HOST_TIER env-var injection). Not invoked by
 # the default `test` target because it requires a non-production build.
-# CI runs `make clean && make TESTING_BUILD=1 && make test-injection`
-# as a separate matrix row.
+# No workflow invokes this target, so host_floor_enforce.sh currently runs
+# nowhere in CI; test/regression/regression_coverage_lint.sh records that
+# as an explicit exemption rather than letting it pass for coverage.
 test-injection: bwa-mem3
 	BWA_MEM3_TESTING=./bwa-mem3 INJECTED_TIER=sse41 PARITY_FA=/dev/null \
 		./test/regression/host_floor_enforce.sh

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -32,6 +32,9 @@ jobs. Each script:
 | `ndebug_gate_lint_selftest.sh` | the lint above still flags real gates, so its `PASS` means something | "NDEBUG gate lint still detects gates"              |
 | `debug_macro_flag_lint.sh`   | the opt-in macro build's `-D` list and the `BWA_MEM3_DEBUG_*` macros in `src/` still name each other | "Opt-in macro -D list matches the macros in src/"   |
 | `debug_macro_flag_lint_selftest.sh` | the lint above still detects a drifted list, so its `PASS` means something | "Macro list lint still detects drift"               |
+| `regression_coverage_lint.sh` | every script in this directory is named by a CI workflow, or by a Makefile target CI invokes — not just by `make test` | "Every regression script is run by CI"              |
+| `regression_coverage_lint_selftest.sh` | the lint above still detects an unrun script, so its `PASS` means something | "Coverage lint still detects an unrun script"       |
+| `version_banner.sh`          | `bwa-mem3 version` prints the SIMD floor and runtime tier lines        | "Version banner regression"                         |
 
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is
 the authoritative list, and `ci.yml` is where each one is actually wired up.

--- a/test/regression/coverage_exemptions.txt
+++ b/test/regression/coverage_exemptions.txt
@@ -1,0 +1,15 @@
+# Regression scripts deliberately not run by CI.
+#
+# Read by test/regression/regression_coverage_lint.sh. One script basename per
+# line (no .sh), blank lines and # comments ignored. Every entry needs a reason
+# above it: an exemption is a decision to leave a regression script uncovered,
+# and it should cost a reviewable line rather than passing in silence.
+#
+# The lint also fails when an entry here IS run by CI, and when an entry names
+# no script under test/regression/ at all -- so an exemption that has become
+# untrue, or that outlived the script it covered, cannot quietly accumulate.
+
+# Needs a TESTING_BUILD=1 binary (BWAMEM3_TESTING_HOST_TIER injection), which
+# no workflow builds. Covering it means paying for another build; until that is
+# decided it is honestly uncovered rather than quietly assumed covered.
+host_floor_enforce

--- a/test/regression/regression_coverage_lint.sh
+++ b/test/regression/regression_coverage_lint.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+# Every script in test/regression/ must be wired into CI, not just into
+# `make test`. What that resolves to in practice -- a workflow naming the
+# script, or invoking a Makefile target whose recipe runs it -- is spelled out
+# below; this lint checks the wiring, not that the run happened.
+#
+# The regression scripts are enumerated in two independent, hand-maintained
+# places: the `test:` target in the Makefile, and explicit steps and loops in
+# .github/workflows/. A script listed in one and not the other still looks
+# wired up -- it has a home, it passes when run by hand -- while in fact no
+# automated run ever executes it. Nothing fails; the coverage just is not
+# there.
+#
+# CI does not invoke `make test`. It builds with `make test-binaries` and then
+# runs the regression scripts from its own list, so the `test:` recipe is a
+# developer convenience rather than the thing CI executes. That makes the
+# Makefile list and the workflow list genuinely independent, and drift between
+# them invisible. Both scripts this lint was written for were found that way:
+# one reachable only from `test:`, one only from `test-injection`, a target no
+# workflow names.
+#
+# A script counts as covered when a workflow names it, or when it is in the
+# recipe of a Makefile target a workflow actually invokes. Anything else has to
+# be listed in test/regression/coverage_exemptions.txt with the reason -- so a
+# script nothing runs is a reviewable line there rather than silence.
+#
+# Sibling lints: ndebug_gate_lint.sh, debug_macro_flag_lint.sh. Same failure
+# in each case -- a check that reads as green while doing no work.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+if (($# > 1)); then
+    echo "usage: ${BASH_SOURCE[0]##*/} [repo-root-to-check]" >&2
+    exit 2
+fi
+
+# Optional argument so regression_coverage_lint_selftest.sh can aim the same
+# resolution at a fixture tree; a lint that has stopped resolving anything
+# reports the same PASS as one whose lists agree.
+#
+# Checked rather than left to `cd` to fail under `set -e`: bash's own `cd:` line
+# carries no FAIL: prefix, so the one way of pointing this lint at nothing that
+# is reachable from the command line would be the one failure a caller
+# scanning for the family's format does not see.
+if (($# == 1)); then
+    if [[ ! -d $1 ]]; then
+        echo "FAIL: '$1' is not a directory -- nothing was checked" >&2
+        exit 1
+    fi
+    cd "$1"
+fi
+
+workflow_dir=".github/workflows"
+script_dir="test/regression"
+makefile="Makefile"
+
+for required in "$workflow_dir" "$script_dir" "$makefile"; do
+    if [[ ! -e $required ]]; then
+        echo "FAIL: $required missing under $PWD -- nothing was checked" >&2
+        exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Scripts deliberately not run by CI.
+#
+# Kept in a data file rather than an array in here, so adding an exemption is a
+# reviewable one-line diff next to its reason, and so this list can be exercised
+# by the self-test against fixture trees that carry their own.
+# ---------------------------------------------------------------------------
+exemptions_file="$script_dir/coverage_exemptions.txt"
+exempt_scripts=()
+if [[ -f $exemptions_file ]]; then
+    while IFS= read -r entry; do
+        entry="${entry%%#*}"
+        entry="${entry//[[:space:]]/}"
+        if [[ -n $entry ]]; then
+            exempt_scripts+=("$entry")
+        fi
+    done < "$exemptions_file"
+fi
+
+# Read loops rather than `mapfile`, which is bash 4+: macOS still ships bash
+# 3.2 as /bin/bash, and the sibling lints run there. A lint that cannot run on
+# a contributor's shell is the same missing coverage by another route.
+workflow_files=()
+while IFS= read -r file; do
+    [[ -n $file ]] && workflow_files+=("$file")
+done < <(find "$workflow_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+if ((${#workflow_files[@]} == 0)); then
+    echo "FAIL: no workflow files under $workflow_dir/ -- nothing was checked" >&2
+    exit 1
+fi
+
+scripts=()
+while IFS= read -r file; do
+    [[ -n $file ]] && scripts+=("$file")
+done < <(find "$script_dir" -type f -name '*.sh' | sort)
+if ((${#scripts[@]} == 0)); then
+    echo "FAIL: no scripts under $script_dir/ -- nothing was checked" >&2
+    exit 1
+fi
+
+workflow_text="$(cat "${workflow_files[@]}")"
+
+# ---------------------------------------------------------------------------
+# Recipes of Makefile targets that a workflow actually invokes.
+#
+# Matched as `make [flags/vars...] <target>` so a target is only counted when a
+# workflow really calls it. Substring matching would be worse than useless
+# here: `test` would match every `make test-binaries` line, pull the `test:`
+# recipe in, and mark as covered exactly the scripts this lint exists to find.
+#
+# Both halves therefore treat the target name as a literal. In the ERE it is
+# escaped; the recipe scan compares whole names instead of building a regex out
+# of one. Interpolated raw, this Makefile's own `.PHONY`, `.SUFFIXES`, `.c.o`
+# and `.cpp.o` each turn their `.` into a wildcard, and a target that matches
+# the wrong line attaches the wrong recipe -- over-counting coverage in the
+# same silent direction as the substring trap above.
+# ---------------------------------------------------------------------------
+invoked_recipes=""
+while IFS= read -r target; do
+    [[ -z $target ]] && continue
+
+    # Target names are drawn from [A-Za-z0-9_.-] by the enumeration below, and
+    # `.` is the only ERE metacharacter in that set.
+    target_re="${target//./\\.}"
+    # `make` must be the whole tool name. Unanchored it also matches the tail of
+    # `cmake`, `gmake` and `nmake`, so `cmake --build <target>` -- a line that
+    # never runs this Makefile -- would resolve that target and count its recipe
+    # as covered. Spelled out rather than as `\b`/`[[:<:]]`, neither of which is
+    # portable across GNU and BSD grep. `/` is deliberately not excluded:
+    # `/usr/bin/make check` is a real invocation.
+    if ! grep -qE \
+        "(^|[^A-Za-z0-9_])make([[:space:]]+[^[:space:]]+)*[[:space:]]+${target_re}([[:space:]]|\$)" \
+        <<< "$workflow_text"; then
+        continue
+    fi
+    recipe="$(awk -v t="$target" '
+        # A rule line opens a recipe; a later unindented, non-comment line
+        # closes it. One rule line may name several targets ("fmt lint: deps")
+        # and the recipe belongs to each, so the whole list left of ":" is
+        # searched -- anchoring on a single leading name misses every target
+        # but the first, and reports its scripts as run by nothing.
+        /^[^\t#]/ && index($0, ":") > 0 {
+            in_recipe = 0
+            n = split(substr($0, 1, index($0, ":") - 1), names, /[ \t]+/)
+            for (i = 1; i <= n; i++) {
+                if (names[i] == t) in_recipe = 1
+            }
+            next
+        }
+        in_recipe && /^\t/ { print; next }
+        in_recipe && !/^\t/ && !/^#/ && NF { in_recipe = 0 }
+    ' "$makefile")"
+    invoked_recipes+="$recipe"$'\n'
+done < <(awk '
+    # Rule lines only. Plenty of other lines carry a ":": assignments
+    # (`.DEFAULT_GOAL := ...`), and directives whose arguments hide one inside a
+    # substitution reference (`-include $(OBJS:.o=.d)`). Both would otherwise
+    # enumerate as targets, with whatever follows read as their recipe.
+    #
+    # So the whole list left of ":" must consist of nothing but target names --
+    # one token that is not a name disqualifies the line, rather than being
+    # dropped while its neighbours are kept.
+    /^[a-zA-Z0-9_.-]/ && index($0, ":") > 0 {
+        head = substr($0, 1, index($0, ":") - 1)
+        if (substr($0, index($0, ":") + 1, 1) == "=") next
+        if (substr($0, index($0, ":") + 1, 2) == ":=") next
+        n = split(head, names, /[ \t]+/)
+        for (i = 1; i <= n; i++) {
+            if (names[i] !~ /^[a-zA-Z0-9_.-]+$/) next
+        }
+        for (i = 1; i <= n; i++) print names[i]
+    }
+' "$makefile" | sort -u)
+
+covered_text="$workflow_text"$'\n'"$invoked_recipes"
+
+# ---------------------------------------------------------------------------
+# Coverage is matched on whole reference tokens, not substrings.
+#
+# Every lint here ships beside an `_selftest` sibling whose name contains it, so
+# a substring match reads `regression_coverage_lint` as covered on the strength
+# of `regression_coverage_lint_selftest.sh` alone -- and dropping the shorter
+# script's own reference would then leave it uncovered and still green. Same
+# class of bug as the `make test-binaries` trap above, one level down.
+#
+# Splitting the text on everything that cannot appear inside a script reference
+# leaves whole tokens (`alpha.sh`, `alpha_selftest.sh`) to compare exactly,
+# which needs no regex escaping of the names. `.` and `-` stay inside tokens so
+# a name carrying either is still matched as a unit rather than in pieces --
+# `alpha-beta` is as much its own script as `alpha_selftest` is.
+#
+# Keeping `.` and `-` means a reference ending a sentence would otherwise
+# tokenize as `alpha.sh.` and match nothing, so trailing runs of them are
+# trimmed. The Makefile already writes one reference that way.
+# ---------------------------------------------------------------------------
+covered_tokens="$(LC_ALL=C tr -c 'A-Za-z0-9_.-' '\n' <<< "$covered_text" \
+    | sed 's/[.-]*$//' | sort -u)"
+
+failures=0
+exempt_used=()
+
+for path in "${scripts[@]}"; do
+    name="$(basename "$path" .sh)"
+
+    # `${a[@]+"${a[@]}"}` rather than `"${a[@]}"`: under `set -u`, bash 3.2
+    # treats an empty array's expansion as an unbound variable, and an empty
+    # exemption list is the normal case.
+    is_exempt=0
+    for exempt in ${exempt_scripts[@]+"${exempt_scripts[@]}"}; do
+        if [[ $name == "$exempt" ]]; then
+            is_exempt=1
+            break
+        fi
+    done
+
+    # Herestring, not `printf ... | grep`: with `set -o pipefail`, `grep -q`
+    # exits on its first match, printf dies of SIGPIPE, and the pipeline
+    # reports 141 -- turning a found script into "not covered" for whichever
+    # names happen to appear early enough in the text to short-circuit grep.
+    #
+    # Both spellings count: references carry the extension (`alpha.sh`), while
+    # a bare name is how a script gets mentioned without one.
+    if grep -qxF -- "$name" <<< "$covered_tokens" \
+        || grep -qxF -- "$name.sh" <<< "$covered_tokens"; then
+        if ((is_exempt)); then
+            echo "FAIL: $path is listed as exempt but IS run by CI -- drop the" >&2
+            echo "      exemption so the list keeps meaning something." >&2
+            failures=$((failures + 1))
+        fi
+        continue
+    fi
+
+    if ((is_exempt)); then
+        exempt_used+=("$name")
+        echo "note: $name is not run by CI (listed as exempt)"
+        continue
+    fi
+
+    echo "FAIL: $path is run by no workflow, and by no Makefile target that a" >&2
+    echo "      workflow invokes. It passes only when someone runs it by hand." >&2
+    echo "      Add it to a workflow, or list it in $exemptions_file with a" >&2
+    echo "      reason." >&2
+    failures=$((failures + 1))
+done
+
+# The loop above only reads the exemption list from the script side, so it
+# catches an entry that has become untrue but never one that has stopped naming
+# anything. An exemption whose script was renamed or deleted can no longer be
+# contradicted by any check, and so outlives the change that made it
+# meaningless -- silence again, in the one file whose whole point is that
+# leaving a script uncovered costs a reviewable line.
+for exempt in ${exempt_scripts[@]+"${exempt_scripts[@]}"}; do
+    found=0
+    for path in "${scripts[@]}"; do
+        if [[ "$(basename "$path" .sh)" == "$exempt" ]]; then
+            found=1
+            break
+        fi
+    done
+    if ((!found)); then
+        echo "FAIL: $exemptions_file exempts '$exempt', which is not a script" >&2
+        echo "      under $script_dir/. Drop the entry, or fix the name." >&2
+        failures=$((failures + 1))
+    fi
+done
+
+if ((failures > 0)); then
+    echo "FAIL: regression_coverage_lint ($failures problem(s))" >&2
+    exit 1
+fi
+
+echo "PASS: regression_coverage_lint (${#scripts[@]} scripts, ${#exempt_used[@]} exempt)"

--- a/test/regression/regression_coverage_lint_selftest.sh
+++ b/test/regression/regression_coverage_lint_selftest.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# test/regression/regression_coverage_lint_selftest.sh
+#
+# Regression: regression_coverage_lint.sh still notices a script nothing runs.
+#
+# The lint prints PASS when every script is covered, and would print the same
+# PASS if its resolution silently stopped resolving -- an empty script list, or
+# a covered_text that matches everything, both satisfy the check vacuously.
+# From CI those are indistinguishable, which is the failure this whole family
+# of lints exists to catch. So the cases below hand it trees that have real
+# gaps and confirm it says so.
+#
+# Two of them guard bugs this lint actually had:
+#
+#   - the `make test-binaries` substring trap. Resolving invoked targets by
+#     substring pulls the `test:` recipe in on any `make test-binaries` line,
+#     which marks as covered precisely the scripts only `make test` runs --
+#     the ones the lint was written to find.
+#
+#   - the SIGPIPE case. `printf "$big" | grep -q` under `set -o pipefail`
+#     returns 141 when grep short-circuits on an early match, so a covered
+#     script reads as uncovered once the text outgrows the pipe buffer. It
+#     bit for real at ~87 KB of workflow text.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+lint="$PWD/test/regression/regression_coverage_lint.sh"
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+
+failures=0
+
+# $1 = workflow body, $2 = Makefile body, $3.. = regression script basenames
+# Set FIXTURE_EXEMPTIONS to the body of the fixture's coverage_exemptions.txt;
+# left empty, no file is written (the lint must cope with that too).
+FIXTURE_EXEMPTIONS=""
+build_fixture() {
+    local workflow="$1" makefile="$2"
+    shift 2
+    local dir="$fixture_root/case" name
+
+    rm -rf "$dir"
+    mkdir -p "$dir/.github/workflows" "$dir/test/regression"
+    printf '%s\n' "$workflow" > "$dir/.github/workflows/ci.yml"
+    printf '%s\n' "$makefile" > "$dir/Makefile"
+    for name in "$@"; do
+        printf '#!/bin/bash\necho %s\n' "$name" > "$dir/test/regression/$name.sh"
+    done
+    if [[ -n $FIXTURE_EXEMPTIONS ]]; then
+        printf '%s\n' "$FIXTURE_EXEMPTIONS" > "$dir/test/regression/coverage_exemptions.txt"
+    fi
+    printf '%s' "$dir"
+}
+
+run_case() {
+    local description="$1" expected="$2" dir="$3"
+    local output status verdict
+    output="$(bash "$lint" "$dir" 2>&1)" && status=0 || status=$?
+    case "$status" in
+        0) verdict=PASS ;;
+        1) verdict=FAIL ;;
+        *) verdict="ERROR(exit $status)" ;;
+    esac
+    if [[ "$verdict" == "$expected" ]]; then
+        echo "  ok   $description -> $verdict"
+    else
+        echo "  FAIL $description: expected $expected, got $verdict" >&2
+        printf '%s\n' "$output" | sed 's/^/       /' >&2
+        failures=$((failures + 1))
+    fi
+}
+
+echo "== covered scripts =="
+run_case "named directly in a workflow" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: bash test/regression/alpha.sh' \
+        'test:
+	echo nothing' alpha)"
+
+run_case "in a Makefile target a workflow invokes" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: make check' \
+        'check:
+	./test/regression/alpha.sh' alpha)"
+
+# One rule line may name several targets, and the recipe belongs to each. Read
+# with a leading-name anchor, only `fmt` resolves and `lint` names nothing, so a
+# workflow that invokes `make lint` reports alpha as run by no one.
+run_case "every target on a multi-target rule line resolves" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: make lint' \
+        'fmt lint:
+	./test/regression/alpha.sh' alpha)"
+
+echo "== uncovered scripts =="
+
+# A target name is a literal, not a pattern. This Makefile really does define
+# `.PHONY`, `.SUFFIXES`, `.c.o` and `.cpp.o`, so a `.` left unescaped in the
+# invocation ERE lets a target match a `make` line that names something else --
+# here `.check` matching `make xcheck`, which drags in a recipe no workflow runs
+# and marks its scripts covered.
+run_case "a dotted target does not wildcard onto another make invocation" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: make xcheck' \
+        'xcheck:
+	echo building
+.check:
+	./test/regression/alpha.sh' alpha)"
+
+# The same literalness on the recipe side: `.check` must attach to its own
+# recipe, not to every rule line the `.` happens to wildcard over. beta is run
+# by `xcheck`, which no workflow invokes, so it has to read as uncovered.
+run_case "a dotted target attaches only to its own recipe" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: make .check' \
+        'xcheck:
+	./test/regression/beta.sh
+.check:
+	./test/regression/alpha.sh' alpha beta)"
+# `make` has to be the whole tool name, not a tail of one. Unanchored it matches
+# inside `cmake`, `gmake` and `nmake`, so a line that never invokes this
+# Makefile at all -- `cmake --build check` here -- resolves `check` and pulls in
+# a recipe nothing runs, marking its scripts covered.
+run_case "a make-suffixed tool name does not invoke a target" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: cmake --build check' \
+        'check:
+	./test/regression/alpha.sh' alpha)"
+
+# The anchor must not go the other way and lose a real invocation: make is
+# routinely spelled with a path, and `/` is not part of the tool name.
+run_case "make invoked by path still resolves its target" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: /usr/bin/make check' \
+        'check:
+	./test/regression/alpha.sh' alpha)"
+
+run_case "referenced nowhere at all" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: echo hi' \
+        'test:
+	echo nothing' orphan)"
+
+run_case "only in a target no workflow invokes" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: make test-binaries' \
+        'test-binaries:
+	echo building
+test:
+	./test/regression/alpha.sh' alpha)"
+
+# The substring trap: `make test-binaries` must not count as invoking `test`.
+run_case "make test-binaries does not pull in the test recipe" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: make -j4 test-binaries' \
+        'test-binaries:
+	echo building
+test:
+	./test/regression/alpha.sh' alpha)"
+
+# The same trap one level down, in the script names themselves. Every lint here
+# ships next to an `_selftest` sibling whose name contains it, so a substring
+# match reads `alpha` as covered on the strength of `alpha_selftest.sh` alone --
+# and dropping alpha's own reference would then go unnoticed.
+run_case "sibling _selftest reference does not cover the shorter name" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: bash test/regression/alpha_selftest.sh' \
+        'test:
+	echo nothing' alpha alpha_selftest)"
+
+run_case "both siblings referenced" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: bash test/regression/alpha_selftest.sh
+      - run: bash test/regression/alpha.sh' \
+        'test:
+	echo nothing' alpha alpha_selftest)"
+
+# Tightening the match must not go so far that ordinary prose stops counting: a
+# reference is often the last thing in a sentence, and the Makefile already
+# carries one written that way.
+run_case "reference followed by punctuation still counts" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: echo see test/regression/alpha.sh.' \
+        'test:
+	echo nothing' alpha)"
+
+echo "== exemptions =="
+# Driven by the fixture's own coverage_exemptions.txt, so these cases keep
+# testing the mechanism no matter what the repository's real list holds --
+# including when it is empty.
+FIXTURE_EXEMPTIONS='# reason goes here
+
+orphan'
+run_case "exempt script may be uncovered" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: echo hi' \
+        'test:
+	echo nothing' orphan)"
+
+# An exemption that is no longer true has to be removed, or the list decays
+# into a place where covered scripts go to be forgotten.
+run_case "exempt script that IS covered is rejected" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: bash test/regression/orphan.sh' \
+        'test:
+	echo nothing' orphan)"
+
+# An exemption whose script no longer exists is the same decay in the other
+# direction: it names nothing, so it can never be contradicted, and it outlives
+# the rename or deletion that made it meaningless.
+FIXTURE_EXEMPTIONS='# script was renamed away
+ghost'
+run_case "exemption naming no script is rejected" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: bash test/regression/alpha.sh' \
+        'test:
+	echo nothing' alpha)"
+
+# Comments and blank lines are not script names.
+FIXTURE_EXEMPTIONS='# orphan
+'
+run_case "commented-out entry does not exempt" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: echo hi' \
+        'test:
+	echo nothing' orphan)"
+FIXTURE_EXEMPTIONS=""
+
+echo "== resolution that stopped resolving must not report PASS =="
+empty_wf="$(build_fixture 'jobs: {}' 'test:
+	echo nothing' alpha)"
+rm -f "$empty_wf/.github/workflows/ci.yml"
+run_case "no workflow files" FAIL "$empty_wf"
+
+no_scripts="$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: echo hi' 'test:
+	echo nothing')"
+run_case "no regression scripts" FAIL "$no_scripts"
+
+no_makefile="$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: bash test/regression/alpha.sh' 'test:
+	echo nothing' alpha)"
+rm -f "$no_makefile/Makefile"
+run_case "no Makefile" FAIL "$no_makefile"
+
+# Regression for the SIGPIPE bug: the name appears at the very top, then far
+# more text than a pipe buffer holds. A piped `grep -q` short-circuits, printf
+# takes SIGPIPE, and pipefail turns the match into a miss.
+big_dir="$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: bash test/regression/alpha.sh' \
+    'test:
+	echo nothing' alpha)"
+{
+    printf '# filler to push the workflow text past the pipe buffer\n'
+    for _ in $(seq 1 4000); do
+        printf '# xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n'
+    done
+} >> "$big_dir/.github/workflows/ci.yml"
+workflow_bytes="$(wc -c < "$big_dir/.github/workflows/ci.yml" | tr -d ' ')"
+run_case "early match in >64KB of workflow text ($workflow_bytes bytes)" PASS "$big_dir"
+
+bash "$lint" one two > /dev/null 2>&1 && usage_status=0 || usage_status=$?
+if ((usage_status == 2)); then
+    echo "  ok   too many arguments -> usage error (exit 2)"
+else
+    echo "  FAIL too many arguments: expected exit 2, got $usage_status" >&2
+    failures=$((failures + 1))
+fi
+
+# Checked on the message, not just the status: an unguarded `cd` into a missing
+# directory also dies with exit 1 under `set -e`, so a status-only assertion
+# passes either way. The point of the case is that the failure arrives in this
+# family's own format rather than as bash's raw `cd:` diagnostic.
+absent_dir="$fixture_root/absent"
+absent_out="$(bash "$lint" "$absent_dir" 2>&1)" && absent_status=0 || absent_status=$?
+if ((absent_status == 1)) && [[ $absent_out == FAIL:* ]]; then
+    echo "  ok   argument that is not a directory -> FAIL"
+else
+    echo "  FAIL argument that is not a directory: expected exit 1 and a FAIL: message," >&2
+    echo "       got exit $absent_status: $absent_out" >&2
+    failures=$((failures + 1))
+fi
+
+if ((failures > 0)); then
+    echo "FAIL: regression_coverage_lint_selftest ($failures case(s))" >&2
+    exit 1
+fi
+
+echo "PASS: regression_coverage_lint_selftest"


### PR DESCRIPTION
test/regression/ is enumerated in two independent, hand-maintained
places: the `test:` target in the Makefile, and explicit steps and loops
in .github/workflows/. CI does not invoke `make test` -- it builds with
`make test-binaries` and then runs the scripts from its own list -- so a
script wired into one list and not the other still looks wired up while
no automated run ever executes it. Nothing fails. The coverage simply is
not there.

Two scripts were in that state:

  - version_banner.sh, reachable only from `test:`. CI ran `./bwa-mem3
    version` as a liveness check, but nothing asserted what the banner
    says, which is the SIMD floor and runtime tier lines and the
    BWAMEM3_FORCE_TIER downgrade. Now run on every matrix row, since
    those lines are exactly what differs across arch and floor.

  - host_floor_enforce.sh, reachable only from `test-injection`, a target
    no workflow names. It needs a TESTING_BUILD=1 binary, so covering it
    means paying for another build row. That is a real cost decision, so
    it is recorded as an explicit exemption with the reason rather than
    quietly assumed covered. The comment above `test-injection` claiming
    CI runs it as a separate matrix row was false, and is corrected.

Add test/regression/regression_coverage_lint.sh, which requires every
script in the directory to be named by a workflow, or to sit in the
recipe of a Makefile target a workflow actually invokes, or to be listed
as exempt with a reason.

Invoked targets are matched as `make [flags/vars...] <target>`, not by
substring. Substring matching is worse than useless here: `test` occurs
in every `make test-binaries` line, which would pull the `test:` recipe
into the covered set and mark as covered exactly the scripts this lint
exists to find. The self-test pins that.

Membership is tested with a herestring rather than `printf ... | grep`.
Under `set -o pipefail` a piped `grep -q` returns 141 when it
short-circuits on an early match and printf takes SIGPIPE, so a covered
script reads as uncovered. That is silent, and it only appears once the
scanned text outgrows the pipe buffer -- it bit at ~87 KB of workflow
text, making roughly half the scripts look unrun. The self-test covers it
with a >64 KB fixture whose match is at the top.

Runs as its own CI job (seconds, no toolchain) and from `make test`.

> **Stacked on #336** — it targets `ci/debug-macro-flag-lint` because both PRs add a lint job to `ci.yml` and a line to the `test:` recipe. Retarget to `main` once #336 merges; the diff shown here is this PR's own changes only.

## Validation

- Lint passes on the resulting tree: 34 scripts, 1 exempt.
- Self-test: 12 cases (covered directly / via an invoked target, four ways to be uncovered, both exemption directions, three ways the resolution can cover nothing, and the >64 KB SIGPIPE regression).
- Mutation-tested: reverting the herestring to the piped form fails the >64 KB case; resolving invoked targets by substring fails both substring-trap cases.
- `shellcheck -S style` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated checks ensuring all regression tests are included in CI or explicitly documented as exceptions.
  * Added self-tests covering regression detection, configuration validation, and edge cases.
  * Added version-banner verification across all build configurations.

* **Documentation**
  * Updated regression test documentation with coverage and version-banner checks.
  * Documented approved exceptions and validation rules.

* **Chores**
  * Expanded the standard test command to run regression coverage checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->