### PR TITLE
docs(test): describe the source-only lints' input contract

### DIFF
--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -3,10 +3,14 @@
 End-to-end parity and invariant checks. `chr22_parity.sh` runs on every
 matrix row; the rest run on the canonical AVX2 row only, except
 `profile_slice_cpu.sh`, which runs from the `profiling-build` job (see below),
-and the two `ndebug_gate_lint*` scripts, which need no binary at all and run
-from the `ndebug-gate-lint` job. Each script:
+and the `ndebug_gate_lint*` and `debug_macro_flag_lint*` scripts, which need no
+binary at all and run from the `ndebug-gate-lint` and `debug-macro-flag-lint`
+jobs. Each script:
 
-- is self-contained (set -euo pipefail; explicit env-var contract)
+- is self-contained (set -euo pipefail; explicit input contract — env vars for
+  every script but the source-only lints, which instead take an optional
+  positional directory so their self-tests can aim the same checks at a fixture
+  tree)
 - emits `PASS:` on success and `FAIL:` on failure
 - returns nonzero on failure
 
@@ -32,9 +36,14 @@ from the `ndebug-gate-lint` job. Each script:
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is
 the authoritative list, and `ci.yml` is where each one is actually wired up.
 
-Each script reads its inputs from environment variables — see the comment
-block at the top of each file. `.github/workflows/ci.yml` sets those vars
-and invokes the scripts.
+Every script but the source-only lints reads its inputs from environment
+variables — see the comment block at the top of each file. The lints read no
+environment at all: `ndebug_gate_lint.sh` takes the directory to scan (default
+`src/`) and `debug_macro_flag_lint.sh` takes the repository root to check
+(default: this repository), each as an optional positional argument, and the
+two `*_selftest.sh` scripts take no input, since they build the fixture trees
+they aim those lints at. `.github/workflows/ci.yml` sets the required vars and
+invokes the scripts.
 
 One exception to "any binary will do": `profile_slice_cpu.sh` asserts on
 `--profile` output, which a default build compiles out entirely, so it needs a


### PR DESCRIPTION
The regression README states that every script takes an explicit env-var contract. That stopped being true when the source-only lints landed: neither `ndebug_gate_lint.sh` nor `debug_macro_flag_lint.sh` reads any environment at all. Each takes an optional positional directory instead — the tree to scan and the repository root to check — so that their self-tests can aim the same checks at a fixture tree of known-good and known-bad input.

The intro paragraph had drifted the same way. It still named only the `ndebug_gate_lint` pair and the single job that runs them, though a second lint family, its self-test, and its own CI job landed alongside them in #336.

Describe every shape instead of only the oldest one. A reader following the stated contract would otherwise look for env vars that do not exist, or expect one lint job where there are two.

Docs only — no behavior change. Rebased onto `main` after #336 landed, which is what surfaced the second lint family. Touches a different part of the same file than #338, so the two can merge in any order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the four lint scripts and their dedicated CI jobs.
  * Documented the distinction between source-only lint checks and binary-dependent scripts.
  * Added guidance on positional directory inputs and self-test behavior.
  * Clarified that non-lint scripts use environment variables, while CI supplies required inputs to all scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
