### PR TITLE
ci: run the SIMD floor enforcement check on the canonical row

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,8 +276,14 @@ jobs:
       # line. It was wired only into `make test`, which no workflow invokes, so
       # until now it ran nowhere in CI. Every row rather than the canonical one:
       # the lines it checks are exactly what differs across arch and floor.
+      #
+      # EXPECTED_FLOOR makes the floor line an assertion rather than a presence
+      # check -- without it the row only proves the banner has a floor, not that
+      # it names the tier this row was built for. The script skips the
+      # comparison when EXPECTED_FLOOR is empty, so the arch_flag="" rows (ARM,
+      # macOS, single-binary) still run the rest of the checks.
       - name: Version banner regression
-        run: BWA_MEM3=./bwa-mem3 bash test/regression/version_banner.sh
+        run: BWA_MEM3=./bwa-mem3 EXPECTED_FLOOR=${{ matrix.arch_flag }} bash test/regression/version_banner.sh
 
       - name: Build doctest framework and unit binary
         # Invoke via the parent `test-binaries` target so ARCH_FLAGS
@@ -809,12 +815,48 @@ jobs:
           make clean
           make -j"$(nproc)" arch=${{ matrix.arch_flag }} \
             CXX=${{ matrix.cxx || 'g++' }} \
+            USE_MIMALLOC=${{ matrix.use_mimalloc }} \
             EXTRA_CXXFLAGS="-DBWA_MEM3_DEBUG_CHN_FLT_XCHECK -DBWA_MEM3_DEBUG_RID_CHECK -DBWA_MEM3_DEBUG_UNGAPPED_XCHECK -DBSW8_ASSERT_ENVELOPE -DBWA_MEM3_DEBUG_POISON -DBWAMEM3_UGP_PROFILE=1"
           BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
           CHR22_FA=/tmp/chr22/chr22.fa \
           BWA_CHR22_FA=/tmp/chr22/bwa_chr22.fa \
           CHR22_SIM_DIR=/tmp/chr22-sim \
           bash test/regression/chr22_parity.sh
+
+      - name: SIMD floor enforcement (TESTING_BUILD, injected below-floor tier)
+        if: matrix.canonical == true
+        # What happens when the binary lands on a host older than the floor it
+        # was built for is a user-facing promise: refuse with exit 2 and a
+        # readable [E::bwamem3] message, not a SIGILL. host_floor_enforce.sh
+        # asserts exactly that, using the BWAMEM3_TESTING_HOST_TIER hook to
+        # inject a below-floor tier, and it had never run in CI -- it hangs off
+        # `test-injection`, a target no workflow invoked.
+        #
+        # Invoked through the target rather than by calling the script, so the
+        # env contract (injected tier, PARITY_FA) lives in one place and the
+        # target itself stays exercised. The row is avx2, so sse41 is below
+        # floor. The reference is never opened -- the precheck fires first --
+        # so /dev/null is a real fixture here, not a shortcut.
+        #
+        # Placed here for the same reason as the step above: it replaces
+        # $GITHUB_WORKSPACE/bwa-mem3 with a differently-configured binary, and
+        # the ASAN step that follows does its own `make clean`. The flags are
+        # repeated on the second `make` so it sees the same configuration and
+        # treats the build as up to date instead of rebuilding.
+        #
+        # USE_MIMALLOC is carried from the row rather than left to the Makefile
+        # default, which is what every other build step here does. TESTING_BUILD
+        # is meant to vary one thing against the row's configuration; the
+        # canonical row happens to be USE_MIMALLOC=1 and so is the default, so
+        # omitting it is a no-op only until that row changes.
+        run: |
+          make clean
+          make -j"$(nproc)" arch=${{ matrix.arch_flag }} \
+            CXX=${{ matrix.cxx || 'g++' }} \
+            USE_MIMALLOC=${{ matrix.use_mimalloc }} TESTING_BUILD=1
+          make test-injection arch=${{ matrix.arch_flag }} \
+            CXX=${{ matrix.cxx || 'g++' }} \
+            USE_MIMALLOC=${{ matrix.use_mimalloc }} TESTING_BUILD=1
 
       - name: Short-read SE smoke (chr22, ASAN, dense+variable-length)
         if: matrix.canonical == true

--- a/Makefile
+++ b/Makefile
@@ -872,9 +872,13 @@ shell-fix:
 # Regression test that requires a binary built with TESTING_BUILD=1
 # (enables BWAMEM3_TESTING_HOST_TIER env-var injection). Not invoked by
 # the default `test` target because it requires a non-production build.
-# No workflow invokes this target, so host_floor_enforce.sh currently runs
-# nowhere in CI; test/regression/regression_coverage_lint.sh records that
-# as an explicit exemption rather than letting it pass for coverage.
+# CI invokes this target on the canonical row, after rebuilding in-row with
+# TESTING_BUILD=1 (see "SIMD floor enforcement" in .github/workflows/ci.yml).
+# Keep it invoked from there -- and do not treat
+# test/regression/regression_coverage_lint.sh as the backstop for that. It
+# counts a script as covered when a workflow *names* it, and that step's own
+# explanatory comment names host_floor_enforce.sh, so deleting the `make
+# test-injection` line would leave the lint green.
 test-injection: bwa-mem3
 	BWA_MEM3_TESTING=./bwa-mem3 INJECTED_TIER=sse41 PARITY_FA=/dev/null \
 		./test/regression/host_floor_enforce.sh

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -1,11 +1,13 @@
 # Regression scripts
 
-End-to-end parity and invariant checks. `chr22_parity.sh` runs on every
-matrix row; the rest run on the canonical AVX2 row only, except
-`profile_slice_cpu.sh`, which runs from the `profiling-build` job (see below),
-and the `ndebug_gate_lint*` and `debug_macro_flag_lint*` scripts, which need no
-binary at all and run from the `ndebug-gate-lint` and `debug-macro-flag-lint`
-jobs. Each script:
+End-to-end parity and invariant checks. `chr22_parity.sh` and
+`version_banner.sh` run on every matrix row; the rest run on the canonical
+AVX2 row only, except for the ones wired to a job of their own:
+`profile_slice_cpu.sh` runs from `profiling-build` (see below), and the
+`ndebug_gate_lint*`, `debug_macro_flag_lint*`, `shell_lint*` and
+`regression_coverage_lint*` pairs need no binary at all and run from
+`ndebug-gate-lint`, `debug-macro-flag-lint`, `shell-lint` and
+`regression-coverage-lint` respectively. Each script:
 
 - is self-contained (set -euo pipefail; explicit input contract — env vars for
   every script but the source-only lints, which instead take an optional
@@ -32,8 +34,11 @@ jobs. Each script:
 | `ndebug_gate_lint_selftest.sh` | the lint above still flags real gates, so its `PASS` means something | "NDEBUG gate lint still detects gates"              |
 | `debug_macro_flag_lint.sh`   | the opt-in macro build's `-D` list and the `BWA_MEM3_DEBUG_*` macros in `src/` still name each other | "Opt-in macro -D list matches the macros in src/"   |
 | `debug_macro_flag_lint_selftest.sh` | the lint above still detects a drifted list, so its `PASS` means something | "Macro list lint still detects drift"               |
+| `shell_lint.sh`              | every tracked `*.sh` is shellcheck-clean and shfmt-formatted           | "Tracked shell scripts are shellcheck-clean and shfmt-formatted" |
+| `shell_lint_selftest.sh`     | the lint above still rejects bad scripts, so its `PASS` means something | "Shell lint still detects bad scripts"             |
 | `regression_coverage_lint.sh` | every script in this directory is named by a CI workflow, or by a Makefile target CI invokes — not just by `make test` | "Every regression script is run by CI"              |
 | `regression_coverage_lint_selftest.sh` | the lint above still detects an unrun script, so its `PASS` means something | "Coverage lint still detects an unrun script"       |
+| `host_floor_enforce.sh`      | below-floor hosts get exit 2 + a readable error, not a SIGILL (needs `TESTING_BUILD=1`) | "SIMD floor enforcement (TESTING_BUILD, injected below-floor tier)" |
 | `version_banner.sh`          | `bwa-mem3 version` prints the SIMD floor and runtime tier lines        | "Version banner regression"                         |
 
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is

--- a/test/regression/coverage_exemptions.txt
+++ b/test/regression/coverage_exemptions.txt
@@ -8,8 +8,7 @@
 # The lint also fails when an entry here IS run by CI, and when an entry names
 # no script under test/regression/ at all -- so an exemption that has become
 # untrue, or that outlived the script it covered, cannot quietly accumulate.
-
-# Needs a TESTING_BUILD=1 binary (BWAMEM3_TESTING_HOST_TIER injection), which
-# no workflow builds. Covering it means paying for another build; until that is
-# decided it is honestly uncovered rather than quietly assumed covered.
-host_floor_enforce
+#
+# Currently empty, and worth keeping that way. The only entry this file ever
+# held was host_floor_enforce, which is now covered by an in-row TESTING_BUILD=1
+# rebuild on the canonical row rather than left uncovered.


### PR DESCRIPTION
host_floor_enforce.sh asserts a user-facing promise: a binary that lands
on a host below its build's SIMD floor refuses with exit 2 and a readable
[E::bwamem3] message naming the detected tier, and `version` emits the
matching warning. The alternative, if that precheck ever regresses, is an
illegal-instruction crash on the user's machine.

It has never run in CI. It hangs off `test-injection`, a target no
workflow invoked, so it only ever ran when someone typed `make
test-injection` by hand. The comment above that target claimed CI ran it
as a separate matrix row; that was already corrected as false.

Build TESTING_BUILD=1 in-row on the canonical row and invoke the target,
in the slot immediately before the ASAN step -- the same placement and
for the same reason as the opt-in macro build that precedes it: both
replace the workspace binary, and the ASAN step does its own `make
clean`. Going through `make test-injection` rather than calling the
script keeps the injection contract in one place and keeps the target
itself exercised.

The check is nearly free once built. The precheck fires before the
reference is opened, so PARITY_FA=/dev/null is a real fixture rather than
a shortcut, and the row is avx2, which makes sse41 a genuine below-floor
tier.

With this, coverage_exemptions.txt is empty: every script in
test/regression/ is now reachable from a workflow. The lint fails if an
exempt entry turns out to be covered, so dropping the entry is not
optional here -- it is what makes the change consistent.

> **Stacked on #338** (which is stacked on #336). Retarget down the chain as each merges; the diff here is this PR's own changes only.

## Validation

- `regression_coverage_lint` now reports **34 scripts, 0 exempt** — every script in `test/regression/` is reachable from a workflow.
- The coverage lint's self-test stays green with an empty exemption list, because its exemption cases are driven by fixture-local `coverage_exemptions.txt` files rather than the repository's real one.
- All six lints and self-tests pass locally; `ci.yml` parses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI validation of reported SIMD compatibility floors across build configurations.
  * Added enforcement checks to reject builds targeting unsupported instruction tiers.
  * Ensured version-banner regression checks run consistently across all CI build configurations.

* **Documentation**
  * Clarified regression testing, shell linting, coverage checks, and SIMD host-floor enforcement.
  * Documented how CI invokes and validates injection tests, including dedicated lint and coverage checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->