### PR TITLE
feat(meth)!: let --bam choose the output container under --meth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,6 +650,14 @@ jobs:
           HD_PARITY_WORK_DIR=/tmp/hd-parity \
           bash test/regression/default_hd_parity.sh
 
+      - name: --meth output container follows --bam
+        if: matrix.canonical == true
+        run: |
+          BWA_MEM3="$GITHUB_WORKSPACE/bwa-mem3" \
+          METH_SAM_PHIX_FA="$GITHUB_WORKSPACE/test/fixtures/phix.fa" \
+          METH_SAM_WORK_DIR=/tmp/meth-sam-output \
+          bash test/regression/meth_sam_output.sh
+
       - name: SE alignment smoke (chr22)
         if: matrix.canonical == true
         run: |

--- a/docs/_generated/cli/mem.txt
+++ b/docs/_generated/cli/mem.txt
@@ -104,10 +104,11 @@ Input/output options:
                  (4 sigma from the mean if absent) and min of the insert size distribution.
                  FR orientation only. [inferred]
 Methylation (--meth) options:
-   --meth[=CHEM] enable inline bwameth-style C→T/G→A read conversion + meth-aware BAM
-                 emission. Implies --bam. Requires the reference to have been built
-                 with `bwa-mem3 index --meth` (emits the original index plus a
-                 ref.fa.meth.* converted seed index).
+   --meth[=CHEM] enable inline bwameth-style C→T/G→A read conversion + meth-aware
+                 record emission (XM:Z/XG:Z/XR:Z). Output is SAM text by default,
+                 as without --meth; add --bam for BAM. Requires the reference to
+                 have been built with `bwa-mem3 index --meth` (emits the original
+                 index plus a ref.fa.meth.* converted seed index).
                  CHEM selects the chemistry and thus the XM:Z call polarity:
                    emseq  bisulfite/EM-seq, UNmethylated C converts [default]
                           (aliases: em-seq, bisulfite)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -47,7 +47,7 @@
   - [Conversion details (C->T, G->A)](methylation/conversion.md)
   - [TAPS libraries](methylation/taps.md)
   - [SAM tags: XR, XG, XM](methylation/tags.md)
-  - [Chimera QC and header rewriting](methylation/post-processing.md)
+  - [Chimera QC and header construction](methylation/post-processing.md)
   - [Flags: --meth chemistry, --meth-scoring, QC](methylation/flags.md)
   - [Migrating from bwameth.py c2t](methylation/external-c2t.md)
 - [What's Different from bwa-mem2]()

--- a/docs/src/best-practices/anti-patterns.md
+++ b/docs/src/best-practices/anti-patterns.md
@@ -72,8 +72,8 @@ bwa-mem3 adds several custom SAM tags that bwa-mem2 does not emit: `HN:i`
 aligner found for this read, before the `-h` supplementary cap is applied),
 and — in `--meth` mode — the Bismark-compatible `XR:Z` (read conversion
 direction), `XG:Z` (genome strand), and `XM:Z` (per-base methylation call
-string) tags. It also rewrites `@SQ` header lines in `--meth` mode
-(collapsing `f`/`r` strand prefixes back to one entry per chromosome).
+string) tags. In `--meth` mode it also builds each `@SQ` line from the original
+reference; the doubled `f`/`r` seed contigs never reach the output.
 
 > **Warning — Header and tag mismatch**
 >

--- a/docs/src/best-practices/output-format.md
+++ b/docs/src/best-practices/output-format.md
@@ -47,17 +47,37 @@ contend. A 16:8 split (bwa-mem3:samtools) works well on 24-core machines.
 
 ## Methylation output
 
-The `--meth` path always writes uncompressed BAM internally, regardless of
-the `--bam` flag.  The post-processing step (header rewrite, Bismark
-`XR:Z` / `XG:Z` / `XM:Z` tag emission, opt-in chimera QC) is performed
-inline before the record is handed to htslib, so the same pipeline shape
-applies:
+`--meth` selects bisulfite alignment semantics; it does not select an output
+format.  The container is chosen by `--bam` exactly as it is without `--meth`:
+SAM text by default, BAM with `--bam`.  The post-processing step (`@SQ` built
+from the original reference, Bismark `XR:Z` / `XG:Z` / `XM:Z` tag emission,
+opt-in chimera QC) is
+performed inline before the record is handed to htslib, so the same pipeline
+shape applies:
 
 ```bash
 bwa-mem3 mem --meth --bam=0 -t 16 ref.fa R1.fq.gz R2.fq.gz \
   | samtools sort -@ 8 -o out.bam -
 samtools index out.bam
 ```
+
+**What the two containers share.** `--meth` and `--meth --bam` run one
+`bam1_t` construction path and hand the finished record to htslib, differing
+only in the `htsFile` mode string, so the equivalence is structural rather than
+sampled: it does not vary with workload, thread count, or SIMD tier. It is over
+decoded **records**, not over headers — the `@PG` `CL:` field records the
+invoking command line and therefore differs, since one run was given `--bam`
+and the other was not. A regression script pins both halves on the committed
+phiX fixture in single-end and paired-end layouts (which take different
+emission paths): records must compare byte-identical, headers byte-identical
+once `CL:` is stripped.
+
+> **Changed in 0.8.0**
+>
+> Through 0.7.x, `--meth` forced BAM and text SAM was unreachable.  If you have
+> a script that relies on `bwa-mem3 mem --meth` producing BAM on stdout, add
+> `--bam` to it.  Piping into `samtools` needs no change: samtools autodetects
+> SAM text.
 
 ## When SAM is appropriate
 

--- a/docs/src/cli/mem.md
+++ b/docs/src/cli/mem.md
@@ -606,8 +606,17 @@ stderr (`[M::main_mem] --fast: ...`) so runs are self-documenting.
 
 Activates bisulfite alignment: each read is projected (R1 `C→T`, R2 `G→A`) to find
 seeds in the converted `.meth` seed index, then extended and scored against the
-**original** 4-letter reference, with inline BAM post-processing and forced
-`--bam` output. The reference must have been indexed with `bwa-mem3 index --meth`.
+**original** 4-letter reference, with inline meth post-processing (Bismark
+`XR:Z`/`XG:Z`/`XM:Z`, opt-in chimera QC). The reference must have been indexed with
+`bwa-mem3 index --meth`.
+
+`--meth` does not choose an output format: records are SAM text by default and BAM
+under `--bam`, the same rule as without `--meth`. Both containers serialize the same
+`bam1_t` and differ only in the `htsFile` mode string, so the two decode to identical
+**records** — headers differ in the `@PG` `CL:` field, which records the invoking
+command line. A regression script pins record and (`CL:`-stripped) header equality on
+the committed phiX fixture in single-end and paired-end layouts. (Through 0.7.x
+`--meth` forced `--bam`; add `--bam` to any script that depended on that.)
 
 Pass the original FASTA prefix as `<idxbase>` (e.g. `ref.fa`); the `ref.fa.meth.*`
 seed index alongside it is found automatically. A legacy bwameth `.bwameth.c2t`

--- a/docs/src/getting-started/quick-meth.md
+++ b/docs/src/getting-started/quick-meth.md
@@ -68,9 +68,10 @@ In one process, `--meth` replaces what bwameth.py does with external tools:
   against the *original* reference, restoring the original bases in `SEQ`.
 - **Applies bwameth-aligned defaults** — `-L 10 -U 100 -T 40 -M -C` plus
   mode-dependent `-B` (`2` for `collapsed`, `4` for `genomic`).
-- **Post-processes the BAM inline** — consolidates `f`/`r` `@SQ` headers back to
-  real chromosomes, emits Bismark `XR`/`XG`/`XM` tags, runs optional
-  `--chimera-qc`, and writes uncompressed BAM ready for `samtools sort`.
+- **Post-processes records inline** — writes `@SQ` from the original reference
+  (the `f`/`r` seed contigs never reach the output), emits Bismark `XR`/`XG`/`XM`
+  tags, and runs optional `--chimera-qc`. Output is SAM text by default and
+  uncompressed BAM under `--bam`, either one ready for `samtools sort`.
 
 See the [Methylation Reference — Overview](../methylation/overview.md) for the
 mechanism in detail, [Flags](../methylation/flags.md) for the scoring modes and

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,8 +18,8 @@ support for things you used to need a wrapper script for.
   genomic`, or `neutral` — the TAPS default — which tolerates a conversion
   without rewarding it). No Python, no inline conversion script, no separate
   post-processing step. One `bwa-mem3 index --meth ref.fa`, one
-  `bwa-mem3 mem --meth ref.fa R1.fq R2.fq`, done — headers consolidated and
-  Bismark tags emitted.
+  `bwa-mem3 mem --meth ref.fa R1.fq R2.fq`, done — original-reference headers
+  and Bismark tags emitted.
 - **Stage the index once, align many.** A `bwa-mem3 shm` subcommand
   pins the FM-index in shared memory so back-to-back runs on the same host
   skip the ~11 GB index read every time.

--- a/docs/src/methylation/bwameth-mapping.md
+++ b/docs/src/methylation/bwameth-mapping.md
@@ -78,9 +78,10 @@ conversion direction itself remains hidden; see
 They differ only in what the *conversion* cell scores: a full match under
 `genomic`, `0` under `neutral`.
 
-**Inline BAM post-processing.** Header rewriting, Bismark `XR`/`XG`/`XM` tags,
-opt-in chimera QC (`--chimera-qc`), and QC-fail propagation happen in the same
-pass. Output is uncompressed BAM (`wb0`) that `samtools sort` reads natively.
+**Inline post-processing.** `@SQ` built from the original reference, Bismark
+`XR`/`XG`/`XM` tags, opt-in chimera QC (`--chimera-qc`), and QC-fail propagation
+happen in the same pass. Output is SAM text by default and uncompressed BAM
+(`wb0`) under `--bam`; `samtools sort` reads either natively.
 
 **bwameth-aligned defaults (collapsed).** `--meth-scoring collapsed` applies
 `-B 2 -L 10 -U 100 -T 40 -M -C`, mirroring bwameth's `bwa mem -T 40 -B 2 -L 10
@@ -105,8 +106,8 @@ differ:
 
 | Field | bwameth.py | bwa-mem3 --meth |
 |-------|-----------|-----------------|
-| `@SQ` headers | One per real chromosome | One per real chromosome |
-| Read placement (collapsed) | reference | Closely tracks at the standard case; ~1% of records differ in `POS`/`CIGAR`/`MAPQ` (re-validate if pinned to a bwameth release) |
+| `@SQ` headers | One per original reference sequence | One per original reference sequence |
+| Read placement (collapsed) | reference | Closely tracks at the standard case; ~1% of records differ in `POS`/`CIGAR`/`MAPQ` on typical WGBS/EM-seq, `POS` alone in a few tenths of a percent (see the callout at the top of this page) — re-validate if pinned to a bwameth release |
 | Methylation aux tags | `YS:Z`, `YC:Z`, `YD:Z` | `XR:Z`, `XG:Z`, `XM:Z` (Bismark) |
 | `@PG` | `ID:bwameth` | `ID:bwa-mem3-meth` |
 | Chimera QC threshold | Longest M < 44% of read | Same (44%), opt-in via `--chimera-qc` |
@@ -144,5 +145,5 @@ bwameth-compatible placement (`collapsed`) or variant-aware scoring (`genomic`,
 [Overview](overview.md) ·
 [Conversion details](conversion.md) ·
 [SAM tags: XR, XG, XM](tags.md) ·
-[Chimera QC and header rewriting](post-processing.md) ·
+[Chimera QC and header construction](post-processing.md) ·
 [Related Projects: bwameth.py](../related-projects/bwameth.md)

--- a/docs/src/methylation/flags.md
+++ b/docs/src/methylation/flags.md
@@ -313,7 +313,7 @@ don't collide. There is no flag to override this — `-V` is a no-op for
 
 **See also:**
 [Overview](overview.md) ·
-[Chimera QC and header rewriting](post-processing.md) ·
+[Chimera QC and header construction](post-processing.md) ·
 [SAM tags: XR, XG, XM](tags.md) ·
 [Best Practices → Methylation defaults](../best-practices/methylation.md) ·
 [CLI Reference → mem](../cli/mem.md)

--- a/docs/src/methylation/flags.md
+++ b/docs/src/methylation/flags.md
@@ -110,7 +110,10 @@ when you want one BAM that serves both methylation *and* variant calling, or wan
 the aligner to distinguish real variants from conversions. Prefer `neutral` for
 TAPS (its default), where conversions are sparse and rewarding them as matches
 costs placement specificity — it keeps variants visible for variant calling on the
-same terms as `genomic` while placing sparse-conversion reads more accurately.
+same terms as `genomic` while placing sparse-conversion reads more accurately
+(+0.24–0.28 pp over `genomic` on the 4.07 M-read simulated-TAPS-against-hg38
+measurement described under [`--meth[={emseq|taps}]`](#--methemseqtaps); no
+equivalent measurement exists for real TAPS libraries yet).
 
 > **Note — `-B` follows the mode, but you can override it**
 >
@@ -138,10 +141,11 @@ arbitrary reading. Tag names are case-insensitive.
 
 ```bash
 # Drop the methylation call string; keep the strand labels.
-bwa-mem3 mem --meth --meth-tags '^XM' ref.fa r1.fq r2.fq > out.bam
+# (SAM text, since `--bam` is absent — add `--bam` for a BAM container.)
+bwa-mem3 mem --meth --meth-tags '^XM' ref.fa r1.fq r2.fq > out.sam
 
 # Identical, spelled as an inclusion list (no quoting needed).
-bwa-mem3 mem --meth --meth-tags XR,XG ref.fa r1.fq r2.fq > out.bam
+bwa-mem3 mem --meth --meth-tags XR,XG ref.fa r1.fq r2.fq > out.sam
 ```
 
 An exclusion may be written `^XM` **or** `-XM`. Prefer `-XM` in scripts: a bare

--- a/docs/src/methylation/overview.md
+++ b/docs/src/methylation/overview.md
@@ -3,8 +3,10 @@
 `bwa-mem3 mem --meth` is a single-binary, single-command methylation aligner,
 supporting both **bisulfite/EM-seq** (the default) and **TAPS**
 (`--meth=taps`). One `bwa-mem3 index --meth` builds the reference, and one
-`bwa-mem3 mem --meth` aligns raw FASTQ to a sorted-ready BAM — no Python, no
+`bwa-mem3 mem --meth` aligns raw FASTQ to sorted-ready records — no Python, no
 piped read-conversion preprocessor, and no separate post-processing script.
+`--meth` selects alignment semantics only; the output container is `--bam`'s
+job — SAM text by default, BAM with `--bam`.
 
 > **Pick the chemistry.** Both chemistries convert C→T as far as the aligner can
 > see, so the same index and scoring serve both — but they invert the *meaning*
@@ -26,7 +28,12 @@ variant in the conversion direction itself (a genuine C→T at a reference `C`),
 which no single read can tell apart from a conversion — see
 [how `NM`/`MD` are computed](#how-nmmd-are-computed-under---meth).
 
-The non-`--meth` code path is byte-for-byte unchanged.
+`--meth` adds no divergence to the non-`--meth` path: without the flag, output
+is unchanged. As everywhere on this fork, a byte comparison that demonstrates
+that must hold the batch partition fixed — compare at the same `-t`, or pass
+`-K` to both sides — since batch boundaries feed `mem_pestat` and can move a
+small number of records on their own. See
+[Equivalence → batch size, `-t`, and why comparisons need `-K`](../whats-different/equivalence.md#batch-size--t-and-why-comparisons-need--k).
 
 ## How `NM`/`MD` are computed under `--meth`
 
@@ -78,9 +85,9 @@ about converted bases. This is controlled by `--meth-scoring`:
 
 | Mode | Default? | Matrix | `-B` | Behavior |
 |------|----------|--------|------|----------|
-| **`collapsed`** | **`--meth` / `--meth=emseq`** | frees C↔T *and* G↔A both ways (two cells), each scored as a full match | `2` | bwameth-compatible **placement** — C/T and G/A are interchangeable, so it closely tracks bwameth's collapsed-space mapping. A close approximation, **not** exact: ~1% of records differ in `POS`/`CIGAR`/`MAPQ`, so re-validate if pinned to a bwameth release. |
+| **`collapsed`** | **`--meth` / `--meth=emseq`** | frees C↔T *and* G↔A both ways (two cells), each scored as a full match | `2` | bwameth-compatible **placement** — C/T and G/A are interchangeable, so it closely tracks bwameth's collapsed-space mapping. A close approximation, **not** exact: ~1% of records differ in `POS`/`CIGAR`/`MAPQ` on typical WGBS/EM-seq ([full caveat](bwameth-mapping.md)), so re-validate if pinned to a bwameth release. |
 | **`genomic`** | no (opt-in) | frees only the conversion direction (one cell), scored as a full match | `4` | **variant-aware** — the mirror cell stays penalised, so a real C/T or G/A variant scores as a mismatch and stays visible in `NM`/`MD`, making the BAM usable for variant calling. A variant in the conversion direction itself is still hidden ([why](#which-real-variants-stay-visible)). |
-| **`neutral`** | **`--meth=taps`** | frees only the conversion direction (one cell), scored `0` | `4` | **variant-aware and conservative** — a conversion is tolerated but not rewarded, so a sparse TAPS conversion no longer over-credits a spurious C→T alignment. Real variants stay visible in `NM`/`MD` on the same terms as `genomic`; measured +0.24–0.28 pp placement over `genomic` on simulated TAPS. |
+| **`neutral`** | **`--meth=taps`** | frees only the conversion direction (one cell), scored `0` | `4` | **variant-aware and conservative** — a conversion is tolerated but not rewarded, so a sparse TAPS conversion no longer over-credits a spurious C→T alignment. Real variants stay visible in `NM`/`MD` on the same terms as `genomic`; +0.24–0.28 pp placement over `genomic`, measured on 4.07 M simulated TAPS reads against full hg38 across three methylation loads ([full arms and method](taps.md#what---methtaps-changes)). |
 
 The default follows the chemistry: `--meth` and `--meth=emseq` default to
 `collapsed`, so existing methylation pipelines see bwameth-compatible read
@@ -106,7 +113,7 @@ flowchart LR
     A[Raw FASTQ\nR1 / R2] -->|project R1 C→T,\nR2 G→A for SEEDING ONLY| B[seed in .meth\ndoubled seed index]
     B -->|remap each seed →\noriginal coords + OT/OB hypothesis| C[extend + SCORE\nORIGINAL read vs ORIGINAL ref\nper-strand asymmetric matrix]
     C -->|--meth-scoring\ncollapsed / genomic / neutral| D[original-alphabet\nalignment]
-    D -->|XR/XG/XM Bismark tags\noptional --chimera-qc| E[BAM output]
+    D -->|XR/XG/XM Bismark tags\noptional --chimera-qc| E[SAM text by default\nBAM on request]
 ```
 
 Steps:
@@ -140,8 +147,8 @@ Steps:
    Bismark `XR:Z` (read conversion), `XG:Z` (genome strand), and `XM:Z` (per-base
    methylation call) tags. Optional `--chimera-qc` (off by default, matching
    Bismark) flags chimeric reads. The `@PG ID:bwa-mem3-meth` line records the
-   command line. Output is uncompressed BAM (`wb0`); pipe directly to
-   `samtools sort`.
+   command line. Output is SAM text by default and uncompressed BAM (`wb0`)
+   under `--bam`; pipe either directly to `samtools sort`.
 
 ## Quick-start commands
 
@@ -184,5 +191,5 @@ bwa-mem3 mem --meth=taps -t 16 ref.fa R1.fq.gz R2.fq.gz \
 [bwameth.py drop-in mapping](bwameth-mapping.md) ·
 [Conversion details](conversion.md) ·
 [SAM tags: XR, XG, XM](tags.md) ·
-[Chimera QC and header rewriting](post-processing.md) ·
+[Chimera QC and header construction](post-processing.md) ·
 [Quick start: methylation alignment](../getting-started/quick-meth.md)

--- a/docs/src/methylation/post-processing.md
+++ b/docs/src/methylation/post-processing.md
@@ -1,43 +1,51 @@
-# Chimera QC and Header Rewriting
+# Chimera QC and header construction
 
 After the alignment kernel produces `mem_aln_t` records, `bwa-mem3 --meth`
-applies a set of post-processing steps before writing BAM output. These steps
+applies a set of post-processing steps before writing its output. These steps
 are implemented in `src/meth_bam.cpp` and run in the same process, in the same
-pass over the aligned records.
+pass over the aligned records. They are independent of the output container —
+`--meth` writes SAM text by default and BAM under `--bam`, and the records are
+identical either way.
 
-## `@SQ` header consolidation
+## `@SQ` headers come from the original reference
 
-The `.meth` seed reference (`ref.fa.meth.fa`) contains two contigs for each
+The `.meth` **seed** reference (`ref.fa.meth.fa`) contains two contigs for each
 chromosome:
 
 - `fchr1`, `fchr2`, … — C→T projections of each chromosome.
 - `rchr1`, `rchr2`, … — G→A projections of each chromosome.
 
-If the raw alignment header were written directly, every downstream tool would
-see twice as many sequences as there are real chromosomes, with unfamiliar
-`f`/`r`-prefixed names. `meth_bam_writer_open` instead builds a consolidated
-header using the `meth_chrom_map_t`:
+Those `f`/`r` contigs exist only for seeding, and they never reach the output.
+Since D3 (#174), `--meth` emits native original-alphabet output: seeds are
+remapped to original coordinates plus an OT/OB hypothesis at the end of the
+seeding phase (`orig_tid = seed_rid / 2`, `hypothesis = seed_rid & 1`), so every
+mapped `mem_aln_t` that reaches the writer already carries an **original** rid.
+Unmapped records keep the `rid = -1` sentinel `mem_reg2aln` gives them.
 
-1. `meth_chrom_map_build_from_bns` iterates over `bns->anns` and strips the
-   leading `f`/`r` from each contig name.
-2. The first contig with a given stripped name registers that name in the output
-   list; subsequent contigs with the same stripped name map to the same output
-   index.
-3. The BAM `@SQ` lines are written from the consolidated list — one `SN:` per
-   real chromosome.
+`meth_bam_writer_open` therefore builds `@SQ` straight from the original
+(un-converted) reference's `bns->anns` — one `SN:` per reference sequence, in the
+original reference's order — and enriches each line with the `M5`/`UR`/`AS`/`SP`
+identity tags from that reference's `.hdr`/`.dict` sidecar when one is present.
 
-RNAME, RNEXT, and SA/XA tag contig references in every record are rewritten
-through `cmap->out_tid` and `cmap->output_names` so they reference the
-consolidated names. The mapping from internal (doubled-ref) contig index to
-output contig index is `cmap->out_tid[p.rid]`.
+Per record, `meth_mem_aln_to_bam` sets RNAME and RNEXT from `p.rid` and
+`mp->rid` directly. `SA:Z` names are looked up in `bns->anns` and `XA:Z` is
+emitted verbatim. There is no name rewriting and no contig-index translation
+anywhere on the path.
 
-> **Note — TLEN computation uses consolidated TIDs**
+> **Historical note**
 >
-> Template length (TLEN) is computed using the consolidated output TIDs, not the
-> internal `p.rid` values. Two mates that rescue onto `fchr1` and `rchr1`
-> respectively both map to output `chr1`, so TLEN is reported as a non-zero
-> distance rather than zero (which would happen if the mismatched internal TIDs
-> were used).
+> Before D3, output carried the doubled reference's coordinates and a
+> `meth_chrom_map_t` collapsed the `f`/`r` names at emit time, translating every
+> RNAME/RNEXT/SA/XA reference through an `out_tid` table. That map and its
+> consolidation step were removed when the coordinate cutover landed; the
+> original-alphabet rids make it unnecessary. Documentation describing
+> `meth_chrom_map_*`, `out_tid`, or `output_names` refers to the pre-D3 design.
+
+TLEN is computed from `p.pos`/`mp->pos` when both mates carry a CIGAR and land
+on the same contig (`tid == mtid`). Because rids are already original, that test
+is a plain same-chromosome check — the pre-D3 subtlety, where two mates rescued
+onto `fchr1` and `rchr1` had different internal rids for the same real
+chromosome, cannot arise.
 
 ## Chimera QC heuristic (opt-in)
 
@@ -116,13 +124,14 @@ and reproducibility.
 
 > **Tip — Verifying the header**
 >
-> After alignment, confirm consolidation and provenance with:
+> After alignment, confirm the header and provenance with (samtools autodetects
+> both containers, so this works on `--meth` and `--meth --bam` output alike):
 >
 > ```bash
 > samtools view -H out.bam | grep -E '^@SQ|^@PG'
 > ```
 >
-> You should see one @SQ line per chromosome (no f/r prefixes) and both
+> You should see one @SQ line per reference sequence (no f/r prefixes) and both
 > `@PG ID:bwa-mem3` and `@PG ID:bwa-mem3-meth` entries.
 
 ---

--- a/docs/src/methylation/tags.md
+++ b/docs/src/methylation/tags.md
@@ -32,14 +32,17 @@ biscuit's per-read methylation tools.
 | Property | Value |
 |----------|-------|
 | Type | `Z` (NUL-terminated string) |
-| Values | `CT` (aligned to original top, `f-`-prefixed contig) or `GA` (aligned to original bottom, `r-`-prefixed contig) |
-| Set by | `meth_mem_aln_to_bam` from `meth_chrom_map_t.direction` |
+| Values | `CT` (aligned to the original top strand, OT) or `GA` (aligned to the original bottom strand, OB) |
+| Set by | `meth_mem_aln_to_bam` from the winning hypothesis `mem_aln_t.meth_hypothesis` (`1` = OT → `CT`, `0` = OB → `GA`) — not from a contig-name prefix |
 | Emitted on | Mapped records only |
 
-`XG:Z` indicates which doubled-reference strand the read aligned to:
+`XG:Z` indicates which strand of the original genome the read aligned to. The
+call comes from the hypothesis that won scoring, which corresponds to the seed
+contig the read seeded against — but the contig name itself never reaches the
+output, since RNAME is an original-reference contig:
 
-- `CT` — read aligned under the OT (top-strand) hypothesis (`f`-prefixed seed contig).
-- `GA` — read aligned under the OB (bottom-strand) hypothesis (`r`-prefixed seed contig).
+- `CT` — read aligned under the OT (top-strand) hypothesis (seeded on `f`*).
+- `GA` — read aligned under the OB (bottom-strand) hypothesis (seeded on `r`*).
 
 For properly paired directional reads, R1 and R2 of a fragment naturally
 share `XG:Z`. Discordant pairs (flagged with `0x200` only when `--chimera-qc`
@@ -147,6 +150,6 @@ XM:Z:..z..h..Z..x..h.....Z..
 [Overview](overview.md) ·
 [bwameth.py drop-in mapping](bwameth-mapping.md) ·
 [Conversion details](conversion.md) ·
-[Chimera QC and header rewriting](post-processing.md) ·
+[Chimera QC and header construction](post-processing.md) ·
 [Flags: --set-as-failed, --chimera-qc](flags.md) ·
 [User Guide → Output: SAM/BAM, headers, tags](../user-guide/output.md)

--- a/docs/src/reference/glossary.md
+++ b/docs/src/reference/glossary.md
@@ -11,7 +11,7 @@ The first line of a SAM file header. Specifies the SAM format version (`VN`) and
 A SAM header line recording a program that processed the file, including `ID`, `PN`, `VN`, and `CL` fields. bwa-mem3 inserts `ID:bwa-mem3` (or `ID:bwa-mem3-meth` in methylation mode). See [Output: SAM/BAM, headers, tags](../user-guide/output.md).
 
 **@SQ header**
-A SAM header line describing a reference sequence (chromosome). Contains the sequence name (`SN`) and length (`LN`). In methylation mode, bwa-mem3 post-processes `@SQ` lines to collapse `f`/`r`-prefixed contig names back to one entry per chromosome. See [Chimera QC and header rewriting](../methylation/post-processing.md).
+A SAM header line describing a reference sequence (chromosome). Contains the sequence name (`SN`) and length (`LN`). In methylation mode, `@SQ` is written directly from the original (un-converted) reference, so the `f`/`r`-prefixed contigs of the `.meth` seed index never appear in output. See [Chimera QC and header construction](../methylation/post-processing.md).
 
 **BAM**
 Binary Alignment Map — a compressed, binary encoding of SAM. Produced by bwa-mem3 when the `--bam` flag is given or when output is piped through samtools. See [Output: SAM/BAM, headers, tags](../user-guide/output.md).
@@ -23,7 +23,7 @@ A heuristic variant of the Smith-Waterman alignment algorithm that restricts the
 Cytosine-to-thymine in-silico conversion applied to reads (or reference) before methylation alignment. In `--meth` mode, bwa-mem3 converts R1 reads C→T and R2 reads G→A inline, without writing intermediate FASTQ files. See [Conversion details (C->T, G->A)](../methylation/conversion.md).
 
 **Chimera**
-A read alignment where the aligned portion is short relative to the read length, often indicating a mapping artefact or a true chimeric molecule. In methylation mode, bwa-mem3 applies a chimera QC heuristic: if the longest contiguous M/=/X CIGAR run is less than 44% of the read length, the alignment is flagged 0x200, the proper-pair bit is cleared, and MAPQ is capped at 1. See [Chimera QC and header rewriting](../methylation/post-processing.md).
+A read alignment where the aligned portion is short relative to the read length, often indicating a mapping artefact or a true chimeric molecule. In methylation mode, bwa-mem3 applies a chimera QC heuristic: if the longest contiguous M/=/X CIGAR run is less than 44% of the read length, the alignment is flagged 0x200, the proper-pair bit is cleared, and MAPQ is capped at 1. See [Chimera QC and header construction](../methylation/post-processing.md).
 
 **FASTQ**
 A text format for raw sequencing reads. Each record contains a sequence identifier, the nucleotide sequence, a separator, and per-base quality scores in ASCII-encoded Phred format. bwa-mem3 accepts gzip-compressed FASTQ as input. See [Quick start: align paired-end FASTQs](../getting-started/quick-align.md).

--- a/docs/src/related-projects/bwameth.md
+++ b/docs/src/related-projects/bwameth.md
@@ -36,8 +36,8 @@ G/A variant in the direction *opposite* the conversion as a mismatch (visible in
 direction itself is indistinguishable from a conversion under either design
 ([why](../methylation/overview.md#which-real-variants-stay-visible)).
 
-It rewrites the `@SQ` headers to consolidate the per-strand contig pairs back to
-canonical chromosome names, emits Bismark-compatible `XR:Z` / `XG:Z` / `XM:Z`
+It writes `@SQ` headers directly from the original reference, so output carries
+the original reference contig names, emits Bismark-compatible `XR:Z` / `XG:Z` / `XM:Z`
 auxiliary tags, and writes a `@PG ID:bwa-mem3-meth` header. The bwameth.py-style
 chimera QC heuristic is available via `--chimera-qc` (off by default — Bismark
 behavior). The [Methylation Reference](../methylation/overview.md) documents the

--- a/docs/src/user-guide/output.md
+++ b/docs/src/user-guide/output.md
@@ -79,11 +79,15 @@ bwa-mem3 neither adds nor removes tags in it.
 > which always emits `AH:*` — at the cost of the `M5`/`UR`/`AS`/`SP` metadata
 > the `.dict` carries.
 
-In methylation mode (`--meth`), the doubled reference contains sequences with
-an `f` or `r` prefix in their names. The inline BAM post-processor collapses
-these back to canonical chromosome names so that the output `@SQ` lines match
-a standard non-methylation alignment. See
-[Chimera QC and header rewriting](../methylation/post-processing.md).
+In methylation mode (`--meth`), the `f`/`r`-prefixed contigs of the doubled
+`.meth` seed reference are used for seeding only and never reach the output.
+`@SQ` is written directly from the original (un-converted) reference, so the
+lines carry the same reference names and lengths a standard non-methylation
+alignment does. They are not guaranteed to be byte-identical to it: the
+standard path can emit the index's `.hdr`/`.dict` sidecar `@SQ` records
+verbatim, whereas methylation mode builds each line from `bns->anns` and then
+merges the sidecar's identity tags onto it. See
+[Chimera QC and header construction](../methylation/post-processing.md).
 
 ### `@PG`
 
@@ -161,7 +165,7 @@ MAPQ semantics are inherited from bwa-mem2 and follow the same scoring model.
 In methylation mode, alignments identified as chimeras (longest `M`/`=`/`X`
 run covering less than 44% of the read length) have their MAPQ capped at 1 and
 the `0x200` (QC fail) flag set. See
-[Chimera QC and header rewriting](../methylation/post-processing.md).
+[Chimera QC and header construction](../methylation/post-processing.md).
 
 ---
 

--- a/docs/src/whats-different/features.md
+++ b/docs/src/whats-different/features.md
@@ -31,8 +31,11 @@ index layout is **not** the same as bwameth.py's single `.bwameth.c2t` reference
 index, preserving the original bases on the first-class `bseq1_t.meth_orig_seq`
 field (a `YS:Z`/`YC:Z` comment carrier is a fallback only; neither reaches the
 BAM). It then extends and **scores against the original 4-letter reference** with
-a per-strand asymmetric matrix, consolidates the `f`/`r` contig pairs back to one
-`@SQ` per real chromosome, emits Bismark-compatible `XR:Z` (read conversion
+a per-strand asymmetric matrix, writes one `@SQ` per original reference
+sequence straight from the original reference
+([#174](https://github.com/fg-labs/bwa-mem3/pull/174), which moved seeds onto
+original coordinates and removed the `f`/`r` header-rewrite step), emits
+Bismark-compatible `XR:Z` (read conversion
 direction), `XG:Z` (genome strand), and `XM:Z` (per-base methylation call string)
 auxiliary tags, restores the original bases into the BAM SEQ field for CpG-calling
 tools, optionally applies a chimera QC heuristic (longest M/=/X run < 44% of read

--- a/src/bwamem.cpp
+++ b/src/bwamem.cpp
@@ -3302,9 +3302,11 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str,
                  bseq1_t *s, int n, const mem_aln_t *list, int which, const mem_aln_t *m_)
 {
     SpEncodeScope _enc;   /* stage_prof: time the SAM/BAM build (all return paths) */
-    /* BAM short-circuit: meth_mode applies the bisulfite overlay (chrom
-     * consolidation, YD:Z, chimera QC), plain bam_mode uses the generic
-     * writer. Either path leaves `str` untouched. */
+    /* bam1_t short-circuit: meth_mode applies the bisulfite overlay (Bismark
+     * XR:Z/XG:Z/XM:Z, opt-in chimera QC), plain bam_mode uses the generic
+     * writer. Either path leaves `str` untouched, so callers must branch on
+     * mem_opt_records_are_bam(), not opt->bam_mode — --meth builds bam1_t even
+     * when the container is SAM text. */
     if (opt->meth_mode) {
         struct bam1_t *b = bam_writer_alloc();
         if (b == NULL)

--- a/src/bwamem.h
+++ b/src/bwamem.h
@@ -208,9 +208,11 @@ typedef struct mem_opt_t {
      * (1 = OT, 0 = OB) via mem_opt_meth_mat(). */
     int8_t mat_ot[25];      // OT (C→T) meth matrix; valid only under --meth
     int8_t mat_ob[25];      // OB (G→A) meth matrix; valid only under --meth
-    int    bam_mode;        // 1 = emit BAM instead of SAM text (--bam); meth_mode implies this
+    int    bam_mode;        // 1 = emit BAM instead of SAM text (--bam). Orthogonal
+                            // to meth_mode: --meth picks alignment semantics, --bam
+                            // picks the container, on every mode alike.
     int    bam_level;       // 0..9, BGZF deflate level (0 = uncompressed)
-    int    meth_mode;       // 1 = bisulfite mode (--meth); implies bam_mode
+    int    meth_mode;       // 1 = bisulfite mode (--meth)
     int    meth_scoring;    // bisulfite matrix mode (--meth-scoring):
                             // MEM_METH_SCORING_{COLLAPSED,GENOMIC,NEUTRAL}
     int    meth_chem;       // methylation chemistry (--meth=emseq|taps): meth_chem_t.
@@ -480,6 +482,20 @@ static inline uint8_t *mem_aln_ref_string(const worker_t *w) {
 static inline const int8_t *mem_opt_meth_mat(const mem_opt_t *opt, int meth_hypothesis) {
     if (!opt->meth_mode || meth_hypothesis < 0) return opt->mat;
     return (meth_hypothesis & 1) ? opt->mat_ot : opt->mat_ob;
+}
+
+/* True when mem_aln2sam() builds records as bam1_t (pushed to bseq1_t.bams) and
+ * leaves the SAM kstring_t untouched, rather than formatting SAM text into it.
+ *
+ * This is NOT the same question as "is the output file BAM". --meth always
+ * builds bam1_t — the bisulfite overlay (XM:Z, XG:Z, chimera QC) is written into
+ * the aux block, and htslib serializes that to either container — so a --meth run
+ * WITHOUT --bam still takes the bam1_t path and then writes SAM text. Callers
+ * that skip the `str.s` handoff must test THIS, not opt->bam_mode; testing
+ * bam_mode alone would send `--meth` (no `--bam`) down the text branch and trip
+ * its `assert(str.s != 0)` on a string nothing ever wrote to. */
+static inline int mem_opt_records_are_bam(const mem_opt_t *opt) {
+    return opt->bam_mode || opt->meth_mode;
 }
 
 

--- a/src/bwamem_pair.cpp
+++ b/src/bwamem_pair.cpp
@@ -882,9 +882,11 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns,
         for (i = 0; i < n_aa[0]; ++i)
             mem_aln2sam(opt, bns, &str, &s[0], n_aa[0], aa[0], i, &h[1]);
 
-        if (opt->bam_mode) {
-            /* BAM path (meth or generic): mem_aln2sam short-circuited
-             * into s->bams, leaving str untouched. Skip the str.s dance. */
+        if (mem_opt_records_are_bam(opt)) {
+            /* bam1_t path (meth or generic): mem_aln2sam short-circuited into
+             * s->bams, leaving str untouched. Skip the str.s dance. Note this
+             * is NOT opt->bam_mode — --meth without --bam still builds bam1_t
+             * and would hit the `assert(str.s != 0)` below. */
             s[0].sam = NULL;
             str.l = 0;
             for (i = 0; i < n_aa[1]; ++i)
@@ -1479,9 +1481,11 @@ int mem_sam_pe_batch_post(const mem_opt_t *opt, const bntseq_t *bns,
         for (i = 0; i < n_aa[0]; ++i)
             mem_aln2sam(opt, bns, &str, &s[0], n_aa[0], aa[0], i, &h[1]);
 
-        if (opt->bam_mode) {
-            /* BAM path (meth or generic): mem_aln2sam short-circuited
-             * into s->bams, leaving str untouched. Skip the str.s dance. */
+        if (mem_opt_records_are_bam(opt)) {
+            /* bam1_t path (meth or generic): mem_aln2sam short-circuited into
+             * s->bams, leaving str untouched. Skip the str.s dance. Note this
+             * is NOT opt->bam_mode — --meth without --bam still builds bam1_t
+             * and would hit the `assert(str.s != 0)` below. */
             s[0].sam = NULL;
             str.l = 0;
             for (i = 0; i < n_aa[1]; ++i)

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -32,6 +32,7 @@ Authors: Vasimuddin Md <vasimuddin.md@intel.com>; Sanchit Misra <sanchit.misra@i
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h> /* strcasecmp(): POSIX declares it here, not in string.h */
 #include "bwa_madvise.h"
 #if NUMA_ENABLED
 #include <numa.h>
@@ -1136,6 +1137,10 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
         if (sp_enabled()) {
             ret->prof.write_wall = sp_wall() - sp_w0;
             ret->prof.write_bytes = sp_wbytes;
+            /* bam_mode, NOT mem_opt_records_are_bam(): this asks whether the
+             * write path DEFLATES, and only --bam does. A --meth run without
+             * --bam builds bam1_t but htslib serializes them as plain text, so
+             * there is no compression stage to fuse — it belongs in `else`. */
             if (aux->opt->bam_mode) {            /* htslib fuses compress+diskwrite */
                 ret->prof.write_compress = ret->prof.write_wall;   /* diskwrite stays NaN */
             } else {
@@ -1586,10 +1591,11 @@ static void usage(const mem_opt_t *opt)
     fprintf(stderr, "                 (4 sigma from the mean if absent) and min of the insert size distribution.\n");
     fprintf(stderr, "                 FR orientation only. [inferred]\n");
     fprintf(stderr, "Methylation (--meth) options:\n");
-    fprintf(stderr, "   --meth[=CHEM] enable inline bwameth-style C→T/G→A read conversion + meth-aware BAM\n");
-    fprintf(stderr, "                 emission. Implies --bam. Requires the reference to have been built\n");
-    fprintf(stderr, "                 with `bwa-mem3 index --meth` (emits the original index plus a\n");
-    fprintf(stderr, "                 ref.fa.meth.* converted seed index).\n");
+    fprintf(stderr, "   --meth[=CHEM] enable inline bwameth-style C→T/G→A read conversion + meth-aware\n");
+    fprintf(stderr, "                 record emission (XM:Z/XG:Z/XR:Z). Output is SAM text by default,\n");
+    fprintf(stderr, "                 as without --meth; add --bam for BAM. Requires the reference to\n");
+    fprintf(stderr, "                 have been built with `bwa-mem3 index --meth` (emits the original\n");
+    fprintf(stderr, "                 index plus a ref.fa.meth.* converted seed index).\n");
     fprintf(stderr, "                 CHEM selects the chemistry and thus the XM:Z call polarity:\n");
     fprintf(stderr, "                   emseq  bisulfite/EM-seq, UNmethylated C converts [default]\n");
     fprintf(stderr, "                          (aliases: em-seq, bisulfite)\n");
@@ -1835,7 +1841,8 @@ int main_mem(int argc, char *argv[])
     // comment: added option '5' in the list
     //
     // Long-only options for bisulfite mode (bwa-mem3 meth fork):
-    //   --meth              Enable inline bwameth-style c2t + post-processing + BAM output.
+    //   --meth              Enable inline bwameth-style c2t + post-processing. Output
+    //                       container is --bam's job, same as without --meth.
     //                       Expects a reference built with `bwa-mem3 index --meth`.
     //   --set-as-failed f|r Flag alignments to this strand as QC-fail (0x200)
     //   --chimera-qc        Enable the bwameth.py-style longest-M <44% chimera heuristic
@@ -2037,7 +2044,10 @@ int main_mem(int argc, char *argv[])
 #endif
         else if (c == OPT_METH) {
             opt->meth_mode = 1;
-            opt->bam_mode = 1;  /* meth implies BAM output */
+            /* --meth selects bisulfite ALIGNMENT semantics only; the output
+             * container is --bam's job here exactly as it is without --meth.
+             * (Through 0.7.x this set bam_mode=1, which made text SAM
+             * unreachable under --meth — there was no flag that undid it.) */
             /* Optional chemistry argument. getopt_long's optional_argument only
              * accepts the `--meth=taps` form (a separate word is treated as a
              * positional), so a bare `--meth` leaves optarg NULL => em-seq. */
@@ -2929,12 +2939,15 @@ int main_mem(int argc, char *argv[])
                                 ? bwa_load_hdr_from_index(meth_orig_ref_prefix)
                                 : NULL;
 
-    /* Output path:
-     *  - --meth: open meth_bam_writer with strand-consolidated SQ headers.
-     *    Honors -o/-f (target path) or stdout ("-").
+    /* Output path. --meth picks the WRITER (it owns the meth @SQ/@PG header and
+     * the bam1_t overlay); --bam picks the CONTAINER within whichever writer.
+     *  - --meth [--bam]: open meth_bam_writer, which serializes its bam1_t to
+     *    BGZF under --bam and to SAM text without it. Honors -o/-f or stdout.
      *  - --bam (no --meth): open generic bam_writer; htslib writes its own
      *    @HD + @SQ + @PG header. Honors -o/-f or stdout.
-     *  - SAM text: open -o/-f path (if any) as a FILE*; bwa_print_sam_hdr2. */
+     *  - SAM text (no --meth, no --bam): open -o/-f path (if any) as a FILE*;
+     *    bwa_print_sam_hdr2. Note the meth writer claims -o itself in the first
+     *    branch, so this fopen stays unreachable under --meth. */
     bam_writer_t *bam_writer = NULL;
 #ifdef DISABLE_OUTPUT
     /* profile-build (-DDISABLE_OUTPUT) skips ALL filesystem-touching output
@@ -2992,9 +3005,10 @@ int main_mem(int argc, char *argv[])
         g_meth_bam_writer = meth_bam_writer_open(meth_out_path, aux.meth_orig_bns,
                                                  bwa_pg, NULL,
                                                  hdr_line, meth_orig_hdr_lines,
-                                                 opt->bam_level);
+                                                 opt->bam_mode, opt->bam_level);
         if (g_meth_bam_writer == NULL) {
-            fprintf(stderr, "ERROR: meth: failed to open BAM writer for '%s'\n", meth_out_path);
+            fprintf(stderr, "ERROR: meth: failed to open %s writer for '%s'\n",
+                    opt->bam_mode ? "BAM" : "SAM", meth_out_path);
             g_meth_orig_pac = NULL;
             free(opt);
             delete aux.fmi;

--- a/src/fastmap.h
+++ b/src/fastmap.h
@@ -111,7 +111,10 @@ typedef struct {
 	int      ref_string_is_shm;   /* 1 if ref_string aliases shm pages; do not _mm_free. */
 	FMI_search *fmi;
 	uint8_t *shm_base;            /* if non-NULL, the active /bwaidx-<base> mapping */
-	struct bam_writer_s *bam_writer;  /* non-NULL when opt->bam_mode is set */
+	/* Generic (non-meth) BAM writer: non-NULL only when opt->bam_mode is set
+	 * AND opt->meth_mode is not -- under --meth the meth writer owns output
+	 * (g_meth_bam_writer) in both containers, and this stays NULL. */
+	struct bam_writer_s *bam_writer;
 	/* D3 (--meth) ORIGINAL-reference handles, resident alongside (and distinct
 	 * from) the seed FM-index in `fmi`. The seed index (`fmi->idx->bns/pac`) is
 	 * the f/r-doubled converted reference used for candidate generation; these

--- a/src/meth_bam.cpp
+++ b/src/meth_bam.cpp
@@ -62,10 +62,10 @@ static int sq_line_has_kv(const char *line, size_t line_len,
 
 /* Append to `out` the reference-identity tags (M5/UR/AS/SP) found on the @SQ
  * line of `hdr_text` whose SN equals `sn`, each as "\t<TAG>:<value>". Used to
- * enrich the consolidated --meth @SQ with identity tags from the *original*
- * (pre-c2t) reference's .hdr/.dict sidecar, matched by SN. Enrichment is gated
- * on the sidecar line's LN also equalling `expected_len` (the chrom-map
- * length): a SN match with a differing LN means a stale or foreign sidecar
+ * enrich the --meth @SQ with identity tags from the *original* (pre-c2t)
+ * reference's .hdr/.dict sidecar, matched by SN. Enrichment is gated on the
+ * sidecar line's LN also equalling `expected_len` (the contig length from the
+ * original bns): a SN match with a differing LN means a stale or foreign sidecar
  * whose M5/UR would misidentify the sequence, so nothing is appended in that
  * case. Appends nothing if `hdr_text` is NULL/empty or has no matching @SQ.
  * SN is unique in a valid header, so the first match wins. */
@@ -116,8 +116,9 @@ static int meth_append_sq_extra_tags(const char *hdr_text, const char *sn,
 
 /* Append to `out` every record line of `hdr_text` that is NOT @HD or @SQ
  * (i.e. @CO/@PG/@RG and any others), each terminated by '\n'. @SQ is skipped
- * because the consolidated @SQ block is authoritative (its identity tags are
- * merged separately by meth_append_sq_extra_tags); @HD is skipped because the
+ * because the @SQ block built from the original reference is authoritative
+ * (its identity tags are merged separately by meth_append_sq_extra_tags); @HD
+ * is skipped because the
  * writer emits its own.
  *
  * Returns 0 on success, -1 if a kstring append failed -- the same contract as
@@ -144,6 +145,7 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
                                         const char *meth_pg_cl,
                                         const char *hdr_line,
                                         const char *orig_idx_hdr_lines,
+                                        int bam,
                                         int compression_level)
 {
     if (path_or_dash == NULL || bns == NULL) return NULL;
@@ -152,8 +154,13 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
 
     if (compression_level < 0) compression_level = 0;
     if (compression_level > 9) compression_level = 9;
+    /* The container is the ONLY difference between the two output formats: the
+     * records below are the same bam1_t either way, and htslib serializes them
+     * to BGZF ("wb<level>") or to text ("w"). Keeping one construction path is
+     * what makes `--meth` and `--meth --bam` byte-identical after decode. */
     char mode[8];
-    snprintf(mode, sizeof(mode), "wb%d", compression_level);
+    if (bam) snprintf(mode, sizeof(mode), "wb%d", compression_level);
+    else     snprintf(mode, sizeof(mode), "w");
     w->fp = hts_open(path_or_dash, mode);
     if (w->fp == NULL) { free(w); return NULL; }
 
@@ -180,7 +187,7 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
      *
      * AH:* on ALT contigs is appended from the ORIGINAL bns, matching both
      * upstreams' generated @SQ (bwa/bwa.c:432, bwa-mem2/src/bwa.cpp:538) and
-     * our SAM text path; this consolidated block was written without it and
+     * our SAM text path; this block was written without it and
      * dropped ALT status for every ALT-aware reference. It cannot collide with
      * the sidecar enrichment: meth_append_sq_extra_tags copies only
      * M5/UR/AS/SP, never AH. Appended BEFORE those tags so the line reads
@@ -209,7 +216,7 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
     /* Original reference's non-@HD/@SQ sidecar records (@CO/@PG/@RG),
      * forwarded after @SQ and before the user header — mirroring the index
      * tier of bam_writer_open's precedence (index > default, below user). Its
-     * @SQ is consumed into the enriched consolidated block above and its @HD
+     * @SQ is consumed into the enriched @SQ block above and its @HD
      * is the writer's own, so both are dropped here. `orig_idx_hdr_lines` is
      * loaded from the *original* (pre-c2t) reference prefix by main_mem; the
      * c2t index's own sidecar (which describes the doubled f/r converted
@@ -229,7 +236,7 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
      * forwarded sidecar records, before the @PG lines, matching the default
      * writer's precedence (user > index > default) so a -R read group becomes
      * an @RG header that the per-record RG:Z tags (stamped from bwa_rg_id
-     * below) actually reference. The consolidated @SQ above is authoritative
+     * below) actually reference. The @SQ block above is authoritative
      * for --meth, so a user -H that re-supplies @SQ for an already-emitted
      * contig will make htslib reject the add and the open fails loudly rather
      * than emitting duplicate references. */
@@ -382,11 +389,13 @@ int meth_mem_aln_to_bam(bam1_t *b,
         bam_n_cigar = (size_t)p.n_cigar;
     }
 
-    /* TLEN is emitted on the consolidated (post-remap) contigs, so it must be
-     * gated on tid/mtid equality — not p.rid/mp->rid. Mates that rescue onto
-     * opposite projected strands (f* vs r*) of the same real chromosome have
-     * different internal rids but the same output tid, and SAM expects a real
-     * TLEN when RNAME==RNEXT. */
+    /* TLEN is defined only when both mates are placed on the same contig, which
+     * is what SAM means by RNAME==RNEXT. Since D3 PR-5, tid/mtid ARE p.rid /
+     * mp->rid (original rids straight from the seed→original remap), so this is
+     * a plain same-chromosome test. Pre-D3 it was not: output ran on
+     * consolidated contigs, and mates rescued onto opposite projected strands
+     * (f* vs r*) of one real chromosome had different internal rids but the same
+     * output tid — hence the gate on tid/mtid rather than the raw rids. */
     hts_pos_t tlen = 0;
     if (mp && tid >= 0 && mtid >= 0 && tid == mtid
         && p.n_cigar > 0 && m.n_cigar > 0) {

--- a/src/meth_bam.h
+++ b/src/meth_bam.h
@@ -39,10 +39,15 @@ extern meth_bam_writer_t *g_meth_bam_writer;
  * outside --meth. */
 extern const uint8_t *g_meth_orig_pac;
 
-/* Open a BAM writer at path ("-" for stdout). `bns` is the ORIGINAL
- * (un-converted) reference whose contigs become the @SQ block directly
- * (D3 PR-5: no f/r consolidation). `compression_level` is the BGZF deflate
- * level: 0 = uncompressed, 1..9 = deflate. `hdr_line` is the assembled user
+/* Open a meth record writer at path ("-" for stdout). `bam` selects the
+ * container: non-zero = BGZF BAM (`--bam`), 0 = plain-text SAM (the default,
+ * matching non-meth output). Both write the SAME bam1_t records built by
+ * meth_mem_aln_to_bam — only htslib's serialization differs — so the meth
+ * overlay (XM:Z/XG:Z/XR:Z, chimera QC) is identical either way.
+ * `bns` is the ORIGINAL (un-converted) reference whose contigs become the @SQ
+ * block directly (D3 PR-5: no f/r consolidation). `compression_level` is the
+ * BGZF deflate level: 0 = uncompressed, 1..9 = deflate; ignored when `bam` is
+ * 0. `hdr_line` is the assembled user
  * header text (-R read group and/or -H lines, '\n'-joined, no trailing
  * newline), or NULL — emitted verbatim after the @SQ block so a -R read
  * group lands as an @RG header, matching the default (non-meth) writer.
@@ -58,13 +63,14 @@ meth_bam_writer_t *meth_bam_writer_open(const char *path_or_dash,
                                         const char *meth_pg_cl,
                                         const char *hdr_line,
                                         const char *orig_idx_hdr_lines,
+                                        int bam,
                                         int compression_level);
 
 /* Write one bam1_t. Returns 0 on success, -1 on error. */
 int meth_bam_writer_write(meth_bam_writer_t *w, struct bam1_t *b);
 
-/* Close the writer and flush the BGZF EOF marker. Frees internal hdr and
- * htsFile. Returns 0 on success, -1 on error. */
+/* Close the writer, flushing the BGZF EOF marker when the container is BAM.
+ * Frees internal hdr and htsFile. Returns 0 on success, -1 on error. */
 int meth_bam_writer_close(meth_bam_writer_t *w);
 
 /* --- mem_aln_t -> bam1_t --------------------------------------------- */

--- a/test/meth/test.sh
+++ b/test/meth/test.sh
@@ -3,7 +3,8 @@
 #
 # Layer 1 (always runs):  valid BAM emission.
 #   - binary builds and runs with --meth
-#   - produces uncompressed BAM readable by samtools
+#   - produces uncompressed BAM readable by samtools (--bam; --meth alone emits
+#     SAM text, so the BGZF assertions below require it explicitly)
 #   - @PG ID:bwa-mem3-meth present
 #   - BGZF EOF marker at tail
 #   - --set-as-failed / --chimera-qc parse cleanly
@@ -48,7 +49,7 @@ if [[ ! -f ref.fa.bwameth.c2t.bwt.2bit.64 ]]; then
     "$BWAMEM3" index --meth ref.fa > /dev/null 2>&1
 fi
 
-"$BWAMEM3" mem --meth -t 2 ref.fa t_R1.fastq.gz 2> /dev/null > "$BAM"
+"$BWAMEM3" mem --meth --bam -t 2 ref.fa t_R1.fastq.gz 2> /dev/null > "$BAM"
 
 EXPECT_EOF="1f8b08040000000000ff0600424302001b0003000000000000000000"
 ACTUAL_EOF="$(tail -c 28 "$BAM" | od -An -v -t x1 | tr -d ' \n')"
@@ -74,14 +75,14 @@ if [[ "$TOTAL" -lt 1 ]]; then
     exit 1
 fi
 
-"$BWAMEM3" mem --meth --set-as-failed f --chimera-qc \
+"$BWAMEM3" mem --meth --bam --set-as-failed f --chimera-qc \
     ref.fa t_R1.fastq.gz 2> /dev/null > "$BAM2"
 if [[ ! -s "$BAM2" ]]; then
     echo "FAIL: --set-as-failed + --chimera-qc produced empty output"
     exit 1
 fi
 
-echo "OK layer 1: bwa-mem3 mem --meth (records=$TOTAL, BGZF-EOF ok, @PG bwa-mem3-meth ok)"
+echo "OK layer 1: bwa-mem3 mem --meth --bam (records=$TOTAL, BGZF-EOF ok, @PG bwa-mem3-meth ok)"
 
 # --- Bismark XR:Z / XG:Z / XM:Z emission assertions ----------------------
 # Every primary mapped record (FLAG & 0x904 == 0) must carry XR:Z:(CT|GA),

--- a/test/meth/test_bismark_tags.sh
+++ b/test/meth/test_bismark_tags.sh
@@ -86,7 +86,10 @@ fi
 
 # Run bwa-mem3 on the simulated FASTQs.
 MINE_BAM="$SCRATCH/bismark-tags-mine.bam"
-"$BWAMEM3" mem --meth -t 2 ref.fa "$R1" "$R2" 2> /dev/null > "$MINE_BAM"
+# --bam: samtools would autodetect --meth's default SAM text just fine, but this
+# test compares against a BAM golden through `samtools sort -O bam`, so keep both
+# sides in the same container.
+"$BWAMEM3" mem --meth --bam -t 2 ref.fa "$R1" "$R2" 2> /dev/null > "$MINE_BAM"
 
 # Sort both by qname so per-qname comparison is straightforward.
 "$SAMTOOLS" sort -n -@ 2 -O bam -o "${PREFIX}.golden.qsort.bam" "$GOLDEN_BAM"

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -24,6 +24,7 @@ jobs. Each script:
 | `compat_byte_identical.sh`   | `--compat=bwa-mem2` suppresses only MQ/HN/@HD; rest byte-identical    | "--compat byte-identical regression (phix)"         |
 | `header_parity.sh`           | `AH:*` on generated @SQ (#281); `--compat` skips the .hdr/.dict sidecar | "header parity regression (AH:*, --compat @HD/@SQ)" |
 | `default_hd_parity.sh`       | default `@HD` byte-identical across SAM/`--bam`/`--meth` (#288)        | "default @HD parity across output paths"            |
+| `meth_sam_output.sh`         | `--meth` emits SAM text by default and BAM under `--bam`, same records | "--meth output container follows --bam"             |
 | `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
 | `cohort_ramp_validation.sh`  | `--cohort-ramp-first`/`-ratio` reject malformed values; env warns and falls back | "Cohort ramp values are validated (flag and environment alike)" |
 | `rescue_kmer_options.sh`     | `--rescue-kmer`/`--rescue-band` reject malformed and out-of-range values; the `=` form is required | "--rescue-kmer/--rescue-band reject malformed values" |

--- a/test/regression/default_hd_parity.sh
+++ b/test/regression/default_hd_parity.sh
@@ -2,7 +2,7 @@
 # test/regression/default_hd_parity.sh
 #
 # Regression: the DEFAULT `@HD` record must be byte-identical on every output
-# path — SAM text, `--bam`, and `--meth`.
+# path — SAM text, `--bam`, `--meth` (SAM text) and `--meth --bam`.
 #
 # It was not. Each of the three writers hardcoded its own literal, and the two
 # BAM ones had drifted, so the same run emitted a different `@HD` depending on
@@ -17,12 +17,18 @@
 # a fourth writer, or a "fix" to any one of the three, has to keep them equal.
 #
 # The assertion is equality ACROSS PATHS *and* against the expected string.
-# Equality alone would pass if all three drifted together; the literal alone
+# Equality alone would pass if they all drifted together; the literal alone
 # would not catch one path diverging on a value the test did not think to
 # check. Both are cheap, so assert both.
 #
 # `--compat` is out of scope here: it suppresses the default `@HD` entirely,
 # which compat_byte_identical.sh covers. This is about DEFAULT output.
+#
+# `samtools` is a REQUIRED dependency, not an optional one: two of the four
+# paths under test (`--bam` and `--meth --bam`) are BGZF, so without it the
+# script can only check the two text paths — half the parity this test exists
+# to assert. Exiting zero on that partial run would report the cross-path
+# assertion as passing when it never executed.
 #
 # Inputs (env vars):
 #   BWA_MEM3        — path to the bwa-mem3 binary under test
@@ -35,6 +41,11 @@ set -euo pipefail
 : "${HD_PARITY_PHIX_FA:?HD_PARITY_PHIX_FA must be set}"
 : "${HD_PARITY_WORK_DIR:?HD_PARITY_WORK_DIR must be set}"
 
+command -v samtools > /dev/null 2>&1 || {
+    echo "FAIL: samtools not on PATH; the --bam and --meth --bam @HD paths cannot be checked" >&2
+    exit 1
+}
+
 # The one true default, duplicated here ON PURPOSE: a test that read the
 # constant from the source it is testing could not catch the constant changing.
 EXPECT=$'@HD\tVN:1.5\tSO:unsorted\tGO:query'
@@ -42,7 +53,7 @@ EXPECT=$'@HD\tVN:1.5\tSO:unsorted\tGO:query'
 mkdir -p "$HD_PARITY_WORK_DIR"
 cd "$HD_PARITY_WORK_DIR"
 # Remove only this script's own artifacts (never `rm -rf` a caller-supplied path).
-rm -f phix.fa phix.fa.* phix.dict phix.meth.* r1.fq r2.fq ./*.sam ./*.bam ./*.hdr ./*.log
+rm -f phix.fa phix.fa.* phix.dict phix.meth.* r1.fq r2.fq ./*.sam ./*.bam ./*.hdr ./*.log ./*.err
 
 cp "$HD_PARITY_PHIX_FA" phix.fa
 ref=phix.fa
@@ -86,41 +97,46 @@ echo "default @HD by output path:"
 sam_hd=$(grep -m1 '^@HD' sam.sam || true)
 check "SAM text" "$sam_hd"
 
-if ! command -v samtools > /dev/null 2>&1; then
-    echo "SKIP: samtools not on PATH — --bam and --meth paths not checked"
-    echo "PASS: default @HD parity (SAM text only)"
-    exit 0
-fi
+# --- --meth, no --bam: SAM text, so no samtools needed ---
+# Built unconditionally: the cleanup above removes phix.fa.* (which includes
+# phix.fa.meth.*), so an "is it already there" guard would never be false.
+# Built before the samtools gate so this path is checked on hosts without it.
+"$BWA_MEM3" index --meth "$ref" > index-meth.log 2>&1 \
+    || {
+        echo "FAIL: bwa-mem3 index --meth failed" >&2
+        cat index-meth.log >&2
+        exit 1
+    }
+"$BWA_MEM3" mem --meth "$ref" r1.fq > meth.sam 2> meth-sam.err \
+    || {
+        echo "FAIL: bwa-mem3 mem --meth exited non-zero" >&2
+        cat meth-sam.err >&2
+        exit 1
+    }
+meth_sam_hd=$(grep -m1 '^@HD' meth.sam || true)
+check "--meth" "$meth_sam_hd"
 
 # --- --bam ---
 "$BWA_MEM3" mem --bam "$ref" r1.fq r2.fq > bam.bam 2> bam.err
 bam_hd=$(samtools view -H --no-PG bam.bam | grep -m1 '^@HD' || true)
 check "--bam" "$bam_hd"
 
-# --- --meth (needs the D3 seed index) ---
-if [[ ! -s "$ref.meth.bwt.2bit.64" || ! -s "$ref.meth.amb" ||
-    ! -s "$ref.meth.ann" || ! -s "$ref.meth.pac" ]]; then
-    "$BWA_MEM3" index --meth "$ref" > index-meth.log 2>&1 \
-        || {
-            echo "FAIL: bwa-mem3 index --meth failed" >&2
-            cat index-meth.log >&2
-            exit 1
-        }
-fi
-"$BWA_MEM3" mem --meth "$ref" r1.fq > meth.bam 2> meth.err \
+# --- --meth --bam (the meth writer's BGZF container) ---
+"$BWA_MEM3" mem --meth --bam "$ref" r1.fq > meth.bam 2> meth-bam.err \
     || {
-        echo "FAIL: bwa-mem3 mem --meth exited non-zero" >&2
-        cat meth.err >&2
+        echo "FAIL: bwa-mem3 mem --meth --bam exited non-zero" >&2
+        cat meth-bam.err >&2
         exit 1
     }
 meth_hd=$(samtools view -H --no-PG meth.bam | grep -m1 '^@HD' || true)
-check "--meth" "$meth_hd"
+check "--meth --bam" "$meth_hd"
 
-# Equality across paths is implied by all three matching EXPECT, but assert it
+# Equality across paths is implied by all of them matching EXPECT, but assert it
 # directly so a future change that relaxes EXPECT still cannot let them drift.
-if [ "$sam_hd" != "$bam_hd" ] || [ "$sam_hd" != "$meth_hd" ]; then
+if [ "$sam_hd" != "$bam_hd" ] || [ "$sam_hd" != "$meth_sam_hd" ] \
+    || [ "$sam_hd" != "$meth_hd" ]; then
     echo "FAIL: default @HD differs across output paths" >&2
     exit 1
 fi
 
-echo "PASS: default @HD is byte-identical across SAM text, --bam and --meth"
+echo "PASS: default @HD is byte-identical across SAM text, --bam, --meth and --meth --bam"

--- a/test/regression/meth_sam_output.sh
+++ b/test/regression/meth_sam_output.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# test/regression/meth_sam_output.sh
+#
+# Regression: `--meth` selects bisulfite ALIGNMENT semantics, not an output
+# format. Output format is chosen by `--bam` on every mode alike.
+#
+# It was not. `--meth` hard-set `opt->bam_mode = 1` in the option parser, and
+# the writer opened `hts_open(path, "wb<level>")` unconditionally, so text SAM
+# was unreachable under `--meth` — there was no flag that could undo it. That
+# made the CLI mean two different things depending on the mode: `--bam` was
+# opt-in without `--meth` and forced with it.
+#
+# This pins the uniform rule:
+#   mem --meth        -> SAM text  (same default as non-meth)
+#   mem --meth --bam  -> BGZF BAM  (same opt-in as non-meth)
+#
+# The third assertion is the one that matters: the two must carry byte-identical
+# RECORDS. Text and BAM share one bam1_t construction path and differ only in
+# the htsFile mode, so a divergence here means someone reintroduced a second
+# formatting path for meth — exactly the drift that gave the three writers three
+# different default @HD lines (fg-labs/bwa-mem3#288).
+#
+# `samtools` is a REQUIRED dependency, not an optional one: the record- and
+# header-parity assertions below need it, and they are the only checks that
+# would catch the drift described above. Skipping them and still exiting zero
+# would report a green run for a check that never executed.
+#
+# Inputs (env vars):
+#   BWA_MEM3             — path to the bwa-mem3 binary under test
+#   METH_SAM_PHIX_FA     — path to test/fixtures/phix.fa
+#   METH_SAM_WORK_DIR    — directory for fixture-private intermediates
+
+set -euo pipefail
+
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+: "${METH_SAM_PHIX_FA:?METH_SAM_PHIX_FA must be set}"
+: "${METH_SAM_WORK_DIR:?METH_SAM_WORK_DIR must be set}"
+
+command -v samtools > /dev/null 2>&1 || {
+    echo "FAIL: samtools not on PATH; the text/BAM record and header parity checks cannot run" >&2
+    exit 1
+}
+
+mkdir -p "$METH_SAM_WORK_DIR"
+cd "$METH_SAM_WORK_DIR"
+# Remove only this script's own artifacts (never `rm -rf` a caller-supplied path).
+rm -f phix.fa phix.fa.* phix.dict phix.meth.* r1.fq pe1.fq pe2.fq ./*.sam ./*.bam ./*.log ./*.err ./records-*.txt
+
+cp "$METH_SAM_PHIX_FA" phix.fa
+ref=phix.fa
+
+"$BWA_MEM3" index "$ref" > index.log 2>&1
+"$BWA_MEM3" index --meth "$ref" > index-meth.log 2>&1 \
+    || {
+        echo "FAIL: bwa-mem3 index --meth failed" >&2
+        cat index-meth.log >&2
+        exit 1
+    }
+
+# Bisulfite-converted reads sliced from phix. Deterministic, no PRNG.
+#
+# SE: unmethylated C -> T on the read, which is what the OT hypothesis undoes.
+#
+# PE: directional (Lister) protocol — convert the FRAGMENT C -> T, then R1 is
+# its 5' end and R2 the reverse complement of its 3' end, so R2 shows G -> A in
+# its own orientation (what OB expects). Converting both mates C -> T instead
+# would make R2 unalignable under OB and every pair would fall out of pairing.
+#
+# The insert size MUST vary. mem_pair() scores against the inferred FR insert
+# distribution, and a single fixed insert gives it zero width — mem_pair then
+# returns 0 for every pair and they all take the `no_pairing` path, which
+# silently skips the paired emission branch this test exists to cover. Verified:
+# with a uniform 300 bp insert the branch is reached 0 times; with the spread
+# below, 2468 times.
+python3 - << 'PY'
+seq = "".join(l.strip() for l in open("phix.fa") if not l.startswith(">")).upper()
+comp = str.maketrans("ACGT", "TGCA")
+
+with open("r1.fq", "w") as fh:
+    for i, off in enumerate([200, 900, 1600, 2400]):
+        read = seq[off:off+120].replace("C", "T")
+        fh.write("@p%d\n%s\n+\n%s\n" % (i, read, "I"*120))
+
+inserts = [260, 280, 300, 320, 340, 360, 380, 400]
+with open("pe1.fq", "w") as a, open("pe2.fq", "w") as b:
+    n = 0
+    for off in range(0, len(seq) - 450, 2):
+        ins = inserts[n % len(inserts)]
+        conv = seq[off:off+ins].replace("C", "T")
+        r1, r2 = conv[:120], conv[-120:][::-1].translate(comp)
+        if len(r1) < 120 or len(r2) < 120:
+            continue
+        a.write("@v%d\n%s\n+\n%s\n" % (n, r1, "I"*120))
+        b.write("@v%d\n%s\n+\n%s\n" % (n, r2, "I"*120))
+        n += 1
+PY
+
+# --- default: text SAM, no --bam ---
+"$BWA_MEM3" mem --meth "$ref" r1.fq > meth.sam 2> meth-sam.err \
+    || {
+        echo "FAIL: mem --meth exited non-zero ($?)" >&2
+        cat meth-sam.err >&2
+        exit 1
+    }
+
+# A BGZF/gzip stream starts with 0x1f 0x8b; SAM text starts with '@'. Read the
+# first byte rather than trusting `file`, which is not installed everywhere.
+first_byte=$(head -c 1 meth.sam | od -An -tx1 | tr -d ' \n')
+if [ "$first_byte" != "40" ]; then
+    echo "FAIL: mem --meth did not emit SAM text (first byte 0x$first_byte, expected 0x40 '@')" >&2
+    exit 1
+fi
+grep -q '^@HD' meth.sam || {
+    echo "FAIL: --meth SAM text has no @HD" >&2
+    exit 1
+}
+grep -q '^@SQ' meth.sam || {
+    echo "FAIL: --meth SAM text has no @SQ" >&2
+    exit 1
+}
+
+# The meth-only tags must survive the text path — they are built into the
+# bam1_t aux block, so a text writer that dropped them would be a real bug.
+grep -q 'XM:Z:' meth.sam || {
+    echo "FAIL: --meth SAM text is missing XM:Z" >&2
+    exit 1
+}
+grep -q 'XG:Z:' meth.sam || {
+    echo "FAIL: --meth SAM text is missing XG:Z" >&2
+    exit 1
+}
+grep -q 'XR:Z:' meth.sam || {
+    echo "FAIL: --meth SAM text is missing XR:Z" >&2
+    exit 1
+}
+
+sam_records=$(grep -cv '^@' meth.sam || true)
+if [ "$sam_records" -eq 0 ]; then
+    echo "FAIL: --meth SAM text has no alignment records" >&2
+    exit 1
+fi
+
+# --- PE: the paired emission branch must survive the text container ---
+# This is the branch that actually broke. mem_aln2sam() short-circuits into
+# bam1_t under --meth and never writes the SAM kstring_t, so the paired branch
+# in mem_sam_pe_batch_post/mem_sam_pe has to be selected on "records are bam1_t"
+# (bam_mode || meth_mode), not on bam_mode alone. Selecting on bam_mode alone
+# sends --meth-without--bam into the text branch and aborts on its
+# `assert(str.s != 0)`. Verified: that variant exits 134 on exactly this input.
+"$BWA_MEM3" mem --meth "$ref" pe1.fq pe2.fq > meth-pe.sam 2> meth-pe.err \
+    || {
+        echo "FAIL: mem --meth PE exited non-zero ($?)" >&2
+        tail -5 meth-pe.err >&2
+        exit 1
+    }
+pe_records=$(grep -cv '^@' meth-pe.sam || true)
+if [ "$pe_records" -eq 0 ]; then
+    echo "FAIL: --meth PE SAM text has no alignment records" >&2
+    exit 1
+fi
+# Proper pairs (0x2) prove pairing actually resolved rather than every pair
+# falling out to the single-end path, which would not exercise the branch.
+proper=$(mawk '!/^@/ && int($2/2)%2==1' meth-pe.sam | wc -l | tr -d ' ')
+if [ "$proper" -eq 0 ]; then
+    echo "FAIL: --meth PE produced no proper pairs — the paired branch was not exercised" >&2
+    exit 1
+fi
+
+# --- opt-in: --meth --bam is BGZF ---
+"$BWA_MEM3" mem --meth --bam "$ref" r1.fq > meth.bam 2> meth-bam.err \
+    || {
+        echo "FAIL: mem --meth --bam exited non-zero ($?)" >&2
+        cat meth-bam.err >&2
+        exit 1
+    }
+"$BWA_MEM3" mem --meth --bam "$ref" pe1.fq pe2.fq > meth-pe.bam 2> meth-pe-bam.err \
+    || {
+        echo "FAIL: mem --meth --bam PE exited non-zero ($?)" >&2
+        tail -5 meth-pe-bam.err >&2
+        exit 1
+    }
+magic=$(head -c 2 meth.bam | od -An -tx1 | tr -d ' \n')
+if [ "$magic" != "1f8b" ]; then
+    echo "FAIL: mem --meth --bam did not emit BGZF (magic 0x$magic, expected 0x1f8b)" >&2
+    exit 1
+fi
+
+samtools quickcheck meth.bam meth-pe.bam
+
+# --- the two containers must agree, record for record and header for header ---
+# --no-PG so samtools does not stamp its own @PG onto one side only.
+
+# Records: byte-identical, no exceptions. This is the assertion with teeth, and
+# it runs on BOTH read layouts — SE and PE take different emission paths
+# (mem_reg2sam vs the paired branch in mem_sam_pe_batch_post), and it was the
+# paired one that regressed.
+for layout in "se:meth.sam:meth.bam" "pe:meth-pe.sam:meth-pe.bam"; do
+    name=${layout%%:*}
+    rest=${layout#*:}
+    txt=${rest%%:*}
+    bin=${rest#*:}
+    samtools view --no-PG "$txt" > "records-$name-text.txt"
+    samtools view --no-PG "$bin" > "records-$name-bam.txt"
+    if ! cmp -s "records-$name-text.txt" "records-$name-bam.txt"; then
+        echo "FAIL: --meth SAM text and --meth --bam differ in $name records" >&2
+        diff "records-$name-text.txt" "records-$name-bam.txt" | head -20 >&2 || true
+        exit 1
+    fi
+done
+
+# Header: identical except the `@PG ... CL:` line, which records the invoking
+# command line and therefore MUST differ — one run was given --bam and the other
+# was not. Strip only the CL: field, not the whole @PG record, so a drift in
+# ID/PN/VN still fails.
+strip_cl() { sed 's/\tCL:.*$//'; }
+samtools view -H --no-PG meth.sam | strip_cl > text-hdr.sam
+samtools view -H --no-PG meth.bam | strip_cl > bam-hdr.sam
+if ! cmp -s text-hdr.sam bam-hdr.sam; then
+    echo "FAIL: --meth SAM text and --meth --bam headers differ (beyond @PG CL:)" >&2
+    diff text-hdr.sam bam-hdr.sam | head -20 >&2 || true
+    exit 1
+fi
+
+echo "PASS: --meth defaults to SAM text; --meth --bam emits identical records as BGZF (SE $sam_records, PE $pe_records)"


### PR DESCRIPTION
## What

`--meth` forced BAM output and text SAM was unreachable — no flag could undo it. This makes `--bam` mean the same thing in every mode:

| | before | after |
|---|---|---|
| `mem --meth` | BGZF BAM | **SAM text** |
| `mem --meth --bam` | BGZF BAM | BGZF BAM |
| `mem` / `mem --bam` | SAM text / BAM | unchanged |

`--meth` now selects bisulfite alignment semantics only; the container is `--bam`'s job, exactly as it is without `--meth`.

## Why this shape

The alternative was an additive `--sam` opt-out that cancels the implication. That keeps the inconsistency and adds a third flag whose only purpose is to undo a rule that shouldn't exist — and which would be a no-op in non-meth mode, where SAM is already the default. One rule beats two flags plus an exception. There is also no technical reason for the implication: the entire difference is the `hts_open` mode string, and record construction is identical either way.

## How it works

Nothing about record construction changes. `--meth` still builds `bam1_t` so the bisulfite overlay (`XM:Z`/`XG:Z`/`XR:Z`, chimera QC) lands in the aux block; htslib serializes those same records to BGZF under `--bam` and to text without it. The two decode to byte-identical records — the new regression asserts exactly that, for both SE and PE.

## The non-obvious part

Both paired-end emission sites gated "skip the `str.s` handoff" on `opt->bam_mode`. Since `mem_aln2sam()` short-circuits into `bam1_t` under `--meth` and never writes the SAM `kstring_t`, dropping the implication sent `--meth`-without-`--bam` down the text branch and onto its `assert(str.s != 0)`. Those now test `mem_opt_records_are_bam()` (`bam_mode || meth_mode`).

This is easy to miss, and worth knowing for anyone testing near it: the branch is not reached by SE reads, nor by a handful of pairs, nor even by thousands of pairs at a **fixed** insert size — a zero-width insert distribution makes `mem_pair()` return 0 and every pair falls to the `no_pairing` path. With a varied insert the branch fires on every pair, and the old guard aborts at exit 134. The test's read generator varies the insert deliberately; there is a comment saying so, because "simplifying" it back to a constant would silently void the coverage.

The profiling site in the write loop deliberately stays on `bam_mode` — it asks whether the write path deflates, which only `--bam` does.

## Validation

- New `test/regression/meth_sam_output.sh`: pins the container rule, covers the PE branch above, and asserts text/BAM record equality for SE and PE (4936 PE records). Fails against the pre-change binary.
- `default_hd_parity.sh` extended to all four output paths; its `--meth` case moved above the samtools gate since that path no longer needs samtools.
- All eight existing `--meth` regressions pass unchanged — they read output through samtools, which autodetects SAM text.
- `test/meth/test.sh` (46,406 records) and the unit suite pass. `test/meth/test.sh` and `test_bismark_tags.sh` gained an explicit `--bam`, since they assert on the BGZF EOF marker and compare against a BAM golden.
- `-o`, `--bam=6`, and the compressed-BAM warning verified under `--meth`. htslib does not infer the container from the output filename extension, so `--meth -o out.bam` is text, consistent with the non-meth path.

## Breaking change

`bwa-mem3 mem --meth` now writes SAM text. Scripts that relied on BAM on stdout need `--bam`. Piping into samtools needs no change. Flagged as `feat!` with a `BREAKING CHANGE:` footer, so release-please cuts this as 0.8.0.

## Second commit — unrelated pre-existing doc drift

While checking what `--meth` output actually looks like I found the docs describing a mechanism deleted in D3 (#174). The `@SQ` consolidation section documented `meth_chrom_map_t`, `meth_chrom_map_build_from_bns`, `cmap->out_tid` and `cmap->output_names` — `grep -rn meth_chrom_map src/` returns nothing. D3's own commit body says: *"The f/r chrom map (meth_chrom_map_*) and its consolidation are removed."*

The claim had spread to seven files plus the glossary. The second commit rewrites the section around what the code does, keeps a short historical note so the pre-D3 terminology stays findable, and retitles the page (it is no longer "Header Rewriting" — nothing is rewritten). It also fixes two stale code comments from the same cutover: `bwamem.cpp` cited `YD:Z` as part of the meth overlay (emitted nowhere; replaced by `XG:Z`), and `tags.md` sourced `XG:Z` from the deleted chrom map rather than `mem_aln_t.meth_hypothesis`.

Reviewable independently of commit 1 — docs and comments only.

## Reading order

1. `src/fastmap.cpp` — the option parser and writer selection
2. `src/bwamem.h` — `mem_opt_records_are_bam()` and why it is not `bam_mode`
3. `src/meth_bam.cpp` / `.h` — the container parameter
4. `test/regression/meth_sam_output.sh` — the contract
5. commit 2 on its own


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `--meth` now outputs SAM by default and BAM only when `--bam` is specified.
  - SAM and BAM outputs contain equivalent methylation alignment records.
  - Methylation headers use original reference sequences and exclude seed-only contigs.

- **Documentation**
  - Updated output guidance, compatibility notes, headers, tags, and post-processing terminology.

- **Tests**
  - Added regression coverage for format selection, headers, tags, paired reads, and cross-format consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->