### PR TITLE
perf(mem): reserve the cohort accumulator from task_size instead of doubling

### DIFF
--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -974,6 +974,55 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
             if (aux->cohort_n + ret->n_seqs > aux->cohort_cap) {
                 int want = aux->cohort_n + ret->n_seqs;
                 int cap  = aux->cohort_cap ? aux->cohort_cap : 1024;
+                /* A cohort with more slices still coming: project its final read
+                 * count from this slice's mean read length and reserve it in one
+                 * go.
+                 *
+                 * Doubling from 1024 instead takes ~13 reallocs to reach a
+                 * default t=64 cohort (task_size = chunk_size * nthreads = 640
+                 * Mbase, ~4.27M reads) and lands on the next power of two --
+                 * 8388608 slots for 4266668 reads, i.e. ~330 MB of bseq1_t held
+                 * and never used. The cohort's size is not a surprise: the ramp
+                 * appends slices until it reaches aux->task_size bases, so one
+                 * projection is enough.
+                 *
+                 * Deliberately NOT projected on the cohort's first slice, even
+                 * though that is where the reallocs would be saved. On the first
+                 * slice "more is coming" is not yet known: a file that ends
+                 * exactly at the slice boundary returns sz == slice_target with
+                 * seqs != NULL, which fails every cohort_complete test, so the
+                 * slice looks mid-cohort and EOF only surfaces on the next read
+                 * as the empty flush item (see the memcpy guard below). Projecting
+                 * there would reserve a whole task_size -- ~330 MB for what turns
+                 * out to be one ~16 Mbase slice, strictly worse than the doubling
+                 * this replaces. Waiting for cohort_n > 0 makes a second slice the
+                 * proof that the input did not end, and costs only the first
+                 * slice's doublings, which are small and cheap.
+                 *
+                 * Idempotent across later slices: the projected total is the same
+                 * each time and cap only ever moves up, so slices 3+ recompute it
+                 * and find nothing to do.
+                 *
+                 * The doubling below is kept as the fallback: if reads later in
+                 * the cohort are shorter than this slice's mean, the projection
+                 * undershoots and growth proceeds exactly as before. Capacity
+                 * only ever affects allocation, never which reads land in the
+                 * cohort, so output is unchanged either way. */
+                if (aux->cohort_n > 0 && !ret->cohort_complete && ret->n_seqs > 0) {
+                    int64_t slice_bases = 0;
+                    for (int i = 0; i < ret->n_seqs; ++i)
+                        slice_bases += ret->seqs[i].l_seq;
+                    if (slice_bases > 0 && aux->task_size > slice_bases) {
+                        /* +2 for the rounding slack: both readers stop at the
+                         * first whole-record, even-n boundary at or PAST each
+                         * request, so the cohort can end a record or two past
+                         * task_size. */
+                        double projected = (double) ret->n_seqs *
+                                           ((double) aux->task_size / (double) slice_bases) + 2.0;
+                        if (projected > (double) cap && projected < (double) INT_MAX)
+                            cap = (int) projected;
+                    }
+                }
                 while (cap < want) cap <<= 1;
                 /* Temporary + err_fatal, not assert -- see the regs growth in
                  * step 1. A release-build realloc failure here would null the
@@ -985,6 +1034,13 @@ ktp_data_t *kt_pipeline(void *shared, int step, void *data, mem_opt_t *opt, work
                     err_fatal(__func__, "failed to grow the cohort buffer to %d reads", cap);
                 aux->cohort_seqs = cohort_tmp;
                 aux->cohort_cap = cap;
+                /* -v 4 only: capacity has no effect on output, so this exists
+                 * purely so a test can tell a projected reservation from a
+                 * doubled one. Default verbosity is 3, so ordinary runs and every
+                 * stderr-parsing test see exactly what they saw before. */
+                if (bwa_verbose >= 4)
+                    fprintf(stderr, "[0000] cohort_reserve: cap: %d, held: %d\n",
+                            cap, aux->cohort_n + ret->n_seqs);
             }
             /* Guarded because the EOF-on-slice-boundary item reaches here with
              * seqs == NULL and n_seqs == 0 -- it exists only to flush the cohort

--- a/test/regression/cohort_slice_identity.sh
+++ b/test/regression/cohort_slice_identity.sh
@@ -216,6 +216,47 @@ if [ "$fail" -ne 0 ]; then
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# The same EOF-on-a-boundary input, now checking what the cohort RESERVED.
+#
+# Capacity never changes the output, so the identity checks above pass either
+# way and cannot see this. The cohort accumulator projects its final read count
+# from a slice's mean read length, which is only sound while more input is
+# coming -- and on the first slice that is not yet known. A file ending exactly
+# on the boundary returns a full-size slice with seqs != NULL, so it fails every
+# cohort_complete test and reads as mid-cohort; EOF only surfaces on the next
+# read. Projecting there reserves a whole task_size for a cohort that turns out
+# to be one slice (measured: 40002 slots held 9766 reads at -K 4000000, and the
+# ratio grows with task_size -- ~330 MB of never-used bseq1_t at a default t=64).
+#
+# Doubling alone never exceeds 2x what it holds, so that is the bound: it passes
+# for any growth by doubling and fails for a task_size projection. -v 4 because
+# the reservation line is opt-in; default verbosity is unchanged.
+# ---------------------------------------------------------------------------
+BWA_MEM3_COHORT_SLICE_ALL=1 \
+    "$BWA_MEM3" mem -t 4 -K "$K" --cohort-slices 3 -v 4 \
+    "$CHR22_FA" "$WORK/eof.r1.fastq.gz" "$WORK/eof.r2.fastq.gz" \
+    > /dev/null 2> "$WORK/eof_reserve.err"
+
+reserve_line=$(grep -m1 'cohort_reserve:' "$WORK/eof_reserve.err" || true)
+if [ -z "$reserve_line" ]; then
+    echo "FAIL: no 'cohort_reserve:' line under -v 4, so the reservation could" >&2
+    echo "      not be checked. The accumulator must still log it." >&2
+    exit 1
+fi
+res_cap=$(echo "$reserve_line" | sed -E 's/.*cap: ([0-9]+).*/\1/')
+res_held=$(echo "$reserve_line" | sed -E 's/.*held: ([0-9]+).*/\1/')
+
+if [ "$res_held" -ge 1024 ] && [ "$res_cap" -ge $(( res_held * 2 )) ]; then
+    echo "FAIL: the cohort reserved $res_cap slots while holding $res_held reads." >&2
+    echo "      Growth by doubling never exceeds 2x, so this is a task_size" >&2
+    echo "      projection fired on a cohort whose input had already ended." >&2
+    echo "      See the cohort_n > 0 gate in kt_pipeline step 1 (src/fastmap.cpp):" >&2
+    echo "      a second slice is what proves more input exists." >&2
+    exit 1
+fi
+echo "  EOF-on-boundary reservation: cap $res_cap for $res_held reads (under 2x)"
+
 echo "PASS: output is identical with and without cohort slicing, including with"
 echo "      every cohort sliced 8 ways, and when the input ends exactly on a"
-echo "      slice boundary."
+echo "      slice boundary -- which also reserves no more than doubling would."


### PR DESCRIPTION
## What

The multi-slice cohort accumulator (`aux->cohort_seqs`) grew by doubling from 1024 reads. But the cohort's final size is not a surprise — the ramp keeps appending slices until it reaches `aux->task_size` bases, so the total is predictable from the first slice's mean read length. Project it once, on the first slice, and reserve it.

## Why

Doubling takes ~13 reallocs to reach a default `-t 64` cohort (`task_size = chunk_size * nthreads` = 640 Mbase, ~4.27M reads) and lands on the next power of two: **8388608 slots for 4266668 reads**. At `sizeof(bseq1_t) == 80` that is **~330 MB reserved and never used**, plus the cumulative copy of the growth chain.

The overshoot scales with thread count, which is the case that matters as the thread ladder extends:

| config | cohort reads | used | doubled cap | overshoot | doublings |
|---|---:|---:|---:|---:|---:|
| `-K 160M`, t=64 | 1,066,668 | 85 MB | 168 MB | **83 MB** | 11 |
| default, t=64 | 4,266,668 | 341 MB | 671 MB | **330 MB** | 13 |
| default, t=192 | 12.8 M | 1.02 GB | 1.34 GB | **320 MB** | 14 |

Only the multi-slice path is affected. Steady-state cohorts are single-slice and never reach this branch, so this is **one reservation per run** — this is a memory-footprint change, not a throughput one.

## Design notes

- **Gated on `!ret->cohort_complete`** so an input that fits entirely in the first slice — small files, and the last cohort under the `BWA_MEM3_COHORT_SLICE_ALL` stress knob — still reserves only what it needs rather than a full `task_size` worth. Without this guard, aligning a 1000-read file would reserve a whole cohort.
- **Doubling is kept as the fallback.** If reads later in the cohort are shorter than the first slice's mean, the projection undershoots and growth proceeds exactly as before.
- **`+2` slack** because both readers stop at the first whole-record, even-`n` boundary at or *past* each request, so a cohort can end a record or two past `task_size`.

## Byte-identity

Capacity affects allocation only, never which reads land in the cohort. Verified against `origin/main` on 120k simulated E. coli PE pairs with a bimodal insert (`N(300,25)` 2/3 + `N(520,40)` 1/3, seed 42), run under `BWA_MEM3_COHORT_SLICE_ALL=1` so every cohort slices:

| `-K` | lines | md5 | result |
|---|---:|---|---|
| 8000000 | 240002 | `515615a9b3dd1b8c3373b66335b8b0f0` | identical |
| 2000000 | 240002 | `addf9e24ec4d271e924de8aa0f76f157` | identical |

The insert distribution is deliberately variable, and the two `-K` values give **different digests to each other** — that is the non-vacuity check `test/regression/cohort_slice_identity.sh` argues for: cohort composition really does move the output here, so identity between the arms is meaningful rather than trivially true.

**Projection accuracy** (`-K 2000000`, first cohort): the first slice is 796 reads / 119400 bases and projects **13335** against an actual cohort of **13334** reads — off by one, replacing five doublings (cap 16384, 23% overshoot) with a single exact reservation.

`make test` passes (doctest 19/19 cases, 23/23 assertions; all regression scripts PASS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved cohort data loading by proactively reserving buffer capacity when read volume can be estimated.
  * Retained adaptive growth as a fallback when estimates are unavailable or insufficient.
  * Reduced unnecessary buffer over-reservation when input ends at a slice boundary, improving memory efficiency.
* **Diagnostics**
  * Added detailed verbosity output showing selected cohort capacity and currently held reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->