### PR TITLE
docs(test): replace the dead phiX example for running a regression test

### DIFF
--- a/docs/src/developer-guide/regression-tests.md
+++ b/docs/src/developer-guide/regression-tests.md
@@ -8,13 +8,13 @@ bwa-mem3 has three categories of tests — **unit**, **integration**, and **regr
 |---|---|---|---|
 | unit | `test/bwa_mem3_tests_unit` | None; all inputs synthetic | Every matrix row |
 | integration | `test/bwa_mem3_tests_integration` | Small committed FASTAs / FMI in `test/fixtures/` | SSE4.1, AVX2, ARM64 Linux, macOS ARM |
-| regression | `test/regression/*.sh` | Downloaded references (phiX, chr22) + bwa + dwgsim | Canonical AVX2 row only |
+| regression | `test/regression/*.sh` | Committed phiX in `test/fixtures/`; chr22 downloaded by CI, with reads simulated by holodeck; bwa for the parity diffs | Canonical AVX2 row, except `chr22_parity.sh` (every row) and the source-only lints (their own jobs) |
 
 **Unit tests** must use only synthetic inputs generated programmatically and complete in under 100 ms each. They exercise individual kernels in isolation: kswv scoring, banded Smith-Waterman, KSW, FM-index operations, SMEM extraction, BAM encoding, and pair handling.
 
 **Integration tests** may load small committed fixtures from `test/fixtures/` and have a per-test budget of 10 seconds. They exercise cross-component paths: index loading, SMEM-to-alignment pipelines, and output format validation.
 
-**Regression tests** are standalone bash scripts that shell out to the `bwa-mem3` binary, may diff against third-party tool output (bwa, bwa-meth, samtools), and require fixtures that are either committed to the fixtures directory or downloaded by CI at run time.
+**Regression tests** are standalone bash scripts that shell out to the `bwa-mem3` binary, may diff against third-party tool output (bwa, bwa-meth, samtools), and require fixtures that are either committed to the fixtures directory or downloaded by CI at run time. The source-only lints are the exception: they read `src/` and `ci.yml` directly, need no binary and no fixtures, and run in their own CI jobs.
 
 ## Running tests locally
 
@@ -46,15 +46,24 @@ make test
 
 ### Running a regression test locally
 
-Regression scripts expect certain environment variables to point at fixtures. The phiX parity test requires `dwgsim`:
+Most regression scripts take their inputs from environment variables naming a binary and its fixtures — see the comment block at the top of each script, and `test/regression/README.md` for the contract. The source-only lints take neither, so they are the cheapest thing to run:
 
 ```bash
-mkdir -p /tmp/ci-test && cd /tmp/ci-test
-curl -sL "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/819/615/GCF_000819615.1_ViralProj14015/GCF_000819615.1_ViralProj14015_genomic.fna.gz" | gunzip > phix174.fa
-dwgsim -z 42 -N 500 -1 150 -2 150 -r 0.001 -S 2 phix174.fa reads
-cd -
-BWA_MEM2="$(pwd)/bwa-mem3" CI_TEST_DIR=/tmp/ci-test bash test/regression/phix_parity.sh
+bash test/regression/ndebug_gate_lint.sh        # no build, no fixtures
+bash test/regression/debug_macro_flag_lint.sh
 ```
+
+For a script that does need the binary, the phiX-backed ones use a committed fixture, so they need no download and no third-party tool:
+
+```bash
+make                                             # builds ./bwa-mem3
+BWA_MEM3="$(pwd)/bwa-mem3" \
+COMPAT_PHIX_FA="$(pwd)/test/fixtures/phix.fa" \
+COMPAT_WORK_DIR=/tmp/compat-bytes \
+bash test/regression/compat_byte_identical.sh
+```
+
+The chr22 scripts are the expensive end: they want a chr22 reference indexed for both `bwa` and `bwa-mem3` plus a holodeck read simulation, which is why CI caches them. `ci.yml` is the reference for how each script's inputs get staged.
 
 ## Test framework
 

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -6,7 +6,7 @@ bwa-mem3 tests are organized into three categories — **unit**, **integration**
 |----------------|------------------------------------|----------------------------------------------|--------------------------------------|
 | **unit**       | `test/bwa_mem3_tests_unit`         | None. All inputs synthetic.                  | Every matrix row                     |
 | **integration**| `test/bwa_mem3_tests_integration`  | Small committed FASTAs / FMI under `test/fixtures/` | SSE4.1, AVX2, ARM64 Linux, macOS ARM |
-| **regression** | `test/regression/*.sh`             | Downloaded references (phiX, chr22) + bwa + dwgsim | Canonical AVX2 row only      |
+| **regression** | `test/regression/*.sh`             | Committed phiX in `test/fixtures/`; chr22 downloaded by CI, reads simulated by holodeck; bwa for the parity diffs | Canonical AVX2 row, except `chr22_parity.sh` (every row) and the source-only lints (own jobs) |
 
 Design rationale: see the internal test framework design spec (not committed).
 
@@ -48,21 +48,29 @@ bash test/run_unit_tests.sh               # runs fmi_test, smem2_test, sa2ref_te
 
 ### Run regression checks
 
-Regression scripts expect upstream CI to have staged their inputs. To run one locally:
+Most regression scripts expect the caller to have staged their inputs, named by environment variables — see the comment block at the top of each script, and `test/regression/README.md` for the contract. The source-only lints take neither a binary nor fixtures, so they are the cheapest thing to run:
 
 ```bash
-# Example: phiX parity. Needs dwgsim to be installed.
-mkdir -p /tmp/ci-test && cd /tmp/ci-test
-curl -sL "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/819/615/GCF_000819615.1_ViralProj14015/GCF_000819615.1_ViralProj14015_genomic.fna.gz" \
-  | gunzip > phix174.fa
-dwgsim -z 42 -N 500 -1 150 -2 150 -r 0.001 -S 2 phix174.fa reads
-cd -
-BWA_MEM3="$(pwd)/bwa-mem3" CI_TEST_DIR=/tmp/ci-test bash test/regression/phix_parity.sh
+# No build, no fixtures: these read src/ and ci.yml directly.
+bash test/regression/ndebug_gate_lint.sh
+bash test/regression/debug_macro_flag_lint.sh
 ```
+
+For a script that does need the binary, the phiX-backed ones use a committed fixture, so they need no download and no third-party tool:
+
+```bash
+make                                             # builds ./bwa-mem3
+BWA_MEM3="$(pwd)/bwa-mem3" \
+COMPAT_PHIX_FA="$(pwd)/test/fixtures/phix.fa" \
+COMPAT_WORK_DIR=/tmp/compat-bytes \
+bash test/regression/compat_byte_identical.sh
+```
+
+The chr22 scripts are the expensive end: they want a chr22 reference indexed for both `bwa` and `bwa-mem3` plus a holodeck read simulation, which is why CI caches them. `ci.yml` is the reference for how each script's inputs get staged.
 
 ## Running tests in CI
 
-- **ci.yml** runs unit tests on every matrix row, integration tests on the four widened canonical rows, and regression tests on the canonical AVX2 row only.
+- **ci.yml** runs unit tests on every matrix row, integration tests on the four widened canonical rows, and regression tests on the canonical AVX2 row — except `chr22_parity.sh`, which runs on every row, and the source-only lints, which run in their own jobs alongside the build matrix (they need no binary, so they do not wait on it).
 - JUnit artifacts are uploaded per row (`unit-results-<name>.xml`, `integration-results-<name>.xml`). Download them from a failed run's Actions page to see fine-grained assertion output.
 - **proto-neon-kswv.yml** runs `./test/bwa_mem3_tests_unit --test-suite="unit/kswv"` on proto branches.
 


### PR DESCRIPTION
The "Running a regression test locally" section in `docs/src/developer-guide/regression-tests.md` and the identical block in `test/TESTING.md` both walk the reader through downloading phiX174, simulating reads with `dwgsim`, and running `test/regression/phix_parity.sh` with `BWA_MEM2` and `CI_TEST_DIR`. Every part of that is dead: `phix_parity.sh` was removed when the parity tests migrated to holodeck/chr22 in #89, no script in `test/regression/` reads `BWA_MEM2` or `CI_TEST_DIR` (the binary is `BWA_MEM3` everywhere), and CI no longer installs `dwgsim`. The only worked example either doc offers ends in `No such file or directory`.

Both replacement examples were run on this branch before being written down:

```
$ bash test/regression/ndebug_gate_lint.sh
PASS: ndebug_gate_lint (no NDEBUG preprocessor gates in src/)
$ bash test/regression/debug_macro_flag_lint.sh
PASS: debug_macro_flag_lint (ci.yml -D list and src/ macros agree)
$ BWA_MEM3=... COMPAT_PHIX_FA=.../test/fixtures/phix.fa COMPAT_WORK_DIR=/tmp/compat-bytes \
    bash test/regression/compat_byte_identical.sh
PASS: compat byte-identical regression          # exit 0
```

The lints are first because they need no build and no fixtures, which makes them the cheapest thing a newcomer can run to see the shape of a regression script. `compat_byte_identical.sh` follows as the "needs the binary" case, and it reads the phiX fixture committed under `test/fixtures/`, so it still needs no download and no third-party tool. The chr22 scripts — the ones that genuinely need `bwa` and a holodeck simulation — are described rather than scripted, pointing at `ci.yml` as the reference for how inputs get staged.

While confirming the example, the surrounding claims in the same two files turned out to have drifted with it, so they are corrected here rather than left to be found again: phiX is committed rather than downloaded, reads come from holodeck rather than `dwgsim`, `chr22_parity.sh` runs on every matrix row rather than the canonical one, and the source-only lints run in their own jobs alongside the matrix (verified: no `needs:` in `ci.yml`, so they do not wait on the build).

Deliberately not touched: `docs/src/whats-different/build-infra.md:25` also names `phix_parity`, but as part of a historical record of what an earlier PR did, which was accurate when written.

Docs only — no behavior change. Related to #339, which fixes the same class of drift in `test/regression/README.md`; independent of it and of #338, and can merge in any order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified regression-testing categories, including committed phiX fixtures, downloaded chr22 inputs, source-only lint checks, and BWA-based parity comparisons.
  * Added local commands for running source-only lints and phiX compatibility tests.
  * Documented prerequisites and procedures for chr22 checks, including staged indexes and simulated reads.
  * Clarified CI coverage for unit tests, integration tests, parity checks, and lint jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->