### PR TITLE
ci: check the regression README against the scripts it describes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,26 @@ jobs:
       - name: Every regression script is run by CI
         run: bash test/regression/regression_coverage_lint.sh
 
+  # Same shape again. Separate so the failure reads as "the regression README
+  # went stale" rather than as a finding about src/.
+  readme-contract-lint:
+    name: Regression README contract (README <-> test/regression/)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      # Runs first, for the same reason as the three jobs above: deciding which
+      # scripts read no environment is a heuristic over shell text, and a
+      # heuristic that has stopped matching reports a clean README.
+      - name: README lint still detects drift
+        run: bash test/regression/readme_contract_lint_selftest.sh
+
+      - name: README still describes the regression scripts
+        run: bash test/regression/readme_contract_lint.sh
+
   build-and-test:
     strategy:
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -856,6 +856,8 @@ test: test-binaries $(STANDALONE_TESTS_IN_TEST_TARGET) bwa-mem3
 	./test/regression/shell_lint.sh
 	./test/regression/regression_coverage_lint_selftest.sh
 	./test/regression/regression_coverage_lint.sh
+	./test/regression/readme_contract_lint_selftest.sh
+	./test/regression/readme_contract_lint.sh
 
 # Shell lint on its own, and its autofix. Separate from `test` because the
 # whole point is to run them without a build: both are source-only and finish

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -4,10 +4,10 @@ End-to-end parity and invariant checks. `chr22_parity.sh` and
 `version_banner.sh` run on every matrix row; the rest run on the canonical
 AVX2 row only, except for the ones wired to a job of their own:
 `profile_slice_cpu.sh` runs from `profiling-build` (see below), and the
-`ndebug_gate_lint*`, `debug_macro_flag_lint*`, `shell_lint*` and
-`regression_coverage_lint*` pairs need no binary at all and run from
-`ndebug-gate-lint`, `debug-macro-flag-lint`, `shell-lint` and
-`regression-coverage-lint` respectively. Each script:
+`ndebug_gate_lint*`, `debug_macro_flag_lint*`, `shell_lint*`,
+`regression_coverage_lint*` and `readme_contract_lint*` pairs need no binary at
+all and run from `ndebug-gate-lint`, `debug-macro-flag-lint`, `shell-lint`,
+`regression-coverage-lint` and `readme-contract-lint` respectively. Each script:
 
 - is self-contained (set -euo pipefail; explicit input contract — env vars for
   every script but the source-only lints, which instead take an optional
@@ -41,18 +41,32 @@ AVX2 row only, except for the ones wired to a job of their own:
 | `regression_coverage_lint_selftest.sh` | the lint above still detects an unrun script, so its `PASS` means something | "Coverage lint still detects an unrun script"       |
 | `host_floor_enforce.sh`      | below-floor hosts get exit 2 + a readable error, not a SIGILL (needs `TESTING_BUILD=1`) | "SIMD floor enforcement (TESTING_BUILD, injected below-floor tier)" |
 | `version_banner.sh`          | `bwa-mem3 version` prints the SIMD floor and runtime tier lines        | "Version banner regression"                         |
+| `readme_contract_lint.sh`    | this README names no script that was deleted, and its source-only-lint block lists exactly the scripts that read no environment | "README still describes the regression scripts"     |
+| `readme_contract_lint_selftest.sh` | the lint above still detects a stale README, so its `PASS` means something | "README lint still detects drift"                  |
 
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is
 the authoritative list, and `ci.yml` is where each one is actually wired up.
 
 Every script but the source-only lints reads its inputs from environment
-variables — see the comment block at the top of each file. The lints read no
-environment at all: `ndebug_gate_lint.sh` takes the directory to scan (default
-`src/`) and `debug_macro_flag_lint.sh` takes the repository root to check
-(default: this repository), each as an optional positional argument, and the
-two `*_selftest.sh` scripts take no input, since they build the fixture trees
-they aim those lints at. `.github/workflows/ci.yml` sets the required vars and
-invokes the scripts.
+variables — see the comment block at the top of each file.
+`.github/workflows/ci.yml` sets the required vars and invokes the scripts.
+
+<!-- source-only lints: begin -->
+The source-only lints read no environment at all. Each takes the directory to
+work on as an optional positional argument, so that its self-test can aim the
+same checks at a fixture tree; each self-test takes no input, since it builds
+the trees it aims its lint at.
+
+| Lint | Positional argument | Self-test |
+|------|---------------------|-----------|
+| `ndebug_gate_lint.sh`         | directory to scan (default `src/`)                  | `ndebug_gate_lint_selftest.sh`         |
+| `debug_macro_flag_lint.sh`    | repository root to check (default: this repository) | `debug_macro_flag_lint_selftest.sh`    |
+| `regression_coverage_lint.sh` | repository root to check (default: this repository) | `regression_coverage_lint_selftest.sh` |
+| `readme_contract_lint.sh`     | repository root to check (default: this repository) | `readme_contract_lint_selftest.sh`     |
+<!-- source-only lints: end -->
+
+`readme_contract_lint.sh` checks that block against the scripts themselves, so
+a lint added without a row here fails CI rather than going unmentioned.
 
 One exception to "any binary will do": `profile_slice_cpu.sh` asserts on
 `--profile` output, which a default build compiles out entirely, so it needs a

--- a/test/regression/readme_contract_lint.sh
+++ b/test/regression/readme_contract_lint.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# test/regression/readme_contract_lint.sh
+#
+# Check that test/regression/README.md still describes the scripts next to it.
+#
+# The README is prose plus a table, and the two rot differently. A new script
+# reliably gets a table row, because adding one is part of writing the script.
+# The prose around the table -- which jobs run what, and which scripts take
+# environment variables versus a positional directory -- reliably does not,
+# because nothing points at it. That has happened twice:
+#
+#   - the README claimed every script "reads its inputs from environment
+#     variables" for as long as ndebug_gate_lint.sh, which reads none, had
+#     existed;
+#   - when the debug_macro_flag_lint pair landed it got its two table rows,
+#     while the intro kept naming "the two ndebug_gate_lint* scripts" and the
+#     single job that ran them.
+#
+# Both were caught by a human reading the file for an unrelated reason. This
+# lint makes the two claims that actually drifted checkable:
+#
+#   1. Every test/regression/*.sh the README names still exists. The reverse --
+#      requiring every script to appear -- is deliberately NOT checked: the
+#      README says in as many words that its table is "a reading guide, not an
+#      inventory", and a lint that forced it to become one would be arguing
+#      with the file it is checking. A row for a script that was deleted is a
+#      different thing: it is not a judgement call about coverage, it is a
+#      broken reference. The developer guide carried one for the better part of
+#      a year, telling readers to run a phix_parity.sh that no longer existed.
+#
+#   2. The set of scripts that read no environment at all is exactly the set
+#      named in the README's source-only-lint block. Add a lint and forget the
+#      prose, or give an existing lint an env var without moving it out, and
+#      this fails.
+#
+# Check 2 needs to know where the claim lives, so the README marks it:
+#
+#     <!-- source-only lints: begin -->
+#     ... naming each script that takes no environment ...
+#     <!-- source-only lints: end -->
+#
+# The markers are the contract. Prose inside them can be rewritten freely --
+# only the script names it mentions are checked.
+#
+# "Reads no environment" is decided by reading the script: a variable that is
+# referenced but never assigned anywhere in the file is an input from the
+# environment. Shell-provided names (BASH_SOURCE, PWD, IFS, ...) are excluded
+# by the allowlist below, since no caller sets those to configure a run.
+#
+# Input:
+#   $1  optional repository root to check; defaults to this repository. The
+#       argument exists so readme_contract_lint_selftest.sh can aim the same
+#       checks at a fixture tree of known-good and known-bad input, which is
+#       the only way to tell "the README is accurate" apart from "the checks
+#       stopped checking".
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+if (($# > 1)); then
+    echo "usage: ${BASH_SOURCE[0]##*/} [repo-root-to-check]" >&2
+    exit 2
+fi
+
+# Checked rather than left to `cd` to fail under `set -e`: bash's own `cd:` line
+# carries no FAIL: prefix, so the one way of pointing this lint at nothing that
+# is reachable from the command line would be the one failure a caller scanning
+# for the family's format does not see.
+if (($# == 1)); then
+    if [[ ! -d $1 ]]; then
+        echo "FAIL: '$1' is not a directory -- nothing was checked" >&2
+        exit 1
+    fi
+    cd "$1"
+fi
+
+regression_dir="test/regression"
+readme="$regression_dir/README.md"
+
+# Every way this lint can end up checking nothing has to be a failure, not a
+# PASS. A lint that silently checks nothing reads as green while doing no work,
+# which is the same class of bug as the drift it exists to catch.
+if [[ ! -d $regression_dir ]]; then
+    echo "FAIL: no $regression_dir/ under $PWD -- nothing was checked" >&2
+    exit 1
+fi
+if [[ ! -f $readme ]]; then
+    echo "FAIL: $readme missing under $PWD -- nothing was checked" >&2
+    exit 1
+fi
+
+scripts=()
+while IFS= read -r path; do
+    scripts+=("${path##*/}")
+done < <(find "$regression_dir" -maxdepth 1 -type f -name '*.sh' | sort)
+
+if ((${#scripts[@]} == 0)); then
+    echo "FAIL: no *.sh under $regression_dir/ -- nothing was checked" >&2
+    exit 1
+fi
+
+failures=0
+
+# What counts as a reference to a script in this README. Both checks read names
+# out of the file with it -- check 1 from the whole README, check 2 from inside
+# the source-only block -- so it is written once: two copies would let check 2
+# go on matching an older shape after check 1 was widened, which is this lint's
+# own failure mode turned inward.
+script_name_pattern='[A-Za-z_][A-Za-z0-9_.-]*\.sh'
+
+# --- Check 1: every script the README names still exists. ------------------
+
+# Names are taken from the whole file rather than just the table, so a script
+# retired out of a prose sentence is caught the same way as one retired out of
+# a row. A bare `*.sh` cannot come out of the pattern above, which has to start
+# on a letter or underscore, so a glob like `test/regression/*.sh` yields no
+# name at all; the skip below states that intent for anyone who widens it.
+mentioned=()
+while IFS= read -r name; do
+    [[ $name == '*.sh' ]] && continue
+    mentioned+=("$name")
+done < <(grep -oE "$script_name_pattern" "$readme" | sort -u)
+
+if ((${#mentioned[@]} == 0)); then
+    echo "FAIL: $readme names no *.sh at all -- check 1 detected nothing" >&2
+    exit 1
+fi
+
+dangling=()
+for name in "${mentioned[@]}"; do
+    if [[ ! -f "$regression_dir/$name" ]]; then
+        dangling+=("$name")
+    fi
+done
+
+if ((${#dangling[@]} > 0)); then
+    echo "FAIL: $readme names scripts that do not exist under $regression_dir/:" >&2
+    printf '  %s\n' "${dangling[@]}" >&2
+    echo >&2
+    echo "A reader following the README runs a script that is not there. Drop the" >&2
+    echo "reference, or point it at whatever replaced the script." >&2
+    failures=1
+fi
+
+# --- Check 2: the source-only-lint block lists exactly the env-free scripts. -
+
+begin_marker='<!-- source-only lints: begin -->'
+end_marker='<!-- source-only lints: end -->'
+
+for marker in "$begin_marker" "$end_marker"; do
+    count="$(grep -cF -- "$marker" "$readme" || true)"
+    if [[ $count != 1 ]]; then
+        echo "FAIL: $readme has $count copies of '$marker' -- expected exactly 1" >&2
+        echo "      (check 2 cannot locate the source-only-lint block)" >&2
+        exit 1
+    fi
+done
+
+begin_line="$(grep -nF -- "$begin_marker" "$readme" | cut -d: -f1)"
+end_line="$(grep -nF -- "$end_marker" "$readme" | cut -d: -f1)"
+
+# Ordering first, because the emptiness test below cannot tell the two apart:
+# an end marker above its begin marker also leaves nothing between them, and
+# reporting that as an empty block sends the reader to look at contents that are
+# right there in the file.
+if ((end_line < begin_line)); then
+    echo "FAIL: the source-only-lint markers in $readme are the wrong way round --" >&2
+    echo "      end on line $end_line, begin on line $begin_line" >&2
+    exit 1
+fi
+
+if ((end_line <= begin_line + 1)); then
+    echo "FAIL: the source-only-lint block in $readme is empty -- nothing to check" >&2
+    exit 1
+fi
+
+block="$(sed -n "$((begin_line + 1)),$((end_line - 1))p" "$readme")"
+
+# Names the shell itself provides. A script reading only these takes no
+# configuration from its caller, so it still counts as source-only.
+shell_provided_names='^(BASH|BASHPID|BASH_ARGC|BASH_ARGV|BASH_COMMAND|BASH_LINENO|BASH_REMATCH|BASH_SOURCE|BASH_SUBSHELL|BASH_VERSINFO|BASH_VERSION|COLUMNS|EUID|FUNCNAME|GROUPS|HISTFILE|HOME|HOSTNAME|HOSTTYPE|IFS|LINENO|LINES|MACHTYPE|OLDPWD|OPTARG|OPTIND|OSTYPE|PATH|PIPESTATUS|PPID|PS1|PS2|PS4|PWD|RANDOM|REPLY|SECONDS|SHELL|SHLVL|UID)$'
+
+# Emit only the parts of a script where a `$NAME` would actually expand:
+# comments, single-quoted spans, and backslash-escaped dollars are dropped.
+#
+# This is the difference between reading a script and grepping it. Two of these
+# scripts hold shell text as data -- fixture bodies for their self-tests --
+# inside single quotes that may run over several lines, so a line-at-a-time
+# filter cannot see where the quote opened. `'${MAKE:-make}'` is a string; the
+# same characters unquoted are an environment read. Tracking the quote state
+# across the whole file is what tells them apart.
+#
+# Not handled: quoted heredocs (`<<'EOF'`), whose body is also literal. Their
+# contents are still scanned, which can only over-detect inputs -- a script
+# would be kept out of the source-only block rather than slipped into it, so
+# the failure is loud.
+strip_non_expanding() {
+    # Both quote states are tracked, not just single. A single quote inside a
+    # double-quoted string is a literal character and opens nothing -- the
+    # `'"'"'` idiom these scripts use to embed a quote is exactly that shape,
+    # and reading its quote as an opener inverts the state for the whole rest
+    # of the file.
+    awk '
+    BEGIN { single = 0; double = 0 }
+    {
+        line = $0
+        out = ""
+        i = 1
+        n = length(line)
+        while (i <= n) {
+            c = substr(line, i, 1)
+            if (single) {
+                if (c == "\047") single = 0
+                i++
+                continue
+            }
+            if (double) {
+                # Inside double quotes a backslash still escapes, and `$` still
+                # expands, so the contents are kept.
+                if (c == "\\") { out = out " "; i += 2; continue }
+                if (c == "\"") double = 0
+                else out = out c
+                i++
+                continue
+            }
+            if (c == "\047") { single = 1; i++; continue }
+            if (c == "\"") { double = 1; i++; continue }
+            # A backslash quotes the next character, so `\$FOO` is a literal
+            # dollar sign. Drop both, leaving a space so adjacent words do not
+            # fuse into a new token.
+            if (c == "\\") { out = out " "; i += 2; continue }
+            # A `#` starting a word begins a comment that runs to end of line.
+            if (c == "#" && (i == 1 || substr(line, i - 1, 1) ~ /[ \t;&|()]/)) break
+            out = out c
+            i++
+        }
+        print out
+    }' "$1"
+}
+
+# A variable that is referenced but never assigned anywhere in the file is an
+# input from the environment. Assignment covers the plain, prefix, `local`,
+# `export`, `declare`/`readonly`/`typeset`, `for NAME in`, and `read -r NAME`
+# forms -- anything the script sets for itself is not something a caller passes
+# in.
+#
+# One shape defeats that rule and has to be recognised on its own:
+#
+#     MAKE="${MAKE:-make}"
+#
+# is an assignment, but the value assigned is whatever the caller exported. The
+# `:-` `-` `:=` `:?` `?` `:+` `+` expansions exist precisely to consume an
+# outside value, so a name used in one is an environment input no matter what
+# else the script does with it. Without this, make_default_goal.sh and
+# make_header_deps.sh -- whose only inputs are MAKE and MAKE_ARGS, both
+# defaulted this way -- would be misread as source-only.
+env_inputs_of() {
+    local file="$1"
+
+    local code
+    code="$(strip_non_expanding "$file")"
+
+    local referenced assigned defaulted
+    referenced="$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*|\$[A-Za-z_][A-Za-z0-9_]*' <<< "$code" \
+        | sed -E 's/^\$\{?//' | sort -u || true)"
+    assigned="$({
+        grep -oE '(^|[[:space:]]|[;&|(])[A-Za-z_][A-Za-z0-9_]*=' <<< "$code" \
+            | sed -E 's/^[^A-Za-z_]*//; s/=$//'
+        grep -oE '\bfor[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' <<< "$code" \
+            | sed -E 's/^for[[:space:]]+//'
+        grep -oE '\bread[[:space:]]+(-[A-Za-z]+[[:space:]]+)*[A-Za-z_][A-Za-z0-9_]*' <<< "$code" \
+            | sed -E 's/.*[[:space:]]//'
+    } | sort -u || true)"
+    defaulted="$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*:?[-=?+]' <<< "$code" \
+        | sed -E 's/^\$\{//; s/:?[-=?+]$//' | sort -u || true)"
+
+    {
+        comm -23 <(printf '%s\n' "$referenced") <(printf '%s\n' "$assigned")
+        printf '%s\n' "$defaulted"
+    } | sort -u | grep -E '^[A-Z][A-Z0-9_]*$' | grep -vE "$shell_provided_names" || true
+}
+
+source_only=()
+env_reading=()
+for script in "${scripts[@]}"; do
+    if [[ -z "$(env_inputs_of "$regression_dir/$script")" ]]; then
+        source_only+=("$script")
+    else
+        env_reading+=("$script")
+    fi
+done
+
+# Not a possible state today, and a bug in env_inputs_of if it ever is: it
+# would make check 2 vacuous while still printing PASS.
+if ((${#source_only[@]} == 0)); then
+    echo "FAIL: no script under $regression_dir/ reads zero environment variables" >&2
+    echo "      -- check 2 detected nothing, which means it is no longer checking" >&2
+    exit 1
+fi
+
+# Membership is decided against the block's script names, extracted with the
+# shared pattern above, rather than against its raw text. A substring search
+# reads one name as another whenever one is a suffix of the other: with
+# `other_lint.sh` in the block, `grep -qF lint.sh` matches its row, so an
+# omitted source-only `lint.sh` reports as present and an env-reading `lint.sh`
+# reports as wrongly listed. Both directions are wrong, and the first is silent.
+block_names="$(grep -oE "$script_name_pattern" <<< "$block" | sort -u || true)"
+
+block_names_contains() {
+    grep -qxF -- "$1" <<< "$block_names"
+}
+
+missing_from_block=()
+for script in "${source_only[@]}"; do
+    if ! block_names_contains "$script"; then
+        missing_from_block+=("$script")
+    fi
+done
+
+wrongly_in_block=()
+for script in "${env_reading[@]}"; do
+    if block_names_contains "$script"; then
+        wrongly_in_block+=("$script")
+    fi
+done
+
+if ((${#missing_from_block[@]} > 0)); then
+    echo "FAIL: these scripts read no environment but the source-only-lint block" >&2
+    echo "      in $readme does not name them:" >&2
+    printf '  %s\n' "${missing_from_block[@]}" >&2
+    echo >&2
+    echo "The block is what tells a reader which scripts need no setup. Name them" >&2
+    echo "there, with the positional argument each one takes." >&2
+    failures=1
+fi
+
+if ((${#wrongly_in_block[@]} > 0)); then
+    echo "FAIL: the source-only-lint block in $readme names these scripts, but they" >&2
+    echo "      do read environment variables:" >&2
+    for script in "${wrongly_in_block[@]}"; do
+        echo "  $script ($(env_inputs_of "$regression_dir/$script" | tr '\n' ' '))" >&2
+    done
+    echo >&2
+    echo "Either move them out of the block or drop the environment input." >&2
+    failures=1
+fi
+
+if ((failures != 0)); then
+    exit 1
+fi
+
+echo "PASS: readme_contract_lint (${#mentioned[@]} scripts named and present; ${#source_only[@]} source-only)"

--- a/test/regression/readme_contract_lint_selftest.sh
+++ b/test/regression/readme_contract_lint_selftest.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# test/regression/readme_contract_lint_selftest.sh
+#
+# Regression: readme_contract_lint.sh still recognises a stale README.
+#
+# The lint it tests has one observable behaviour on a healthy tree -- it prints
+# PASS -- and that is also what it prints when its own matching has stopped
+# matching anything. Those two states are indistinguishable from CI, which is
+# the same "green while doing no work" failure the lint exists to catch in the
+# README. The only way to tell them apart is to hand it trees it must reject
+# and check that it does.
+#
+# That is not hypothetical for this lint in particular. Deciding whether a
+# script "reads no environment" is a heuristic over shell text, and it was
+# wrong twice while being written: it first read `MAKE="${MAKE:-make}"` as an
+# assignment rather than an environment input, and then read the same
+# expansion inside its own header comment as live code. Either mistake moves a
+# script between the two sets silently.
+#
+# Fixtures are generated here rather than committed: each case is a two-file
+# tree, and a directory of those away from the expectations that name them is
+# harder to read than the cases below.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+lint="test/regression/readme_contract_lint.sh"
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+
+failures=0
+
+readonly BEGIN_MARKER='<!-- source-only lints: begin -->'
+readonly END_MARKER='<!-- source-only lints: end -->'
+
+# Build a fixture tree: a README, plus one script per "name:body" pair given
+# after it. Returns the tree's path on stdout.
+make_tree() {
+    local name="$1" readme_body="$2"
+    shift 2
+
+    local dir="$fixture_root/$name"
+    rm -rf "$dir"
+    mkdir -p "$dir/test/regression"
+    printf '%s\n' "$readme_body" > "$dir/test/regression/README.md"
+
+    local spec
+    for spec in "$@"; do
+        printf '%s\n' "${spec#*:}" > "$dir/test/regression/${spec%%:*}"
+    done
+
+    printf '%s' "$dir"
+}
+
+# Run the lint over a fixture tree and check the verdict. `expected` is FLAG
+# (the lint must reject it, exit 1) or PASS (must accept it, exit 0).
+check_tree() {
+    local description="$1" expected="$2" dir="$3"
+
+    local output status
+    output="$(bash "$lint" "$dir" 2>&1)" && status=0 || status=$?
+
+    local verdict
+    case "$status" in
+        0) verdict=PASS ;;
+        1) verdict=FLAG ;;
+        *) verdict="EXIT$status" ;;
+    esac
+
+    if [[ $verdict == "$expected" ]]; then
+        echo "  ok   $description -> $expected"
+    else
+        echo "  FAIL $description -> got $verdict, wanted $expected" >&2
+        printf '       %s\n' "$output" >&2
+        failures=1
+    fi
+}
+
+# A README whose source-only block names exactly the scripts passed in.
+readme_naming() {
+    local rows="" name
+    for name in "$@"; do
+        rows+="- \`$name\` takes an optional positional directory"$'\n'
+    done
+    printf '%s\n\n%s\n%s%s\n' \
+        "Every script but the source-only lints reads its inputs from the environment." \
+        "$BEGIN_MARKER" "$rows" "$END_MARKER"
+}
+
+# The fixture bodies below are shell source held as data, so every `$` in them
+# must survive into the fixture file unexpanded. Single quotes are the point,
+# not an oversight -- and the lint under test has to read them as data too,
+# which is what several of the cases check.
+# shellcheck disable=SC2016
+
+# A script that takes the named environment variable, and one that takes none.
+readonly ENV_SCRIPT='set -euo pipefail
+: "${BWA_MEM3:?BWA_MEM3 must be set}"
+echo "PASS: fixture"'
+# shellcheck disable=SC2016
+readonly SOURCE_ONLY_SCRIPT='set -euo pipefail
+scan_root="${1:-src}"
+echo "PASS: fixture $scan_root"'
+# shellcheck disable=SC2016
+readonly DEFAULTED_ENV_SCRIPT='set -euo pipefail
+MAKE="${MAKE:-make}"
+"$MAKE" --version'
+
+# A script that holds shell text as data -- the shape of the self-tests next to
+# this one, which build fixture scripts from single-quoted constants spanning
+# several lines. Everything between the inner quotes is a string; nothing in it
+# is an environment read. Written with the `'"'"'` idiom so the inner quotes
+# survive into the fixture file.
+# shellcheck disable=SC2016
+readonly QUOTED_DATA_SCRIPT='set -euo pipefail
+payload='"'"'set -euo pipefail
+MAKE="${MAKE:-make}"
+: "${BWA_MEM3:?BWA_MEM3 must be set}"'"'"'
+printf '"'"'%s\n'"'"' "$payload" > /dev/null
+echo "PASS: fixture"'
+
+echo "== stale READMEs the lint must reject =="
+
+check_tree "README names a script that was deleted" FLAG \
+    "$(make_tree deleted "$(readme_naming lint.sh)
+
+See also \`retired.sh\` for the older check." \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+check_tree "source-only script missing from the block" FLAG \
+    "$(make_tree unlisted "$(readme_naming lint.sh)
+
+Also here: \`other_lint.sh\`." \
+        "lint.sh:$SOURCE_ONLY_SCRIPT" \
+        "other_lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+# The same omission, with the two names swapped so one is a suffix of the other.
+# A block searched as raw text answers "is `lint.sh` in here?" with the
+# `other_lint.sh` row, so this tree -- whose block names only `other_lint.sh`
+# while `lint.sh` is source-only too -- reports PASS. The case above does not
+# catch it: there the listed name is the shorter one, which no row contains.
+check_tree "source-only script whose name is a suffix of a listed one" FLAG \
+    "$(make_tree suffix_unlisted "$(readme_naming other_lint.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT" \
+        "other_lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+check_tree "env-reading script listed in the block" FLAG \
+    "$(make_tree miscategorised "$(readme_naming lint.sh parity.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT" \
+        "parity.sh:$ENV_SCRIPT")"
+
+# The bug that shipped twice while this lint was being written: a variable both
+# assigned and defaulted from the environment in one expansion is an input.
+check_tree "script whose only input is a defaulted env var" FLAG \
+    "$(make_tree defaulted "$(readme_naming lint.sh build.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT" \
+        "build.sh:$DEFAULTED_ENV_SCRIPT")"
+
+echo "== healthy trees the lint must accept =="
+
+check_tree "block names exactly the source-only scripts" PASS \
+    "$(make_tree healthy "$(readme_naming lint.sh other_lint.sh)
+
+Also here: \`parity.sh\`, which needs a binary." \
+        "lint.sh:$SOURCE_ONLY_SCRIPT" \
+        "other_lint.sh:$SOURCE_ONLY_SCRIPT" \
+        "parity.sh:$ENV_SCRIPT")"
+
+# The loud half of the same collision. `lint.sh` reads the environment and is
+# correctly absent from the block, but a raw-text search finds it in the
+# `other_lint.sh` row and reports it as wrongly listed. That direction fails a
+# healthy tree rather than passing a stale one, so it is asserted as PASS here.
+check_tree "env-reading script whose name is a suffix of a listed one" PASS \
+    "$(make_tree suffix_env "$(readme_naming other_lint.sh)
+
+Also here: \`lint.sh\`, which needs a binary." \
+        "lint.sh:$ENV_SCRIPT" \
+        "other_lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+# `test/regression/*.sh` is a glob, not a reference to a script named `*.sh`.
+check_tree "glob in prose is not a dangling reference" PASS \
+    "$(make_tree glob "$(readme_naming lint.sh)
+
+\`ls test/regression/*.sh\` is the authoritative list." \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+# An env var named only in a header comment is documentation, not an input.
+check_tree "env var named only in a comment is not an input" PASS \
+    "$(make_tree commented "$(readme_naming lint.sh)" \
+        "lint.sh:# Inputs: none. Contrast \${BWA_MEM3:-} in the parity scripts.
+$SOURCE_ONLY_SCRIPT")"
+
+# Shell text held as data. This is the shape of the self-tests next to this
+# one, which build fixture scripts from single-quoted constants that run over
+# several lines: `${MAKE:-make}` inside them is a string, not an expansion, and
+# only tracking the quote state across lines can tell the difference. Dropping
+# that tracking leaves every other case here passing, so without this one the
+# self-test does not cover it.
+check_tree "env var inside a multi-line single-quoted string is not an input" PASS \
+    "$(make_tree quoted_data "$(readme_naming lint.sh)" \
+        "lint.sh:$QUOTED_DATA_SCRIPT")"
+
+# An apostrophe inside a double-quoted message is a literal character, not the
+# start of a quoted span. Reading it as one shifts the quote state for
+# everything after, which turns the single-quoted payload on the next line into
+# live code and invents an input the script does not take.
+check_tree "apostrophe in a double-quoted string does not shift quote state" PASS \
+    "$(make_tree apostrophe "$(readme_naming lint.sh)" \
+        "lint.sh:set -euo pipefail
+label=\"the lint's own message\"
+payload='\${BWA_MEM3:?BWA_MEM3 must be set}'
+echo \"\$label \$payload\" > /dev/null
+echo \"PASS: fixture\"")"
+
+echo "== a lint that checked nothing must not report PASS =="
+
+no_readme_dir="$(make_tree no-readme "$(readme_naming lint.sh)" \
+    "lint.sh:$SOURCE_ONLY_SCRIPT")"
+rm -f "$no_readme_dir/test/regression/README.md"
+check_tree "no README" FLAG "$no_readme_dir"
+
+check_tree "no scripts at all" FLAG \
+    "$(make_tree no-scripts "$(readme_naming lint.sh)")"
+
+check_tree "no source-only script in the tree" FLAG \
+    "$(make_tree none-source-only "$(readme_naming parity.sh)" \
+        "parity.sh:$ENV_SCRIPT")"
+
+check_tree "README with no block markers" FLAG \
+    "$(make_tree no-markers "Every script reads its inputs from the environment." \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+check_tree "README with an empty block" FLAG \
+    "$(make_tree empty-block "$(printf '%s\n%s\n' "$BEGIN_MARKER" "$END_MARKER")" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+# Reported as an ordering problem rather than as an empty block: the end marker
+# above its begin marker also leaves nothing between the two, so the emptiness
+# test alone would name the wrong edit.
+check_tree "README with its block markers the wrong way round" FLAG \
+    "$(make_tree swapped-markers "$(printf '%s\n%s\n%s\n' \
+        "Prose naming lint.sh." "$END_MARKER" "$BEGIN_MARKER")" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+check_tree "README naming no script at all" FLAG \
+    "$(make_tree no-names "$(printf '%s\n%s\nnothing here\n%s\n' \
+        "Prose with no script names." "$BEGIN_MARKER" "$END_MARKER")" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+# Checked on the message, not just the status: an unguarded `cd` into a missing
+# directory also dies with exit 1 under `set -e`, so a status-only assertion
+# passes either way. The point of the case is that the failure arrives in this
+# family's own format rather than as bash's raw `cd:` diagnostic.
+missing_dir="$fixture_root/does-not-exist"
+missing_out="$(bash "$lint" "$missing_dir" 2>&1)" && missing_status=0 || missing_status=$?
+if ((missing_status == 1)) && [[ $missing_out == FAIL:* ]]; then
+    echo "  ok   missing directory -> FLAG"
+else
+    echo "  FAIL missing directory -> expected exit 1 and a FAIL: message," >&2
+    echo "       got exit $missing_status: $missing_out" >&2
+    failures=1
+fi
+
+bash "$lint" one two > /dev/null 2>&1 && usage_status=0 || usage_status=$?
+if ((usage_status == 2)); then
+    echo "  ok   too many arguments -> usage error (exit 2)"
+else
+    echo "  FAIL too many arguments -> exit $usage_status, wanted 2" >&2
+    failures=1
+fi
+
+if ((failures != 0)); then
+    echo "FAIL: readme_contract_lint_selftest" >&2
+    exit 1
+fi
+
+echo "PASS: readme_contract_lint_selftest"


### PR DESCRIPTION
`test/regression/README.md` is a table plus the prose around it, and the two rot differently. A new script reliably gets a table row, because adding one is part of writing the script. The prose reliably does not, because nothing points at it. That has now happened twice, and both times a human found it while reading the file for an unrelated reason:

- the README claimed every script "reads its inputs from environment variables" for as long as `ndebug_gate_lint.sh`, which reads none, had existed — that is what #339 fixes;
- when the `debug_macro_flag_lint` pair landed in #336 it got its two table rows, while the intro kept naming "the two `ndebug_gate_lint*` scripts" and the single job that ran them.

This adds `readme_contract_lint.sh` and its self-test, in the same shape as the two source-only lints already here: no binary, no fixtures, an optional positional repo root so the self-test can aim it at a fixture tree, its own CI job, and a `make test` line.

**Check 1 — every script the README names still exists.** The reverse (every script must appear) is deliberately *not* checked: the README says in as many words that its table is "a reading guide, not an inventory", and a lint forcing it to become one would be arguing with the file it checks. A row for a deleted script is a different thing — not a judgement call about coverage, just a broken reference. The developer guide carried one of those for the better part of a year (#345).

**Check 2 — the scripts that read no environment are exactly the ones named in the README's source-only-lint block.** The block is delimited by HTML comments, so the prose inside stays free to be rewritten; only the script names it mentions are checked. This is the check that would have caught both instances above.

Deciding "reads no environment" means reading shell text, so it follows the quoting rules rather than grepping: a name is an input if it is referenced and never assigned, **or** if it appears in a `${VAR:-...}`-style expansion, which is an assignment whose value comes from the caller. Comments, single-quoted spans — including the multi-line ones the self-tests use to hold fixture scripts — and backslash-escaped dollars are not code and are dropped first.

Both of those were bugs while writing it, which is the argument for the self-test being more than a formality:

| Mutation | Self-test |
|---|---|
| drop the `${VAR:-...}` detection | 10 cases fail |
| drop single-quote tracking | 2 cases fail |
| drop double-quote tracking (an apostrophe in a message shifts the state) | 1 case fails |
| drop the dangling-reference check | 1 case fails |

The double-quote case is the one worth noting: without a fixture for it the mutation survived the self-test while breaking the real tree, so the case was added after the mutation run rather than before it.

Current state on this branch:

```
$ bash test/regression/readme_contract_lint.sh
PASS: readme_contract_lint (18 scripts named and present; 6 source-only)
$ bash test/regression/readme_contract_lint_selftest.sh
PASS: readme_contract_lint_selftest
```

`shellcheck` is clean on both files.

**Stacked on #339**, whose paragraph this restructures into the marked block — the README edit would conflict otherwise. Retarget to `main` once that lands. Independent of #338: that one checks every script is *invoked* by CI or the Makefile, which is a different failure from the README describing them wrongly; they compose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the regression README contract lint and self-test.
  * Clarified script listings, source-only markers, validation rules, and related checks.

* **Tests**
  * Added checks for stale, missing, malformed, empty, or invalid regression README entries.
  * Added coverage for environment variables, comments, quoting, globs, multiline data, and apostrophes.
  * Integrated these validations into the standard test workflow and continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->