### PR TITLE
test: capture expected exit codes without toggling errexit

### DIFF
--- a/test/bam_compress_warn_test.sh
+++ b/test/bam_compress_warn_test.sh
@@ -77,14 +77,10 @@ expect() {
     local label="$1" want_rc="$2" want_warns="$3"
     shift 3
     local err="$tmpdir/$label.err"
-    local rc warns grep_rc
+    local rc=0 warns grep_rc=0
 
-    set +e
-    "$bin" mem "$@" > /dev/null 2> "$err"
-    rc=$?
-    warns="$(grep -c 'WARNING: --bam=' "$err")"
-    grep_rc=$?
-    set -e
+    "$bin" mem "$@" > /dev/null 2> "$err" || rc=$?
+    warns="$(grep -c 'WARNING: --bam=' "$err")" || grep_rc=$?
 
     # grep exits 1 when there are no matches -- an expected result here -- and
     # >1 only on a real error such as an unreadable capture file.

--- a/test/help_prescan_test.sh
+++ b/test/help_prescan_test.sh
@@ -53,10 +53,8 @@ tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 # --- 1. Real `mem --help` short-circuits: option list, no banner, exit 0. ---
-set +e
-"$bin" mem --help > "$tmpdir/help.out" 2> "$tmpdir/help.err"
-rc=$?
-set -e
+rc=0
+"$bin" mem --help > "$tmpdir/help.out" 2> "$tmpdir/help.err" || rc=$?
 [[ $rc -eq 0 ]] \
     || {
         echo "FAIL: mem --help exited with $rc, expected 0" >&2
@@ -81,10 +79,8 @@ fi
 # exit 0, and SAM must be written to a file literally named `--help`. Run
 # from the tmp dir so the output file lands there even though `--help`
 # looks like an option.
-set +e
-(cd "$tmpdir" && "$bin" mem -o "--help" "$ref" "$reads" > run.out 2> run.err)
-rc=$?
-set -e
+rc=0
+(cd "$tmpdir" && "$bin" mem -o "--help" "$ref" "$reads" > run.out 2> run.err) || rc=$?
 [[ $rc -eq 0 ]] \
     || {
         echo "FAIL: 'mem -o --help' exited $rc, expected 0" >&2
@@ -111,10 +107,8 @@ grep -q 'Executing in' "$tmpdir/run.err" \
 # invalid @RG, but the banner must still be printed first and the run must
 # exit non-zero (so the test can't pass if `--help` were ever wrongly
 # consumed and the run completed successfully).
-set +e
-"$bin" mem -R "--help" "$ref" "$reads" > "$tmpdir/rg.out" 2> "$tmpdir/rg.err"
-rc=$?
-set -e
+rc=0
+"$bin" mem -R "--help" "$ref" "$reads" > "$tmpdir/rg.out" 2> "$tmpdir/rg.err" || rc=$?
 [[ $rc -ne 0 ]] \
     || {
         echo "FAIL: 'mem -R --help' exited 0; expected non-zero (invalid @RG)" >&2
@@ -133,11 +127,9 @@ grep -q 'Executing in' "$tmpdir/rg.err" \
 # --- 4. `mem --set-as-failed --help <ref> <reads>` -- long option with a ----
 # required argument; the banner must still be printed and the run must
 # exit non-zero.
-set +e
+rc=0
 "$bin" mem --set-as-failed "--help" "$ref" "$reads" \
-    > "$tmpdir/saf.out" 2> "$tmpdir/saf.err"
-rc=$?
-set -e
+    > "$tmpdir/saf.out" 2> "$tmpdir/saf.err" || rc=$?
 [[ $rc -ne 0 ]] \
     || {
         echo "FAIL: 'mem --set-as-failed --help' exited 0; expected non-zero (--help is not a valid 'f'|'r' value)" >&2

--- a/test/regression/all_tiers_parity.sh
+++ b/test/regression/all_tiers_parity.sh
@@ -174,12 +174,10 @@ for vi in "${!VARIANT_LABELS[@]}"; do
         # whole script with no message at all -- the aligner's stderr goes to a
         # per-tier log, so the operator saw "Generating SAM for tier=X" and a
         # bare exit code. Say what happened and show the log.
-        set +e
+        rc=0
         BWAMEM3_FORCE_TIER="$t" "$BWA_MEM3" mem -t 1 ${vargs[@]+"${vargs[@]}"} \
             "$PARITY_FA" "$PARITY_R1" "$PARITY_R2" \
-            > "$OUT_DIR/$vlabel.$t.sam" 2> "$OUT_DIR/$vlabel.$t.log"
-        rc=$?
-        set -e
+            > "$OUT_DIR/$vlabel.$t.sam" 2> "$OUT_DIR/$vlabel.$t.log" || rc=$?
         if [[ $rc -ne 0 ]]; then
             echo "FAIL: [$vlabel] bwa-mem3 exited $rc at tier=$t" >&2
             sed 's/^/      /' "$OUT_DIR/$vlabel.$t.log" | tail -10 >&2

--- a/test/regression/chain_scratch_per_thread.sh
+++ b/test/regression/chain_scratch_per_thread.sh
@@ -74,18 +74,15 @@ PY
 # Report the isolated per-thread scratch allocation, in MB, for a given -t / -K.
 scratch_mb_for() {
     local t="$1" k="$2" err="$WORK/t$1k$2.err"
-    local rc mb
+    local rc=0 mb
 
     # The exit status is asserted, not assumed, for two reasons. worker_alloc
     # reports the scratch line early, so a run that printed it and then died
     # would otherwise yield a perfectly comparable number from a failed run. And
     # the per-chunk resize guard in kt_pipeline step 1 reports a violation by
     # exiting non-zero -- see the note below on why that guard exists.
-    set +e
     "$BWA_MEM3" mem -t "$t" -K "$k" "$CHR22_FA" \
-        "$WORK/r1.fq.gz" "$WORK/r2.fq.gz" > /dev/null 2> "$err"
-    rc=$?
-    set -e
+        "$WORK/r1.fq.gz" "$WORK/r2.fq.gz" > /dev/null 2> "$err" || rc=$?
     if [ "$rc" -ne 0 ]; then
         echo "FAIL: 'bwa-mem3 mem -t $t -K $k' exited $rc" >&2
         tail -20 "$err" >&2
@@ -95,9 +92,7 @@ scratch_mb_for() {
     # grep exits 1 when the line is absent, which under `set -e` (plus pipefail)
     # would abort the script on the assignment itself and never reach the
     # diagnostic below -- so the failure is caught explicitly instead.
-    set +e
-    mb=$(grep -m1 "per-thread chaining scratch" "$err" | sed 's/.*scratch: *//; s/ MB.*//')
-    set -e
+    mb="$(grep -m1 "per-thread chaining scratch" "$err" | sed 's/.*scratch: *//; s/ MB.*//')" || mb=""
     if [ -z "$mb" ]; then
         echo "FAIL: could not find the per-thread scratch line in $err" >&2
         echo "      (worker_alloc must report it; see src/fastmap.cpp)" >&2

--- a/test/regression/cohort_slice_identity.sh
+++ b/test/regression/cohort_slice_identity.sh
@@ -199,14 +199,11 @@ echo "  EOF-on-boundary: truncating to $pairs pairs ($expected records), the fir
 echo "                   partial slice's exact size"
 
 align_eof() { # $1 = tag, $2 = --cohort-slices value, $3 = slice-every-cohort (0/1)
-    local tag="$1" slices="$2" all="$3" n rc
-    set +e
+    local tag="$1" slices="$2" all="$3" n rc=0
     BWA_MEM3_COHORT_SLICE_ALL="$all" \
         "$BWA_MEM3" mem -t 4 -K "$K" --cohort-slices "$slices" \
         "$CHR22_FA" "$WORK/eof.r1.fastq.gz" "$WORK/eof.r2.fastq.gz" \
-        > "$WORK/$tag.full.sam" 2> "$WORK/$tag.err"
-    rc=$?
-    set -e
+        > "$WORK/$tag.full.sam" 2> "$WORK/$tag.err" || rc=$?
     [ "$rc" -eq 0 ] || {
         echo "FAIL: $tag exited $rc" >&2
         tail -15 "$WORK/$tag.err" >&2

--- a/test/regression/host_floor_enforce.sh
+++ b/test/regression/host_floor_enforce.sh
@@ -29,12 +29,10 @@ OUT_DIR="$(mktemp -d -t bwamem3-enforce-XXXXXX)"
 trap 'rm -rf "$OUT_DIR"' EXIT
 
 # --- Scenario 1: bwa-mem3 mem refuses ---
-set +e
+rc=0
 BWAMEM3_TESTING_HOST_TIER="$INJECTED_TIER" \
     "$BWA_MEM3_TESTING" mem "$PARITY_FA" /dev/null /dev/null \
-    > "$OUT_DIR/mem.stdout" 2> "$OUT_DIR/mem.stderr"
-rc=$?
-set -e
+    > "$OUT_DIR/mem.stdout" 2> "$OUT_DIR/mem.stderr" || rc=$?
 
 if [[ $rc -ne 2 ]]; then
     echo "FAIL: bwa-mem3 mem exited $rc (expected 2)" >&2
@@ -66,11 +64,9 @@ if ! grep -q 'BASELINE_ARCH' "$OUT_DIR/mem.stderr"; then
 fi
 
 # --- Scenario 2: bwa-mem3 version warns but exits 0 ---
-set +e
+rc=0
 BWAMEM3_TESTING_HOST_TIER="$INJECTED_TIER" \
-    "$BWA_MEM3_TESTING" version > "$OUT_DIR/version.stdout" 2> "$OUT_DIR/version.stderr"
-rc=$?
-set -e
+    "$BWA_MEM3_TESTING" version > "$OUT_DIR/version.stdout" 2> "$OUT_DIR/version.stderr" || rc=$?
 
 if [[ $rc -ne 0 ]]; then
     echo "FAIL: bwa-mem3 version exited $rc (expected 0)" >&2

--- a/test/regression/rescue_kmer_options.sh
+++ b/test/regression/rescue_kmer_options.sh
@@ -63,11 +63,8 @@ fails=0
 # Always uses the `=` form so a leading '-' in the value is not taken for another
 # option.
 reject() {
-    local optword="$1" want="$2" rc
-    set +e
-    "$BWA_MEM3" mem "$optword" "$ref" "$reads" > /dev/null 2> "$err"
-    rc=$?
-    set -e
+    local optword="$1" want="$2" rc=0
+    "$BWA_MEM3" mem "$optword" "$ref" "$reads" > /dev/null 2> "$err" || rc=$?
     if [[ "$rc" -eq 0 ]]; then
         echo "FAIL: '$optword' was accepted; expected a non-zero exit"
         fails=$((fails + 1))
@@ -126,10 +123,8 @@ accept "--rescue-band=1000000"
 # following word: `mem --rescue-kmer 6 ref reads` leaves THREE positionals, and
 # `6` is taken as the index base. Pinning this keeps the docs and the --help
 # --fast expansion honest about the `=` form.
-set +e
-"$BWA_MEM3" mem --rescue-kmer 6 "$ref" "$reads" > /dev/null 2> "$err"
-rc=$?
-set -e
+rc=0
+"$BWA_MEM3" mem --rescue-kmer 6 "$ref" "$reads" > /dev/null 2> "$err" || rc=$?
 if [[ "$rc" -eq 0 ]]; then
     echo "FAIL: '--rescue-kmer 6' (space-separated) unexpectedly succeeded;"
     echo "      it should leave 6 as a positional argument"


### PR DESCRIPTION
Stacked on #344 — review that first; this PR's diff is the last commit only.

Follow-up to the `reject()` nitpick on #344. That review asked one call site to capture an expected non-zero exit with `|| rc=$?` instead of a `set +e` window. Sweeping the shape across the tree found 13 sites in 7 more scripts; this converts all of them, so the codebase has one idiom rather than two.

## Why

A `set +e` window stops checking **every** command inside it, not only the one it was opened for. Each window here holds a single command today, so this is latent rather than a live bug — but the failure mode is silent. A command added between the call and `rc=$?` simply stops being checked, and the diff that adds it does not look wrong. `rc=0` + `|| rc=$?` narrows the exemption to exactly the command that needs it, and is what `run_mem()` in `cohort_ramp_validation.sh` and `reject()` in `chunk_cap_optin.sh` already do.

No shellcheck finding covers this, so the shell gate is green either way.

## Two sites that were not mechanical

- **`bam_compress_warn_test.sh`** captured **two** statuses in one window — the aligner’s and a following `grep`’s. They are now captured separately (`|| rc=$?`, `|| grep_rc=$?`), which also removes the ordering trap where anything inserted between them would clobber `$?`.
- **`chain_scratch_per_thread.sh`** used `set +e` around a pipeline **assignment** with no status capture at all, purely to tolerate `grep`’s exit 1 when the line is absent. That is now `|| mb=""`, keeping the existing `[ -z "$mb" ]` diagnostic reachable — under errexit plus pipefail the bare assignment aborts the script with no message at all.

## Validation

Verified per site rather than in bulk, because most of these branches are unreachable on a healthy binary.

| Script | Sites | How |
|---|---|---|
| `help_prescan_test.sh` | 4 | run end-to-end against a local build — PASS |
| `bam_compress_warn_test.sh` | 1 | run end-to-end — PASS |
| `rescue_kmer_options.sh` | 2 | run end-to-end — PASS |
| `host_floor_enforce.sh` | 2 | stub binary, success **and** injected failure |
| `chain_scratch_per_thread.sh` | 2 | stub binary; success, injected failure, and the scratch-line-absent case |
| `all_tiers_parity.sh` | 1 | stub binary faking a second sweepable tier; success and injected failure |
| `cohort_slice_identity.sh` | 1 | its own `align_eof()` text extracted from the file; success and injected failure |

The six stub-driven ones only reach the converted branch when the aligner **fails**, which a real run never does — so each was checked to report the injected exit code rather than swallow it. `chain_scratch`'s `grep` path was checked with the scratch line absent, which is the case that previously aborted silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability when validating expected command failures and warnings.
  - Preserved strict error handling while accurately capturing exit statuses.
  - Maintained existing assertions for help, regression, option validation, parity, and resource-reporting scenarios.
  - Improved failure reporting for regression checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->