### PR TITLE
test(meth): check the fixtures, not a variable nothing reads

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -226,8 +226,12 @@ reviews:
         the two mates of a pair; and mate rescue that scores only one bisulfite
         hypothesis (test/regression/meth_rescue_batched_identical.sh pins the
         batched rescue against the per-pair path). Require coverage by the meth
-        regression scripts (test/regression/meth_*.sh), including the bwa-meth
-        oracle comparison (meth_oracle.sh).
+        regression scripts (test/regression/meth_*.sh), including the end-to-end
+        `--meth` harness wrapper (meth_oracle.sh). Do not ask that wrapper for
+        bwameth equivalence: despite the name, Layers 2-3 (bwameth structural
+        and byte equivalence) were retired in D3, since the genomic
+        `--meth-scoring` mode is variant-aware rather than collapsed and so
+        diverges from bwameth by design. It asserts Layer 1 only.
         CRITICAL: the non-`--meth` code path is contractually byte-for-byte
         unchanged — flag any edit that puts a methylation branch, extra field, or
         changed default on the normal path.
@@ -418,6 +422,11 @@ reviews:
       # Stated as an allowlist on purpose. A denylist of the actual internal
       # names would have to spell them out in a world-readable file, which is
       # the exact disclosure this check exists to prevent.
+      #
+      # The bar for an entry is "a reader could look it up", not "we wrote it":
+      # holodeck is on the list because it is a public repository whose clone
+      # URL is already hardcoded in test/meth/test_bismark_tags.sh, so the name
+      # discloses nothing that the tree does not already say out loud.
       - name: "Public-repo hygiene"
         mode: "error"
         instructions: >-
@@ -430,7 +439,9 @@ reviews:
           publicly citable project. Treat as allowed only names a reader could
           look up: this repository and its own scripts, upstream bwa, bwa-mem2,
           bwa-meth, Bismark, samtools, htslib, libsais, mimalloc, sse2neon,
-          zlib-ng, dwgsim, and standard OS or cloud instance-type designations.
+          zlib-ng, dwgsim, holodeck (the public read simulator this repository
+          already clones by URL in test/meth/test_bismark_tags.sh), and standard
+          OS or cloud instance-type designations.
           Any other proper-noun tool, harness, bucket, fleet, queue, or internal
           project name is a FAIL. (2) An object-store URL (`s3://`, `gs://`,
           `az://`) or bucket name. (3) A cloud account number, an EC2 instance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -776,10 +776,16 @@ jobs:
           cp bwa-meth-oracle/example/t_R2.fastq.gz test/meth/
           ls -la test/meth/
 
-      - name: Run --meth Layers 1-3
+      # No BWAMETH_DIR: the checkout above is a fixture source, not an oracle
+      # binary, and the copy step is what makes it reachable. Nothing under
+      # test/meth/ has read that variable since Layers 2-3 were retired.
+      #
+      # "Layer 1", not "Layers 1-3", for the same reason: the harness retired
+      # Layers 2-3 in D3, so a step named for them would advertise coverage no
+      # longer being run. Renamed alongside the row in test/regression/README.md
+      # that quotes this step name.
+      - name: Run --meth Layer 1
         if: matrix.canonical == true
-        env:
-          BWAMETH_DIR: ${{ github.workspace }}/bwa-meth-oracle
         run: bash test/regression/meth_oracle.sh
 
       - name: --meth whole-aligner regressions (D3)

--- a/test/meth/test.sh
+++ b/test/meth/test.sh
@@ -32,6 +32,20 @@ fi
 
 cd "$HERE"
 
+# The fixtures are gitignored and are copied in from the bwa-meth checkout --
+# see the "Copy bwa-meth fixtures into test/meth/" step in ci.yml. Checked here
+# because the indexing step below sends both streams to /dev/null: without
+# this, a missing ref.fa surfaced as a bare `exit 2` with no output at all,
+# since `set -e` aborts before any of this script's own diagnostics can run.
+for fixture in ref.fa t_R1.fastq.gz; do
+    if [[ ! -f "$fixture" || ! -s "$fixture" ]]; then
+        echo "ERROR: fixture $PWD/$fixture is missing, empty, or not a regular file."
+        echo "       These are gitignored. Copy them from a bwa-meth checkout:"
+        echo "         cp <bwa-meth>/example/{ref.fa,t_R1.fastq.gz,t_R2.fastq.gz} $PWD/"
+        exit 2
+    fi
+done
+
 # Every BAM this test writes goes into a private per-run directory. Fixed names
 # under /tmp can be pre-created as symlinks by another local user, in which case
 # the redirections below would follow them and clobber an unrelated file; they

--- a/test/meth/test_bismark_tags.sh
+++ b/test/meth/test_bismark_tags.sh
@@ -33,6 +33,19 @@ if ! command -v cargo > /dev/null 2>&1; then
     exit 0
 fi
 
+# Checked BEFORE the holodeck build below, which clones and compiles a Rust
+# project and costs minutes -- failing after that for a file we could have
+# checked first is a poor trade. ref.fa is gitignored and is copied in from the
+# bwa-meth checkout; see the "Copy bwa-meth fixtures into test/meth/" step in
+# ci.yml. Without this check a missing ref.fa surfaced as a bare `exit 2` with
+# no output, because the indexing step below sends both streams to /dev/null.
+if [[ ! -f "$HERE/ref.fa" || ! -s "$HERE/ref.fa" ]]; then
+    echo "ERROR: fixture $HERE/ref.fa is missing, empty, or not a regular file." >&2
+    echo "       It is gitignored. Copy it from a bwa-meth checkout:" >&2
+    echo "         cp <bwa-meth>/example/ref.fa $HERE/" >&2
+    exit 2
+fi
+
 if [[ ! -x "$HOLODECK_BIN" ]]; then
     echo "[layer 3] cloning + building holodeck @ $HOLODECK_SHA ..."
     rm -rf "$HOLODECK_DIR"

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -12,7 +12,7 @@ all and run from `ndebug-gate-lint`, `debug-macro-flag-lint`, `shell-lint`,
 - is self-contained (set -euo pipefail; explicit input contract — env vars for
   every script but the source-only lints, which instead take an optional
   positional directory so their self-tests can aim the same checks at a fixture
-  tree)
+  tree, and `meth_oracle.sh`, which reads no input at all)
 - emits `PASS:` on success and `FAIL:` on failure
 - returns nonzero on failure
 
@@ -27,7 +27,7 @@ all and run from `ndebug-gate-lint`, `debug-macro-flag-lint`, `shell-lint`,
 | `header_parity.sh`           | `AH:*` on generated @SQ (#281); `--compat` skips the .hdr/.dict sidecar | "header parity regression (AH:*, --compat @HD/@SQ)" |
 | `default_hd_parity.sh`       | default `@HD` byte-identical across SAM/`--bam`/`--meth` (#288)        | "default @HD parity across output paths"            |
 | `meth_sam_output.sh`         | `--meth` emits SAM text by default and BAM under `--bam`, same records | "--meth output container follows --bam"             |
-| `meth_oracle.sh`             | `--meth` Layers 1–3 match bwa-meth oracle                             | "Run --meth Layers 1-3"                             |
+| `meth_oracle.sh`             | `--meth` Layer 1 (valid BAM emission) via the harness under `test/meth/`; Layers 2–3 retired in D3 | "Run --meth Layer 1"                                |
 | `cohort_ramp_validation.sh`  | `--cohort-ramp-first`/`-ratio` reject malformed values; env warns and falls back | "Cohort ramp values are validated (flag and environment alike)" |
 | `rescue_kmer_options.sh`     | `--rescue-kmer`/`--rescue-band` reject malformed and out-of-range values; the `=` form is required | "--rescue-kmer/--rescue-band reject malformed values" |
 | `profile_slice_cpu.sh`       | `--profile` accounts for a partial cohort slice's compute CPU (needs `STAGE_PROF=1`) | "Partial cohort slices report their compute CPU"    |
@@ -47,15 +47,17 @@ all and run from `ndebug-gate-lint`, `debug-macro-flag-lint`, `shell-lint`,
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is
 the authoritative list, and `ci.yml` is where each one is actually wired up.
 
-Every script but the source-only lints reads its inputs from environment
-variables — see the comment block at the top of each file.
+Every script but the ones named in the block below reads its inputs from
+environment variables — see the comment block at the top of each file.
 `.github/workflows/ci.yml` sets the required vars and invokes the scripts.
 
 <!-- source-only lints: begin -->
-The source-only lints read no environment at all. Each takes the directory to
-work on as an optional positional argument, so that its self-test can aim the
-same checks at a fixture tree; each self-test takes no input, since it builds
-the trees it aims its lint at.
+These scripts read no environment at all.
+
+The source-only lints each take the directory to work on as an optional
+positional argument, so that its self-test can aim the same checks at a fixture
+tree; each self-test takes no input, since it builds the trees it aims its lint
+at.
 
 | Lint | Positional argument | Self-test |
 |------|---------------------|-----------|
@@ -63,10 +65,20 @@ the trees it aims its lint at.
 | `debug_macro_flag_lint.sh`    | repository root to check (default: this repository) | `debug_macro_flag_lint_selftest.sh`    |
 | `regression_coverage_lint.sh` | repository root to check (default: this repository) | `regression_coverage_lint_selftest.sh` |
 | `readme_contract_lint.sh`     | repository root to check (default: this repository) | `readme_contract_lint_selftest.sh`     |
+
+`meth_oracle.sh` is the one env-free script that is not a lint, and it takes no
+argument either. It wraps the `--meth` harness under `test/meth/`, whose inputs
+are the gitignored fixtures CI copies in there, plus an optional `SAMTOOLS`
+naming a samtools off `PATH`; the wrapper's whole job is to invoke that harness
+and mark the result, so it passes the environment through rather than reading
+or pinning any of it. "Reads no environment" is a claim about each script
+itself — which is also how `readme_contract_lint.sh` decides it — not about
+everything it may go on to run.
 <!-- source-only lints: end -->
 
 `readme_contract_lint.sh` checks that block against the scripts themselves, so
-a lint added without a row here fails CI rather than going unmentioned.
+a script that stops reading the environment without gaining a mention here
+fails CI rather than going unnoticed.
 
 One exception to "any binary will do": `profile_slice_cpu.sh` asserts on
 `--profile` output, which a default build compiles out entirely, so it needs a

--- a/test/regression/meth_oracle.sh
+++ b/test/regression/meth_oracle.sh
@@ -1,17 +1,56 @@
 #!/usr/bin/env bash
 # test/regression/meth_oracle.sh
 #
-# Regression: bwa-mem3 --meth Layers 1-3 match the bwa-meth oracle.
+# Regression: bwa-mem3 --meth Layer 1 -- the test/meth/test.sh harness.
 #
-# Was: the "Run --meth Layers 1-3" step inline in ci.yml. This is a thin
-# wrapper that re-invokes the existing test/meth/test.sh harness.
+# Was: the "Run --meth Layers 1-3" step inline in ci.yml, from when that harness
+# still asserted bwameth structural/byte equivalence. Layers 2-3 were retired in
+# D3; this is a thin wrapper that re-invokes what is left of it.
 #
 # Inputs:
-#   BWAMETH_DIR — path to the checked-out bwa-meth oracle repo
-#   (and test/meth fixtures copied into test/meth/ by the caller —
-#    see ci.yml "Copy bwa-meth fixtures into test/meth/" step)
+#   The test/meth fixtures (ref.fa, t_R1.fastq.gz), copied into test/meth/ by
+#   the caller -- see the "Copy bwa-meth fixtures into test/meth/" step in
+#   ci.yml. test/meth/test.sh checks for them and says where they come from.
+#
+#   Nothing is read from the environment HERE, which is what puts this script in
+#   the source-only block of test/regression/README.md -- that contract is about
+#   what a script itself reads, and readme_contract_lint.sh decides it by reading
+#   the file. The child honors ${SAMTOOLS:-samtools}, and the environment is
+#   passed through to it untouched on purpose: pinning SAMTOOLS here would take
+#   away the one knob a caller has for aiming the harness at a samtools that is
+#   not on PATH, and would buy nothing -- no caller sets it today.
+#
+# This used to demand BWAMETH_DIR. Nothing reads it any more: test/meth/test.sh
+# dropped its last use when Layers 2-3 (bwameth structural/byte equivalence)
+# were retired, so the bwa-meth checkout is now a source of FIXTURES rather
+# than of an oracle binary. Keeping the guard meant this wrapper refused to run
+# over a variable no code consumed, while the precondition that can actually be
+# missing -- the fixtures -- went unchecked.
 set -euo pipefail
 
-: "${BWAMETH_DIR:?BWAMETH_DIR must be set}"
+# Run from the repository root, the way the rest of this directory does. The
+# harness path below is repo-relative, so resolving it against the caller's
+# working directory made every invocation from anywhere else fail with a bare
+# 127 -- and this script's whole point is that its failures say what is wrong.
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
-exec bash test/meth/test.sh
+# Not `exec`: that forwards the child's exit status but emits neither of the
+# PASS:/FAIL: markers every script in this directory owes its caller (see
+# test/regression/README.md). The status is captured explicitly rather than
+# left to `set -e`, which would abort before the FAIL: line could print. The
+# child's own OK:/FAIL: lines still reach our streams untouched; this only adds
+# the regression-level marker on top, and re-raises the child's status
+# unchanged so a failure is never downgraded to a pass.
+status=0
+bash test/meth/test.sh || status=$?
+if [[ $status -ne 0 ]]; then
+    echo "FAIL: test/meth/test.sh exited $status"
+    exit "$status"
+fi
+
+# Deliberately not "Layers 1-3": test/meth/test.sh retired Layers 2-3 (bwameth
+# structural/byte equivalence) in D3 and now asserts Layer 1 only. Claiming the
+# retired layers passed would be the same vacuous green this script exists to
+# rule out. The ci.yml step name and the README table row that quotes it are
+# renamed to match, so all three now say the same thing.
+echo "PASS: --meth Layer 1 (test/meth/test.sh; Layers 2-3 retired in D3)"


### PR DESCRIPTION
Rebased onto `main` after #344, #346 and #347 landed; this is now a single commit on top of `main`.

> **Merge-order note:** #346 added `readme_contract_lint.sh`, whose check 2 requires the set of env-free scripts to match the README's source-only-lint block exactly. Dropping `BWAMETH_DIR` here makes `meth_oracle.sh` the first env-free script that is not a lint, so this PR also updates that block — without it the lint fails. Verified locally: `PASS: readme_contract_lint (25 scripts named and present; 9 source-only)`.

The `--meth` oracle test guarded on `BWAMETH_DIR` and never checked the one precondition that can actually be missing, so both of its failure modes were misleading.

## `BWAMETH_DIR` is dead

`test/meth/test.sh` dropped its last use of it when Layers 2-3 (bwameth structural/byte equivalence) were retired — the bwa-meth checkout is now a source of **fixtures**, not of an oracle binary. But `meth_oracle.sh` still hard-failed without the variable, and `ci.yml` still set it, so the wrapper refused to run over something no code consumed.

Both are dropped. The checkout and the fixture-copy step that makes it useful are untouched.

## The fixtures were unchecked

`ref.fa` and `t_R1.fastq.gz` are gitignored and copied in by CI, so on a developer box they are simply absent. The indexing step sends both streams to `/dev/null`, so `set -e` aborted before any diagnostic could run:

```
$ ./test/meth/test.sh ; echo "exit=$?"
exit=2          # ...and nothing else. Takes a `bash -x` run to interpret.
```

Both scripts now check for the fixtures up front, alongside the binary and samtools checks already there:

```
ERROR: fixture .../test/meth/ref.fa is missing or empty.
       These are gitignored. Copy them from a bwa-meth checkout:
         cp <bwa-meth>/example/{ref.fa,t_R1.fastq.gz,t_R2.fastq.gz} .../test/meth/
```

In `test_bismark_tags.sh` the check deliberately goes **before** the holodeck clone-and-build, which costs minutes — failing after that for a file we could have checked first is a poor trade. Missing-fixture now exits in 0.25s instead of after the build.

## Two follow-ons from review

`meth_oracle.sh` now emits the `PASS:`/`FAIL:` markers every script in `test/regression/` owes its caller. It `exec`d the child, which forwards the exit status but emits neither marker, so a green run was indistinguishable from one that never ran. The marker says **Layer 1**, not "Layers 1-3" — `test/meth/test.sh` retired Layers 2-3 in D3, and asserting bwameth equivalence that nothing checked would be the same vacuous green the script is there to rule out. `test/regression/README.md` is updated to match: it claimed every script but the source-only lints reads its input from environment variables, and dropping `BWAMETH_DIR` left this one env-free.

The fixture check requires `-f` as well as `-s`. `[[ -s dir ]]` is true for a non-empty **directory**, so a directory sitting where `ref.fa` belongs would have passed the guard and failed later inside the silenced index step.

`holodeck` is added to the public-repo hygiene allowlist in `.coderabbit.yaml`. The bar for that list is "a name a reader could look up", and `fg-labs/holodeck` is a public repository whose clone URL is already hardcoded in `test/meth/test_bismark_tags.sh`.

## Validation

Both directions, and the interesting one is the second:

- **Fixtures absent** — all three entry points (`test.sh`, `test_bismark_tags.sh`, `meth_oracle.sh`) name the missing file and the command to get it, instead of exiting silently.
- **Fixtures present** — `meth_oracle.sh` runs to completion **with `BWAMETH_DIR` unset**, which is what proves the guard was vacuous; `test_bismark_tags.sh` still matches golden truth on 4000 records with 0 XR/XG/XM mismatches.
- `ci.yml` still parses, and the bwa-meth checkout and copy steps are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear preflight checks for required test fixtures.
  * Tests now stop early with actionable instructions when fixtures are missing, empty, or invalid.
  * Removed reliance on retired environment-variable configuration for regression tests.
  * Improved regression reporting with explicit pass and fail markers while preserving error statuses.

* **Documentation**
  * Clarified that methylation regression testing covers Layer 1 only.
  * Updated guidance for fixture-based inputs, setup requirements, and supported test options.
  * Documented publicly citable testing tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

