### PR TITLE
ci: stop counting a workflow comment as regression-script coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -874,11 +874,10 @@ shell-fix:
 # the default `test` target because it requires a non-production build.
 # CI invokes this target on the canonical row, after rebuilding in-row with
 # TESTING_BUILD=1 (see "SIMD floor enforcement" in .github/workflows/ci.yml).
-# Keep it invoked from there -- and do not treat
-# test/regression/regression_coverage_lint.sh as the backstop for that. It
-# counts a script as covered when a workflow *names* it, and that step's own
-# explanatory comment names host_floor_enforce.sh, so deleting the `make
-# test-injection` line would leave the lint green.
+# test/regression/regression_coverage_lint.sh is the backstop: it ignores
+# comments, so the step's explanatory prose naming host_floor_enforce.sh no
+# longer stands in for the invocation, and deleting the `make test-injection`
+# line turns the lint red.
 test-injection: bwa-mem3
 	BWA_MEM3_TESTING=./bwa-mem3 INJECTED_TIER=sse41 PARITY_FA=/dev/null \
 		./test/regression/host_floor_enforce.sh

--- a/test/regression/regression_coverage_lint.sh
+++ b/test/regression/regression_coverage_lint.sh
@@ -20,9 +20,12 @@
 # workflow names.
 #
 # A script counts as covered when a workflow names it, or when it is in the
-# recipe of a Makefile target a workflow actually invokes. Anything else has to
-# be listed in test/regression/coverage_exemptions.txt with the reason -- so a
-# script nothing runs is a reviewable line there rather than silence.
+# recipe of a Makefile target a workflow actually invokes. Comments do not
+# count, on either side: a step's comment usually names the script the step
+# runs, so counting it would let the coverage outlive the invocation that
+# produced it. Anything else has to be listed in
+# test/regression/coverage_exemptions.txt with the reason -- so a script nothing
+# runs is a reviewable line there rather than silence.
 #
 # Sibling lints: ndebug_gate_lint.sh, debug_macro_flag_lint.sh. Same failure
 # in each case -- a check that reads as green while doing no work.
@@ -104,7 +107,96 @@ if ((${#scripts[@]} == 0)); then
     exit 1
 fi
 
-workflow_text="$(cat "${workflow_files[@]}")"
+# ---------------------------------------------------------------------------
+# Comments are stripped before anything is matched against this text.
+#
+# A script counts as covered when a workflow names it. Without this, a workflow
+# *comment* naming a script satisfies that -- and comments here routinely name
+# the very script the step below runs, because the comment explains why it runs.
+# So the coverage survives deleting the thing that produces it: remove the
+# invocation, leave the comment that describes it, and the lint stays green
+# while nothing runs the script. That is the same read-as-green-while-doing-no-
+# work failure the lint exists to catch, one level up.
+#
+# `#` opens a comment only where a word starts and only outside quotes, which
+# is the rule in both YAML and the shell inside a `run:` block. Both halves
+# matter, and they pull in opposite directions:
+#
+#   - A word starts at the start of a line, after whitespace, and after a
+#     control operator -- `;`, `&`, `|`, `(`, `)` -- which ends the command
+#     before it. Treating only whitespace as the boundary reads `echo hi;# bash
+#     foo.sh` as a token, so the commented-out invocation counts as coverage:
+#     this lint's own bug, one level down.
+#   - Inside '...' or "..." a `#` is a literal, whatever precedes it. Truncating
+#     at the `#` in `echo "counted # of reads" && bash foo.sh` drops the real
+#     invocation after it and calls a script CI does run uncovered.
+#
+# A `#` inside a token (`sha256#...`, a URL fragment) is left alone by the same
+# word-start rule, and a backslash escapes the character after it.
+#
+# A quote opens a quoted run only when it does not follow a word character and
+# its partner is on the same line, and state resets at each newline rather than
+# carrying across the file. All three rules exist for the same reason: an
+# apostrophe in prose -- `- name: Don't rebuild` -- is far more common here than
+# a string spanning lines, and treating one as an opening quote would make every
+# `#` after it on that line read as a literal. That is the false-coverage
+# direction, which is the one that fails silently.
+#
+# Pairing alone does not get there, because the partner it finds may be another
+# prose apostrophe on the far side of the comment: in `- name: Don't rebuild  #
+# runs alpha.sh when it's stale` the two apostrophes pair across the `#`, the
+# comment reads as quoted text, and the script it names counts as covered. So a
+# quote must also start a word. An apostrophe inside one is prose (`Don't`,
+# `it's`); a real opening quote follows whitespace or punctuation (`bash -c
+# '...'`, `--flag='a # b'`, `$'...'`), never a letter or digit.
+#
+# The Makefile recipes gathered below are stripped the same way, and so is the
+# text the target-invocation search reads: a comment mentioning
+# `make test-injection` must not count as invoking that target either.
+# ---------------------------------------------------------------------------
+strip_comments() {
+    awk '
+    {
+        n = length($0)
+        in_single = 0
+        in_double = 0
+        kept = ""
+        for (i = 1; i <= n; i++) {
+            c = substr($0, i, 1)
+            if (in_single) {
+                if (c == "\047") in_single = 0
+                kept = kept c
+                continue
+            }
+            if (c == "\\" && i < n) {
+                kept = kept c substr($0, i + 1, 1)
+                i++
+                continue
+            }
+            if (in_double) {
+                if (c == "\"") in_double = 0
+                kept = kept c
+                continue
+            }
+            if (c == "\047" || c == "\"") {
+                prev = (i == 1) ? "" : substr($0, i - 1, 1)
+                if (prev !~ /[A-Za-z0-9]/ && index(substr($0, i + 1), c)) {
+                    if (c == "\047") in_single = 1; else in_double = 1
+                }
+                kept = kept c
+                continue
+            }
+            if (c == "#") {
+                prev = (i == 1) ? "" : substr($0, i - 1, 1)
+                if (prev == "" || prev ~ /[ \t;&|()]/) break
+            }
+            kept = kept c
+        }
+        print kept
+    }'
+}
+
+workflow_text="$(cat "${workflow_files[@]}" | strip_comments)"
 
 # ---------------------------------------------------------------------------
 # Recipes of Makefile targets that a workflow actually invokes.
@@ -155,7 +247,7 @@ while IFS= read -r target; do
         }
         in_recipe && /^\t/ { print; next }
         in_recipe && !/^\t/ && !/^#/ && NF { in_recipe = 0 }
-    ' "$makefile")"
+    ' "$makefile" | strip_comments)"
     invoked_recipes+="$recipe"$'\n'
 done < <(awk '
     # Rule lines only. Plenty of other lines carry a ":": assignments

--- a/test/regression/regression_coverage_lint_selftest.sh
+++ b/test/regression/regression_coverage_lint_selftest.sh
@@ -150,6 +150,149 @@ run_case "make invoked by path still resolves its target" PASS \
         'check:
 	./test/regression/alpha.sh' alpha)"
 
+# A comment naming a script is not coverage. This is the case that made the
+# check dishonest: a step's comment routinely names the very script the step
+# runs, because the comment is there to explain why it runs. So the coverage
+# outlived the thing producing it -- delete the invocation, keep the comment,
+# and the lint stayed green with nothing running the script.
+run_case "a workflow comment naming a script is not coverage" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      # runs test/regression/alpha.sh on the canonical row
+      - run: echo hi' \
+        'test:
+	echo nothing' alpha)"
+
+# The same rule on the target-invocation side: a comment mentioning `make check`
+# must not resolve the check recipe and drag its scripts in.
+run_case "a commented-out make invocation does not resolve a target" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      # we used to run: make check
+      - run: echo hi' \
+        'check:
+	./test/regression/alpha.sh' alpha)"
+
+# Stripping must take the comment and nothing else: a real invocation with a
+# trailing comment on the same line is the normal way these steps are written.
+run_case "an invocation with a trailing comment still counts" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: bash test/regression/alpha.sh  # the canonical row runs this' \
+        'test:
+	echo nothing' alpha)"
+
+# `#` opens a comment only at line start or after whitespace. Inside a token it
+# is just a character, and truncating there would drop real text.
+run_case "a mid-token # does not start a comment" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: curl -o x https://example.invalid/a#frag && bash test/regression/alpha.sh' \
+        'test:
+	echo nothing' alpha)"
+
+# "After whitespace" is not the whole rule for where a word starts. A control
+# operator ends the command before it, so `#` directly after one opens a comment
+# just as it does after a space -- and reading that as a token instead means the
+# commented-out invocation behind it counts, which is this lint's own bug.
+run_case "a comment opened after a control operator is not coverage" FAIL \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: echo hi;# bash test/regression/alpha.sh' \
+        'test:
+	echo nothing' alpha)"
+
+# The other direction, and the reason the rule cannot just add `;&|()` to the
+# set of characters a comment may follow: inside a quoted string `#` is a
+# literal, whatever precedes it. Truncating there drops the real invocation
+# after it and reports a script that CI does run as uncovered.
+run_case "a # inside a quoted string does not start a comment" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: echo "counted # of reads" && bash test/regression/alpha.sh' \
+        'test:
+	echo nothing' alpha)"
+
+# A backslash escapes the character after it, which matters exactly once: an
+# escaped quote inside a quoted string must not close it. Read as a closing
+# quote, the rest of the line is outside quotes, the `#` after it opens a
+# comment, and the real invocation behind that is dropped -- a script CI does
+# run reported as uncovered.
+#
+# Spelled with an escaped quote rather than the more obvious `echo hi \# bash
+# alpha.sh`, which does not test this at all: there the `#` is preceded by a
+# backslash, which is not a word boundary, so the word-start rule alone keeps
+# the line whole and the case passes with escape handling deleted. Deleting it
+# turns this case red, which is the only reason to write it down.
+run_case "an escaped quote does not close a quoted string" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: printf "a\"b # c" && bash test/regression/alpha.sh' \
+        'test:
+	echo nothing' alpha)"
+
+# An apostrophe in prose is not an opening quote. Reading it as one would leave
+# the rest of the line quoted, so the comment after it never strips and the
+# script it names counts -- the silent direction of being wrong, reached by a
+# step name that is merely written in English.
+run_case "an apostrophe does not quote the rest of the line" FAIL \
+    "$(build_fixture "jobs:
+  build:
+    steps:
+      - name: Don't rebuild  # bash test/regression/alpha.sh
+        run: echo hi" \
+        'test:
+	echo nothing' alpha)"
+
+# Pairing alone is not enough to keep a prose apostrophe from quoting the line,
+# because the partner it finds may be a second prose apostrophe on the far side
+# of the comment. Here `Don't` pairs with `it's`, the `#` between them lands
+# inside the quoted run, the comment survives stripping, and the script it names
+# counts as covered -- the whole defect this lint was changed to remove, reached
+# through a step name and a comment both merely written in English. So a quote
+# must start a word as well as pair.
+run_case "a comment between two prose apostrophes is not coverage" FAIL \
+    "$(build_fixture "jobs:
+  build:
+    steps:
+      - name: Don't rebuild  # runs test/regression/alpha.sh when it's stale
+        run: echo hi" \
+        'test:
+	echo nothing' alpha)"
+
+# Word start is not the whole guard either. A lone apostrophe after whitespace
+# starts a word, so only the same-line partner rule keeps it from opening a run
+# that swallows the comment behind it. Without this case nothing pins that rule:
+# every other quoted case here is decided by word start before pairing is
+# consulted, so pairing could be deleted and the suite would stay green.
+run_case "a lone apostrophe with no partner does not open a quoted run" FAIL \
+    "$(build_fixture "jobs:
+  build:
+    steps:
+      - name: The ' character  # bash test/regression/alpha.sh
+        run: echo hi" \
+        'test:
+	echo nothing' alpha)"
+
+# The other direction of the word-start rule: a real opening quote follows
+# whitespace or punctuation, never a letter or digit, and must still open. An
+# `=` before it is the common spelling in these steps, and the `#` it protects
+# has to stay a literal so the invocation after it survives.
+run_case "a quote after punctuation still opens a quoted run" PASS \
+    "$(build_fixture 'jobs:
+  build:
+    steps:
+      - run: grep --regexp='"'"'a # b'"'"' x || bash test/regression/alpha.sh' \
+        'test:
+	echo nothing' alpha)"
+
 run_case "referenced nowhere at all" FAIL \
     "$(build_fixture 'jobs:
   build:


### PR DESCRIPTION
Stacked on #340. Closes a hole in the coverage lint that #340 makes load-bearing.

## The problem

`regression_coverage_lint.sh` counts a script as covered when a workflow names it. It read the workflow files verbatim, so a name in a **comment** satisfied that — and comments in these steps routinely name the very script the step runs, because the comment is there to explain why it runs.

So the coverage outlives the thing that produces it. Delete the invocation, leave the comment describing it, and the lint stays green while nothing runs the script. That is the read-as-green-while-doing-no-work failure this lint exists to catch, one level up from the drift it was written for.

Not hypothetical. `make test-injection` is invoked from exactly one line of `ci.yml`, and that step's own comment names `host_floor_enforce.sh`. Deleting the line:

```
$ bash test/regression/regression_coverage_lint.sh
PASS: regression_coverage_lint (39 scripts, 0 exempt)
```

Green, with `host_floor_enforce.sh` running nowhere. #340 had just dropped that script's exemption on the strength of that invocation, so the guarantee was load-bearing at exactly the moment it was weakest — before #340 the script was honestly marked uncovered; after it, it was marked covered by a check that would not notice the coverage disappearing.

## The fix

Strip comments before matching, on both sides: the workflow text, the recipes of invoked Makefile targets, and the text the target-invocation search reads — a comment mentioning `make test-injection` must not resolve that target either.

`#` opens a comment only at the start of a line or after whitespace, which is the rule in both YAML and the shell inside a `run:` block, so a `#` inside a token (a URL fragment, `sha256#…`) is left alone. Stripping every `#` would truncate real commands.

The narrow scope is deliberate. This does **not** change the documented naming-counts-as-coverage contract — a script named in a real command still counts, and the self-test still asserts that (`reference followed by punctuation still counts`). Requiring a parsed invocation would be a much larger design change, and this repository's Makefile genuinely writes one reference as prose in a recipe.

## Verification

- **No fallout**: no script here was covered only by a comment. The lint still resolves the same **39 scripts with 0 exemptions**.
- **Closes the hole**: with the `make test-injection` line deleted the lint now fails and names `host_floor_enforce.sh` — verified in both directions.
- **Four new self-test cases**, each confirmed failing against the pre-fix script: a comment naming a script is not coverage; a commented-out `make check` does not resolve the target; an invocation with a trailing comment still counts; a mid-token `#` does not start a comment. Self-test is 29 cases, passing under bash 3.2 and 5.3.
- shellcheck and shfmt clean across all 67 tracked scripts; the NDEBUG and opt-in-macro lint families pass.

The comment above `test-injection` said the lint was *not* a backstop for that invocation. That was true and is now false, so it is corrected here rather than left to contradict the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regression coverage checks to ignore commented-out scripts and Makefile commands.
  * Preserved valid special characters, quoted text, and trailing comments in command content.

* **Tests**
  * Added regression tests for comments and special characters in workflow files and Makefile recipes.
  * Expanded validation of script coverage and target invocation behavior.

* **Documentation**
  * Clarified that commented content is ignored and explicit target invocation is required for coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->