### PR TITLE
ci: check the README's ci.yml origin column against the workflows

### DIFF
--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -41,7 +41,7 @@ all and run from `ndebug-gate-lint`, `debug-macro-flag-lint`, `shell-lint`,
 | `regression_coverage_lint_selftest.sh` | the lint above still detects an unrun script, so its `PASS` means something | "Coverage lint still detects an unrun script"       |
 | `host_floor_enforce.sh`      | below-floor hosts get exit 2 + a readable error, not a SIGILL (needs `TESTING_BUILD=1`) | "SIMD floor enforcement (TESTING_BUILD, injected below-floor tier)" |
 | `version_banner.sh`          | `bwa-mem3 version` prints the SIMD floor and runtime tier lines        | "Version banner regression"                         |
-| `readme_contract_lint.sh`    | this README names no script that was deleted, and its source-only-lint block lists exactly the scripts that read no environment | "README still describes the regression scripts"     |
+| `readme_contract_lint.sh`    | this README names no script that was deleted, its source-only-lint block lists exactly the scripts that read no environment, and every row's `Origin in ci.yml` names a step a workflow defines | "README still describes the regression scripts"     |
 | `readme_contract_lint_selftest.sh` | the lint above still detects a stale README, so its `PASS` means something | "README lint still detects drift"                  |
 
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is

--- a/test/regression/readme_contract_lint.sh
+++ b/test/regression/readme_contract_lint.sh
@@ -17,7 +17,7 @@
 #     single job that ran them.
 #
 # Both were caught by a human reading the file for an unrelated reason. This
-# lint makes the two claims that actually drifted checkable:
+# lint makes the three claims that actually drifted checkable:
 #
 #   1. Every test/regression/*.sh the README names still exists. The reverse --
 #      requiring every script to appear -- is deliberately NOT checked: the
@@ -32,6 +32,14 @@
 #      named in the README's source-only-lint block. Add a lint and forget the
 #      prose, or give an existing lint an env var without moving it out, and
 #      this fails.
+#
+#   3. Every row of the table names a CI step that a workflow actually defines.
+#      This one drifted too, and in the same direction: two rows named steps
+#      that did not exist, because a later change merged the two steps they
+#      described into a single step and only the workflow was updated. The
+#      column exists to send a reader to the step that runs the script, so a
+#      name that is not in any workflow is a broken reference -- check 1's
+#      failure with the two sides swapped.
 #
 # Check 2 needs to know where the claim lives, so the README marks it:
 #
@@ -347,8 +355,155 @@ if ((${#wrongly_in_block[@]} > 0)); then
     failures=1
 fi
 
+# --- Check 3: the table's "Origin in ci.yml" column names real steps. -------
+
+# The table's third column quotes the name of the CI step that runs each
+# script. Nothing kept it honest, and it drifted: two rows named steps that did
+# not exist, because a later PR merged the two steps they described into one
+# and only the workflow was updated. The column then sends a reader to a step
+# name they cannot find, which is the same broken reference check 1 catches in
+# the other direction.
+#
+# The table is located by its header rather than by position, so the README can
+# grow other tables without this check wandering into them -- the lint block
+# further down has three columns too, and its third is a script name.
+workflow_dir=".github/workflows"
+column_header='Origin in ci.yml'
+
+if [[ ! -d $workflow_dir ]]; then
+    echo "FAIL: no $workflow_dir/ under $PWD -- check 3 cannot verify step names" >&2
+    exit 1
+fi
+
+workflow_files=()
+while IFS= read -r file; do
+    [[ -n $file ]] && workflow_files+=("$file")
+done < <(find "$workflow_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+
+if ((${#workflow_files[@]} == 0)); then
+    echo "FAIL: no workflow files under $workflow_dir/ -- check 3 cannot verify" >&2
+    echo "      step names" >&2
+    exit 1
+fi
+
+# Step names only (`- name:`), not job names: the column names steps, and a job
+# name would let a row point at something that runs no script.
+#
+# `|| true` on the grep, because a workflow set that defines no steps at all is
+# a state this check reports itself, below, with a message that says so. Left to
+# fail, `set -o pipefail` propagates grep's exit 1 out of the substitution and
+# the script dies on it instead -- as 123 under GNU xargs and 1 under BSD, which
+# is how the self-test case for this came to pass locally and fail in CI while
+# never once reaching the branch it was written to exercise.
+#
+# The last two expressions drop YAML's optional quoting around the value. A step
+# name containing `: ` has to be written `- name: "Regression: option
+# validation"` or YAML reads it as a nested mapping, and comparing that spelling
+# against the README's bare name reports a step the workflow plainly defines as
+# missing -- with a remediation line telling the reader to correct a column that
+# is already right.
+step_names="$({ grep -hE '^[[:space:]]*-[[:space:]]+name:[[:space:]]' \
+    "${workflow_files[@]}" || true; } \
+    | sed -E -e 's/^[[:space:]]*-[[:space:]]+name:[[:space:]]*//' \
+        -e 's/[[:space:]]+$//' \
+        -e 's/^"(.*)"$/\1/' \
+        -e "s/^'(.*)'\$/\1/" \
+    | sort -u)"
+
+if [[ -z $step_names ]]; then
+    echo "FAIL: no '- name:' steps found under $workflow_dir/ -- check 3 detected" >&2
+    echo "      nothing, which means it is no longer checking" >&2
+    exit 1
+fi
+
+# Table rows only. The header string is not unique in the file: the table's own
+# row for this lint quotes it while describing what check 3 does, and prose is
+# free to name the column too. The row is below the header so `head -1` gets
+# past it either way, but a sentence naming the column *above* the table would
+# otherwise be taken for the header, and the row loop then finds no rows under
+# it and reports a table that is fine as empty.
+#
+# `|| true` for the same reason as the step-name grep above: a README carrying
+# no such table is the state the next branch reports, but an unguarded grep
+# exits 1 and `set -o pipefail` carries that out of the substitution, killing
+# the script on this assignment before it can say so.
+header_line="$({ grep -nE "^\|.*$column_header" "$readme" || true; } \
+    | head -1 | cut -d: -f1)"
+if [[ -z $header_line ]]; then
+    echo "FAIL: $readme has no table column headed '$column_header'" >&2
+    echo "      -- check 3 cannot locate the table" >&2
+    exit 1
+fi
+
+# Rows run from the separator line under the header to the first line that is
+# no longer a table row.
+#
+# The separator is matched by shape -- a line of nothing but pipes, hyphens,
+# colons and spaces -- rather than by "contains ---". A data cell is free to
+# contain three hyphens, and the loose test drops that row from both the check
+# and row_count: a row opting out of check 3 in silence, which is the thing
+# check 3 exists to prevent.
+separator_row='^\|[[:space:]:|-]+$'
+origins=()
+row_count=0
+while IFS= read -r line; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    [[ $line == '|'* ]] || break
+    [[ $line =~ $separator_row ]] && continue
+    cell="$(cut -d'|' -f4 <<< "$line")"
+    cell="${cell#"${cell%%[![:space:]]*}"}"
+    cell="${cell%"${cell##*[![:space:]]}"}"
+    row_count=$((row_count + 1))
+    origins+=("$cell")
+done < <(tail -n "+$((header_line + 1))" "$readme")
+
+if ((row_count == 0)); then
+    echo "FAIL: the '$column_header' table in $readme has no rows -- nothing checked" >&2
+    exit 1
+fi
+
+# Every row must quote a step name. An unquoted cell is reported rather than
+# skipped: a row that opts out silently is how the column would rot again.
+#
+# `?*` between the quotes, so an empty `""` lands here rather than downstream. A
+# name stripped to nothing is an empty grep pattern, which reports as a step no
+# workflow defines -- true, but printed as a blank line under a heading that
+# says the column names steps, which tells the reader nothing about which row.
+unquoted=()
+missing_steps=()
+for cell in "${origins[@]}"; do
+    if [[ $cell != '"'?*'"' ]]; then
+        unquoted+=("$cell")
+        continue
+    fi
+    name="${cell%\"}"
+    name="${name#\"}"
+    if ! grep -qxF -- "$name" <<< "$step_names"; then
+        missing_steps+=("$name")
+    fi
+done
+
+if ((${#unquoted[@]} > 0)); then
+    echo "FAIL: rows in the '$column_header' table whose cell does not hold a" >&2
+    echo "      quoted step name:" >&2
+    printf '  %s\n' "${unquoted[@]}" | sort -u >&2
+    echo >&2
+    echo "The column names the ci.yml step that runs the script, in double quotes." >&2
+    failures=1
+fi
+
+if ((${#missing_steps[@]} > 0)); then
+    echo "FAIL: the '$column_header' column in $readme names steps that no workflow" >&2
+    echo "      under $workflow_dir/ defines:" >&2
+    printf '  %s\n' "${missing_steps[@]}" | sort -u >&2
+    echo >&2
+    echo "A reader looking for these in ci.yml will not find them. Update the column" >&2
+    echo "to the step's current name, or add the step." >&2
+    failures=1
+fi
+
 if ((failures != 0)); then
     exit 1
 fi
 
-echo "PASS: readme_contract_lint (${#mentioned[@]} scripts named and present; ${#source_only[@]} source-only)"
+echo "PASS: readme_contract_lint (${#mentioned[@]} scripts named and present; ${#source_only[@]} source-only; $row_count ci.yml step names)"

--- a/test/regression/readme_contract_lint_selftest.sh
+++ b/test/regression/readme_contract_lint_selftest.sh
@@ -33,16 +33,42 @@ failures=0
 readonly BEGIN_MARKER='<!-- source-only lints: begin -->'
 readonly END_MARKER='<!-- source-only lints: end -->'
 
-# Build a fixture tree: a README, plus one script per "name:body" pair given
-# after it. Returns the tree's path on stdout.
+# The step name every fixture's workflow defines, and that readme_naming puts
+# in the table's origin column. Check 3 compares the two, so the default tree
+# has to satisfy it or every case below would fail for the wrong reason.
+readonly DEFAULT_STEP='Run the regression scripts'
+readonly FIXTURE_JOB_NAME='The build job'
+
+# Extra step names for the fixture workflow, one per line, written into the
+# workflow verbatim so a case can give a step the YAML quoting a real one needs.
+# Set around the case that wants it; reset after, the way FIXTURE_EXEMPTIONS is
+# used in the sibling coverage-lint self-test.
+FIXTURE_STEPS=""
+
+# Build a fixture tree: a README, a workflow, plus one script per "name:body"
+# pair given after it. Returns the tree's path on stdout.
 make_tree() {
     local name="$1" readme_body="$2"
     shift 2
 
     local dir="$fixture_root/$name"
     rm -rf "$dir"
-    mkdir -p "$dir/test/regression"
+    mkdir -p "$dir/test/regression" "$dir/.github/workflows"
     printf '%s\n' "$readme_body" > "$dir/test/regression/README.md"
+
+    # Every tree carries a workflow, because check 3 treats a missing one as
+    # "nothing was checked" rather than as a pass -- so a tree without it would
+    # make every case here fail on the workflow instead of on what it tests.
+    # The job carries a name of its own, so a case can aim the origin column at
+    # it and confirm a job name does not satisfy a column that names steps.
+    {
+        printf 'jobs:\n  build:\n    name: %s\n    steps:\n' "$FIXTURE_JOB_NAME"
+        printf '      - name: %s\n' "$DEFAULT_STEP"
+        local step
+        while IFS= read -r step; do
+            [[ -n $step ]] && printf '      - name: %s\n' "$step"
+        done <<< "$FIXTURE_STEPS"
+    } > "$dir/.github/workflows/ci.yml"
 
     local spec
     for spec in "$@"; do
@@ -54,8 +80,14 @@ make_tree() {
 
 # Run the lint over a fixture tree and check the verdict. `expected` is FLAG
 # (the lint must reject it, exit 1) or PASS (must accept it, exit 0).
+#
+# The optional fourth argument is a phrase the report has to carry. A verdict
+# alone cannot tell two rejection branches apart, so a case that exists to move
+# a tree from one branch to another reads the same before and after the change
+# it pins -- green while checking nothing, which is the failure this whole file
+# is here to prevent. Such a case names its branch.
 check_tree() {
-    local description="$1" expected="$2" dir="$3"
+    local description="$1" expected="$2" dir="$3" must_say="${4-}"
 
     local output status
     output="$(bash "$lint" "$dir" 2>&1)" && status=0 || status=$?
@@ -67,23 +99,48 @@ check_tree() {
         *) verdict="EXIT$status" ;;
     esac
 
-    if [[ $verdict == "$expected" ]]; then
-        echo "  ok   $description -> $expected"
-    else
+    if [[ $verdict != "$expected" ]]; then
         echo "  FAIL $description -> got $verdict, wanted $expected" >&2
         printf '       %s\n' "$output" >&2
         failures=1
+        return
     fi
+
+    if [[ -n $must_say && $output != *"$must_say"* ]]; then
+        echo "  FAIL $description -> $expected, but the report never says" >&2
+        echo "       '$must_say'" >&2
+        printf '       %s\n' "$output" >&2
+        failures=1
+        return
+    fi
+
+    echo "  ok   $description -> $expected"
 }
 
-# A README whose source-only block names exactly the scripts passed in.
+# A README whose source-only block names exactly the scripts passed in, and
+# whose table gives each one an origin step the fixture workflow defines.
+#
+# `ORIGIN_OVERRIDE` replaces the origin cell of every row, so a case can aim a
+# stale or unquoted value at check 3 without rebuilding the README by hand.
+ORIGIN_OVERRIDE=""
 readme_naming() {
-    local rows="" name
+    local rows="" table="" name origin
+    # Spelled out rather than as `${ORIGIN_OVERRIDE:-...}`: check 2 of the lint
+    # under test reads a name used in a `:-` expansion as an environment input
+    # by design, which would move this self-test out of the source-only set it
+    # belongs in -- and the lint would then correctly fail on its own README.
+    if [[ -n $ORIGIN_OVERRIDE ]]; then
+        origin="$ORIGIN_OVERRIDE"
+    else
+        origin="\"$DEFAULT_STEP\""
+    fi
     for name in "$@"; do
         rows+="- \`$name\` takes an optional positional directory"$'\n'
+        table+="| \`$name\` | what it checks | $origin |"$'\n'
     done
-    printf '%s\n\n%s\n%s%s\n' \
+    printf '%s\n\n| Script | What it checks | Origin in ci.yml |\n|---|---|---|\n%s\n%s\n%s%s\n' \
         "Every script but the source-only lints reads its inputs from the environment." \
+        "$table" \
         "$BEGIN_MARKER" "$rows" "$END_MARKER"
 }
 
@@ -212,7 +269,133 @@ payload='\${BWA_MEM3:?BWA_MEM3 must be set}'
 echo \"\$label \$payload\" > /dev/null
 echo \"PASS: fixture\"")"
 
+echo "== the ci.yml origin column ==" # check 3
+
+# The drift this check was added for: two rows named steps that no longer
+# existed, because a PR merged the two steps they described into one and only
+# the workflow was updated. A reader following the column looks for a step name
+# that is not there.
+ORIGIN_OVERRIDE='"A step no workflow defines"'
+check_tree "origin column names a step ci.yml does not define" FLAG \
+    "$(make_tree stale-origin "$(readme_naming lint.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+# An unquoted cell is rejected rather than skipped: a row that opts out of the
+# check silently is how the column rots again.
+ORIGIN_OVERRIDE='Run the regression scripts'
+check_tree "origin cell that is not quoted is rejected" FLAG \
+    "$(make_tree unquoted-origin "$(readme_naming lint.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+# An empty pair of quotes names no step, so it belongs with the unquoted cells
+# rather than downstream, where the name strips to an empty grep pattern and is
+# reported as a blank line under a heading about missing steps. Both branches
+# exit 1, so the branch is named: on the verdict alone this case reads green
+# against a lint that still routes the cell the wrong way.
+ORIGIN_OVERRIDE='""'
+check_tree "origin cell holding an empty pair of quotes is rejected" FLAG \
+    "$(make_tree empty-origin "$(readme_naming lint.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")" \
+    "does not hold a"
+ORIGIN_OVERRIDE=""
+
+# The column names a *step*, not a job. A job name would let a row point at
+# something that runs no script, so it must not satisfy the check.
+ORIGIN_OVERRIDE="\"$FIXTURE_JOB_NAME\""
+check_tree "a job name does not satisfy the origin column" FLAG \
+    "$(make_tree job-name-origin "$(readme_naming lint.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+ORIGIN_OVERRIDE=""
+
+# The README has more than one three-column table, and the other one's third
+# column holds a script name rather than a step name. Locating the table by
+# position instead of by its header reads those rows as origins and reports
+# every one of them as a step that does not exist.
+check_tree "a second table is not read as origins" PASS \
+    "$(make_tree second-table "$(readme_naming lint.sh)
+
+| Lint | Positional argument | Self-test |
+|------|---------------------|-----------|
+| \`lint.sh\` | directory to scan | \`lint.sh\` |" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+# A data cell may contain three hyphens. Recognising the separator row by
+# "contains ---" rather than by its shape drops such a row from the check and
+# from the row count -- a row opting out of check 3 in silence, which is what an
+# unquoted cell is rejected for two cases above. Only the second row here is
+# stale, so the case can only reach FLAG if that row was read.
+emdash_readme="$(
+    cat << EOF
+Every script but the source-only lints reads its inputs from the environment.
+
+| Script | What it checks | Origin in ci.yml |
+|---|---|---|
+| \`lint.sh\` | a plain cell | "$DEFAULT_STEP" |
+| \`other.sh\` | a cell holding --- three hyphens | "A step no workflow defines" |
+
+$BEGIN_MARKER
+- \`lint.sh\` takes an optional positional directory
+- \`other.sh\` takes an optional positional directory
+$END_MARKER
+EOF
+)"
+check_tree "a data cell holding --- is still read as a row" FLAG \
+    "$(make_tree emdash-cell "$emdash_readme" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT" "other.sh:$SOURCE_ONLY_SCRIPT")"
+
+# YAML's quoting is not part of the step name. A name containing `: ` cannot be
+# written unquoted at all, so a check that compares the quoted spelling reports
+# a step the workflow plainly defines as missing -- and tells the reader to fix
+# a column that is already correct.
+FIXTURE_STEPS='"Regression: option validation"'
+ORIGIN_OVERRIDE='"Regression: option validation"'
+check_tree "a double-quoted step name satisfies the column" PASS \
+    "$(make_tree double-quoted-step "$(readme_naming lint.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+FIXTURE_STEPS="'Regression: single quoted'"
+ORIGIN_OVERRIDE='"Regression: single quoted"'
+check_tree "a single-quoted step name satisfies the column" PASS \
+    "$(make_tree single-quoted-step "$(readme_naming lint.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+FIXTURE_STEPS=""
+ORIGIN_OVERRIDE=""
+
+# The header string is not unique in the file: the real README quotes it inside
+# the row that describes this very check. Locating the table with a plain match
+# takes the first prose mention instead and reports the table under it as empty.
+check_tree "the column header named in prose above the table" PASS \
+    "$(make_tree prose-header "$(printf '%s\n\n%s\n' \
+        "The Origin in ci.yml column names the step that runs each script." \
+        "$(readme_naming lint.sh)")" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
 echo "== a lint that checked nothing must not report PASS =="
+
+no_workflows_dir="$(make_tree no-workflows "$(readme_naming lint.sh)" \
+    "lint.sh:$SOURCE_ONLY_SCRIPT")"
+rm -rf "$no_workflows_dir/.github"
+check_tree "no workflows directory" FLAG "$no_workflows_dir"
+
+empty_workflow_dir="$(make_tree empty-workflow "$(readme_naming lint.sh)" \
+    "lint.sh:$SOURCE_ONLY_SCRIPT")"
+printf 'jobs: {}\n' > "$empty_workflow_dir/.github/workflows/ci.yml"
+check_tree "workflow defining no steps" FLAG "$empty_workflow_dir"
+
+# A README with no origin table at all leaves check 3 with nothing to compare,
+# which is the same green-while-doing-no-work state the rest of this block
+# guards against.
+#
+# Named rather than left to the status, because the header search is a grep
+# pipeline: with no table to match, an unguarded grep exits 1 and `pipefail`
+# carries that out of the command substitution, killing the script on the
+# assignment with exit 1 -- the same status this branch reports, and no message
+# at all. Status alone reads FLAG either way.
+check_tree "README with no origin table" FLAG \
+    "$(make_tree no-origin-table "$(printf '%s\n\n%s\n- %s takes a directory\n%s\n' \
+        "Prose naming lint.sh but carrying no table." "$BEGIN_MARKER" "lint.sh" "$END_MARKER")" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT")" \
+    "no table column headed 'Origin in ci.yml'"
 
 no_readme_dir="$(make_tree no-readme "$(readme_naming lint.sh)" \
     "lint.sh:$SOURCE_ONLY_SCRIPT")"


### PR DESCRIPTION
Adds a third check to the lint #346 introduced, rather than a fourth README lint. #346 has merged, so this is now a single commit on `main`.

## The problem

The regression-script table's third column, `Origin in ci.yml`, names the CI step that runs each script. Nothing kept it honest, and it drifted the same way the prose #346 checks did — two rows named steps that did not exist:

| Row | Column says | In `ci.yml` |
|---|---|---|
| `rescue_kmer_options.sh` | `"--rescue-kmer/--rescue-band reject malformed values"` | absent |
| `rescue_skip_options.sh` | `"--rescue-skip requires --rescue-kmer and composes with --fast"` | absent |

Both described a state the workflow never reached: a later change merged the two steps into a single `--rescue-kmer/--rescue-band/--rescue-skip option validation` step and updated only the workflow. A reader following the column looks for a step name that is in no workflow.

That is check 1's failure with the two sides swapped — a broken reference, not a judgement call about coverage — which is why this belongs in this lint rather than in a new one.

## Check 3

Every row of that table must carry a double-quoted step name, and that name must match a `- name:` step under `.github/workflows/`.

- **Job names are deliberately not accepted.** The column names the step that runs the script; a job-level `name:` would let a row point at something that runs nothing.
- **The table is located by its header, not by position.** The README already carries a second three-column table whose third column holds a *script* name — reading that one as origins reports every row as a step that does not exist. A self-test case pins this; it was a real mistake made while prototyping the check.
- **An unquoted cell is reported, not skipped.** A row that opts out in silence is how the column rotted in the first place.

## Four parsing details that make that last claim true

Each of these is a way the check could have read as green while quietly skipping a row or rejecting a healthy one, and each has a case:

- **The separator row is matched by shape** — a line of nothing but pipes, hyphens, colons and spaces — not by "contains `---`". A data cell is free to hold three hyphens, and the loose test drops that row from both the check and the row count. That is a row opting out in silence, which is the thing being guarded against.
- **YAML's quoting is stripped off an extracted step name.** A step name containing `: ` cannot be written unquoted at all, so comparing the quoted spelling reports a step the workflow plainly defines as missing — and the remediation line then tells the reader to correct a column that is already right.
- **The header is located on a table row**, not anywhere in the file. The string is not unique — the table's own row for this lint quotes it while describing what the check does — and a sentence naming the column *above* the table would otherwise be read as the header, leaving a healthy table reported as empty.
- **An empty `""` is rejected with the unquoted cells** rather than carried downstream, where it strips to an empty grep pattern and is reported as a blank line under a heading about missing steps.

## Verification

Runs clean on this repository: **25 scripts named and present; 8 source-only; 25 ci.yml step names**.

Every fixture tree in the self-test now carries a workflow and a table, because a missing one is "nothing was checked" rather than a pass — all pre-existing cases still pass unchanged. Self-test goes from 20 cases to 32; the twelve new ones are a stale step name, an unquoted cell, an empty pair of quotes, a job name, a second table not read as origins, a data cell holding three hyphens, a double- and a single-quoted step name, the column header named in prose above the table, no workflows directory, a workflow defining no steps, and a README with no origin table.

Eleven of the twelve were confirmed **passing against the pre-change lint and failing after it**. The twelfth could not be: an empty `""` is rejected either way, and only the branch it is rejected on changes. So `check_tree` grew an optional phrase the report has to carry, and that case names its branch — on the verdict alone it would read green against a lint that still routes the cell the wrong way, which is this file's own failure mode turned inward.

Passing under bash 3.2 and 5.3; shellcheck and shfmt clean across all 70 tracked scripts; the NDEBUG, opt-in-macro, coverage and shell lint families all pass.

## One thing worth a look

`ORIGIN_OVERRIDE` in the self-test is spelled with an `if` rather than `${ORIGIN_OVERRIDE:-...}` on purpose. Check 2 reads a name used in a `:-` expansion as an environment input **by design**, so the obvious spelling moved the self-test out of the source-only set and made the lint fail on its own README — correctly, and it caught me doing it. Worth knowing that the heuristic bites internal variables too, not just real inputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified README requirements for linking CI origins to workflow-defined steps.
  - Expanded lint guidance to document validation checks and report validated CI references.

- **Bug Fixes**
  - Improved detection of missing, malformed, stale, ambiguous, or nonexistent workflow-origin entries.

- **Tests**
  - Added regression coverage for workflow-origin validation, table parsing, quoting, and no-workflow scenarios.
  - Enhanced self-tests to distinguish diagnostics for different validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->