### PR TITLE
fix: check debug_macro_flag_lint's directory argument before cd

### DIFF
--- a/test/regression/debug_macro_flag_lint.sh
+++ b/test/regression/debug_macro_flag_lint.sh
@@ -41,7 +41,18 @@ fi
 # Optional argument so debug_macro_flag_lint_selftest.sh can aim the same
 # checks at a fixture tree; there is no other way to tell "the lists agree"
 # apart from "the extraction stopped extracting".
+#
+# Checked rather than left to `cd` to fail under `set -e`: bash's own `cd:` line
+# carries no FAIL: prefix, so the one way of pointing this lint at nothing that
+# is reachable from the command line would be the one failure a caller scanning
+# for the family's format does not see. Same guard as
+# test/regression/regression_coverage_lint.sh, the other lint taking this
+# argument.
 if (($# == 1)); then
+    if [[ ! -d $1 ]]; then
+        echo "FAIL: '$1' is not a directory -- nothing was checked" >&2
+        exit 1
+    fi
     cd "$1"
 fi
 

--- a/test/regression/debug_macro_flag_lint_selftest.sh
+++ b/test/regression/debug_macro_flag_lint_selftest.sh
@@ -349,6 +349,18 @@ printf '#ifdef BWA_MEM3_DEBUG_ALPHA\n#endif\n' > "$wrong_src_dir/src"
 check_dir "src path is a regular file" "$wrong_src_dir" 1 \
     'src is not a directory'
 
+# The argument itself, rather than the tree under it. Asserted on the message
+# and not just the status, because an unguarded `cd` into a missing directory
+# also dies with exit 1 under `set -e` -- a status-only case passes whether or
+# not the path is checked. What is under test is that the failure arrives in
+# this family's own format instead of as bash's raw `cd:` diagnostic. Hence the
+# FAIL: prefix in the expected text, which the other cases leave off: elsewhere
+# the message body alone identifies the branch, but here the prefix *is* the
+# behaviour under test.
+absent_dir="$fixture_root/absent"
+check_dir "argument that is not a directory" "$absent_dir" 1 \
+    "FAIL: '$absent_dir' is not a directory"
+
 # The expected text is derived from $lint rather than spelled out: the lint
 # prints its own basename, so a hardcoded name would make this case fail for a
 # renamed copy of the script instead of for the behaviour under test.


### PR DESCRIPTION
Follow-up to #338, which added this guard to `regression_coverage_lint.sh`. `debug_macro_flag_lint.sh` takes the same optional repo-root argument through the same code shape and had the same gap; it was left out of that PR to keep it scoped, and is fixed here.

The argument was passed straight to `cd`. Given a path that is not a directory the script died on bash's own `cd: ...: No such file or directory` under `set -e`, so the single way of pointing this lint at nothing reported in a format that a caller scanning for the family's `FAIL:` output does not match. Reproduced before fixing.

The check now runs before the `cd`, reusing the wording of the `$src_dir` check a few lines below. The path is quoted, because an empty argument otherwise renders as a blank gap — and an empty argument previously did not fail at all: `cd ""` succeeds and stays put, so the lint silently checked the repo root instead of the tree it was handed.

**The self-test asserts the message, not just the status,** which is the point worth flagging for review. An unguarded `cd` failing under `set -e` also exits 1, so a status-only case passes whether or not the guard exists. The new case reuses the existing `check_dir` helper, which already takes an expected-text argument for this reason, and was confirmed failing against the pre-fix script — it reported the raw `cd:` line.

The two scripts taking this argument are now consistent; no other script in `test/regression/` takes one.

**Verification:** the self-test passes under bash 3.2 and 5.3 (macOS still ships 3.2 as `/bin/bash`, and this family runs there); `/nope/nope`, a path that is a regular file, and the empty string each fail with the `FAIL:` line; the no-argument path still passes against this repo; all four lint families in `test/regression/` pass; shellcheck and shfmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for optional repository paths, providing a clear failure message when the path does not exist or is not a directory.
  * Prevented unclear errors caused by attempting to change into invalid directories.

* **Tests**
  * Added regression coverage for invalid lint target directories and their expected diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->