### PR TITLE
ci: format cohort_slice_identity.sh so the shell lint gate passes

### DIFF
--- a/test/regression/cohort_slice_identity.sh
+++ b/test/regression/cohort_slice_identity.sh
@@ -279,7 +279,7 @@ fi
 res_cap=$(echo "$reserve_line" | sed -E 's/.*cap: ([0-9]+).*/\1/')
 res_held=$(echo "$reserve_line" | sed -E 's/.*held: ([0-9]+).*/\1/')
 
-if [ "$res_held" -ge 1024 ] && [ "$res_cap" -ge $(( res_held * 2 )) ]; then
+if [ "$res_held" -ge 1024 ] && [ "$res_cap" -ge $((res_held * 2)) ]; then
     echo "FAIL: the cohort reserved $res_cap slots while holding $res_held reads." >&2
     echo "      Growth by doubling never exceeds 2x, so this is a task_size" >&2
     echo "      projection fired on a cohort whose input had already ended." >&2


### PR DESCRIPTION
The shell lint gate (shellcheck + shfmt) currently rejects `test/regression/cohort_slice_identity.sh`, so CI on `main` is red and every branch rebased onto `main` inherits the failure.

```
FAIL: not shfmt-formatted:
  test/regression/cohort_slice_identity.sh
```

## The change

One line. The arithmetic expansion on the reserve-growth assertion is spelled `$(( res_held * 2 ))`; shfmt writes it `$((res_held * 2))`. The expansion is identical either way — this is formatting only, with no behavior change.

## Why it slipped through

The two changes raced. The branch that added this assertion was written before the gate existed and merged after it, so the gate never ran against this line on a pull request. The gate itself is working exactly as intended; it is reporting real, if trivial, drift.

## Validation

Produced by the gate's own fixer (`./test/regression/shell_lint.sh --fix`) rather than by hand, using shfmt v3.13.1 and shellcheck 0.11.0 — the versions `ci.yml` pins — so the result is exactly the formatting CI asks for. The fixer rewrote all 68 tracked scripts and this is the only one whose bytes changed.

On this branch:

- `shell_lint.sh` — PASS (68 scripts: shellcheck clean, shfmt-formatted)
- `shell_lint_selftest.sh` — PASS
- `bash -n` on the edited script — clean
