### PR TITLE
docs: correct the developer guide's account of the source-only lints

### DIFF
--- a/docs/src/developer-guide/regression-tests.md
+++ b/docs/src/developer-guide/regression-tests.md
@@ -8,13 +8,13 @@ bwa-mem3 has three categories of tests — **unit**, **integration**, and **regr
 |---|---|---|---|
 | unit | `test/bwa_mem3_tests_unit` | None; all inputs synthetic | Every matrix row |
 | integration | `test/bwa_mem3_tests_integration` | Small committed FASTAs / FMI in `test/fixtures/` | SSE4.1, AVX2, ARM64 Linux, macOS ARM |
-| regression | `test/regression/*.sh` | Committed phiX in `test/fixtures/`; chr22 downloaded by CI, with reads simulated by holodeck; bwa for the parity diffs | Canonical AVX2 row, except `chr22_parity.sh` (every row) and the source-only lints (their own jobs) |
+| regression | `test/regression/*.sh` | Committed phiX in `test/fixtures/`; chr22 downloaded by CI, with reads simulated by holodeck; bwa for the parity diffs | Mostly the canonical AVX2 row; a few run on every row, and the source-only lints run in jobs of their own. `test/regression/README.md` has the per-script breakdown |
 
 **Unit tests** must use only synthetic inputs generated programmatically and complete in under 100 ms each. They exercise individual kernels in isolation: kswv scoring, banded Smith-Waterman, KSW, FM-index operations, SMEM extraction, BAM encoding, and pair handling.
 
 **Integration tests** may load small committed fixtures from `test/fixtures/` and have a per-test budget of 10 seconds. They exercise cross-component paths: index loading, SMEM-to-alignment pipelines, and output format validation.
 
-**Regression tests** are standalone bash scripts that shell out to the `bwa-mem3` binary, may diff against third-party tool output (bwa, bwa-meth, samtools), and require fixtures that are either committed to the fixtures directory or downloaded by CI at run time. The source-only lints are the exception: they read `src/` and `ci.yml` directly, need no binary and no fixtures, and run in their own CI jobs.
+**Regression tests** are standalone bash scripts that shell out to the `bwa-mem3` binary, may diff against third-party tool output (bwa, bwa-meth, samtools), and require fixtures that are either committed to the fixtures directory or downloaded by CI at run time. The source-only lints are the exception: each one reads files already in the repository — `src/`, `ci.yml`, the `Makefile`, the regression scripts, or the README beside them, depending on the lint — so they need no binary and no fixtures, and run in their own CI jobs.
 
 ## Running tests locally
 
@@ -46,7 +46,7 @@ make test
 
 ### Running a regression test locally
 
-Most regression scripts take their inputs from environment variables naming a binary and its fixtures — see the comment block at the top of each script, and `test/regression/README.md` for the contract. The source-only lints take neither, so they are the cheapest thing to run:
+Most regression scripts take their inputs from environment variables naming a binary and its fixtures — see the comment block at the top of each script, and `test/regression/README.md` for the contract. The lints need no binary and no fixtures, so they are the cheapest thing to run. Most take no environment either, only an optional directory naming what to check: the delimited source-only-lint block in `test/regression/README.md` names exactly those, with the argument each one takes. `shell_lint.sh` is the near-miss worth knowing about — it takes the same optional directory, but also honours `SHELL_LINT_REQUIRED`, so it is deliberately *not* in that block. Two examples:
 
 ```bash
 bash test/regression/ndebug_gate_lint.sh        # no build, no fixtures

--- a/docs/src/whats-different/build-infra.md
+++ b/docs/src/whats-different/build-infra.md
@@ -23,7 +23,10 @@ PR #34 establishes the long-term test infrastructure for bwa-mem3:
   keep working.
 - Five inline CI bash regression blocks are extracted to
   `test/regression/*.sh` (phix_parity, chr22_parity, thread_determinism,
-  bam_roundtrip, meth_oracle).
+  bam_roundtrip, meth_oracle). `phix_parity.sh` no longer exists:
+  [PR #89](https://github.com/fg-labs/bwa-mem3/pull/89) migrated the parity
+  checks from dwgsim/phiX174 to holodeck/chr22 and folded it into
+  `chr22_parity.sh`.
 - A `coverage` CI job builds `libbwa.a` and both test binaries with
   `COVERAGE=1` (`-O0 --coverage`), runs both test binaries, collects Cobertura
   XML via `gcovr`, and uploads to Codecov via `codecov/codecov-action`.


### PR DESCRIPTION
Three claims in `docs/src/developer-guide/regression-tests.md` had fallen behind the regression suite, plus one dangling script name in `docs/src/whats-different/build-infra.md`. All of it is prose that nothing points at, which is why it drifted rather than being caught.

### `regression-tests.md`

**"The source-only lints read `src/` and `ci.yml` directly."** True of both when there were two. There are now four pairs and it holds for at most two of them: `shell_lint` reads every tracked `*.sh`, `regression_coverage_lint` reads `ci.yml` plus the `Makefile` plus `coverage_exemptions.txt`, and neither reads `src/` at all. Replaced with what they actually have in common — they read files already in the tree, so they need no binary and no fixtures.

**The test-category table's exception list.** It gave the exceptions to "canonical AVX2 row" as `chr22_parity.sh` and the source-only lints. `version_banner.sh` also runs on every row, and `profile_slice_cpu.sh` runs from `profiling-build`. That list has now drifted twice, so rather than extend it a third time it points at `test/regression/README.md`, which carries the per-script breakdown.

**The "cheapest thing to run" block** named two of the eight source-only scripts with nothing marking the list as partial. It now says so and points at the delimited block that is complete.

**One clarification while in there.** The source-only-lint block in `test/regression/README.md` is defined by *reading no environment*; needing no binary is a separate property, and the guide used "source-only" loosely enough to run the two together. `shell_lint.sh` is exactly where they come apart — it takes the same optional directory argument as the others, but also honours `SHELL_LINT_REQUIRED`, so it is deliberately **not** in that block. Worth stating explicitly: without it, the block reads like an oversight and invites a well-meant "fix" that breaks the contract it encodes.

### `build-infra.md`

The record of PR #34 lists `phix_parity` among five extracted regression scripts. As a statement about what PR #34 did that is accurate, so it stays — but PR #89 removed the script when parity migrated from dwgsim/phiX174 to holodeck/chr22, so as written it sends a reader after a file that has not existed for a year. It now notes where it went, rather than deleting a true statement about the past.

### Validation

Prose only — no code, no CLI snippets, so the generated CLI drift check is unaffected. `mdbook build` is clean (exit 0) with no warning on either edited file; the six warnings it does emit are pre-existing and all in the generated changelog. Every factual claim in the new text was checked against the tree: which scripts run on every matrix row, which read environment variables (and which ones), that `shell_lint.sh` accepts the optional directory, and that `phix_parity.sh` was deleted by the parity migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified regression-test CI coverage, including per-row execution and dedicated source-only lint jobs.
  * Expanded source-only linting guidance, including local arguments, required environment variables, and the `SHELL_LINT_REQUIRED` exception.
  * Documented that phiX174 parity checks now run within the chromosome 22 parity workflow after removal of the standalone check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->