### PR TITLE
ci: enforce the PASS:/FAIL: marker contract the README already states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,7 +562,7 @@ jobs:
         # chr22_parity.sh running on the sse41, avx2 and arm64 build jobs.
         #
         # On a runner without AVX-512BW there is only one sweepable tier and the
-        # script reports SKIPPED, not PASS — so this step is a no-op there rather
+        # script reports SKIP:, not PASS: — so this step is a no-op there rather
         # than a false green. It still earns its place: the script had rotted
         # unrun to the point of aborting on its first tier, and this keeps that
         # from recurring silently.

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -13,13 +13,16 @@ all and run from `ndebug-gate-lint`, `debug-macro-flag-lint`, `shell-lint`,
   every script but the source-only lints, which instead take an optional
   positional directory so their self-tests can aim the same checks at a fixture
   tree, and `meth_oracle.sh`, which reads no input at all)
-- emits `PASS:` on success and `FAIL:` on failure
+- emits `PASS:` on success and `FAIL:` on failure, and `SKIP:` where a check
+  cannot run (a missing tool, a host with nothing to compare) — a skipped check
+  is reported as skipped, never as a pass
 - returns nonzero on failure
 
 | Script                       | What it checks                                                        | Origin in ci.yml                                    |
 |------------------------------|-----------------------------------------------------------------------|-----------------------------------------------------|
 | `chr22_parity.sh`            | bwa vs bwa-mem3 SAM parity on ~50k PE holodeck reads (chr22)          | "Compare chr22 bwa vs bwa-mem3 (parity)"            |
 | `thread_determinism.sh`      | `-t 1` == `-t 4` output after sort on chr22                           | "Thread-determinism smoke (chr22, -t 1 vs -t 4)"    |
+| `all_tiers_parity.sh`        | one binary, one host: byte-identical SAM on the staged `PARITY_FA`/`PARITY_R1`/`PARITY_R2` workload (the same chr22 holodeck PE reads as `chr22_parity.sh`) whichever kernel `BWAMEM3_FORCE_TIER` selects. Real coverage needs an x86 host where both avx2 and avx512bw are sweepable; anywhere else — arm64, or x86 without AVX-512BW — there is one tier and it reports `SKIP:` | "SIMD tier parity (avx2 vs avx512bw, chr22)"        |
 | `bam_roundtrip.sh`           | `--bam=6` BAM decodes and has same record count as SAM (chr22)        | "--bam=6 roundtrip smoke (chr22)"                   |
 | `short_read_smoke.sh`        | ASAN SE on 25-50 bp variable-length dense-chr22 reads (PR #100 fix)   | "Short-read SE smoke (chr22, ASAN, dense+variable-length)" |
 | `supp_rep_hard_cap.sh`       | `--supp-rep-hard-cap` forces MAPQ=0 on repetitive-seed supps (#101)   | "--supp-rep-hard-cap repetitive-seed regression"    |
@@ -27,6 +30,7 @@ all and run from `ndebug-gate-lint`, `debug-macro-flag-lint`, `shell-lint`,
 | `header_parity.sh`           | `AH:*` on generated @SQ (#281); `--compat` skips the .hdr/.dict sidecar | "header parity regression (AH:*, --compat @HD/@SQ)" |
 | `default_hd_parity.sh`       | default `@HD` byte-identical across SAM/`--bam`/`--meth` (#288)        | "default @HD parity across output paths"            |
 | `meth_sam_output.sh`         | `--meth` emits SAM text by default and BAM under `--bam`, same records | "--meth output container follows --bam"             |
+| `meth_collapsed_scoring.sh`  | `--meth-scoring collapsed` also frees the conversion mirror cell, so a ref-T→read-C substitution scores `a+b` above `genomic` and reports NM=0 against its NM=1 | "--meth whole-aligner regressions (D3)"             |
 | `meth_oracle.sh`             | `--meth` Layer 1 (valid BAM emission) via the harness under `test/meth/`; Layers 2–3 retired in D3 | "Run --meth Layer 1"                                |
 | `cohort_ramp_validation.sh`  | `--cohort-ramp-first`/`-ratio` reject malformed values; env warns and falls back | "Cohort ramp values are validated (flag and environment alike)" |
 | `rescue_kmer_options.sh`     | `--rescue-kmer`/`--rescue-band` reject malformed and out-of-range values; the `=` form is required | "--rescue-kmer/--rescue-band reject malformed values" |
@@ -42,7 +46,7 @@ all and run from `ndebug-gate-lint`, `debug-macro-flag-lint`, `shell-lint`,
 | `regression_coverage_lint_selftest.sh` | the lint above still detects an unrun script, so its `PASS` means something | "Coverage lint still detects an unrun script"       |
 | `host_floor_enforce.sh`      | below-floor hosts get exit 2 + a readable error, not a SIGILL (needs `TESTING_BUILD=1`) | "SIMD floor enforcement (TESTING_BUILD, injected below-floor tier)" |
 | `version_banner.sh`          | `bwa-mem3 version` prints the SIMD floor and runtime tier lines        | "Version banner regression"                         |
-| `readme_contract_lint.sh`    | this README names no script that was deleted, its source-only-lint block lists exactly the scripts that read no environment, and every row's `Origin in ci.yml` names a step a workflow defines | "README still describes the regression scripts"     |
+| `readme_contract_lint.sh`    | this README names no script that was deleted, its source-only-lint block lists exactly the scripts that read no environment, every row's `Origin in ci.yml` names a step a workflow defines, and every script can emit the `PASS:`/`FAIL:` markers above | "README still describes the regression scripts"     |
 | `readme_contract_lint_selftest.sh` | the lint above still detects a stale README, so its `PASS` means something | "README lint still detects drift"                  |
 
 The table is a reading guide, not an inventory — `ls test/regression/*.sh` is

--- a/test/regression/all_tiers_parity.sh
+++ b/test/regression/all_tiers_parity.sh
@@ -16,7 +16,7 @@
 # stronger oracle than self-comparison, and transitive across the three builds.
 #
 # Real coverage needs an avx512bw host: on an avx2-only x86 runner, or on arm64,
-# there is exactly one sweepable tier and the script reports SKIPPED rather than
+# there is exactly one sweepable tier and the script reports SKIP: rather than
 # claiming a pass it did not earn.
 #
 # Inputs:
@@ -131,7 +131,7 @@ fi
 # A host below the batched floor (an sse41/sse42/avx baseline build) has nothing
 # to sweep. Say so plainly instead of reporting an empty pass.
 if [[ "${#TIERS[@]}" -eq 0 ]]; then
-    echo "ALL TIERS PARITY: SKIPPED -- host tier '$HOST_TIER' is below the batched-kswv"
+    echo "SKIP: all_tiers_parity -- host tier '$HOST_TIER' is below the batched-kswv"
     echo "  floor (avx2), so this build has no sweepable tiers. Its correctness is covered"
     echo "  by chr22_parity.sh, which runs on this build in CI and asserts byte-identity"
     echo "  against bwa. This is NOT a pass."
@@ -216,10 +216,10 @@ if [[ "$EXIT" -ne 0 ]]; then
     exit "$EXIT"
 fi
 if [[ "$COMPARISONS" -eq 0 ]]; then
-    echo "ALL TIERS PARITY: SKIPPED -- only one testable tier on this host (${TIERS[*]}),"
+    echo "SKIP: all_tiers_parity -- only one testable tier on this host (${TIERS[*]}),"
     echo "  so nothing was compared. This is expected on arm64 and on x86 hosts without"
     echo "  AVX-512BW; it is NOT a pass. Run on an avx512bw host for real coverage."
     exit 0
 fi
-echo "ALL TIERS PARITY: PASS ($COMPARISONS comparison(s) across ${#TIERS[@]} tiers: ${TIERS[*]})"
+echo "PASS: all_tiers_parity ($COMPARISONS comparison(s) across ${#TIERS[@]} tiers: ${TIERS[*]})"
 exit 0

--- a/test/regression/meth_collapsed_scoring.sh
+++ b/test/regression/meth_collapsed_scoring.sh
@@ -185,4 +185,4 @@ NM_LIT=$(mawk '!/^@/{for(i=12;i<=NF;i++) if(substr($i,1,5)=="NM:i:"){print subst
 # even at -B 0, which is exactly why -B 0 is harmless off the --meth path.
 [ "$NM_LIT" = "1" ] || fail "non-meth -B 0 should keep literal NM: NM=$NM_LIT, want 1"
 
-echo "OK"
+echo "PASS: meth_collapsed_scoring (collapsed-space --meth scoring, and literal NM preserved off the --meth path at -B 0)"

--- a/test/regression/readme_contract_lint.sh
+++ b/test/regression/readme_contract_lint.sh
@@ -41,6 +41,27 @@
 #      name that is not in any workflow is a broken reference -- check 1's
 #      failure with the two sides swapped.
 #
+#   4. Every script can emit both of the markers the README requires of it:
+#      "emits `PASS:` on success and `FAIL:` on failure". That bullet had been
+#      in the README since the directory existed and had never been checked,
+#      and three of the forty-three scripts did not honour it --
+#      all_tiers_parity.sh printed "ALL TIERS PARITY: PASS (" with no colon
+#      after PASS, meth_collapsed_scoring.sh ended on a bare `echo "OK"`, and
+#      meth_oracle.sh `exec`d its child and emitted nothing of its own. The
+#      last one matters most: a wrapper that prints no marker looks exactly
+#      like a wrapper that never ran, which is the failure the markers exist
+#      to make visible.
+#
+#      This is a source check, not a runtime one -- it asks whether the
+#      literals are reachable in the file, not whether a given run printed
+#      them. A script that emits PASS: only down a branch this lint cannot
+#      evaluate still satisfies it. That is the same bargain the other lints
+#      here make, and it is enough to catch all three cases above. What it does
+#      not accept is a marker the script cannot print: comments are dropped
+#      first, using the same quote-state walk check 2 needs, because a header
+#      block quoting the contract -- or a `# PASS:` after live code -- is the
+#      one shape a raw substring match reliably gets wrong.
+#
 # Check 2 needs to know where the claim lives, so the README marks it:
 #
 #     <!-- source-only lints: begin -->
@@ -190,27 +211,48 @@ block="$(sed -n "$((begin_line + 1)),$((end_line - 1))p" "$readme")"
 # configuration from its caller, so it still counts as source-only.
 shell_provided_names='^(BASH|BASHPID|BASH_ARGC|BASH_ARGV|BASH_COMMAND|BASH_LINENO|BASH_REMATCH|BASH_SOURCE|BASH_SUBSHELL|BASH_VERSINFO|BASH_VERSION|COLUMNS|EUID|FUNCNAME|GROUPS|HISTFILE|HOME|HOSTNAME|HOSTTYPE|IFS|LINENO|LINES|MACHTYPE|OLDPWD|OPTARG|OPTIND|OSTYPE|PATH|PIPESTATUS|PPID|PS1|PS2|PS4|PWD|RANDOM|REPLY|SECONDS|SHELL|SHLVL|UID)$'
 
-# Emit only the parts of a script where a `$NAME` would actually expand:
-# comments, single-quoted spans, and backslash-escaped dollars are dropped.
+# Walk a script tracking shell quote state, and emit it with the parts the
+# shell would not read as code dropped. Two checks want different parts
+# dropped, but finding either needs the same tracking, so the walk is written
+# once and the difference is one flag:
+#
+#   $2 = 0  keep only where a `$NAME` would expand: comments, single-quoted
+#           spans, and backslash-escaped characters all go (check 2).
+#   $2 = 1  keep everything the script could still print: only comments go,
+#           and both kinds of quoted span keep their contents (check 4).
 #
 # This is the difference between reading a script and grepping it. Two of these
 # scripts hold shell text as data -- fixture bodies for their self-tests --
 # inside single quotes that may run over several lines, so a line-at-a-time
 # filter cannot see where the quote opened. `'${MAKE:-make}'` is a string; the
-# same characters unquoted are an environment read. Tracking the quote state
-# across the whole file is what tells them apart.
+# same characters unquoted are an environment read, and `# PASS:` after live
+# code is a comment where `"# PASS:"` is output. Tracking the quote state
+# across the whole file is what tells each pair apart.
 #
 # Not handled: quoted heredocs (`<<'EOF'`), whose body is also literal. Their
-# contents are still scanned, which can only over-detect inputs -- a script
-# would be kept out of the source-only block rather than slipped into it, so
-# the failure is loud.
-strip_non_expanding() {
+# contents are still scanned as code. For check 2 that can only over-detect
+# inputs -- a script would be kept out of the source-only block rather than
+# slipped into it, so the failure is loud. For check 4 a `#` opening a line of
+# heredoc body is read as a comment, which is what the whole-line filter this
+# replaced did to every heredoc alike.
+#
+# Also not handled: command substitution, whose body re-opens quoting the walk
+# reads as a continuation of the enclosing line. `v="$(mawk -F'"' '/x/' "$f")"`
+# leaves the walk one quote out of step, and every line after it is scanned in
+# the wrong state until something happens to re-balance it. Two scripts in this
+# tree do that today, both self-tests that build fixture scripts. The two checks
+# fail in opposite directions again, and only one of them is loud: check 2 reads
+# quoted text as code and over-detects inputs, while check 4 stops stripping
+# comments and would accept a script that only describes the markers. Neither
+# does so on this tree -- no script's markers come from a comment -- but that is
+# the shape to re-check here if a marker case ever passes when it should not.
+scan_shell_text() {
     # Both quote states are tracked, not just single. A single quote inside a
     # double-quoted string is a literal character and opens nothing -- the
     # `'"'"'` idiom these scripts use to embed a quote is exactly that shape,
     # and reading its quote as an opener inverts the state for the whole rest
     # of the file.
-    awk '
+    awk -v keep_quoted="$2" '
     BEGIN { single = 0; double = 0 }
     {
         line = $0
@@ -221,13 +263,19 @@ strip_non_expanding() {
             c = substr(line, i, 1)
             if (single) {
                 if (c == "\047") single = 0
+                else if (keep_quoted) out = out c
                 i++
                 continue
             }
             if (double) {
                 # Inside double quotes a backslash still escapes, and `$` still
                 # expands, so the contents are kept.
-                if (c == "\\") { out = out " "; i += 2; continue }
+                if (c == "\\") {
+                    if (keep_quoted) out = out substr(line, i, 2)
+                    else out = out " "
+                    i += 2
+                    continue
+                }
                 if (c == "\"") double = 0
                 else out = out c
                 i++
@@ -236,9 +284,15 @@ strip_non_expanding() {
             if (c == "\047") { single = 1; i++; continue }
             if (c == "\"") { double = 1; i++; continue }
             # A backslash quotes the next character, so `\$FOO` is a literal
-            # dollar sign. Drop both, leaving a space so adjacent words do not
-            # fuse into a new token.
-            if (c == "\\") { out = out " "; i += 2; continue }
+            # dollar sign and `\#` is not a comment. For check 2 both go,
+            # leaving a space so adjacent words do not fuse into a new token;
+            # for check 4 the quoted character is still printable text.
+            if (c == "\\") {
+                if (keep_quoted) out = out substr(line, i, 2)
+                else out = out " "
+                i += 2
+                continue
+            }
             # A `#` starting a word begins a comment that runs to end of line.
             if (c == "#" && (i == 1 || substr(line, i - 1, 1) ~ /[ \t;&|()]/)) break
             out = out c
@@ -246,6 +300,16 @@ strip_non_expanding() {
         }
         print out
     }' "$1"
+}
+
+# The parts of a script where a `$NAME` would expand.
+strip_non_expanding() {
+    scan_shell_text "$1" 0
+}
+
+# The parts of a script that are not comments -- quoted spans kept whole.
+strip_comments() {
+    scan_shell_text "$1" 1
 }
 
 # A variable that is referenced but never assigned anywhere in the file is an
@@ -502,8 +566,57 @@ if ((${#missing_steps[@]} > 0)); then
     failures=1
 fi
 
+# --- Check 4: every script can emit the PASS:/FAIL: markers. ---------------
+
+# Matched on the literal `PASS:` / `FAIL:` rather than on an `echo` line,
+# because the marker is just as legitimate coming out of a `printf`, a helper
+# like meth_collapsed_scoring.sh's `fail()`, or a heredoc. A stricter pattern
+# would start arguing with how each script chooses to write.
+#
+# Comments are dropped first, though, because the one shape the loose match
+# gets wrong is the one these scripts all have: a header comment block that
+# quotes the contract it is documenting. This very file's comments name `PASS:`
+# ten times between them. Left in, a script could satisfy a contract about
+# what it prints purely by describing it -- and the header describing the
+# marker is exactly what survives when the `echo` that printed it is deleted.
+#
+# Both whole-line and trailing comments go, which is why this reuses check 2's
+# quote-state walk rather than a `^[[:space:]]*#` filter. The tail of a line is
+# where the two spellings are hardest to tell apart -- `echo done # PASS:`
+# prints nothing while `echo "done # PASS:"` prints the marker -- and only
+# knowing the quote state distinguishes them. Dropping whole-line comments
+# alone leaves the first shape satisfying the contract while emitting nothing,
+# which is the same hole the comment strip exists to close.
+#
+# Marker text held as fixture data is still accepted: a quoted span keeps its
+# contents, so the self-tests next to this one -- which build fixture scripts
+# that print markers -- match on those. That is deliberate, not a leak; each of
+# them prints its own marker too.
+missing_markers=()
+for script in "${scripts[@]}"; do
+    code="$(strip_comments "$regression_dir/$script")"
+    missing=()
+    for marker in 'PASS:' 'FAIL:'; do
+        grep -qF -- "$marker" <<< "$code" || missing+=("$marker")
+    done
+    if ((${#missing[@]} > 0)); then
+        missing_markers+=("$script (${missing[*]})")
+    fi
+done
+
+if ((${#missing_markers[@]} > 0)); then
+    echo "FAIL: these scripts cannot emit the markers $readme requires of them" >&2
+    echo "      (\"emits \`PASS:\` on success and \`FAIL:\` on failure\"):" >&2
+    printf '  %s\n' "${missing_markers[@]}" >&2
+    echo >&2
+    echo "A run that prints no marker is indistinguishable from a script that never" >&2
+    echo "ran. Print \`PASS: <script> (<what was checked>)\` on the success path and" >&2
+    echo "\`FAIL: <what went wrong>\` on each failure path." >&2
+    failures=1
+fi
+
 if ((failures != 0)); then
     exit 1
 fi
 
-echo "PASS: readme_contract_lint (${#mentioned[@]} scripts named and present; ${#source_only[@]} source-only; $row_count ci.yml step names)"
+echo "PASS: readme_contract_lint (${#mentioned[@]} scripts named and present; ${#source_only[@]} source-only; $row_count ci.yml step names; ${#scripts[@]} emit both markers)"

--- a/test/regression/readme_contract_lint_selftest.sh
+++ b/test/regression/readme_contract_lint_selftest.sh
@@ -151,17 +151,26 @@ readme_naming() {
 # shellcheck disable=SC2016
 
 # A script that takes the named environment variable, and one that takes none.
+#
+# Every fixture below carries both a PASS: and a FAIL: literal, because check 4
+# requires them of any script in the tree. The cases here are aimed at checks 1
+# and 2, so the markers are scaffolding rather than the thing under test -- a
+# fixture missing one would FLAG for a reason the case never meant to exercise.
+# The dedicated check-4 cases further down drop a marker on purpose.
 readonly ENV_SCRIPT='set -euo pipefail
 : "${BWA_MEM3:?BWA_MEM3 must be set}"
+[[ -n ${BWA_MEM3:-} ]] || { echo "FAIL: fixture" >&2; exit 1; }
 echo "PASS: fixture"'
 # shellcheck disable=SC2016
 readonly SOURCE_ONLY_SCRIPT='set -euo pipefail
 scan_root="${1:-src}"
+[[ -n $scan_root ]] || { echo "FAIL: fixture" >&2; exit 1; }
 echo "PASS: fixture $scan_root"'
 # shellcheck disable=SC2016
 readonly DEFAULTED_ENV_SCRIPT='set -euo pipefail
 MAKE="${MAKE:-make}"
-"$MAKE" --version'
+"$MAKE" --version || { echo "FAIL: fixture" >&2; exit 1; }
+echo "PASS: fixture"'
 
 # A script that holds shell text as data -- the shape of the self-tests next to
 # this one, which build fixture scripts from single-quoted constants spanning
@@ -173,7 +182,7 @@ readonly QUOTED_DATA_SCRIPT='set -euo pipefail
 payload='"'"'set -euo pipefail
 MAKE="${MAKE:-make}"
 : "${BWA_MEM3:?BWA_MEM3 must be set}"'"'"'
-printf '"'"'%s\n'"'"' "$payload" > /dev/null
+printf '"'"'%s\n'"'"' "$payload" > /dev/null || { echo "FAIL: fixture" >&2; exit 1; }
 echo "PASS: fixture"'
 
 echo "== stale READMEs the lint must reject =="
@@ -266,7 +275,7 @@ check_tree "apostrophe in a double-quoted string does not shift quote state" PAS
         "lint.sh:set -euo pipefail
 label=\"the lint's own message\"
 payload='\${BWA_MEM3:?BWA_MEM3 must be set}'
-echo \"\$label \$payload\" > /dev/null
+echo \"\$label \$payload\" > /dev/null || { echo \"FAIL: fixture\" >&2; exit 1; }
 echo \"PASS: fixture\"")"
 
 echo "== the ci.yml origin column ==" # check 3
@@ -369,6 +378,109 @@ check_tree "the column header named in prose above the table" PASS \
         "The Origin in ci.yml column names the step that runs each script." \
         "$(readme_naming lint.sh)")" \
         "lint.sh:$SOURCE_ONLY_SCRIPT")"
+
+echo "== the PASS:/FAIL: marker contract ==" # check 4
+
+# Every case below names this branch rather than resting on the verdict. Each
+# one hands the lint a tree that is stale in exactly one way, and checks 1-3
+# reject a tree for three other reasons with the same exit 1 -- so a case that
+# tripped one of those by accident reads green while never reaching check 4.
+readonly MARKER_REPORT='cannot emit the markers'
+
+# The three shapes that were actually in the tree when check 4 was written: no
+# PASS: at all (meth_collapsed_scoring.sh ended on a bare `echo "OK"`), a PASS
+# without the colon (all_tiers_parity.sh printed "ALL TIERS PARITY: PASS ("),
+# and neither marker (meth_oracle.sh `exec`d its child and said nothing).
+# shellcheck disable=SC2016
+readonly NO_PASS_SCRIPT='set -euo pipefail
+scan_root="${1:-src}"
+[[ -n $scan_root ]] || { echo "FAIL: fixture" >&2; exit 1; }
+echo "OK"'
+# shellcheck disable=SC2016
+readonly UNCOLONED_PASS_SCRIPT='set -euo pipefail
+scan_root="${1:-src}"
+[[ -n $scan_root ]] || { echo "FAIL: fixture" >&2; exit 1; }
+echo "FIXTURE PARITY: PASS (1 comparison)"'
+readonly NO_MARKER_SCRIPT='set -euo pipefail
+exec bash some/other/harness'
+# The asymmetric case. Every shape above is missing PASS: or missing both, so a
+# check that dropped the FAIL: half entirely would still turn all of them FLAG
+# and this file would report green while covering half the contract.
+# shellcheck disable=SC2016
+readonly NO_FAIL_SCRIPT='set -euo pipefail
+scan_root="${1:-src}"
+[[ -n $scan_root ]] || exit 1
+echo "PASS: fixture"'
+# Both markers present, and neither reachable: a script that documents the
+# contract in its header and prints nothing. That is what a raw substring match
+# accepts, and what the header of the lint itself would have satisfied.
+readonly COMMENT_ONLY_SCRIPT='set -euo pipefail
+# Prints PASS: on success and FAIL: on failure.
+exec bash some/other/harness'
+# The same shape one column over: the markers trail live code instead of
+# starting the line, so a `^[[:space:]]*#` filter leaves them in place while
+# the shell reads them as comment text and the script still prints nothing.
+# Distinguishing this from the quoted `"... # PASS:"` on the line below it is
+# what the lint needs quote state for, and the `PASS` case pins that both ways:
+# the marker in the comment must not count, and the one in the string must.
+readonly TRAILING_COMMENT_SCRIPT='set -euo pipefail
+echo "ran # PASS: fixture"
+exec bash some/other/harness # reports FAIL: on a bad exit'
+# The accepted half of the same rule, in the other quote. Dropping comments has
+# to leave both kinds of quoted span intact, and single quotes are the ones a
+# strip written for `$NAME` expansion would throw away wholesale -- check 2
+# drops them by design, and the two checks share a walk. shell_lint_selftest.sh
+# is this shape today, so getting it wrong would fail a healthy tree.
+# shellcheck disable=SC2016
+readonly SINGLE_QUOTED_MARKER_SCRIPT='set -euo pipefail
+scan_root="${1:-src}"
+[[ -n $scan_root ]] || { printf '"'"'FAIL: fixture\n'"'"' >&2; exit 1; }
+printf '"'"'PASS: fixture\n'"'"''
+
+check_tree "script with no PASS: marker" FLAG \
+    "$(make_tree no-pass-marker "$(readme_naming lint.sh)" \
+        "lint.sh:$NO_PASS_SCRIPT")" \
+    "$MARKER_REPORT"
+
+check_tree "script with no FAIL: marker" FLAG \
+    "$(make_tree no-fail-marker "$(readme_naming lint.sh)" \
+        "lint.sh:$NO_FAIL_SCRIPT")" \
+    "$MARKER_REPORT"
+
+check_tree "script whose PASS lacks the colon" FLAG \
+    "$(make_tree uncoloned-pass "$(readme_naming lint.sh)" \
+        "lint.sh:$UNCOLONED_PASS_SCRIPT")" \
+    "$MARKER_REPORT"
+
+# `other.sh` carries the bad shape while `lint.sh` stays healthy, and both are
+# named in the block because neither reads the environment. Putting the shape on
+# a second script is what keeps check 2 from flagging the tree first, which
+# would let the case pass without ever reaching check 4.
+check_tree "markers only in a comment" FLAG \
+    "$(make_tree comment-only-markers "$(readme_naming lint.sh other.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT" "other.sh:$COMMENT_ONLY_SCRIPT")" \
+    "$MARKER_REPORT"
+
+# Split across two scripts for the same reason. The report is checked down to
+# the marker this tree is missing, because the script's other marker is inside
+# a string on the line above: a lint that dropped the whole line -- comment,
+# quoted text and all -- would flag the tree for both markers and read green
+# here while rejecting every script that prints a marker mid-line.
+check_tree "marker only in a trailing comment" FLAG \
+    "$(make_tree trailing-comment-markers "$(readme_naming lint.sh other.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT" "other.sh:$TRAILING_COMMENT_SCRIPT")" \
+    "other.sh (FAIL:)"
+
+# Both markers missing at once -- the wrapper shape. Split across two scripts
+# for the same reason as the case above.
+check_tree "wrapper emitting neither marker" FLAG \
+    "$(make_tree no-markers "$(readme_naming lint.sh other.sh)" \
+        "lint.sh:$SOURCE_ONLY_SCRIPT" "other.sh:$NO_MARKER_SCRIPT")" \
+    "$MARKER_REPORT"
+
+check_tree "markers only inside single quotes" PASS \
+    "$(make_tree single-quoted-markers "$(readme_naming lint.sh)" \
+        "lint.sh:$SINGLE_QUOTED_MARKER_SCRIPT")"
 
 echo "== a lint that checked nothing must not report PASS =="
 


### PR DESCRIPTION
Stacked on #348 — that PR is the base, so this diff is the last commit only. It genuinely depends on #348: check 3 below cannot pass until `meth_oracle.sh` emits its markers, which is #348's change.

`test/regression/README.md` has said **"emits `PASS:` on success and `FAIL:` on failure"** since the directory existed, and nothing ever checked it. Three of the twenty-five scripts did not honour it, which is about what an unchecked claim earns over that span.

| Script | What it printed |
|---|---|
| `meth_collapsed_scoring.sh` | a bare `echo "OK"` |
| `all_tiers_parity.sh` | `ALL TIERS PARITY: PASS (…)` — the word, but not the marker |
| `meth_oracle.sh` | nothing; it `exec`d its child (fixed in #348) |

The third is the one that matters. A wrapper that prints no marker is indistinguishable from a wrapper that never ran — exactly the failure the markers exist to make visible. #348 fixes that instance; this PR is what stops it recurring.

## The check

Check 3 in `readme_contract_lint.sh` is a **source** check, not a runtime one: it asks whether both literals are reachable in the file, not whether a given run printed them. That is the same bargain the other lints here make, and it catches all three cases above. It matches on the literal rather than on an `echo` line on purpose — the marker is just as legitimate coming out of a `printf` or a `fail()` helper, and a stricter pattern would start arguing with how each script chooses to write.

`all_tiers_parity.sh` keeps both of its SKIPPED paths, renamed to `SKIP:` for consistency with the marker now printed beside them. Those paths deliberately do not say PASS — with one testable tier there is nothing to compare, and the README is explicit that a skipped check must be reported as skipped, never as a pass. Check 3 does not force one on them; it only requires the success path to be able to print `PASS:`, which is now the only place that word appears in the file.

## Selftest

Three new cases, one per shape found in the tree: no `PASS:` at all, a PASS without the colon, and neither marker.

The existing fixtures also had to grow a `FAIL:` literal, and that is not incidental — **every fixture script in that file modelled a script the new check rejects.** Without the change, the check-1 and check-2 cases would have started failing for a reason they were never written to exercise. Worth knowing if you add a fixture later.

## Validation

- `readme_contract_lint.sh` → `PASS: readme_contract_lint (25 scripts named and present; 9 source-only; 42 emit both markers)`
- Reverting `meth_collapsed_scoring.sh`'s marker → `FAIL: … meth_collapsed_scoring.sh (PASS:)`, exit 1
- `readme_contract_lint_selftest.sh` passes, with all three new cases reporting FLAG
- Shell lint clean over all 70 tracked scripts

`all_tiers_parity.sh` and `meth_collapsed_scoring.sh` need a built binary and were not run end-to-end locally — both are syntax- and shellcheck-clean, and CI exercises them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Standardized regression-test status messages with clear `PASS:`, `FAIL:`, and `SKIP:` markers.
  - Improved success output to describe validated behaviors and completed tier comparisons.
  - Expanded self-tests to detect missing, malformed, comment-only, quoted, or incomplete status markers.
  - Continued validating zero-comparison skip behavior.

- **Documentation**
  - Clarified status-marker requirements and coverage checks for regression scripts.
  - Documented additional regression checks and reported the number of validations completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->