### PR TITLE
chore(meth): stop copying a fixture nothing reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,12 +768,17 @@ jobs:
           repository: brentp/bwa-meth
           path: bwa-meth-oracle
 
+      # Only the two fixtures something actually reads. t_R2.fastq.gz was copied
+      # here too until nothing was found to consume it: test/meth/test.sh runs
+      # single-end, and test/meth/test_bismark_tags.sh simulates its own reads.
+      # PE --meth coverage lives in the whole-aligner regressions that exercise
+      # it directly (test/regression/meth_pe_placement.sh and
+      # test/regression/meth_mixed_pe_asym.sh), not here.
       - name: Copy bwa-meth fixtures into test/meth/
         if: matrix.canonical == true
         run: |
           cp bwa-meth-oracle/example/ref.fa test/meth/
           cp bwa-meth-oracle/example/t_R1.fastq.gz test/meth/
-          cp bwa-meth-oracle/example/t_R2.fastq.gz test/meth/
           ls -la test/meth/
 
       # No BWAMETH_DIR: the checkout above is a fixture source, not an oracle

--- a/test/meth/.gitignore
+++ b/test/meth/.gitignore
@@ -3,6 +3,9 @@ ref.fa.*
 ref.c2t.fasta*
 ref_idx.fa*
 t_R1.fastq.gz
+# Nothing here reads t_R2, and CI no longer copies it -- but the bwa-meth
+# example directory ships it, so anyone copying that directory wholesale still
+# lands one here. Kept so it cannot be committed by accident.
 t_R2.fastq.gz
 *.bam
 *.sorted.bam

--- a/test/meth/test.sh
+++ b/test/meth/test.sh
@@ -41,7 +41,7 @@ for fixture in ref.fa t_R1.fastq.gz; do
     if [[ ! -f "$fixture" || ! -s "$fixture" ]]; then
         echo "ERROR: fixture $PWD/$fixture is missing, empty, or not a regular file."
         echo "       These are gitignored. Copy them from a bwa-meth checkout:"
-        echo "         cp <bwa-meth>/example/{ref.fa,t_R1.fastq.gz,t_R2.fastq.gz} $PWD/"
+        echo "         cp <bwa-meth>/example/{ref.fa,t_R1.fastq.gz} $PWD/"
         exit 2
     fi
 done


### PR DESCRIPTION
Stacked on #348 — that PR is the base, so this diff is the last commit only. Sibling of #355; the two touch disjoint files.

CI copied three bwa-meth fixtures into `test/meth/` on every canonical run. Two have consumers. `t_R2.fastq.gz` does not:

- `test/meth/test.sh` runs single-end — `mem --meth --bam -t 2 ref.fa t_R1.fastq.gz`
- `test/meth/test_bismark_tags.sh` simulates its own paired reads

So the third file was copied, listed in `.gitignore`, and named in the copy hint without ever being opened. `grep -rn t_R2` over the tree returned exactly those three sites and no reader.

**PE `--meth` is not losing coverage.** It is exercised directly by the whole-aligner regressions written for it — `test/regression/meth_pe_placement.sh` and `test/regression/meth_mixed_pe_asym.sh` — which build their own inputs. Nothing was relying on this file to reach that path.

## The `.gitignore` entry stays

Deliberately, with a comment saying why it outlives the copy step. The bwa-meth example directory ships `t_R2.fastq.gz`, so anyone copying that directory wholesale — which is what the hint in `test.sh` invites — still lands one in the working tree. Dropping the ignore would trade a dead copy step for a way to accidentally commit a binary fixture, which is the worse of the two.

## Context

Same species as the `BWAMETH_DIR` guard removed in #348: fixture plumbing that outlived its consumer and stayed because nothing pointed at it. Found while auditing that change rather than by any check — which is the argument for keeping the copy step down to what is actually read.

## Validation

- `ci.yml` still parses
- The copy hint now names the two files the preflight checks — confirmed by running it with the fixtures absent
- `grep -rn t_R2` over the tree returns only the `.gitignore` entry and its comment
- Shell lint clean over all 70 tracked scripts
