### PR TITLE
test(meth): run the Layer 1 smoke paired-end again

### DIFF
--- a/test/meth/test.sh
+++ b/test/meth/test.sh
@@ -7,6 +7,7 @@
 #     SAM text, so the BGZF assertions below require it explicitly)
 #   - @PG ID:bwa-mem3-meth present
 #   - BGZF EOF marker at tail
+#   - the run stayed PAIRED: every record flagged 0x1, both mates present
 #   - --set-as-failed / --chimera-qc parse cleanly
 #
 # Layers 2-3 (bwameth structural / byte equivalence) are RETIRED in D3 — see the
@@ -37,7 +38,7 @@ cd "$HERE"
 # because the indexing step below sends both streams to /dev/null: without
 # this, a missing ref.fa surfaced as a bare `exit 2` with no output at all,
 # since `set -e` aborts before any of this script's own diagnostics can run.
-for fixture in ref.fa t_R1.fastq.gz; do
+for fixture in ref.fa t_R1.fastq.gz t_R2.fastq.gz; do
     if [[ ! -f "$fixture" || ! -s "$fixture" ]]; then
         echo "ERROR: fixture $PWD/$fixture is missing, empty, or not a regular file."
         echo "       These are gitignored. Copy them from a bwa-meth checkout:"
@@ -63,7 +64,16 @@ if [[ ! -f ref.fa.bwameth.c2t.bwt.2bit.64 ]]; then
     "$BWAMEM3" index --meth ref.fa > /dev/null 2>&1
 fi
 
-"$BWAMEM3" mem --meth --bam -t 2 ref.fa t_R1.fastq.gz 2> /dev/null > "$BAM"
+# PAIRED-END on purpose. This ran paired until the D3 rewrite dropped the mate
+# while it was retiring Layers 2-3; nothing about that retirement required Layer
+# 1 to go single-end, and going single-end took every assertion below with it.
+# The tag rules these assertions check are per-strand -- R1 to OT (XR:CT), R2 to
+# OB (XR:GA) -- so an SE run exercises one half of the contract and the mate
+# half of the XR/XG assignment is never seen on real reads. The directed PE
+# regressions (test/regression/meth_pe_placement.sh, meth_mixed_pe_asym.sh)
+# cover the placement logic, but on 60 bp hand-written reads over a synthetic
+# reference; this is the only --meth test that sees a real read pair.
+"$BWAMEM3" mem --meth --bam -t 2 ref.fa t_R1.fastq.gz t_R2.fastq.gz 2> /dev/null > "$BAM"
 
 EXPECT_EOF="1f8b08040000000000ff0600424302001b0003000000000000000000"
 ACTUAL_EOF="$(tail -c 28 "$BAM" | od -An -v -t x1 | tr -d ' \n')"
@@ -89,24 +99,84 @@ if [[ "$TOTAL" -lt 1 ]]; then
     exit 1
 fi
 
+# Assert the run was actually paired, so the invocation above cannot quietly
+# revert to single-end and leave every assertion below still passing over half
+# the contract -- which is exactly how the paired coverage was lost the first
+# time. Both mates must be present: 0x1 alone would be satisfied by a batch
+# where one side failed to load.
+PAIRED="$("$SAMTOOLS" view -c -f 0x1 "$BAM" 2> /dev/null)"
+R1_COUNT="$("$SAMTOOLS" view -c -f 0x41 "$BAM" 2> /dev/null)"
+R2_COUNT="$("$SAMTOOLS" view -c -f 0x81 "$BAM" 2> /dev/null)"
+if [[ "$PAIRED" -ne "$TOTAL" ]]; then
+    echo "FAIL: $((TOTAL - PAIRED)) of $TOTAL record(s) are not flagged paired (0x1)"
+    echo "      -- the --meth run above went single-end"
+    exit 1
+fi
+if [[ "$R1_COUNT" -lt 1 || "$R2_COUNT" -lt 1 ]]; then
+    echo "FAIL: expected both mates, got R1=$R1_COUNT R2=$R2_COUNT"
+    exit 1
+fi
+
+# --chimera-qc classifies read PAIRS, so single-end input makes it a no-op.
 "$BWAMEM3" mem --meth --bam --set-as-failed f --chimera-qc \
-    ref.fa t_R1.fastq.gz 2> /dev/null > "$BAM2"
+    ref.fa t_R1.fastq.gz t_R2.fastq.gz 2> /dev/null > "$BAM2"
 if [[ ! -s "$BAM2" ]]; then
     echo "FAIL: --set-as-failed + --chimera-qc produced empty output"
     exit 1
 fi
+# Guarded the same way as the run above, and for the same reason: this is the
+# invocation whose flag NEEDS pairs, so it is the one that must not be allowed
+# to quietly go single-end while a non-empty BAM keeps the check green.
+TOTAL2="$("$SAMTOOLS" view -c "$BAM2" 2> /dev/null)"
+PAIRED2="$("$SAMTOOLS" view -c -f 0x1 "$BAM2" 2> /dev/null)"
+if [[ "$TOTAL2" -lt 1 ]]; then
+    # The -s check above only proves a header was written. Without this, the
+    # paired comparison below is 0 -ne 0 and passes over an empty BAM.
+    echo "FAIL: zero records in the --chimera-qc output BAM"
+    exit 1
+fi
+if [[ "$PAIRED2" -ne "$TOTAL2" ]]; then
+    echo "FAIL: $((TOTAL2 - PAIRED2)) of $TOTAL2 --chimera-qc record(s) are not flagged paired (0x1)"
+    echo "      -- --chimera-qc classifies PAIRS, so that run is a no-op single-end"
+    exit 1
+fi
 
-echo "OK layer 1: bwa-mem3 mem --meth --bam (records=$TOTAL, BGZF-EOF ok, @PG bwa-mem3-meth ok)"
+echo "OK layer 1: bwa-mem3 mem --meth --bam (records=$TOTAL paired, R1=$R1_COUNT R2=$R2_COUNT, BGZF-EOF ok, @PG bwa-mem3-meth ok)"
 
 # --- Bismark XR:Z / XG:Z / XM:Z emission assertions ----------------------
 # Every primary mapped record (FLAG & 0x904 == 0) must carry XR:Z:(CT|GA),
 # XG:Z:(CT|GA), and XM:Z whose payload length equals SEQ length. Unmapped
-# records (FLAG & 0x4) carry XR:Z only. No record emits the legacy Y* tags.
+# records (FLAG & 0x4) carry XR:Z only. Every record's XR:Z must agree with its
+# mate flag. No record emits the legacy Y* tags.
 
 PRIMARY_MAPPED_NO_XR=$("$SAMTOOLS" view -F 0x904 "$BAM" \
     | mawk '!/\tXR:Z:(CT|GA)/{n++} END{print n+0}')
 if [[ "$PRIMARY_MAPPED_NO_XR" -ne 0 ]]; then
     echo "FAIL: $PRIMARY_MAPPED_NO_XR primary mapped record(s) missing XR:Z:(CT|GA)"
+    exit 1
+fi
+
+# XR:Z is the READ conversion, and --meth derives it from the mate alone: R1 is
+# C->T, R2 is G->A (src/fastmap.cpp, `yc = is_r2 ? "GA" : "CT"`). The check
+# above only asserts XR is one of the two legal values, which stays green even
+# if every record were tagged CT -- so it does not actually cover the per-strand
+# assignment that going paired here is meant to exercise. This does: it is the
+# assertion that fails if the R1/R2 classification regresses (the parity and
+# adjacent-name rules that same function uses to pick the mate). Run over EVERY
+# record, not just primary mapped, because XR is emitted on all of them.
+XR_MATE_BAD=$("$SAMTOOLS" view "$BAM" \
+    | mawk '
+        {
+            want = (int($2 / 64) % 2) ? "CT" : ((int($2 / 128) % 2) ? "GA" : "")
+            xr = ""
+            for (i = 12; i <= NF; i++) {
+                if (substr($i, 1, 5) == "XR:Z:") { xr = substr($i, 6); break }
+            }
+            if (want == "" || xr != want) { n++ }
+        }
+        END { print n+0 }')
+if [[ "$XR_MATE_BAD" -ne 0 ]]; then
+    echo "FAIL: $XR_MATE_BAD record(s) with XR:Z not matching the mate (R1 must be CT, R2 must be GA)"
     exit 1
 fi
 
@@ -169,7 +239,7 @@ if [[ "$Y_LEAKS" -ne 0 ]]; then
     exit 1
 fi
 
-echo "OK layer 1 Bismark tags: XR/XG/XM well-formed, no Y* leak"
+echo "OK layer 1 Bismark tags: XR/XG/XM well-formed, XR matches mate, no Y* leak"
 
 # ---------------------------------------------------------------------------
 # Layers 2-3 (bwameth equivalence) RETIRED in D3.

--- a/test/regression/meth_oracle.sh
+++ b/test/regression/meth_oracle.sh
@@ -8,9 +8,11 @@
 # D3; this is a thin wrapper that re-invokes what is left of it.
 #
 # Inputs:
-#   The test/meth fixtures (ref.fa, t_R1.fastq.gz), copied into test/meth/ by
-#   the caller -- see the "Copy bwa-meth fixtures into test/meth/" step in
-#   ci.yml. test/meth/test.sh checks for them and says where they come from.
+#   The test/meth fixtures (ref.fa, t_R1.fastq.gz, t_R2.fastq.gz), copied into
+#   test/meth/ by the caller -- see the "Copy bwa-meth fixtures into test/meth/"
+#   step in ci.yml. The harness runs paired-end, so the mate is as required as
+#   the other two; test/meth/test.sh checks for all three and says where they
+#   come from.
 #
 #   Nothing is read from the environment HERE, which is what puts this script in
 #   the source-only block of test/regression/README.md -- that contract is about


### PR DESCRIPTION
Stacked on #348 — that PR is the base, so this diff is the last commit only. Sibling of #355; the two touch disjoint files. Replaces #356, which had the conclusion backwards.

Layer 1 ran **paired-end** on the bwa-meth example fixtures until the D3 rewrite:

```
"$BWAMEM3" mem --meth --chimera-qc -t 4 ref.fa t_R1.fastq.gz t_R2.fastq.gz
```

`a0296b1` replaced that with a single-end invocation while it was retiring Layers 2-3. Nothing about retiring the bwameth-equivalence layers required Layer 1 to stop being paired, and going single-end took every assertion in the file with it — the XR/XG/XM checks, the `XM` length vs SEQ length check, the unmapped tag-set rule, and the `Y*` leak check have all been running over one half of the contract since. `t_R2.fastq.gz` kept being copied by CI and stopped being read by anything, which is how the regression stayed invisible.

## Why this is a real gap, not a redundant one

The tag rules are **per-strand** — R1 → OT (`XR:CT`), R2 → OB (`XR:GA`) — so the mate half of the XR/XG assignment has had no coverage on real reads at all.

PE `--meth` is not uncovered in general: `test/regression/meth_pe_placement.sh` and `meth_mixed_pe_asym.sh` are both CI-wired and genuinely paired. But both run 60 bp hand-written literal reads over a synthetic reference. **This is the only `--meth` test that sees a real read pair.**

`--chimera-qc` is restored to paired input too — it classifies read *pairs*, so the second invocation has been passing a flag that could not do anything.

## Guarded against silently reverting

The run now asserts every record is flagged paired and that both mates are present:

```
PAIRED=$(samtools view -c -f 0x1  "$BAM")
R1_COUNT=$(samtools view -c -f 0x41 "$BAM")
R2_COUNT=$(samtools view -c -f 0x81 "$BAM")
```

Dropping the mate off the command line now fails loudly instead of leaving the assertions below green over half the input — which is exactly how this was lost the first time. Both mates are checked rather than `0x1` alone, since `0x1` is satisfied by a batch where one side failed to load.

The fixture preflight from #348 now covers `t_R2.fastq.gz`, which also makes its copy hint accurate: it already told the reader to copy all three files while checking only two.

## Validation

- shellcheck/shfmt clean over all 70 tracked scripts
- The preflight names `t_R2.fastq.gz` when absent and proceeds when present (verified with a stub binary)

The paired run itself needs a built binary and the real fixtures, neither available locally — **CI's canonical row runs this script and is the gate.** If the paired invocation surfaces a genuine XR/XG defect on the mate strand, that is the finding, not a reason to revert the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded regression coverage for paired-end methylation data.
  - Added validation that outputs contain matching R1 and R2 records.
  - Success messages now report paired-record counts.

- **Documentation**
  - Clarified paired-end test coverage and noted retired equivalence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->