### PR TITLE
fix(coderabbit): list main in auto_review.base_branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -42,15 +42,16 @@ reviews:
   estimate_code_review_effort: true
   enable_prompt_for_ai_agents: true
 
-  # Review PRs targeting the `fg-main` integration branch in addition to the
-  # repository's default branch (`main`). The default branch is always reviewed;
-  # this list adds extra base branches. Without it, CodeRabbit posts "auto
-  # reviews are disabled on base/target branches other than the default branch"
-  # and skips stacked PRs.
+  # Base branches whose PRs are auto-reviewed. This list REPLACES the default
+  # (the repository's default branch) rather than extending it, so `main` must
+  # be listed explicitly — omitting it made CodeRabbit post "auto reviews are
+  # disabled on base/target branches other than the default branch" and skip
+  # every PR in the repo. `fg-main` is the integration branch stacked PRs target.
   auto_review:
     enabled: true
     drafts: false
     base_branches:
+      - "main"
       - "fg-main"
 
   # Don't spend review budget on vendored submodules, build output, committed


### PR DESCRIPTION
`reviews.auto_review.base_branches` **replaces** the default base-branch list (the repository's default branch) rather than extending it. Restricting it to `fg-main` therefore turned auto-review off for every PR targeting `main`, and `fg-main` does not exist as a branch in this repo — so nothing was auto-reviewed at all.

CodeRabbit answered each new PR with:

> **Review skipped** — Auto reviews are disabled on base/target branches other than the default branch. Base branches to auto review (1): `fg-main`

This lists `main` explicitly alongside `fg-main` and corrects the comment, which asserted the opposite ("The default branch is always reviewed; this list adds extra base branches").

Found while tracking down #355 and #357, which the review queue had parked as permanently non-reviewable on the strength of that notice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review configuration to support pull requests targeting both `main` and `fg-main` branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->